### PR TITLE
Define transport parameters

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -370,6 +370,9 @@ handshake messages on stream 1.  There are two basic functions on this
 interface: one where QUIC requests handshake messages and one where QUIC
 provides handshake packets.
 
+Before starting the handshake QUIC provides TLS with the transport parameters
+(see {{quic_parameters}}) that it wishes to carry.
+
 A QUIC client starts TLS by requesting TLS handshake octets from
 TLS.  The client acquires handshake octets before sending its first packet.
 
@@ -381,12 +384,14 @@ octets are requested from TLS.  TLS might not provide any octets if the
 handshake messages it has received are incomplete or it has no data to send.
 
 Once the TLS handshake is complete, this is indicated to QUIC along with any
-final handshake octets that TLS needs to send.  Once the handshake is complete,
-TLS becomes passive.  TLS can still receive data from its peer and respond in
-kind that data, but it will not need to send more data unless specifically
-requested - either by an application or QUIC.  One reason to send data is that
-the server might wish to provide additional or updated session tickets to a
-client.
+final handshake octets that TLS needs to send.  TLS also provides QUIC with the
+transport parameters that the peer advertised during the handshake.
+
+Once the handshake is complete, TLS becomes passive.  TLS can still receive data
+from its peer and respond in kind, but it will not need to send more data unless
+specifically requested - either by an application or QUIC.  One reason to send
+data is that the server might wish to provide additional or updated session
+tickets to a client.
 
 When the handshake is complete, QUIC only needs to provide TLS with any data
 that arrives on stream 1.  In the same way that is done during the handshake,
@@ -973,11 +978,13 @@ prior to handshake completion:
 Different strategies are appropriate for different types of data.  This document
 proposes that all strategies are possible depending on the type of message.
 
-* Transport parameters and options are made usable and authenticated as part of
-  the TLS handshake (see {{quic_parameters}}).
+* Transport parameters are made usable and authenticated as part of the TLS
+  handshake (see {{quic_parameters}}).
+
 * Most unprotected messages are treated as fatal errors when received except for
   the small number necessary to permit the handshake to complete (see
   {{pre-hs-unprotected}}).
+
 * Protected packets can either be discarded or saved and later used (see
   {{pre-hs-protected}}).
 

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -84,11 +84,13 @@ QUIC.
 
 --- note_Note_to_Readers
 
-Discussion of this draft takes place on the QUIC working group mailing list (quic@ietf.org),
-which is archived at <https://mailarchive.ietf.org/arch/search/?email_list=quic>.
+Discussion of this draft takes place on the QUIC working group mailing list
+(quic@ietf.org), which is archived at
+<https://mailarchive.ietf.org/arch/search/?email_list=quic>.
 
-Working Group information can be found at <https://github.com/quicwg>; source code and issues list
-for this draft can be found at <https://github.com/quicwg/base-drafts/labels/tls>.
+Working Group information can be found at <https://github.com/quicwg>; source
+code and issues list for this draft can be found at
+<https://github.com/quicwg/base-drafts/labels/tls>.
 
 --- middle
 

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -84,13 +84,11 @@ QUIC.
 
 --- note_Note_to_Readers
 
-Discussion of this draft takes place on the QUIC working group mailing list
-(quic@ietf.org), which is archived at
-<https://mailarchive.ietf.org/arch/search/?email_list=quic>.
+Discussion of this draft takes place on the QUIC working group mailing list (quic@ietf.org),
+which is archived at <https://mailarchive.ietf.org/arch/search/?email_list=quic>.
 
-Working Group information can be found at <https://github.com/quicwg>; source
-code and issues list for this draft can be found at
-<https://github.com/quicwg/base-drafts/labels/tls>.
+Working Group information can be found at <https://github.com/quicwg>; source code and issues list
+for this draft can be found at <https://github.com/quicwg/base-drafts/labels/tls>.
 
 --- middle
 
@@ -1141,31 +1139,35 @@ protection for the QUIC negotiation.  This does not prevent version downgrade
 during the handshake, though it means that such a downgrade causes a handshake
 failure.
 
-Protocols that use the QUIC transport MUST use Application Layer Protocol
-Negotiation (ALPN) {{!RFC7301}}.  The ALPN identifier for the protocol MUST be
-specific to the QUIC version that it operates over.  When constructing a
-ClientHello, clients MUST include a list of all the ALPN identifiers that they
-support, regardless of whether the QUIC version that they have currently
-selected supports that protocol.
+TLS uses Application Layer Protocol Negotiation (ALPN) {{!RFC7301}} to select an
+application protocol.  The application-layer protocol MAY restrict the QUIC
+versions that it can operate over.  Servers MUST select an application protocol
+compatible with the QUIC version that the client has selected.
 
-Servers SHOULD select an application protocol based solely on the information in
-the ClientHello, not using the QUIC version that the client has selected.  If
-the protocol that is selected is not supported with the QUIC version that is in
-use, the server MAY send a QUIC version negotiation packet to select a
-compatible version.
-
-If the server cannot select a combination of ALPN identifier and QUIC version it
-MUST abort the connection.  A client MUST abort a connection if the server picks
-an incompatible version of QUIC version and ALPN.
+If the server cannot select a compatible combination of application protocol and
+QUIC version, it MUST abort the connection. A client MUST abort a connection if
+the server picks an incompatible combination of QUIC version and ALPN
+identifier.
 
 
-## QUIC Extension {#quic_parameters}
+## QUIC Transport Parameters Extension {#quic_parameters}
 
-QUIC defines an extension for use with TLS.  That extension defines
-transport-related parameters.  This provides integrity protection for these
-values.  Including these in the TLS handshake also make the values that a client
-sets available to a server one-round trip earlier than parameters that are
-carried in QUIC packets.  This document does not define that extension.
+QUIC transport parameters are carried in a TLS extension. Different versions of
+QUIC might define a different format for this struct.
+
+Including transport parameters in the TLS handshake provides integrity
+protection for these values.
+
+~~~
+   enum {
+      quic_transport_parameters(26), (65535)
+   } ExtensionType;
+~~~
+
+The `extension_data` field of the quic_transport_parameters extension contains a
+value that is defined by the version of QUIC that is in use.  The
+quic_transport_parameters extension carries a TransportParameters when the
+version of QUIC defined in {{QUIC-TRANSPORT}} is used.
 
 
 ## Priming 0-RTT

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -757,10 +757,10 @@ The `extension_data` field of the quic_transport_parameters extension defined in
 therefore used to encode the transport parameters.
 
 QUIC encodes transport parameters into a sequence of octets, which are then
-included in the cryptographic handshake.  Once the handshake completes, TLS
-provides the QUIC with the transport parameters declared by the peer.  Each
-endpoint validates the value provided by its peer.  In particular, version
-negotiation MUST be validated (see {{version-validation}}) before the connection
+included in the cryptographic handshake.  Once the handshake completes, the
+transport parameters declared by the peer are available.  Each endpoint
+validates the value provided by its peer.  In particular, version negotiation
+MUST be validated (see {{version-validation}}) before the connection
 establishment is considered properly complete.
 
 Definitions for each of the defined transport parameters are included in

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -752,7 +752,7 @@ language from Section 3 of {{!I-D.ietf-tls-tls13}}.
 ~~~
 {: #figure-transport-parameters title="Definition of TransportParameters"}
 
-The "extension_data" field of the quic_transport_parameters extension defined in
+The `extension_data` field of the quic_transport_parameters extension defined in
 {{QUIC-TLS}} contains a TransportParameters value.  TLS encoding rules are
 therefore used to encode the transport parameters.
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -847,12 +847,12 @@ The transport parameters include three fields that encode version information.
 These retroactively authenticate the version negotiation (see
 {{version-negotiation}}) that is performed prior to the cryptographic handshake.
 
-Inclusion of these values in an extension provides integrity protection for
-these values.  As a result, modification of version negotiation packets by an
-attacker can be detected.
+The cryptographic handshake provides integrity protection for the negotiated
+version as part of the transport parameters (see {{transport-parameters}}).  As
+a result, modification of version negotiation packets by an attacker can be
+detected.
 
-The client includes two fields in the transport parameters that it includes in
-the TLS ClientHello:
+The client includes two fields in the transport parameters:
 
 * The negotiated_version is the version that was finally selected for use.  This
   MUST be identical to the value that is on the packet that carries the
@@ -865,19 +865,19 @@ the TLS ClientHello:
   {{version-negotiation-packet}}, this will be identical to the
   negotiated_version.
 
-A stateful server can remember how version negotiation was performed and
-validate the initial_version value.
+A server that processes all packets in a stateful fashion can remember how
+version negotiation was performed and validate the initial_version value.
 
-A server that does not maintain state for early packets uses a different
-process. If the initial and negotiated versions are the same, a stateless server
-can accept the value.
+A server that does not maintain state for every packet it receives (i.e., a
+stateless server) uses a different process. If the initial and negotiated
+versions are the same, a stateless server can accept the value.
 
 If the initial version is different from the negotiated_version, a stateless
-server MUST validate the value.  A server MUST check that it would have sent a
-version negotiation packet if it had received a packet with the indicated
-initial_version.  If a server would have accepted the version included in the
-initial_version and the value differs from the value of negotiated_version, the
-server MUST terminate the connection with a TBD error code.
+server MUST check that it would have sent a version negotiation packet if it had
+received a packet with the indicated initial_version.  If a server would have
+accepted the version included in the initial_version and the value differs from
+the value of negotiated_version, the server MUST terminate the connection with a
+QUIC_VERSION_NEGOTIATION_MISMATCH error.
 
 The server includes a list of versions that it would send in any version
 negotiation packet ({{version-negotiation-packet}}) in supported_versions.  This
@@ -886,9 +886,10 @@ value is set even if it did not send a version negotiation packet.
 The client can validate that the negotiated_version is included in the
 supported_versions list and - if version negotiation was performed - that it
 would have selected the negotiated version.  A client MUST terminate the
-connection with a TBD error code if the negotiated_version value is not included
-in the supported_versions list.  A client MUST terminate with a TBD error code
-if version negotiation occurred but it would have selected a different version
+connection with a QUIC_VERSION_NEGOTIATION_MISMATCH error code if the
+negotiated_version value is not included in the supported_versions list.  A
+client MUST terminate with a QUIC_VERSION_NEGOTIATION_MISMATCH error code if
+version negotiation occurred but it would have selected a different version
 based on the value of the supported_versions list.
 
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2248,8 +2248,8 @@ IANA \[SHALL add/has added] a registry for "QUIC Transport Parameters" under a
 
 The "QUIC Transport Parameters" registry governs a 16-bit space.  This space is
 split into two spaces that are governed by different policies.  Values with the
-first byte in the range 0-254 (decimal) are assigned via the Specification
-Required policy {{!RFC5226}}.  Values with the first byte 255 (decimal) are
+first byte in the range 0x00 to 0xfe (in hexadecimal) are assigned via the
+Specification Required policy {{!RFC5226}}.  Values with the first byte 0xff are
 reserved for Private Use {{!RFC5226}}.
 
 Registrations MUST include the following fields:
@@ -2272,6 +2272,18 @@ The nominated expert(s) verify that a specification exists and is readily
 accessible.  The expert(s) are encouraged to be biased towards approving
 registrations unless they are abusive, frivolous, or actively harmful (not
 merely aesthetically displeasing, or architecturally dubious).
+
+The initial contents of this registry are shown in
+{{iana-transport-parameters-initial}}.
+
+| Value | Parameter Name | Specification |
+|:-|:-|:-|
+| 0x0000 | SFCW | {{transport-parameter-definitions}} |
+| 0x0001 | CFCW | {{transport-parameter-definitions}} |
+| 0x0002 | MSPC | {{transport-parameter-definitions}} |
+| 0x0003 | ICSL | {{transport-parameter-definitions}} |
+| 0x0004 | TCID | {{transport-parameter-definitions}} |
+{: #iana-transport-parameters-initial title="Initial QUIC Transport Parameters Entries"}
 
 
 --- back

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -780,10 +780,10 @@ stream_fc_offset (0x0000):
 
 connection_fc_offset (0x0001):
 
-: The connection level flow control offset parameter contains the initial connection
-  flow control window encoded as an unsigned 32-bit integer.  The sender of this
-  parameter sets the byte offset for connection level flow control to this
-  value.  This is equivalent to sending a WINDOW_UPDATE
+: The connection level flow control offset parameter contains the initial
+  connection flow control window encoded as an unsigned 32-bit integer.  The
+  sender of this parameter sets the byte offset for connection level flow
+  control to this value.  This is equivalent to sending a WINDOW_UPDATE
   ({{frame-window-update}}) for stream 0 immediately after completing the
   handshake.
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -870,8 +870,8 @@ The client includes two fields in the transport parameters:
 * The negotiated_version is the version that was finally selected for use.  This
   MUST be identical to the value that is on the packet that carries the
   ClientHello.  A server that receives a negotiated_version that does not match
-  the version of QUIC that is in use MUST terminate the connection with a TBD
-  error code.
+  the version of QUIC that is in use MUST terminate the connection with a
+  QUIC_VERSION_NEGOTIATION_MISMATCH error code.
 
 * The initial_version is the version that the client initially attempted to use.
   If the server did not send a version negotiation packet

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2240,12 +2240,37 @@ packets with ACK frames.
 
 # IANA Considerations
 
-This document has no IANA actions yet.
-
-
 ## QUIC Transport Parameter Registry {#iana-transport-parameters}
 
-TODO: establish a registry for transport parameter identifiers.  Steal from TLS.
+IANA \[SHALL add/has added] a registry for "QUIC Transport Parameters" under a
+"QUIC Protocol" heading.
+
+The "QUIC Transport Parameters" registry governs a 16-bit space.  This space is
+split into two spaces that are governed by different policies.  Values with the
+first byte in the range 0-254 (decimal) are assigned via the Specification
+Required policy {{!RFC5226}}.  Values with the first byte 255 (decimal) are
+reserved for Private Use {{!RFC5226}}.
+
+Registrations MUST include the following fields:
+
+Value:
+
+: The numeric value of the assignment (registrations will be between 0x0000 and
+  0xfeff).
+
+Parameter Name:
+
+: A short mnemonic for the parameter.
+
+Specification:
+
+: A reference to a publicly available specification for the value.
+
+
+The nominated expert(s) verify that a specification exists and is readily
+accessible.  The expert(s) are encouraged to be biased towards approving
+registrations unless they are abusive, frivolous, or actively harmful (not
+merely aesthetically displeasing, or architecturally dubious).
 
 
 --- back

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -202,16 +202,15 @@ strengths of QUIC include:
 
 ## Low-Latency Connection Establishment
 
-QUIC relies on a combined cryptographic and transport handshake for
-setting up a secure transport connection.  QUIC connections are
-expected to commonly use 0-RTT handshakes, meaning that for most QUIC
-connections, data can be sent immediately following the client
-handshake packet, without waiting for a reply from the server.  QUIC
-provides a dedicated stream (Stream ID 1) to be used for performing
-the cryptographic handshake and QUIC options negotiation.  The format of the
-QUIC options and parameters used during negotiation are described in
-this document, but the handshake protocol that runs on Stream ID 1 is
-described in the accompanying cryptographic handshake draft {{QUIC-TLS}}.
+QUIC relies on a combined crypto and transport handshake for setting up a secure
+transport connection.  QUIC connections are expected to commonly use 0-RTT
+handshakes, meaning that for most QUIC connections, data can be sent immediately
+following the client handshake packet, without waiting for a reply from the
+server.  QUIC provides a dedicated stream (Stream ID 1) to be used for
+performing the crypto handshake and QUIC options negotiation.  The format of the
+QUIC options and parameters used during negotiation are described in this
+document, but the handshake protocol that runs on Stream ID 1 is described in
+the accompanying crypto handshake draft {{QUIC-TLS}}.
 
 ## Stream Multiplexing
 
@@ -623,14 +622,13 @@ full 64-bit connection ID.  The content of the Public Reset packet is TBD.
 
 # Life of a Connection
 
-A QUIC connection is a single conversation between two QUIC endpoints.
-QUIC's connection establishment intertwines version negotiation with
-the cryptographic and transport handshakes to reduce connection
-establishment latency, as described in {{handshake}}.  Once
-established, a connection may migrate to a different IP or port at
-either endpoint, due to NAT rebinding or mobility, as described in
-{{migration}}.  Finally a connection may be terminated by either
-endpoint, as described in {{termination}}.
+A QUIC connection is a single conversation between two QUIC endpoints.  QUIC's
+connection establishment intertwines version negotiation with the crypto and
+transport handshakes to reduce connection establishment latency, as described in
+{{handshake}}.  Once established, a connection may migrate to a different IP or
+port at either endpoint, due to NAT rebinding or mobility, as described in
+{{migration}}.  Finally a connection may be terminated by either endpoint, as
+described in {{termination}}.
 
 ## Version Negotiation {#version-negotiation}
 
@@ -680,16 +678,15 @@ Version negotiation uses unprotected data. The result of the negotiation MUST
 be revalidated once the cryptographic handshake has completed (see
 {{version-validation}}).
 
-## Cryptographic and Transport Handshake {#handshake}
+## Crypto and Transport Handshake {#handshake}
 
-QUIC relies on a combined cryptographic and transport handshake to
-minimize connection establishment latency.  QUIC provides a dedicated
-stream (Stream ID 1) to be used for performing a combined connection
-and security handshake (streams are described in detail in
-{{streams}}).  The crypto handshake protocol encapsulates and delivers
-QUIC's transport handshake to the peer on the cryptographic stream.  The
-first QUIC packet sent by client to the server MUST carry handshake
-information as data on Stream ID 1.
+QUIC relies on a combined crypto and transport handshake to minimize connection
+establishment latency.  QUIC provides a dedicated stream (Stream ID 1) to be
+used for performing a combined connection and security handshake (streams are
+described in detail in {{streams}}).  The crypto handshake protocol encapsulates
+and delivers QUIC's transport handshake to the peer on the crypto stream.  The
+first QUIC packet sent by client to the server MUST carry handshake information
+as data on Stream ID 1.
 
 ### Transport Parameters and Options
 
@@ -700,7 +697,7 @@ the document.
 The transport component of the handshake is responsible for exchanging and
 negotiating the following parameters for a QUIC connection.  Not all parameters
 are negotiated; some parameters are sent in just one direction.  These
-parameters and options are encoded and handed off to the cryptographic handshake
+parameters and options are encoded and handed off to the crypto handshake
 protocol to be transmitted to the peer.
 
 #### Encoding
@@ -794,29 +791,27 @@ A server can send a NewSessionTicket message at any time.  This allows it to
 update the state that is included in the ticket.  This might be done to refresh
 the ticket, or in response to changes in the state of a connection.
 
-### Cryptographic Handshake Protocol Features
+### Crypto Handshake Protocol Features
 
-QUIC's current cryptographic handshake mechanism is documented in
-{{QUICCrypto}}.  QUIC does not restrict itself to using a specific
-handshake protocol, so the details of a specific handshake protocol
-are out of this document's scope.  If not explicitly specified in the
-application mapping, TLS is assumed to be the default cryptographic
-handshake protocol, as described in {{QUIC-TLS}}.  An application that
-maps to QUIC MAY however specify an alternative cryptographic
-handshake protocol to be used.
+QUIC's current crypto handshake mechanism is documented in {{QUICCrypto}}.  QUIC
+does not restrict itself to using a specific handshake protocol, so the details
+of a specific handshake protocol are out of this document's scope.  If not
+explicitly specified in the application mapping, TLS is assumed to be the
+default crypto handshake protocol, as described in {{QUIC-TLS}}.  An application
+that maps to QUIC MAY however specify an alternative crypto handshake protocol
+to be used.
 
 The following list of requirements and recommendations documents properties of
 the current prototype handshake which should be provided by any handshake
 protocol.
 
-* The cryptographic handshake MUST ensure that the final negotiated
-  key is distinct for every connection between two endpoints.
+* The crypto handshake MUST ensure that the final negotiated key is distinct for
+  every connection between two endpoints.
 
-* Transport Negotiation: The cryptographic handshake MUST provide a
-  mechanism for the transport component to exchange transport
-  parameters and Source Address Tokens.  To avoid downgrade attacks,
-  the transport parameters sent and received MUST be verified before
-  the handshake completes successfully.
+* Transport Negotiation: The crypto handshake MUST provide a mechanism for the
+  transport component to exchange transport parameters and Source Address
+  Tokens.  To avoid downgrade attacks, the transport parameters sent and
+  received MUST be verified before the handshake completes successfully.
 
 * Connection Establishment in 0-RTT: Since low-latency connection establishment
   is a critical feature of QUIC, the QUIC handshake protocol SHOULD attempt to
@@ -824,27 +819,26 @@ protocol.
   between the same endpoints.
 
 * Source Address Spoofing Defense: Since QUIC handles source address
-  verification, the cryptographic protocol SHOULD NOT impose a
-  separate source address verification mechanism.
+  verification, the crypto protocol SHOULD NOT impose a separate source address
+  verification mechanism.
 
 * Server Config Update: A QUIC server may refresh the source-address token (STK)
   mid-connection, to update the information stored in the STK at the client and
   to extend the period over which 0-RTT connections can be established by the
   client.
 
-* Certificate Compression: Early QUIC experience demonstrated that
-  compressing certificates exchanged during a handshake is valuable in
-  reducing latency.  This additionally helps to reduce the
-  amplification attack footprint when a server sends a large set of
-  certificates, which is not uncommon with TLS.  The cryptographic
-  protocol SHOULD compress certificates and any other information to
+* Certificate Compression: Early QUIC experience demonstrated that compressing
+  certificates exchanged during a handshake is valuable in reducing latency.
+  This additionally helps to reduce the amplification attack footprint when a
+  server sends a large set of certificates, which is not uncommon with TLS.  The
+  crypto protocol SHOULD compress certificates and any other information to
   minimize the number of packets sent during a handshake.
 
 
 ### Version Negotiation Validation {#version-validation}
 
 The following information used during the QUIC handshake MUST be
-cryptographically verified by the cryptographic handshake protocol:
+cryptographically verified by the crypto handshake protocol:
 
 * Client's originally proposed version in its first packet.
 
@@ -1701,9 +1695,8 @@ A StreamID of zero (0x0) is reserved and used for connection-level flow control
 frames ({{flow-control}}); the StreamID of zero cannot be used to establish a
 new stream.
 
-StreamID 1 (0x1) is reserved for the cryptographic handshake.
-StreamID 1 MUST NOT be used for application data, and MUST be the
-first client-initiated stream.
+StreamID 1 (0x1) is reserved for the crypto handshake.  StreamID 1 MUST NOT be
+used for application data, and MUST be the first client-initiated stream.
 
 Streams MUST be created or reserved in sequential order, but MAY be used in
 arbitrary order.  A QUIC endpoint MUST NOT reuse a StreamID on a given
@@ -1756,11 +1749,10 @@ as an ordered byte-stream.  Data received out of order MUST be buffered for
 later delivery, as long as it is not in violation of the receiver's flow control
 limits.
 
-The cryptographic handshake stream, Stream 1, MUST NOT be subject to
-congestion control or connection-level flow control, but MUST be
-subject to stream-level flow control. An endpoint MUST NOT send data
-on any other stream without consulting the congestion controller and
-the flow controller.
+The crypto handshake stream, Stream 1, MUST NOT be subject to congestion control
+or connection-level flow control, but MUST be subject to stream-level flow
+control. An endpoint MUST NOT send data on any other stream without consulting
+the congestion controller and the flow controller.
 
 Flow control is described in detail in {{flow-control}}, and congestion control
 is described in the companion document {{QUIC-RECOVERY}}.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -729,7 +729,6 @@ language from Section 3 of {{!I-D.ietf-tls-tls13}}.
       MSPC(2),
       ICSL(3),
       TCID(4),
-      COPT(5),
       (65535)
    } TransportParameterId;
 
@@ -799,13 +798,8 @@ TCID (0x0004):
   the 5-tuple is sufficient to identify a connection.  This parameter is zero
   length.
 
-COPT (0x0005):
+An endpoint MUST ignore transport parameters that it does not understand.
 
-: Connection options are a repeated parameter.  The parameter contains any
-  connection options being requested by the client or server.  These are
-  typically used for experimentation and will evolve over time.  Example use
-  cases include changing congestion control algorithms and parameters such as
-  initial window.  (TODO: List connection options.)
 
 ### Values of Transport Parameters for 0-RTT
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -777,7 +777,7 @@ CFCW (0x0001):
 : The connection level flow control parameter contains the initial connection
   flow control window encoded as an unsigned 32-bit integer.  The sender of this
   parameter sets the byte offset for connection level flow control to this
-  value.  This is equivalent to sending a WINDOW_UPDATE ({{frame-window-update}}
+  value.  This is equivalent to sending a WINDOW_UPDATE (TODO: section ref)
   for stream 0 immediately after completing the handshake.
 
 MSPC (0x0002):
@@ -1865,13 +1865,12 @@ connection with an error of type QUIC_TOO_MANY_OPEN_STREAMS
 
 ## Stream Concurrency
 
-An endpoint can limit the number of concurrently active incoming streams by
-setting the MSPC parameter (see {{required-transport-parameters}}) in the
-transport parameters. The maximum concurrent streams setting is specific to each
-endpoint and applies only to the peer that receives the setting. That is,
-clients specify the maximum number of concurrent streams the server can
-initiate, and servers specify the maximum number of concurrent streams the
-client can initiate.
+An endpoint limits the number of concurrently active incoming streams by setting
+the MSPC parameter (see {{transport-parameter-definitions}}) in the transport
+parameters. The maximum concurrent streams setting is specific to each endpoint
+and applies only to the peer that receives the setting. That is, clients specify
+the maximum number of concurrent streams the server can initiate, and servers
+specify the maximum number of concurrent streams the client can initiate.
 
 Streams that are in the "open" state or in either of the "half-closed" states
 count toward the maximum number of streams that an endpoint is permitted to
@@ -2293,6 +2292,11 @@ packets with ACK frames.
 # IANA Considerations
 
 This document has no IANA actions yet.
+
+
+## QUIC Transport Parameter Registry {#iana-transport-parameters}
+
+TODO: establish a registry for transport parameter identifiers.  Steal from TLS.
 
 
 --- back

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -682,16 +682,16 @@ TLS provides QUIC with:
 
 * authenticated key exchange, where
 
-** a server is always authenticated,
+   * a server is always authenticated,
 
-** a client is optionally authenticated,
+   * a client is optionally authenticated,
 
-** every connection produces distinct and unrelated keys,
+   * every connection produces distinct and unrelated keys,
 
-** keying material is usable for packet protection for both 0-RTT and 1-RTT
-   packets, and
+   * keying material is usable for packet protection for both 0-RTT and 1-RTT
+     packets, and
 
-** 1-RTT keys have forward secrecy
+   * 1-RTT keys have forward secrecy
 
 * authenticated values for the transport parameters of the peer (see
   {{transport-parameters}})

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -678,66 +678,226 @@ Version negotiation uses unprotected data. The result of the negotiation MUST
 be revalidated once the cryptographic handshake has completed (see
 {{version-validation}}).
 
+
 ## Crypto and Transport Handshake {#handshake}
 
 QUIC relies on a combined crypto and transport handshake to minimize connection
-establishment latency.  QUIC provides a dedicated stream (Stream ID 1) to be
-used for performing a combined connection and security handshake (streams are
-described in detail in {{streams}}).  The crypto handshake protocol encapsulates
-and delivers QUIC's transport handshake to the peer on the crypto stream.  The
-first QUIC packet sent by client to the server MUST carry handshake information
-as data on Stream ID 1.
+establishment latency.  QUIC allocates stream 1 for the cryptographic handshake,
+which uses TLS.
 
-### Transport Parameters and Options
+QUIC provides this stream with reliable, ordered delivery of data.  In return,
+TLS provides QUIC with:
 
-During connection establishment, the handshake must negotiate various transport
-parameters.  The currently defined transport parameters are described later in
-the document.
+* authenticated key exchange, always for the server, optionally for the client
 
-The transport component of the handshake is responsible for exchanging and
-negotiating the following parameters for a QUIC connection.  Not all parameters
-are negotiated; some parameters are sent in just one direction.  These
-parameters and options are encoded and handed off to the crypto handshake
-protocol to be transmitted to the peer.
+* keying material for use in packet packet protection
 
-#### Encoding
+* authenticated values for the transport parameters of the peer (see
+  {{transport-parameters}})
 
-(TODO: Describe format with example)
+* authenticated confirmation of version negotiation (see {{version-validation}})
 
-QUIC encodes the transport parameters and options as tag-value pairs, all as
-7-bit ASCII strings {{!RFC0020}}.  QUIC parameter tags are listed below.
+* authenticated negotiation of an application protocol (TLS uses ALPN
+  {{?RFC7301}} for this purpose)
 
-#### Required Transport Parameters {#required-transport-parameters}
+* for the server, assurance that the client can receive packets that are
+  addressed with the transport address that is claimed by the client (see
+  {{source-address-token}})
 
-* SFCW: Stream Flow Control Window.  The stream level flow control
-  byte offset advertised by the sender of this parameter.
+Details of how TLS is integrated with QUIC is provided in more detail in
+{{QUIC-TLS}}.
 
-* CFCW: Connection Flow Control Window.  The connection level flow
-  control byte offset advertised by the sender of this parameter.
 
-* MSPC: Maxium Streams Per Connection.  The maximum number of incoming
-  streams per connection.
+## Transport Parameters
 
-* ICSL: Idle Connection State Lifetime.  The maximum idle timeout in seconds.
-  The maximum value is 600 seconds (10 minutes).
+During connection establishment, both endpoints make authenticated declarations
+of their transport parameters.  These declarations are made unilaterally by each
+endpoint.  Endpoints are required to comply with the restrictions implied by
+these parameters; the description of each parameter includes rules for its
+handling.
 
-#### Optional Transport Parameters {#optional-transport-parameters}
+The format of the transport parameters is the TransportParameters struct from
+{{figure-transport-parameters}}.  This is described using the presentation
+language from Section 3 of {{!I-D.ietf-tls-tls13}}.
 
-* TCID: Indicates support for truncated Connection IDs.  If sent by a peer,
-  indicates that connection IDs sent to the peer should be truncated to 0 bytes.
-  This is expected to commonly be used by an endpoint where the 5-tuple is
-  sufficient to identify a connection.  For instance, if the 5-tuple is unique
-  at the client, the client MAY send a TCID parameter to the server.  When a
-  TCID parameter is received, an endpoint MAY choose to not send the connection
-  ID on subsequent packets.
+~~~
+   uint32 QuicVersion;
 
-* COPT: Connection Options are a repeated tag field.  The field contains any
+   enum {
+      SFCW(0),
+      CFCW(1),
+      MSPC(2),
+      ICSL(3),
+      TCID(4),
+      COPT(5),
+      (65535)
+   } TransportParameterId;
+
+   struct {
+      TransportParameterId parameter;
+      opaque value<0..2^16-1>;
+   } TransportParameter;
+
+   struct {
+      select (Handshake.msg_type) {
+         case client_hello:
+            QuicVersion negotiated_version;
+            QuicVersion initial_version;
+
+         case encrypted_extensions:
+            QuicVersion supported_versions<2..2^8-4>;
+      };
+      TransportParameter parameters<30..2^16-1>;
+   } TransportParameters;
+~~~
+{: #figure-transport-parameters title="Definition of TransportParameters"}
+
+The "extension_data" field of the quic_transport_parameters extension defined in
+{{QUIC-TLS}} contains a TransportParameters value.  TLS encoding rules are
+therefore used to encode the transport parameters.
+
+Definitions for each of the defined transport parameters are included in
+{{transport-parameter-definitions}}.  Use of the version fields from transport
+parameters is described in {{version-validation}}.
+
+
+### Transport Parameter Definitions
+
+An endpoint MUST include the following parameters in its encoded
+TransportParameters:
+
+SFCW (0x0000):
+
+: The initial stream level flow control parameter is encoded as an unsigned
+  32-bit integer.  The sender of this parameter indicates that the flow control
+  offset for all stream data sent toward it is this value.
+
+CFCW (0x0001):
+
+: The connection level flow control parameter contains the initial connection
+  flow control window encoded as an unsigned 32-bit integer.  The sender of this
+  parameter sets the byte offset for connection level flow control to this
+  value.  This is equivalent to sending a WINDOW_UPDATE ({{frame-window-update}}
+  for stream 0 immediately after completing the handshake.
+
+MSPC (0x0002):
+
+: The maximum number of concurrent streams parameter is encoded as an unsigned
+  32-bit integer.
+
+ICSL (0x0003):
+
+: The idle timeout is a value in seconds that is encoded as an unsigned 16-bit
+  integer.  The maximum value is 600 seconds (10 minutes).
+
+An endpoint MAY use the following transport parameters:
+
+TCID (0x0004):
+
+: The truncated connection identifier parameter indicates that packets sent to
+  the peer can omit the connection ID.  This can be used by an endpoint where
+  the 5-tuple is sufficient to identify a connection.  This parameter is zero
+  length.
+
+COPT (0x0005):
+
+: Connection options are a repeated parameter.  The parameter contains any
   connection options being requested by the client or server.  These are
   typically used for experimentation and will evolve over time.  Example use
   cases include changing congestion control algorithms and parameters such as
   initial window.  (TODO: List connection options.)
 
-### Proof of Source Address Ownership
+### Values of Transport Parameters for 0-RTT
+
+Transport parameters from the server are remembered by the client for 0-RTT
+connections.  If values change as a result of completing the handshake, the
+client is expected to respect the new values.  This introduces some potential
+problems, particularly with respect to transport parameters that establish
+limits:
+
+* A client might exceed a newly declared connection or stream flow control limit
+  with 0-RTT data.  If this occurs, the client ceases transmission as though the
+  flow control limit was reached.  Once WINDOW_UPDATE frames indicating an
+  increase to the affected flow control offsets is received, the client can
+  recommence sending.
+
+* Similarly, a client might exceed the concurrent stream limit declared by the
+  server.  A client MUST reset any streams that exceed this connection.  A
+  server MAY reset these streams.
+
+A client cannot use or rely upon any other transport parameter that was enabled
+in a previous connection.  This includes those defined in this document.  A
+client MUST assume that the transport parameter was absent, unless the
+definition of a transport parameter provides explicit rules for use of the
+option in 0-RTT.
+
+
+### New Transport Parameters
+
+An endpoint MUST ignore transport parameters that it does not support.
+
+The definition of new transport parameters can be used to negotiate new protocol
+behavior.  Endpoints that support features that deviate from this specification
+MUST assume that a peer will operate as described in this document unless it
+provides an explicit signal of support.  A new transport parameter could be used
+to provide this signal.
+
+New transport parameters can be registered according to the rules in
+{{iana-transport-parameters}}.
+
+
+### Version Negotiation Validation {#version-validation}
+
+The transport parameters include three fields that encode version information.
+These retroactively authenticate the version negotiation (see
+{{version-negotiation}}) that is performed prior to the cryptographic handshake.
+
+Inclusion of these values in an extension provides integrity protection for
+these values.  As a result, modification of version negotiation packets by an
+attacker can be detected.
+
+The client includes two fields in the transport parameters that it includes in
+the TLS ClientHello:
+
+* The negotiated_version is the version that was finally selected for use.  This
+  MUST be identical to the value that is on the packet that carries the
+  ClientHello.  A server that receives a negotiated_version that does not match
+  the version of QUIC that is in use MUST terminate the connection with a TBD
+  error code.
+
+* The initial_version is the version that the client initially attempted to use.
+  If the server did not send a version negotiation packet
+  {{version-negotiation-packet}}, this will be identical to the
+  negotiated_version.
+
+A stateful server can remember how version negotiation was performed and
+validate the initial_version value.
+
+A server that does not maintain state for early packets uses a different
+process. If the initial and negotiated versions are the same, a stateless server
+can accept the value.
+
+If the initial version is different from the negotiated_version, a stateless
+server MUST validate the value.  A server MUST check that it would have sent a
+version negotiation packet if it had received a packet with the indicated
+initial_version.  If a server would have accepted the version included in the
+initial_version and the value differs from the value of negotiated_version, the
+server MUST terminate the connection with a TBD error code.
+
+The server includes a list of versions that it would send in any version
+negotiation packet ({{version-negotiation-packet}}) in supported_versions.  This
+value is set even if it did not send a version negotiation packet.
+
+The client can validate that the negotiated_version is included in the
+supported_versions list and - if version negotiation was performed - that it
+would have selected the negotiated version.  A client MUST terminate the
+connection with a TBD error code if the negotiated_version value is not included
+in the supported_versions list.  A client MUST terminate with a TBD error code
+if version negotiation occurred but it would have selected a different version
+based on the value of the supported_versions list.
+
+
+### Proof of Source Address Ownership {#source-address-token}
 
 Transport protocols commonly spend a round trip checking that a client owns the
 transport address (IP and port) that it claims.  Verifying that a client can
@@ -791,6 +951,7 @@ A server can send a NewSessionTicket message at any time.  This allows it to
 update the state that is included in the ticket.  This might be done to refresh
 the ticket, or in response to changes in the state of a connection.
 
+
 ### Crypto Handshake Protocol Features
 
 QUIC's current crypto handshake mechanism is documented in {{QUICCrypto}}.  QUIC
@@ -834,15 +995,6 @@ protocol.
   crypto protocol SHOULD compress certificates and any other information to
   minimize the number of packets sent during a handshake.
 
-
-### Version Negotiation Validation {#version-validation}
-
-The following information used during the QUIC handshake MUST be
-cryptographically verified by the crypto handshake protocol:
-
-* Client's originally proposed version in its first packet.
-
-* Server's version list in it's Version Negotiation packet, if one was sent.
 
 
 ## Connection Migration {#migration}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -77,14 +77,6 @@ informative:
     seriesinfo:
       ACM SIGCOMM 2007
 
-  QUICCrypto:
-    title: "QUIC Crypto"
-    author:
-      - ins: A. Langley
-      - ins: W. Chang
-    date: 2016-05-26
-    target: "http://goo.gl/OuVSxa"
-
   EARLY-DESIGN:
     title: "QUIC: Multiplexed Transport Over UDP"
     author:

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -369,7 +369,7 @@ The fields in the Common Header are the following:
      value for a given direction.  For instance, if a client indicates that the
      5-tuple fully identifies the connection at the client, the connection ID is
      optional in the server-to-client direction. The negotiation is described in
-     {{optional-transport-parameters}}.
+     {{transport-parameter-definitions}}.
 
    * 0x30 = PACKET_NUMBER_SIZE.  These two bits indicate the number of
      low-order-bytes of the packet number that are present in each packet.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -799,8 +799,6 @@ TCID (0x0004):
   the 5-tuple is sufficient to identify a connection.  This parameter is zero
   length.
 
-An endpoint MUST ignore transport parameters that it does not understand.
-
 
 ### Values of Transport Parameters for 0-RTT
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -829,11 +829,11 @@ option in 0-RTT.
 
 An endpoint MUST ignore transport parameters that it does not support.
 
-The definition of new transport parameters can be used to negotiate new protocol
-behavior.  Endpoints that support features that deviate from this specification
-MUST assume that a peer will operate as described in this document unless it
-provides an explicit signal of support.  A new transport parameter could be used
-to provide this signal.
+New transport parameters can be used to negotiate new protocol behavior.
+Endpoints that support features that deviate from this specification MUST assume
+that a peer will operate as described in this document unless it provides an
+explicit signal of support.  A new transport parameter could be used to provide
+this signal.
 
 New transport parameters can be registered according to the rules in
 {{iana-transport-parameters}}.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -834,13 +834,8 @@ option in 0-RTT.
 
 ### New Transport Parameters
 
-An endpoint MUST ignore transport parameters that it does not support.
-
-New transport parameters can be used to negotiate new protocol behavior.
-Endpoints that support features that deviate from this specification MUST assume
-that a peer will operate as described in this document unless it provides an
-explicit signal of support.  A new transport parameter could be used to provide
-this signal.
+New transport parameters can be used to negotiate new protocol behavior.  An
+endpoint MUST ignore transport parameters that it does not support.
 
 New transport parameters can be registered according to the rules in
 {{iana-transport-parameters}}.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -202,15 +202,16 @@ strengths of QUIC include:
 
 ## Low-Latency Connection Establishment
 
-QUIC relies on a combined crypto and transport handshake for setting up a secure
-transport connection.  QUIC connections are expected to commonly use 0-RTT
-handshakes, meaning that for most QUIC connections, data can be sent immediately
-following the client handshake packet, without waiting for a reply from the
-server.  QUIC provides a dedicated stream (Stream ID 1) to be used for
-performing the crypto handshake and QUIC options negotiation.  The format of the
-QUIC options and parameters used during negotiation are described in this
-document, but the handshake protocol that runs on Stream ID 1 is described in
-the accompanying crypto handshake draft {{QUIC-TLS}}.
+QUIC relies on a combined cryptographic and transport handshake for
+setting up a secure transport connection.  QUIC connections are
+expected to commonly use 0-RTT handshakes, meaning that for most QUIC
+connections, data can be sent immediately following the client
+handshake packet, without waiting for a reply from the server.  QUIC
+provides a dedicated stream (Stream ID 1) to be used for performing
+the cryptographic handshake and QUIC options negotiation.  The format of the
+QUIC options and parameters used during negotiation are described in
+this document, but the handshake protocol that runs on Stream ID 1 is
+described in the accompanying cryptographic handshake draft {{QUIC-TLS}}.
 
 ## Stream Multiplexing
 
@@ -268,7 +269,8 @@ fully encrypted.  The parts of the packet header which are not encrypted are
 still authenticated by the receiver, so as to thwart any packet injection or
 manipulation by third parties.  Some early handshake packets, such as the
 Version Negotiation packet, are not encrypted, but information sent in these
-unencrypted handshake packets is later verified under crypto cover.
+unencrypted handshake packets is later verified as part of cryptographic
+processing.
 
 PUBLIC_RESET packets that reset a connection are currently not authenticated.
 
@@ -621,13 +623,14 @@ full 64-bit connection ID.  The content of the Public Reset packet is TBD.
 
 # Life of a Connection
 
-A QUIC connection is a single conversation between two QUIC endpoints.  QUIC's
-connection establishment intertwines version negotiation with the crypto and
-transport handshakes to reduce connection establishment latency, as described in
-{{handshake}}.  Once established, a connection may migrate to a different IP or
-port at either endpoint, due to NAT rebinding or mobility, as described in
-{{migration}}.  Finally a connection may be terminated by either endpoint, as
-described in {{termination}}.
+A QUIC connection is a single conversation between two QUIC endpoints.
+QUIC's connection establishment intertwines version negotiation with
+the cryptographic and transport handshakes to reduce connection
+establishment latency, as described in {{handshake}}.  Once
+established, a connection may migrate to a different IP or port at
+either endpoint, due to NAT rebinding or mobility, as described in
+{{migration}}.  Finally a connection may be terminated by either
+endpoint, as described in {{termination}}.
 
 ## Version Negotiation {#version-negotiation}
 
@@ -677,15 +680,16 @@ Version negotiation uses unprotected data. The result of the negotiation MUST
 be revalidated once the cryptographic handshake has completed (see
 {{version-validation}}).
 
-## Crypto and Transport Handshake {#handshake}
+## Cryptographic and Transport Handshake {#handshake}
 
-QUIC relies on a combined crypto and transport handshake to minimize connection
-establishment latency.  QUIC provides a dedicated stream (Stream ID 1) to be
-used for performing a combined connection and security handshake (streams are
-described in detail in {{streams}}).  The crypto handshake protocol encapsulates
-and delivers QUIC's transport handshake to the peer on the crypto stream.  The
-first QUIC packet sent by client to the server MUST carry handshake information
-as data on Stream ID 1.
+QUIC relies on a combined cryptographic and transport handshake to
+minimize connection establishment latency.  QUIC provides a dedicated
+stream (Stream ID 1) to be used for performing a combined connection
+and security handshake (streams are described in detail in
+{{streams}}).  The crypto handshake protocol encapsulates and delivers
+QUIC's transport handshake to the peer on the cryptographic stream.  The
+first QUIC packet sent by client to the server MUST carry handshake
+information as data on Stream ID 1.
 
 ### Transport Parameters and Options
 
@@ -696,7 +700,7 @@ the document.
 The transport component of the handshake is responsible for exchanging and
 negotiating the following parameters for a QUIC connection.  Not all parameters
 are negotiated; some parameters are sent in just one direction.  These
-parameters and options are encoded and handed off to the crypto handshake
+parameters and options are encoded and handed off to the cryptographic handshake
 protocol to be transmitted to the peer.
 
 #### Encoding
@@ -790,27 +794,29 @@ A server can send a NewSessionTicket message at any time.  This allows it to
 update the state that is included in the ticket.  This might be done to refresh
 the ticket, or in response to changes in the state of a connection.
 
-### Crypto Handshake Protocol Features
+### Cryptographic Handshake Protocol Features
 
-QUIC's current crypto handshake mechanism is documented in {{QUICCrypto}}.  QUIC
-does not restrict itself to using a specific handshake protocol, so the details
-of a specific handshake protocol are out of this document's scope.  If not
-explicitly specified in the application mapping, TLS is assumed to be the
-default crypto handshake protocol, as described in {{QUIC-TLS}}.  An application
-that maps to QUIC MAY however specify an alternative crypto handshake protocol
-to be used.
+QUIC's current cryptographic handshake mechanism is documented in
+{{QUICCrypto}}.  QUIC does not restrict itself to using a specific
+handshake protocol, so the details of a specific handshake protocol
+are out of this document's scope.  If not explicitly specified in the
+application mapping, TLS is assumed to be the default cryptographic
+handshake protocol, as described in {{QUIC-TLS}}.  An application that
+maps to QUIC MAY however specify an alternative cryptographic
+handshake protocol to be used.
 
 The following list of requirements and recommendations documents properties of
 the current prototype handshake which should be provided by any handshake
 protocol.
 
-* The crypto handshake MUST ensure that the final negotiated key is distinct for
-  every connection between two endpoints.
+* The cryptographic handshake MUST ensure that the final negotiated
+  key is distinct for every connection between two endpoints.
 
-* Transport Negotiation: The crypto handshake MUST provide a mechanism for the
-  transport component to exchange transport parameters and Source Address
-  Tokens.  To avoid downgrade attacks, the transport parameters sent and
-  received MUST be verified before the handshake completes successfully.
+* Transport Negotiation: The cryptographic handshake MUST provide a
+  mechanism for the transport component to exchange transport
+  parameters and Source Address Tokens.  To avoid downgrade attacks,
+  the transport parameters sent and received MUST be verified before
+  the handshake completes successfully.
 
 * Connection Establishment in 0-RTT: Since low-latency connection establishment
   is a critical feature of QUIC, the QUIC handshake protocol SHOULD attempt to
@@ -818,26 +824,27 @@ protocol.
   between the same endpoints.
 
 * Source Address Spoofing Defense: Since QUIC handles source address
-  verification, the crypto protocol SHOULD NOT impose a separate source address
-  verification mechanism.
+  verification, the cryptographic protocol SHOULD NOT impose a
+  separate source address verification mechanism.
 
 * Server Config Update: A QUIC server may refresh the source-address token (STK)
   mid-connection, to update the information stored in the STK at the client and
   to extend the period over which 0-RTT connections can be established by the
   client.
 
-* Certificate Compression: Early QUIC experience demonstrated that compressing
-  certificates exchanged during a handshake is valuable in reducing latency.
-  This additionally helps to reduce the amplification attack footprint when a
-  server sends a large set of certificates, which is not uncommon with TLS.  The
-  crypto protocol SHOULD compress certificates and any other information to
+* Certificate Compression: Early QUIC experience demonstrated that
+  compressing certificates exchanged during a handshake is valuable in
+  reducing latency.  This additionally helps to reduce the
+  amplification attack footprint when a server sends a large set of
+  certificates, which is not uncommon with TLS.  The cryptographic
+  protocol SHOULD compress certificates and any other information to
   minimize the number of packets sent during a handshake.
 
 
 ### Version Negotiation Validation {#version-validation}
 
 The following information used during the QUIC handshake MUST be
-cryptographically verified by the crypto handshake protocol:
+cryptographically verified by the cryptographic handshake protocol:
 
 * Client's originally proposed version in its first packet.
 
@@ -1694,8 +1701,9 @@ A StreamID of zero (0x0) is reserved and used for connection-level flow control
 frames ({{flow-control}}); the StreamID of zero cannot be used to establish a
 new stream.
 
-StreamID 1 (0x1) is reserved for the crypto handshake.  StreamID 1 MUST NOT be
-used for application data, and MUST be the first client-initiated stream.
+StreamID 1 (0x1) is reserved for the cryptographic handshake.
+StreamID 1 MUST NOT be used for application data, and MUST be the
+first client-initiated stream.
 
 Streams MUST be created or reserved in sequential order, but MAY be used in
 arbitrary order.  A QUIC endpoint MUST NOT reuse a StreamID on a given
@@ -1748,10 +1756,11 @@ as an ordered byte-stream.  Data received out of order MUST be buffered for
 later delivery, as long as it is not in violation of the receiver's flow control
 limits.
 
-The crypto handshake stream, Stream 1, MUST NOT be subject to congestion control
-or connection-level flow control, but MUST be subject to stream-level flow
-control. An endpoint MUST NOT send data on any other stream without consulting
-the congestion controller and the flow controller.
+The cryptographic handshake stream, Stream 1, MUST NOT be subject to
+congestion control or connection-level flow control, but MUST be
+subject to stream-level flow control. An endpoint MUST NOT send data
+on any other stream without consulting the congestion controller and
+the flow controller.
 
 Flow control is described in detail in {{flow-control}}, and congestion control
 is described in the companion document {{QUIC-RECOVERY}}.
@@ -1932,7 +1941,8 @@ the error code:
   all uses of QUIC.
 
 0xC0000000-0xFFFFFFFF:
-: Cryptographic error codes.  Defined by the crypto handshake protocol in use.
+: Cryptographic error codes.  Defined by the cryptographic handshake protocol
+  in use.
 
 This section lists the defined QUIC transport error codes that may be used in a
 CONNECTION_CLOSE or RST_STREAM frame. Error codes share a common code space.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -776,8 +776,9 @@ CFCW (0x0001):
 : The connection level flow control parameter contains the initial connection
   flow control window encoded as an unsigned 32-bit integer.  The sender of this
   parameter sets the byte offset for connection level flow control to this
-  value.  This is equivalent to sending a WINDOW_UPDATE (TODO: section ref)
-  for stream 0 immediately after completing the handshake.
+  value.  This is equivalent to sending a WINDOW_UPDATE
+  ({{frame-window-update}}) for stream 0 immediately after completing the
+  handshake.
 
 MSPC (0x0002):
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -678,7 +678,7 @@ connection establishment latency.  QUIC allocates stream 1 for the cryptographic
 handshake.  This version of QUIC uses TLS 1.3 {{QUIC-TLS}}.
 
 QUIC provides this stream with reliable, ordered delivery of data.  In return,
-The cryptographic handshake provides QUIC with:
+the cryptographic handshake provides QUIC with:
 
 * authenticated key exchange, where
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2286,7 +2286,7 @@ registrations unless they are abusive, frivolous, or actively harmful (not
 merely aesthetically displeasing, or architecturally dubious).
 
 The initial contents of this registry are shown in
-{{iana-transport-parameters-initial}}.
+{{iana-tp-table}}.
 
 | Value | Parameter Name | Specification |
 |:-|:-|:-|
@@ -2295,7 +2295,7 @@ The initial contents of this registry are shown in
 | 0x0002 | MSPC | {{transport-parameter-definitions}} |
 | 0x0003 | ICSL | {{transport-parameter-definitions}} |
 | 0x0004 | TCID | {{transport-parameter-definitions}} |
-{: #iana-transport-parameters-initial title="Initial QUIC Transport Parameters Entries"}
+{: #iana-tp-table title="Initial QUIC Transport Parameters Entries"}
 
 
 --- back

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -671,14 +671,14 @@ be revalidated once the cryptographic handshake has completed (see
 {{version-validation}}).
 
 
-## Crypto and Transport Handshake {#handshake}
+## Cryptographic and Transport Handshake {#handshake}
 
-QUIC relies on a combined crypto and transport handshake to minimize connection
-establishment latency.  QUIC allocates stream 1 for the cryptographic handshake.
-This version of QUIC uses TLS.
+QUIC relies on a combined cryptographic and transport handshake to minimize
+connection establishment latency.  QUIC allocates stream 1 for the cryptographic
+handshake.  This version of QUIC uses TLS 1.3 {{QUIC-TLS}}.
 
 QUIC provides this stream with reliable, ordered delivery of data.  In return,
-TLS provides QUIC with:
+The cryptographic handshake provides QUIC with:
 
 * authenticated key exchange, where
 
@@ -1809,8 +1809,8 @@ A StreamID of zero (0x0) is reserved and used for connection-level flow control
 frames ({{flow-control}}); the StreamID of zero cannot be used to establish a
 new stream.
 
-StreamID 1 (0x1) is reserved for the crypto handshake.  StreamID 1 MUST NOT be
-used for application data, and MUST be the first client-initiated stream.
+StreamID 1 (0x1) is reserved for the cryptographic handshake.  StreamID 1 MUST
+NOT be used for application data, and MUST be the first client-initiated stream.
 
 Streams MUST be created or reserved in sequential order, but MAY be used in
 arbitrary order.  A QUIC endpoint MUST NOT reuse a StreamID on a given
@@ -1863,10 +1863,10 @@ as an ordered byte-stream.  Data received out of order MUST be buffered for
 later delivery, as long as it is not in violation of the receiver's flow control
 limits.
 
-The crypto handshake stream, Stream 1, MUST NOT be subject to congestion control
-or connection-level flow control, but MUST be subject to stream-level flow
-control. An endpoint MUST NOT send data on any other stream without consulting
-the congestion controller and the flow controller.
+The cryptographic handshake stream, Stream 1, MUST NOT be subject to congestion
+control or connection-level flow control, but MUST be subject to stream-level
+flow control. An endpoint MUST NOT send data on any other stream without
+consulting the congestion controller and the flow controller.
 
 Flow control is described in detail in {{flow-control}}, and congestion control
 is described in the companion document {{QUIC-RECOVERY}}.


### PR DESCRIPTION
This builds on @MikeBishop's work in #99 in a big way.  I have stolen a lot of text from that.

Again, it's the tippy top of a bunch of changes.  #113 comes before this.

Closes #99.