### PR TITLE
Reconcile flag bits in frame type table

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -491,7 +491,7 @@ document.
       | Type-field value |     Frame type     |
       +------------------+--------------------+
       | 1FDOOOSS         |  STREAM            |
-      | 01NTLLMM         |  ACK               |
+      | 01NULLMM         |  ACK               |
       | 00000000 (0x00)  |  PADDING           |
       | 00000001 (0x01)  |  RST_STREAM        |
       | 00000010 (0x02)  |  CONNECTION_CLOSE  |


### PR DESCRIPTION
Trivial change, but not my doc.  Table gives bits as "01NTLLMM" while frame definition gives them as "01N**U**LLMM".  Since the bit is "Unused," I assume that 'U' is correct?