### PR TITLE
Replace SETTINGS with EXTENDED_SETTINGS

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -476,7 +476,8 @@ value.
 
 A zero-length content indicates that the setting value is a Boolean given by the 
 B bit. If Length is not zero, the B bit MUST be zero, and MUST be ignored by 
-receivers. The initial value of each setting is "false." 
+receivers. The initial value of each setting is "false" unless otherwise
+specified by the definition of the setting.
 
 An implementation MUST ignore the contents for any EXTENDED_SETTINGS identifier 
 it does not understand. 
@@ -488,7 +489,13 @@ receives an SETTINGS frame whose stream identifier field is anything other than
 
 The SETTINGS frame affects connection state. A badly formed or incomplete 
 SETTINGS frame MUST be treated as a connection error (Section 5.4.1) of type 
-PROTOCOL_ERROR. 
+PROTOCOL_ERROR.
+
+#### Integer encoding
+
+Settings which are integers are transmitted in network byte order.  Leading
+zero octets are permitted, but implementations SHOULD use only as many bytes as
+are needed to represent the value.
 
 #### Defined SETTINGS Parameters
   
@@ -500,7 +507,8 @@ how each HTTP/2 SETTINGS parameter is mapped:
   : An integer with a maximum value of 2^32 - 1.
 
   SETTINGS_ENABLE_PUSH:
-  : A Boolean
+  : Transmitted as a Boolean.  The default remains "true" as specified in
+    {{!RFC7540}}.
 
   SETTINGS_MAX_CONCURRENT_STREAMS:
   : QUIC requires the maximum number of incoming streams per connection to be

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -442,8 +442,8 @@ also acceptable and proceed with the value it has chosen. (This choice could be
 announced in a field of an extension frame, or in a value in SETTINGS.) 
 
 Different values for the same parameter can be advertised by each peer. For 
-example, a server might support many different signing algorithms, while a 
-resource constrained client has only one or two that it can validate. 
+example, a client might permit a very large HPACK state table while a server 
+chooses to use a small one to conserve memory.
 
 A SETTINGS frame MAY be sent at any time by either endpoint over the lifetime 
 of the connection. 

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -474,11 +474,13 @@ consisting of an unsigned 16-bit setting identifier and a length-prefixed binary
 value.
 
 ~~~~~~~~~~~~~~~
-+-------------------------------+-+-------------+---------------+
-|        Identifier (16)        |B|        Length (15)          |
-+-------------------------------+-+-------------+---------------+
-|                          Contents (?)                       ...
-+---------------------------------------------------------------+
+    0                   1                   2                   3
+    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |        Identifier (16)        |B|        Length (15)          |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |                          Contents (?)                       ...
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 ~~~~~~~~~~~~~~~
 {: #fig-ext-settings title="SETTINGS value format"}
 
@@ -503,7 +505,8 @@ PROTOCOL_ERROR.
 
 Settings which are integers are transmitted in network byte order.  Leading
 zero octets are permitted, but implementations SHOULD use only as many bytes as
-are needed to represent the value.
+are needed to represent the value.  An integer MUST NOT be represented in more
+bytes than would be used to transfer the maximum permitted value.
 
 #### Defined SETTINGS Parameters
   

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -555,12 +555,11 @@ SETTINGS frame MUST be processed in the order they appear, with no other frame
 processing between values. Unsupported parameters MUST be ignored. 
 
 Once all values have been processed, if the REQUEST_ACK flag was set, the 
-recipient MUST immediately emit the following:
+recipient MUST emit the following frames:
 
- - On the connection control stream, a SETTINGS_ACK frame listing the 
-   identifiers whose values were understood and applied. (If none of the values 
-   were understood, the SETTINGS_ACK frame will be empty, but MUST still be
-   sent.) 
+ - On the connection control stream, a SETTINGS_ACK frame 
+   ({{frame-settings-ack}}) listing the identifiers whose values were not 
+   understood.
 
  - On each request control stream which is not in the "half-closed (local)" or
    "closed" state, an empty SETTINGS_ACK frame.
@@ -570,10 +569,11 @@ stream number which was open at the time the SETTINGS frame was received.  All
 streams with higher numbers can safely be assumed to have the new settings in
 effect when they open.
 
-For already-open streams, the empty SETTINGS_ACK frame indicates the point at
-which the new settings took effect, if they did so before the peer half-closed
-the stream.  If the peer closed the stream before receiving the SETTINGS frame,
-the previous settings were in effect for the full lifetime of that stream.
+For already-open streams including the connection control stream, the 
+SETTINGS_ACK frame indicates the point at which the new settings took effect, if 
+they did so before the peer half-closed the stream. If the peer closed the 
+stream before receiving the SETTINGS frame, the previous settings were in effect 
+for the full lifetime of that stream. 
 
 In certain conditions, the SETTINGS_ACK frame can be the first frame on a given
 stream -- this simply indicates that the new settings apply from the beginning
@@ -582,10 +582,14 @@ of that stream.
 If the sender of a SETTINGS frame with the REQUEST_ACK flag set does not 
 receive full acknowledgement within a reasonable amount of time, it MAY issue a 
 connection error ([RFC7540] Section 5.4.1) of type SETTINGS_TIMEOUT.  A full
-acknowledgement has occurred when a SETTINGS_ACK frame has been received on the
-connection control stream, and all message control streams with a Stream ID
-through those given in the SETTINGS_ACK frame have either closed or had a
-SETTINGS_ACK frame sent.
+acknowledgement has occurred when:
+
+ - All previous SETTINGS frames have been fully acknowledged,
+ 
+ - A SETTINGS_ACK frame has been received on the connection control stream,
+
+ - All message control streams with a Stream ID through those given in the
+   SETTINGS_ACK frame have either closed or received a SETTINGS_ACK frame.
 
   
 ### PUSH_PROMISE {#frame-push-promise}

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -443,11 +443,11 @@ is substantially different from {{!RFC7540}}. Individually, a SETTINGS parameter
 can also be referred to as a "setting". 
 
 SETTINGS parameters are not negotiated; they describe characteristics of the 
-sending peer, which are used by the receiving peer. However, a negotiation can 
-be implied by the use of SETTINGS -- a peer uses SETTINGS to advertise a set of 
-supported values. The recipient can then choose which entries from this list are 
-also acceptable and proceed with the value it has chosen. (This choice could be 
-announced in a field of an extension frame, or in a value in SETTINGS.) 
+sending peer, which can be used by the receiving peer. However, a negotiation 
+can be implied by the use of SETTINGS -- a peer uses SETTINGS to advertise a set 
+of supported values. The recipient can then choose which entries from this list 
+are also acceptable and proceed with the value it has chosen. (This choice could 
+be announced in a field of an extension frame, or in its own value in SETTINGS.) 
 
 Different values for the same parameter can be advertised by each peer. For 
 example, a client might permit a very large HPACK state table while a server 


### PR DESCRIPTION
[EXTENDED_SETTINGS](https://tools.ietf.org/html/draft-bishop-httpbis-extended-settings-01) was proposed in the HTTP WG as an extension providing an alternative to the HTTP/2 SETTINGS frame.  While feedback was that it was "the design we should have had for HTTP/2... more general, saves space in most cases, and includes a flag to request acknowledgment", there was also a feeling that as an extension it was overkill since most things that needed settings already used SETTINGS.  The advice was to hold it for HTTP/QUIC and make it the default SETTINGS frame there.  So here it is.

Note that while it uses a slightly different ACK mechanism than HTTP/2 SETTINGS, it's subject to the same timing issues as HTTP/2 SETTINGS ACK over QUIC, namely that you can't know when the setting change has been applied on each stream.  This pull request doesn't fix that; it's tracked by #75 still.