### PR TITLE
QUIC-TLS Extension and version negotiation

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1104,22 +1104,21 @@ protection for the QUIC negotiation.  This does not prevent version downgrade
 during the handshake, though it means that such a downgrade causes a handshake
 failure.
 
-Protocols that use the QUIC transport MUST use Application Layer Protocol
-Negotiation (ALPN) {{!RFC7301}}.  The ALPN identifier for the protocol MUST be
-specific to the QUIC version that it operates over.  When constructing a
-ClientHello, clients MUST include a list of all the ALPN identifiers that they
-support, regardless of whether the QUIC version that they have currently
-selected supports that protocol.
+TLS uses Application Layer Protocol Negotiation (ALPN) {{!RFC7301}} to select an 
+application protocol. The application-layer protocol MAY restrict the QUIC 
+versions that it can operate over. When constructing a ClientHello, clients 
+SHOULD include a list of all the ALPN identifiers that they support, regardless 
+of whether the QUIC version that they have currently selected supports that 
+protocol. 
 
-Servers SHOULD select an application protocol based solely on the information in
-the ClientHello, not using the QUIC version that the client has selected.  If
-the protocol that is selected is not supported with the QUIC version that is in
-use, the server MAY send a QUIC version negotiation packet to select a
-compatible version.
+Servers SHOULD select an application protocol compatible with the QUIC version 
+that the client has selected, if possible. If the protocol that is selected is 
+not supported with the QUIC version that is in use, the server MUST send a QUIC 
+version negotiation packet to select a compatible version. 
 
-If the server cannot select a combination of ALPN identifier and QUIC version it
-MUST abort the connection.  A client MUST abort a connection if the server picks
-an incompatible version of QUIC version and ALPN.
+If the server cannot select a compatible combination of ALPN identifier and QUIC 
+version, it MUST abort the connection. A client MUST abort a connection if the 
+server picks an incompatible combination of QUIC version and ALPN identifier.
 
 
 ## QUIC Extension {#quic_parameters}

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1104,30 +1104,45 @@ protection for the QUIC negotiation.  This does not prevent version downgrade
 during the handshake, though it means that such a downgrade causes a handshake
 failure.
 
-TLS uses Application Layer Protocol Negotiation (ALPN) {{!RFC7301}} to select an 
-application protocol. The application-layer protocol MAY restrict the QUIC 
-versions that it can operate over. When constructing a ClientHello, clients 
-SHOULD include a list of all the ALPN identifiers that they support, regardless 
-of whether the QUIC version that they have currently selected supports that 
-protocol. 
+TLS uses Application Layer Protocol Negotiation (ALPN) {{!RFC7301}} to select an
+application protocol. The application-layer protocol MAY restrict the QUIC
+versions that it can operate over. When constructing a ClientHello, clients
+SHOULD include a list of all the ALPN identifiers that they support, regardless
+of whether the QUIC version that they have currently selected supports that
+protocol.
 
-Servers SHOULD select an application protocol compatible with the QUIC version 
-that the client has selected, if possible. If the protocol that is selected is 
-not supported with the QUIC version that is in use, the server MUST send a QUIC 
-version negotiation packet to select a compatible version. 
+Servers SHOULD select an application protocol compatible with the QUIC version
+that the client has selected, if possible. If the protocol that is selected is
+not supported with the QUIC version that is in use, the server MUST send a QUIC
+version negotiation packet to select a compatible version.
 
-If the server cannot select a compatible combination of ALPN identifier and QUIC 
-version, it MUST abort the connection. A client MUST abort a connection if the 
+If the server cannot select a compatible combination of ALPN identifier and QUIC
+version, it MUST abort the connection. A client MUST abort a connection if the
 server picks an incompatible combination of QUIC version and ALPN identifier.
 
 
 ## QUIC Extension {#quic_parameters}
 
-QUIC defines an extension for use with TLS.  That extension defines
-transport-related parameters.  This provides integrity protection for these
-values.  Including these in the TLS handshake also make the values that a client
-sets available to a server one-round trip earlier than parameters that are
-carried in QUIC packets.  This document does not define that extension.
+QUIC parameters are carried in a TLS extension. That extension carries
+transport-related parameters encoded as an opaque blob whose interpretation is
+specific to the QUIC version in use. This provides integrity protection for
+these values. Including these in the TLS handshake also makes the values that a
+client sets available to a server one round-trip earlier than parameters that
+are carried in QUIC packets. This document defines that extension, but does not
+specify how parameters are encoded in the blob.
+
+    enum {
+        quic_transport_parameters(26), (65535)
+    } ExtensionType;
+
+The `extension_data` field of the
+(`quic_transport_parameters(26)`) extension SHALL
+contain a `TransportParameters` value.
+
+    opaque TransportParameters<1..2^16-1>;
+
+`TransportParameters` contains the opaque blob provided by the QUIC transport
+layer.
 
 
 ## Source Address Validation {#source-address}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -635,10 +635,41 @@ protocol to be transmitted to the peer.
 
 #### Encoding
 
-(TODO: Describe format with example)
+QUIC encodes the transport parameters and options as tag-value pairs.
 
-QUIC encodes the transport parameters and options as tag-value pairs, all as
-7-bit ASCII strings.  QUIC parameter tags are listed below.
+    enum {
+      SFCW(0),
+      CFCW(1),
+      MSPC(2),
+      ICSL(3),
+      TCID(4),
+      COPT(5),
+      VPRP(6),
+      VNGO(7),
+      (255)
+    } OptionTag;
+    
+    opaque TagString<0..2^16-1>;    /* String value for experimental tags */
+    
+    struct {
+      OptionTag tag;         /* option being set */
+      select (Option.tag) {  /* option value */
+        case SFCW:  uint24 Window;
+        case CFCW:  uint24 Window;
+        case MSPC:  uint16 StreamCount;
+        case ICSL:  uint16 Timeout;
+        case TCID:  opaque Ignored;
+        case COPT:  TagString OptionValue;
+      }
+    } Option
+    
+    struct {
+      Option option_list<0..255>
+    } OptionList
+
+The OptionList is passed to the crypto layer to be transported in the handshake
+and cryptographically verified.
+    
 
 #### Required Transport Parameters {#required-transport-parameters}
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -728,6 +728,10 @@ protocol.
   mid-connection, to update the information stored in the STK at the client and
   to extend the period over which 0-RTT connections can be established by the
   client.
+  
+* Application-Layer Protocol Negotiation: The handshake MUST establish the 
+  application-layer protocol which the peers will speak over the QUIC
+  connection.
 
 * Certificate Compression: Early QUIC experience demonstrated that compressing
   certificates exchanged during a handshake is valuable in reducing latency.


### PR DESCRIPTION
Proposal on how to define the TLS extension for QUIC, and thereby fix up some of the version negotiation issues (#89, #97).

Key changes:

- TLS doc *does* define the QUIC extension, but it simply contains an opaque blob transported for whichever QUIC version is being used.
- Parameters encoding is specified, and is more "TLS-y" than the current protocol -- an enum of possible parameters, carried as numbers rather than strings where appropriate, etc.  Plenty of room to add additional parameters, but unrecognized parameters here will be fatal unless we add an explicit length.
- Server's version list is always required in TLS extension, even if no Version Negotiation packet was sent.  Client MAY open a new connection immediately if it discovers the server would have supported a newer version, and SHOULD use the newer version next time.
- Server SHOULD pick an application protocol supported by the client's proposed version; Version Negotiation only if no overlap on the current version.