### PR TITLE
Short abstract

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -96,18 +96,7 @@ informative:
 --- abstract
 
 QUIC is a multiplexed and secure transport protocol that runs on top of UDP.
-QUIC builds on past transport experience, and implements mechanisms that make it
-useful as a modern general-purpose transport protocol.  Using UDP as the basis
-of QUIC is intended to address compatibility issues with legacy clients and
-middleboxes.  QUIC authenticates all of its headers, preventing third parties
-from changing them.  QUIC encrypts most of its headers, thereby limiting
-protocol evolution to QUIC endpoints only.  Therefore, middleboxes, in large
-part, are not required to be updated as new protocol versions are deployed.
-This document describes the core QUIC protocol, including the conceptual design,
-wire format, and mechanisms of the QUIC protocol for connection establishment,
-stream multiplexing, stream and connection-level flow control, and data
-reliability.  Accompanying documents describe QUIC's loss recovery and
-congestion control, and the use of TLS 1.3 for key negotiation.
+
 
 --- note_Note_to_Readers
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -95,7 +95,9 @@ informative:
 
 --- abstract
 
-QUIC is a multiplexed and secure transport protocol that runs on top of UDP.
+This document defines the core of the QUIC transport protocol.  This document
+describes connection establishment, packet format, multiplexing and reliability.
+Accompanying documents describe the cryptographic handshake and loss detection.
 
 
 --- note_Note_to_Readers
@@ -113,13 +115,15 @@ code and issues list for this draft can be found at
 # Introduction
 
 QUIC is a multiplexed and secure transport protocol that runs on top of UDP.
-QUIC builds on past transport experience and implements mechanisms that make it
-useful as a modern general-purpose transport protocol.
+QUIC aims to provide a flexible set of features that allow it to be a
+general-purpose transport for multiple applications.
 
-Using UDP as the substrate, QUIC seeks to be compatible with legacy clients and
-middleboxes.  QUIC authenticates all of its headers, preventing middleboxes and
-other third parties from changing them, and encrypts most of its headers,
-limiting protocol evolution largely to QUIC endpoints only.
+QUIC implements techniques learned from experience with TCP, SCTP and other
+transport protocols.  Using UDP as the substrate, QUIC seeks to be compatible
+with legacy clients and middleboxes.  QUIC authenticates all of its headers and
+encrypts most of the data it exchanges, including its signaling.  This allows
+the protocol to evolve without incurring a dependency on upgrades to
+middleboxes.
 
 This document describes the core QUIC protocol, including the conceptual design,
 wire format, and mechanisms of the QUIC protocol for connection establishment,

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -114,18 +114,20 @@ code and issues list for this draft can be found at
 
 QUIC is a multiplexed and secure transport protocol that runs on top of UDP.
 QUIC builds on past transport experience and implements mechanisms that make it
-useful as a modern general-purpose transport protocol.  Using UDP as the
-substrate, QUIC seeks to be compatible with legacy clients and middleboxes.
-QUIC authenticates all of its headers, preventing middleboxes and other third
-parties from changing them, and encrypts most of its headers, limiting protocol
-evolution largely to QUIC endpoints only.
+useful as a modern general-purpose transport protocol.
+
+Using UDP as the substrate, QUIC seeks to be compatible with legacy clients and
+middleboxes.  QUIC authenticates all of its headers, preventing middleboxes and
+other third parties from changing them, and encrypts most of its headers,
+limiting protocol evolution largely to QUIC endpoints only.
 
 This document describes the core QUIC protocol, including the conceptual design,
 wire format, and mechanisms of the QUIC protocol for connection establishment,
 stream multiplexing, stream and connection-level flow control, and data
-reliability.  Accompanying documents describe QUIC's loss detection and
-congestion control {{QUIC-RECOVERY}}, and the use of TLS 1.3 for key negotiation
-{{QUIC-TLS}}.
+reliability.
+
+Accompanying documents describe QUIC's loss detection and congestion control
+{{QUIC-RECOVERY}}, and the use of TLS 1.3 for key negotiation {{QUIC-TLS}}.
 
 
 # Conventions and Definitions


### PR DESCRIPTION
The abstract was just a repetition of the introduction, which isn't really appropriate.  An abstract doesn't need rationale and all the padding, it should just explain the purpose of the document.  QUIC is conceptually very simple, let's capitalize on that.

I wanted to fix the first sentence of the intro to avoid duplication, but it really is a concise, well-constructed intro.  It could benefit from being split into smaller pieces though.