### PR TITLE
TLS interface overview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,5 @@
 venv/
 issues.json
 lib
-.targets
+.targets.mk
 draft-ietf-quic-tls.md

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -113,12 +113,12 @@ This document uses the terminology established in {{QUIC-TRANSPORT}}.
 
 For brevity, the acronym TLS is used to refer to TLS 1.3.
 
-TLS terminology is used when referring to parts of TLS. Though TLS assumes a 
-continuous stream of octets, it divides that stream into *records*. Most 
-relevant to QUIC are the records that contain TLS *handshake messages*, which 
-are discrete messages that are used for key agreement, authentication and 
-parameter negotiation. Ordinarily, TLS records can also contain *application 
-data*, though in the QUIC usage there is no use of TLS application data. 
+TLS terminology is used when referring to parts of TLS. Though TLS assumes a
+continuous stream of octets, it divides that stream into *records*. Most
+relevant to QUIC are the records that contain TLS *handshake messages*, which
+are discrete messages that are used for key agreement, authentication and
+parameter negotiation. Ordinarily, TLS records can also contain *application
+data*, though in the QUIC usage there is no use of TLS application data.
 
 
 # Protocol Overview
@@ -370,9 +370,8 @@ A QUIC client starts TLS by requesting TLS handshake octets from
 TLS.  The client acquires handshake octets before sending its first packet.
 
 A QUIC server starts the process by providing TLS with any stream 1 octets that
-might have arrived.  Only in-sequence packets are delivered; packets that arrive
-out of order are buffered by QUIC until all preceding packets are available.
-QUIC first provides TLS with octets from stream 1.
+might have arrived.  Only in-sequence frame data is delivered; data that arrives
+out of order are buffered by QUIC until all preceding data is available.
 
 Each time that an endpoint receives data on stream 1, it determines if it can
 deliver the data to TLS.  Any octets that are contiguous with the last data
@@ -540,11 +539,11 @@ Ordinarily, an endpoint retransmits stream data in a new packet.  That packet
 uses the latest packet protection keys.  This simplifies key management when
 there are key updates (see {{key-update}}).
 
-The first flight of handshake messages from both client and server (ClientHello, 
-or ServerHello through to the server's Finished) are critical to the key 
-exchange. The content of these messages is used to determine the keys used to 
-protect later messages. If these are protected with newer keys, they will be 
-indecipherable to the recipient. 
+The first flight of handshake messages from both client and server (ClientHello,
+or ServerHello through to the server's Finished) are critical to the key
+exchange. The content of these messages is used to determine the keys used to
+protect later messages. If these are protected with newer keys, they will be
+indecipherable to the recipient.
 
 Even though newer keys are available, the first flight of TLS handshake messages
 sent by an endpoint MUST NOT be encrypted:

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -113,13 +113,12 @@ This document uses the terminology established in {{QUIC-TRANSPORT}}.
 
 For brevity, the acronym TLS is used to refer to TLS 1.3.
 
-This document uses TLS terminology is used when referring to parts of TLS.
-Though TLS assumes a continuous stream of octets, it divides that stream into
-*records*.  Most relevant to QUIC are the records that contain TLS *handshake
-messages*, which are discrete messages that are used for key agreement,
-authentication and parameter negotiation.  Ordinarily, TLS records can also
-contain *application data*, though in the QUIC usage there is no use of TLS
-application data.
+TLS terminology is used when referring to parts of TLS. Though TLS assumes a 
+continuous stream of octets, it divides that stream into *records*. Most 
+relevant to QUIC are the records that contain TLS *handshake messages*, which 
+are discrete messages that are used for key agreement, authentication and 
+parameter negotiation. Ordinarily, TLS records can also contain *application 
+data*, though in the QUIC usage there is no use of TLS application data. 
 
 
 # Protocol Overview
@@ -259,7 +258,7 @@ document:
 
 # TLS in Stream 1
 
-QUIC reserves stream 1 for a TLS connection.  Stream contains a complete TLS
+QUIC reserves stream 1 for a TLS connection. This stream contains a complete TLS
 connection, which includes the TLS record layer.  Other than the definition of a
 QUIC-specific extension (see Section-TBD), TLS is unmodified for this use.  This
 means that TLS will apply confidentiality and integrity protection to its
@@ -378,8 +377,7 @@ QUIC first provides TLS with octets from stream 1.
 Each time that an endpoint receives data on stream 1, it determines if it can
 deliver the data to TLS.  Any octets that are contiguous with the last data
 provided to TLS can be delivered.  When any octets of TLS data can be delivered,
-then TLS is provided with the data then new handshake octets are requested from
-TLS.
+TLS is provided with the data. New handshake octets are then requested from TLS.
 
 TLS might not provide any octets if the handshake messages it has received are
 incomplete.
@@ -542,11 +540,11 @@ Ordinarily, an endpoint retransmits stream data in a new packet.  That packet
 uses the latest packet protection keys.  This simplifies key management when
 there are key updates (see {{key-update}}).
 
-The handshake messages the first flight of handshake messages from both client
-and server (ClientHello, or ServerHello through to the server's Finished) a
-critical to the key exchange.  The contents of these messages is used to
-determine the keys used to protect later messages.  If these are protected with
-newer keys, they will be indecipherable to the recipient.
+The first flight of handshake messages from both client and server (ClientHello, 
+or ServerHello through to the server's Finished) are critical to the key 
+exchange. The content of these messages is used to determine the keys used to 
+protect later messages. If these are protected with newer keys, they will be 
+indecipherable to the recipient. 
 
 Even though newer keys are available, the first flight of TLS handshake messages
 sent by an endpoint MUST NOT be encrypted:
@@ -969,7 +967,7 @@ ISSUE:
   authenticating the initial value, so that peers can be sure that they haven't
   missed an initial message.
 
-In addition to causing valid packets to be dropped, an attacker to generate
+In addition to causing valid packets to be dropped, an attacker could generate
 packets with an intent of causing the recipient to expend processing resources.
 See {{useless}} for a discussion of these risks.
 

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -312,7 +312,7 @@ ensures that TLS handshake messages are delivered in the correct order.
 
                                            QUIC Frames <any> @C
                             <--------
-@A QUIC STREAM Frame(s) <1>:
+@C QUIC STREAM Frame(s) <1>:
      (end_of_early_data)
      {Finished}
                             -------->

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -376,8 +376,10 @@ out of order are buffered by QUIC until all preceding packets are available.
 QUIC first provides TLS with octets from stream 1.
 
 Each time that an endpoint receives data on stream 1, it determines if it can
-deliver the data to TLS.  When any octets of TLS data can be delivered, then TLS
-is provided with the data then new handshake octets are requested from TLS.
+deliver the data to TLS.  Any octets that are contiguous with the last data
+provided to TLS can be delivered.  When any octets of TLS data can be delivered,
+then TLS is provided with the data then new handshake octets are requested from
+TLS.
 
 TLS might not provide any octets if the handshake messages it has received are
 incomplete.
@@ -430,7 +432,7 @@ Details how secrets are exported from TLS are included in {{key-expansion}}.
 
 ### TLS Interface Summary
 
-Assuming , {{exchange-summary}} summarizes the exchange between
+{{exchange-summary}} summarizes the exchange between
 QUIC and TLS for both client and server.
 
 ~~~
@@ -456,7 +458,7 @@ Handshake Complete
 Handshake Received
 Get Handshake
 ~~~
-
+{: #exchange-summary title="Interaction Summary between QUIC and TLS"}
 
 
 # QUIC Packet Protection {#packet-protection}

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -852,11 +852,11 @@ according to the rules in the TLS protocol.
 
 # Pre-handshake QUIC Messages {#pre-handshake}
 
-Implementations MUST NOT exchange data on any stream other than stream 1 prior
-to the completion of the TLS handshake.  However, QUIC requires the use of
-several types of frame for managing loss detection and recovery.  In addition,
-it might be useful to use the data acquired during the exchange of
-unauthenticated messages for congestion management.
+Implementations MUST NOT exchange data on any stream other than stream 1 without
+packet protection.  QUIC requires the use of several types of frame for managing
+loss detection and recovery during this phase.  In addition, it might be useful
+to use the data acquired during the exchange of unauthenticated messages for
+congestion control.
 
 This section generally only applies to TLS handshake messages from both peers
 and acknowledgments of the packets carrying those messages.  In many cases, the
@@ -953,8 +953,6 @@ Once the TLS handshake is complete, both peers MUST ignore unprotected packets.
 The handshake is complete when the server receives a client's Finished message
 and when a client receives an acknowledgement that their Finished message was
 received.  From that point onward, unprotected messages can be safely dropped.
-Note that the client could retransmit its Finished message to the server, so the
-server cannot reject such a message.
 
 Since only TLS handshake packets and acknowledgments are sent in the clear, an
 attacker is able to force implementations to rely on retransmission for packets
@@ -971,9 +969,9 @@ ISSUE:
   authenticating the initial value, so that peers can be sure that they haven't
   missed an initial message.
 
-In addition to denying endpoints messages, an attacker to generate packets that
-cause no state change in a recipient.  See {{useless}} for a discussion of these
-risks.
+In addition to causing valid packets to be dropped, an attacker to generate
+packets with an intent of causing the recipient to expend processing resources.
+See {{useless}} for a discussion of these risks.
 
 To avoid receiving TLS packets that contain no useful data, a TLS implementation
 MUST reject empty TLS handshake records and any record that is not permitted by

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -373,20 +373,17 @@ A QUIC server starts the process by providing TLS with any stream 1 octets that
 might have arrived.  Only in-sequence frame data is delivered; data that arrives
 out of order are buffered by QUIC until all preceding data is available.
 
-Each time that an endpoint receives data on stream 1, it determines if it can
-deliver the data to TLS.  Any octets that are contiguous with the last data
-provided to TLS can be delivered.  When any octets of TLS data can be delivered,
-TLS is provided with the data. New handshake octets are then requested from TLS.
-
+After providing TLS with data, new handshake octets are then requested from TLS.
 TLS might not provide any octets if the handshake messages it has received are
 incomplete.
 
 Once the TLS handshake is complete, this is indicated to QUIC along with any
 final handshake octets that TLS needs to send.  Once the handshake is complete,
-TLS becomes passive.  TLS might still receive data from its peer and respond to
-that data, but it will not need to send more data unless it is explicitly
-requested.  One reason to send data is that the server might wish to provide
-additional or updated session tickets to a client.
+TLS becomes passive.  TLS can still receive data from its peer and respond in
+kind that data, but it will not need to send more data unless specifically
+requested - either by an application or QUIC.  One reason to send data is that
+the server might wish to provide additional or updated session tickets to a
+client.
 
 Important:
 


### PR DESCRIPTION
This PR attempts to do a few things:

1. Remove the QUIC structural diagram.  That belongs in the main spec, if anywhere.

2. Add some basic material on TLS.

3. Expand on the interface between QUIC (the transport pieces) and TLS.  In the process, hopefully make it clear that this document is talking about the QUIC and interface-y pieces.  I'll likely need more on this later, but it's a start.

I haven't touched later sections of the document; this concentrates on introductory material only.  As a result, there is an inconsistency where this talks about the solution to #27 as though it were fixed.  I plan to add that fix in the next PR, but it was pointless doing the text twice: once as though that fix wasn't coming and again with a fix.