### PR TITLE
Separate error spaces

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -718,63 +718,63 @@ of HTTP/2 error codes into the QUIC error code space.
 
 ## HTTP-Defined QUIC Error Codes {#http-error-codes}
 
-QUIC allocates error codes 0x8000-0xAFFF to application protocol definition.
+QUIC allocates error codes 0x0000-0x3FFF to application protocol definition.
 The following error codes are defined by HTTP for use in QUIC RST_STREAM,
 GOAWAY, and CONNECTION_CLOSE frames.
 
-HTTP_SETTINGS_TIMEOUT (0x8000):
+HTTP_SETTINGS_TIMEOUT (0x00):
 : After sending a SETTINGS frame which requested acknowledgement, the
   acknowledgement was not completed (see {{settings-synchronization}}) in a
   timely manner.
   
-HTTP_PUSH_REFUSED (0x8001):
+HTTP_PUSH_REFUSED (0x01):
 : The server has attempted to push content which the client will not accept
   on this connection.
 
-HTTP_INTERNAL_ERROR (0x8002):
+HTTP_INTERNAL_ERROR (0x02):
 : An internal error has occurred in the HTTP stack.
 
-HTTP_PUSH_ALREADY_IN_CACHE (0x8003):
+HTTP_PUSH_ALREADY_IN_CACHE (0x03):
 : The server has attempted to push content which the client has cached.
 
-HTTP_REQUEST_CANCELLED (0x8004):
+HTTP_REQUEST_CANCELLED (0x04):
 : The client no longer needs the requested data.
 
-HTTP_HPACK_DECOMPRESSION_FAILED (0x8005):
+HTTP_HPACK_DECOMPRESSION_FAILED (0x05):
 : HPACK failed to decompress a frame and cannot continue.
 
-HTTP_CONNECT_ERROR (0x8006):
+HTTP_CONNECT_ERROR (0x06):
 : The connection established in response to a CONNECT request was reset or
   abnormally closed.
   
-HTTP_EXCESSIVE_LOAD (0x8007):
+HTTP_EXCESSIVE_LOAD (0x07):
 : The endpoint detected that its peer is exhibiting a behavior that might be
   generating excessive load.
 
-HTTP_VERSION_FALLBACK (0x8008):
+HTTP_VERSION_FALLBACK (0x08):
 : The requested operation cannot be served over HTTP/QUIC.  The peer should
   retry over HTTP/2.
 
-HTTP_MALFORMED_HEADERS (0x8009):
+HTTP_MALFORMED_HEADERS (0x09):
 : A HEADERS frame has been received with an invalid format.
 
-HTTP_MALFORMED_PRIORITY (0x800A):
+HTTP_MALFORMED_PRIORITY (0x0A):
 : A HEADERS frame has been received with an invalid format.
 
-HTTP_MALFORMED_SETTINGS (0x800B):
+HTTP_MALFORMED_SETTINGS (0x0B):
 : A HEADERS frame has been received with an invalid format.
 
-HTTP_MALFORMED_PUSH_PROMISE (0x800C):
+HTTP_MALFORMED_PUSH_PROMISE (0x0C):
 : A HEADERS frame has been received with an invalid format.
 
-HTTP_MALFORMED_SETTINGS_ACK (0x800D):
+HTTP_MALFORMED_SETTINGS_ACK (0x0D):
 : A HEADERS frame has been received with an invalid format.
 
-HTTP_INTERRUPTED_HEADERS (0x800E):
+HTTP_INTERRUPTED_HEADERS (0x0E):
 : A HEADERS frame without the End Header Block flag was followed by a frame
   other than HEADERS.
   
-HTTP_SETTINGS_ON_WRONG_STREAM (0x800F):
+HTTP_SETTINGS_ON_WRONG_STREAM (0x0F):
 : A SETTINGS frame was received on a request control stream.
 
 

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -366,6 +366,9 @@ Padding MUST NOT be used.  The flags defined are:
   Reserved (0x20):
   : Reserved for HTTP/2 compatibility.
 
+A HEADERS frame with the Reserved bits set MUST be treated as a connection error
+of type HTTP_MALFORMED_HEADERS.
+  
 ~~~~~~~~~~
     0                   1                   2                   3
     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
@@ -384,9 +387,9 @@ The HEADERS frame payload has the following fields:
 
 The next frame on the same stream after a HEADERS frame without the EHB flag set 
 MUST be another HEADERS frame. A receiver MUST treat the receipt of any other 
-type of frame as a stream error. (Note that QUIC can intersperse data from other 
-streams between frames, or even during transmission of frames, so multiplexing 
-is not blocked by this requirement.) 
+type of frame as a stream error of type HTTP_INTERRUPTED_HEADERS. (Note that
+QUIC can intersperse data from other streams between frames, or even during
+transmission of frames, so multiplexing is not blocked by this requirement.) 
 
 A full header block is contained in a sequence of zero or more HEADERS frames 
 without EHB set, followed by a HEADERS frame with EHB set. 
@@ -437,6 +440,10 @@ The HEADERS frame payload has the following fields:
   : An unsigned 8-bit integer representing a priority weight for the stream (see 
     {{!RFC7540}} Section 5.3). Add one to the value to obtain a weight between 1
     and 256. 
+
+A PRIORITY frame MUST have a payload length of nine octets.  A PRIORITY frame
+of any other length MUST be treated as a connection error of type
+HTTP_MALFORMED_PRIORITY.
 
 ### RST_STREAM
 
@@ -508,11 +515,12 @@ not understand.
 SETTINGS frames always apply to a connection, never a single stream, and MUST 
 only be sent on the connection control stream (Stream 3). If an endpoint 
 receives an SETTINGS frame whose stream identifier field is anything other than 
-0x0, the endpoint MUST respond with a connection error. 
+0x0, the endpoint MUST respond with a connection error of type
+HTTP_SETTINGS_ON_WRONG_STREAM.
 
 The SETTINGS frame affects connection state. A badly formed or incomplete 
 SETTINGS frame MUST be treated as a connection error (Section 5.4.1) of type 
-PROTOCOL_ERROR.
+HTTP_MALFORMED_SETTINGS.
 
 #### Integer encoding
 
@@ -588,7 +596,7 @@ of that stream.
  
 If the sender of a SETTINGS frame with the REQUEST_ACK flag set does not 
 receive full acknowledgement within a reasonable amount of time, it MAY issue a 
-connection error ([RFC7540] Section 5.4.1) of type SETTINGS_TIMEOUT.  A full
+connection error ({{errors}}) of type HTTP_SETTINGS_TIMEOUT.  A full
 acknowledgement has occurred when:
 
  - All previous SETTINGS frames have been fully acknowledged,
@@ -633,6 +641,7 @@ TODOs:
  - QUIC stream space may be enlarged; would need to redefine Promised Stream
    field in this case. 
  - No CONTINUATION -- HEADERS have EHB; do we need it here?
+
 
 ### PING
 
@@ -693,20 +702,81 @@ following payload:
 
 On message control streams, the SETTINGS_ACK frame carries no payload, and is
 strictly a synchronization marker for settings application.  See
-{{settings-synchronization}} for more detail.
+{{settings-synchronization}} for more detail.  A SETTINGS_ACK frame with a
+non-zero length MUST be treated as a connection error of type
+HTTP_MALFORMED_SETTINGS_ACK.
+
+On the connection control stream, the SETTINGS_ACK frame MUST have a length 
+which is a multiple of two octets. A SETTINGS_ACK frame of any other length MUST 
+be treated as a connection error of type HTTP_MALFORMED_SETTINGS_ACK. 
+
 
 # Error Handling {#errors}
 
-This section describes the specific error codes defined by HTTP/QUIC and the
-mapping of HTTP/2 error codes into the QUIC error space.  (Work in progress.)
+This section describes the specific error codes defined by HTTP and the mapping
+of HTTP/2 error codes into the QUIC error code space.
 
 ## HTTP-Defined QUIC Error Codes {#http-error-codes}
 
-The following error codes are defined by HTTP/QUIC for use in QUIC RST_STREAM,
+QUIC allocates error codes 0x8000-0xAFFF to application protocol definition.
+The following error codes are defined by HTTP for use in QUIC RST_STREAM,
 GOAWAY, and CONNECTION_CLOSE frames.
 
-QUIC_INVALID_HEADERS_STREAM_DATA (0x38):
-: We received invalid data on the headers stream.
+HTTP_SETTINGS_TIMEOUT (0x8000):
+: After sending a SETTINGS frame which requested acknowledgement, the
+  acknowledgement was not completed (see {{settings-synchronization}}) in a
+  timely manner.
+  
+HTTP_PUSH_REFUSED (0x8001):
+: The server has attempted to push content which the client will not accept
+  on this connection.
+
+HTTP_INTERNAL_ERROR (0x8002):
+: An internal error has occurred in the HTTP stack.
+
+HTTP_PUSH_ALREADY_IN_CACHE (0x8003):
+: The server has attempted to push content which the client has cached.
+
+HTTP_REQUEST_CANCELLED (0x8004):
+: The client no longer needs the requested data.
+
+HTTP_HPACK_DECOMPRESSION_FAILED (0x8005):
+: HPACK failed to decompress a frame and cannot continue.
+
+HTTP_CONNECT_ERROR (0x8006):
+: The connection established in response to a CONNECT request was reset or
+  abnormally closed.
+  
+HTTP_EXCESSIVE_LOAD (0x8007):
+: The endpoint detected that its peer is exhibiting a behavior that might be
+  generating excessive load.
+
+HTTP_VERSION_FALLBACK (0x8008):
+: The requested operation cannot be served over HTTP/QUIC.  The peer should
+  retry over HTTP/2.
+
+HTTP_MALFORMED_HEADERS (0x8009):
+: A HEADERS frame has been received with an invalid format.
+
+HTTP_MALFORMED_PRIORITY (0x800A):
+: A HEADERS frame has been received with an invalid format.
+
+HTTP_MALFORMED_SETTINGS (0x800B):
+: A HEADERS frame has been received with an invalid format.
+
+HTTP_MALFORMED_PUSH_PROMISE (0x800C):
+: A HEADERS frame has been received with an invalid format.
+
+HTTP_MALFORMED_SETTINGS_ACK (0x800D):
+: A HEADERS frame has been received with an invalid format.
+
+HTTP_INTERRUPTED_HEADERS (0x800E):
+: A HEADERS frame without the End Header Block flag was followed by a frame
+  other than HEADERS.
+  
+HTTP_SETTINGS_ON_WRONG_STREAM (0x800F):
+: A SETTINGS frame was received on a request control stream.
+
 
 ## Mapping HTTP/2 Error Codes
 
@@ -714,47 +784,51 @@ The HTTP/2 error codes defined in Section 7 of {{!RFC7540}} map to QUIC error
 codes as follows:
 
 NO_ERROR (0x0):
-: Maps to QUIC_NO_ERROR
+: QUIC_NO_ERROR
 
 PROTOCOL_ERROR (0x1):
-: No single mapping?
+: No single mapping.  See new HTTP_MALFORMED_* error codes defined in
+  {{http-error-codes}}.
 
 INTERNAL_ERROR (0x2)
-: QUIC_INTERNAL_ERROR? (not currently defined in core protocol spec)
+: HTTP_INTERNAL_ERROR in {{http-error-codes}}.
 
 FLOW_CONTROL_ERROR (0x3):
-: QUIC_FLOW_CONTROL_RECEIVED_TOO_MUCH_DATA? (not currently defined in core
-  protocol spec)
+: Not applicable, since QUIC handles flow control.  Would provoke a
+  QUIC_FLOW_CONTROL_RECEIVED_TOO_MUCH_DATA from the QUIC layer.
 
 SETTINGS_TIMEOUT (0x4):
-: (depends on whether we support SETTINGS acks)
+: HTTP_SETTINGS_TIMEOUT in {{http-error-codes}}.
 
 STREAM_CLOSED (0x5):
-: QUIC_STREAM_DATA_AFTER_TERMINATION
+: Not applicable, since QUIC handles stream management.  Would provoke a
+  QUIC_STREAM_DATA_AFTER_TERMINATION from the QUIC layer.
 
 FRAME_SIZE_ERROR (0x6)
-: QUIC_INVALID_FRAME_DATA
+: No single mapping.  See new error codes defined in {{http-error-codes}}.
 
 REFUSED_STREAM (0x7):
-: ?
+: Not applicable, since QUIC handles stream management.  Would provoke a
+  QUIC_TOO_MANY_OPEN_STREAMS from the QUIC layer.
 
 CANCEL (0x8):
-: ?
+: HTTP_REQUEST_CANCELLED in {{http-error-codes}}.
 
 COMPRESSION_ERROR (0x9):
-: QUIC_DECOMPRESSION_FAILURE (not currently defined in core spec)
+: HTTP_HPACK_DECOMPRESSION_FAILED in {{http-error-codes}}.
 
 CONNECT_ERROR (0xa):
-: ? (depends whether we decide to support CONNECT)
+: HTTP_CONNECT_ERROR in {{http-error-codes}}.
 
 ENHANCE_YOUR_CALM (0xb):
-: ?
+: HTTP_EXCESSIVE_LOAD in {{http-error-codes}}.
 
 INADEQUATE_SECURITY (0xc):
-: QUIC_HANDSHAKE_FAILED, QUIC_CRYPTO_NO_SUPPORT
+: Not applicable, since QUIC is assumed to provide sufficient security on all
+  connections.
 
 HTTP_1_1_REQUIRED (0xd):
-: ?
+: HTTP_VERSION_FALLBACK in {{http-error-codes}}.
 
 TODO: fill in missing error code mappings.
 

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1234,86 +1234,86 @@ packets as indicative of an attack.
 # Error codes {#errors}
 
 The portion of the QUIC error code space allocated for the crypto handshake is
-0x4000-0x7FFF. The following error codes are defined when TLS is used for the
+0xB000-0xFFFF. The following error codes are defined when TLS is used for the
 crypto handshake:
 
-TLS_HANDSHAKE_FAILED (0x401c):
+TLS_HANDSHAKE_FAILED (0xB01c):
 : Crypto errors. Handshake failed.
 
-TLS_MESSAGE_OUT_OF_ORDER (0x401d):
+TLS_MESSAGE_OUT_OF_ORDER (0xB01d):
 : Handshake message received out of order.
 
-TLS_TOO_MANY_ENTRIES (0x401e):
+TLS_TOO_MANY_ENTRIES (0xB01e):
 : Handshake message contained too many entries.
 
-TLS_INVALID_VALUE_LENGTH (0x401f):
+TLS_INVALID_VALUE_LENGTH (0xB01f):
 : Handshake message contained an invalid value length.
 
-TLS_MESSAGE_AFTER_HANDSHAKE_COMPLETE (0x4020):
+TLS_MESSAGE_AFTER_HANDSHAKE_COMPLETE (0xB020):
 : A handshake message was received after the handshake was complete.
 
-TLS_INVALID_RECORD_TYPE (0x4021):
+TLS_INVALID_RECORD_TYPE (0xB021):
 : A handshake message was received with an illegal record type.
 
-TLS_INVALID_PARAMETER (0x4022):
+TLS_INVALID_PARAMETER (0xB022):
 : A handshake message was received with an illegal parameter.
 
-TLS_INVALID_CHANNEL_ID_SIGNATURE (0x4034):
+TLS_INVALID_CHANNEL_ID_SIGNATURE (0xB034):
 : An invalid channel id signature was supplied.
 
-TLS_MESSAGE_PARAMETER_NOT_FOUND (0x4023):
+TLS_MESSAGE_PARAMETER_NOT_FOUND (0xB023):
 : A handshake message was received with a mandatory parameter missing.
 
-TLS_MESSAGE_PARAMETER_NO_OVERLAP (0x4024):
+TLS_MESSAGE_PARAMETER_NO_OVERLAP (0xB024):
 : A handshake message was received with a parameter that has no overlap with the 
   local parameter. 
 
-TLS_MESSAGE_INDEX_NOT_FOUND (0x4025):
+TLS_MESSAGE_INDEX_NOT_FOUND (0xB025):
 : A handshake message was received that contained a parameter with too few values.
 
-TLS_UNSUPPORTED_PROOF_DEMAND (0x405e):
+TLS_UNSUPPORTED_PROOF_DEMAND (0xB05e):
 : A demand for an unsupported proof type was received.
 
-TLS_INTERNAL_ERROR (0x4026):
+TLS_INTERNAL_ERROR (0xB026):
 : An internal error occured in handshake processing.
 
-TLS_VERSION_NOT_SUPPORTED (0x4027):
+TLS_VERSION_NOT_SUPPORTED (0xB027):
 : A handshake handshake message specified an unsupported version.
 
-TLS_HANDSHAKE_STATELESS_REJECT (0x4048):
+TLS_HANDSHAKE_STATELESS_REJECT (0xB048):
 : A handshake handshake message resulted in a stateless reject.
 
-TLS_NO_SUPPORT (0x4028):
+TLS_NO_SUPPORT (0xB028):
 : There was no intersection between the crypto primitives supported by the peer 
   and ourselves. 
 
-TLS_TOO_MANY_REJECTS (0x4029):
+TLS_TOO_MANY_REJECTS (0xB029):
 : The server rejected our client hello messages too many times.
 
-TLS_PROOF_INVALID (0x402a):
+TLS_PROOF_INVALID (0xB02a):
 : The client rejected the server's certificate chain or signature.
 
-TLS_DUPLICATE_TAG (0x402b):
+TLS_DUPLICATE_TAG (0xB02b):
 : A handshake message was received with a duplicate tag.
 
-TLS_ENCRYPTION_LEVEL_INCORRECT (0x402c):
+TLS_ENCRYPTION_LEVEL_INCORRECT (0xB02c):
 : A handshake message was received with the wrong encryption level (i.e. it
   should have been encrypted but was not.)
 
-TLS_SERVER_CONFIG_EXPIRED (0x402d):
+TLS_SERVER_CONFIG_EXPIRED (0xB02d):
 : The server config for a server has expired.
 
-TLS_SYMMETRIC_KEY_SETUP_FAILED (0x4035):
+TLS_SYMMETRIC_KEY_SETUP_FAILED (0xB035):
 : We failed to set up the symmetric keys for a connection.
 
-TLS_MESSAGE_WHILE_VALIDATING_CLIENT_HELLO (0x4036):
+TLS_MESSAGE_WHILE_VALIDATING_CLIENT_HELLO (0xB036):
 : A handshake message arrived, but we are still validating the previous 
   handshake message. 
 
-TLS_UPDATE_BEFORE_HANDSHAKE_COMPLETE (0x4041):
+TLS_UPDATE_BEFORE_HANDSHAKE_COMPLETE (0xB041):
 : A server config update arrived before the handshake is complete.
 
-TLS_CLIENT_HELLO_TOO_LARGE (0x405a):
+TLS_CLIENT_HELLO_TOO_LARGE (0xB05a):
 : ClientHello cannot fit in one packet.
 
 

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1233,85 +1233,87 @@ packets as indicative of an attack.
 
 # Error codes {#errors}
 
-The following error codes are defined when TLS is used for the crypto handshake:
+The portion of the QUIC error code space allocated for the crypto handshake is
+0x4000-0x7FFF. The following error codes are defined when TLS is used for the
+crypto handshake:
 
-TLS_HANDSHAKE_FAILED (0x1c):
+TLS_HANDSHAKE_FAILED (0x401c):
 : Crypto errors. Handshake failed.
 
-TLS_MESSAGE_OUT_OF_ORDER (0x1d):
+TLS_MESSAGE_OUT_OF_ORDER (0x401d):
 : Handshake message received out of order.
 
-TLS_TOO_MANY_ENTRIES (0x1e):
+TLS_TOO_MANY_ENTRIES (0x401e):
 : Handshake message contained too many entries.
 
-TLS_INVALID_VALUE_LENGTH (0x1f):
+TLS_INVALID_VALUE_LENGTH (0x401f):
 : Handshake message contained an invalid value length.
 
-TLS_MESSAGE_AFTER_HANDSHAKE_COMPLETE (0x20):
+TLS_MESSAGE_AFTER_HANDSHAKE_COMPLETE (0x4020):
 : A handshake message was received after the handshake was complete.
 
-TLS_INVALID_RECORD_TYPE (0x21):
+TLS_INVALID_RECORD_TYPE (0x4021):
 : A handshake message was received with an illegal record type.
 
-TLS_INVALID_PARAMETER (0x22):
+TLS_INVALID_PARAMETER (0x4022):
 : A handshake message was received with an illegal parameter.
 
-TLS_INVALID_CHANNEL_ID_SIGNATURE (0x34):
+TLS_INVALID_CHANNEL_ID_SIGNATURE (0x4034):
 : An invalid channel id signature was supplied.
 
-TLS_MESSAGE_PARAMETER_NOT_FOUND (0x23):
+TLS_MESSAGE_PARAMETER_NOT_FOUND (0x4023):
 : A handshake message was received with a mandatory parameter missing.
 
-TLS_MESSAGE_PARAMETER_NO_OVERLAP (0x24):
+TLS_MESSAGE_PARAMETER_NO_OVERLAP (0x4024):
 : A handshake message was received with a parameter that has no overlap with the 
   local parameter. 
 
-TLS_MESSAGE_INDEX_NOT_FOUND (0x25):
+TLS_MESSAGE_INDEX_NOT_FOUND (0x4025):
 : A handshake message was received that contained a parameter with too few values.
 
-TLS_UNSUPPORTED_PROOF_DEMAND (0x5e):
+TLS_UNSUPPORTED_PROOF_DEMAND (0x405e):
 : A demand for an unsupported proof type was received.
 
-TLS_INTERNAL_ERROR (0x26):
+TLS_INTERNAL_ERROR (0x4026):
 : An internal error occured in handshake processing.
 
-TLS_VERSION_NOT_SUPPORTED (0x27):
+TLS_VERSION_NOT_SUPPORTED (0x4027):
 : A handshake handshake message specified an unsupported version.
 
-TLS_HANDSHAKE_STATELESS_REJECT (0x48):
+TLS_HANDSHAKE_STATELESS_REJECT (0x4048):
 : A handshake handshake message resulted in a stateless reject.
 
-TLS_NO_SUPPORT (0x28):
+TLS_NO_SUPPORT (0x4028):
 : There was no intersection between the crypto primitives supported by the peer 
   and ourselves. 
 
-TLS_TOO_MANY_REJECTS (0x29):
+TLS_TOO_MANY_REJECTS (0x4029):
 : The server rejected our client hello messages too many times.
 
-TLS_PROOF_INVALID (0x2a):
+TLS_PROOF_INVALID (0x402a):
 : The client rejected the server's certificate chain or signature.
 
-TLS_DUPLICATE_TAG (0x2b):
+TLS_DUPLICATE_TAG (0x402b):
 : A handshake message was received with a duplicate tag.
 
-TLS_ENCRYPTION_LEVEL_INCORRECT (0x2c):
+TLS_ENCRYPTION_LEVEL_INCORRECT (0x402c):
 : A handshake message was received with the wrong encryption level (i.e. it
   should have been encrypted but was not.)
 
-TLS_SERVER_CONFIG_EXPIRED (0x2d):
+TLS_SERVER_CONFIG_EXPIRED (0x402d):
 : The server config for a server has expired.
 
-TLS_SYMMETRIC_KEY_SETUP_FAILED (0x35):
+TLS_SYMMETRIC_KEY_SETUP_FAILED (0x4035):
 : We failed to set up the symmetric keys for a connection.
 
-TLS_MESSAGE_WHILE_VALIDATING_CLIENT_HELLO (0x36):
+TLS_MESSAGE_WHILE_VALIDATING_CLIENT_HELLO (0x4036):
 : A handshake message arrived, but we are still validating the previous 
   handshake message. 
 
-TLS_UPDATE_BEFORE_HANDSHAKE_COMPLETE (0x41):
+TLS_UPDATE_BEFORE_HANDSHAKE_COMPLETE (0x4041):
 : A server config update arrived before the handshake is complete.
 
-TLS_CLIENT_HELLO_TOO_LARGE (0x5a):
+TLS_CLIENT_HELLO_TOO_LARGE (0x405a):
 : ClientHello cannot fit in one packet.
 
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1645,10 +1645,27 @@ to get blocked.
 
 # Error Codes {#error-handling}
 
-This section lists all the QUIC error codes that may be used in a
-CONNECTION_CLOSE frame.  TODO: Trim list and group errors for readabiity.
+Error codes are 32 bits long, with the first two bits indicating the source of
+the error code:
 
-TODO: Discuss error handling beyond just listing error codes.
+0x0000-0x3FFF:
+: QUIC transport error codes, including packet protection errors.  Applicable to
+  all uses of QUIC.
+
+0x4000-0x7FFF:
+: Cryptographic error codes.  Defined by the crypto handshake protocol in use.
+
+0x8000-0xAFFF:
+: Application-specific error codes.  Defined by each application-layer protocol.
+
+0xB000-0xFFFF:
+: Reserved for host-local error codes.  These codes MUST NOT be sent to a peer,
+  but MAY be used in API return codes and logs.
+
+This section lists the defined QUIC transport error codes that may be used in a 
+CONNECTION_CLOSE or RST_STREAM frame. Error codes share a common code space. 
+Some error codes apply only to either streams or the entire connection and have 
+no defined semantics in the other context. 
 
 QUIC_INTERNAL_ERROR (0x01):
 : Connection has reached an invalid state.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1649,184 +1649,184 @@ Error codes are 32 bits long, with the first two bits indicating the source of
 the error code:
 
 0x0000-0x3FFF:
+: Application-specific error codes.  Defined by each application-layer protocol.
+
+0x4000-0x7FFF:
+: Reserved for host-local error codes.  These codes MUST NOT be sent to a peer,
+  but MAY be used in API return codes and logs.
+
+0x8000-0xAFFF:
 : QUIC transport error codes, including packet protection errors.  Applicable to
   all uses of QUIC.
 
-0x4000-0x7FFF:
-: Cryptographic error codes.  Defined by the crypto handshake protocol in use.
-
-0x8000-0xAFFF:
-: Application-specific error codes.  Defined by each application-layer protocol.
-
 0xB000-0xFFFF:
-: Reserved for host-local error codes.  These codes MUST NOT be sent to a peer,
-  but MAY be used in API return codes and logs.
+: Cryptographic error codes.  Defined by the crypto handshake protocol in use.
 
 This section lists the defined QUIC transport error codes that may be used in a 
 CONNECTION_CLOSE or RST_STREAM frame. Error codes share a common code space. 
 Some error codes apply only to either streams or the entire connection and have 
 no defined semantics in the other context. 
 
-QUIC_INTERNAL_ERROR (0x01):
+QUIC_INTERNAL_ERROR (0x8001):
 : Connection has reached an invalid state.
 
-QUIC_STREAM_DATA_AFTER_TERMINATION (0x02):
+QUIC_STREAM_DATA_AFTER_TERMINATION (0x8002):
 : There were data frames after the a fin or reset.
 
-QUIC_INVALID_PACKET_HEADER (0x03):
+QUIC_INVALID_PACKET_HEADER (0x8003):
 : Control frame is malformed.
 
-QUIC_INVALID_FRAME_DATA (0x04):
+QUIC_INVALID_FRAME_DATA (0x8004):
 : Frame data is malformed.
 
-QUIC_MISSING_PAYLOAD (0x30):
+QUIC_MISSING_PAYLOAD (0x8030):
 : The packet contained no payload.
 
-QUIC_INVALID_STREAM_DATA (0x2e):
+QUIC_INVALID_STREAM_DATA (0x802e):
 : STREAM frame data is malformed.
 
-QUIC_OVERLAPPING_STREAM_DATA (0x57):
+QUIC_OVERLAPPING_STREAM_DATA (0x8057):
 : STREAM frame data overlaps with buffered data.
 
-QUIC_UNENCRYPTED_STREAM_DATA (0x3d):
+QUIC_UNENCRYPTED_STREAM_DATA (0x803d):
 : Received STREAM frame data is not encrypted.
 
-QUIC_MAYBE_CORRUPTED_MEMORY (0x59):
+QUIC_MAYBE_CORRUPTED_MEMORY (0x8059):
 : Received a frame which is likely the result of memory corruption.
 
-QUIC_INVALID_RST_STREAM_DATA (0x06):
+QUIC_INVALID_RST_STREAM_DATA (0x8006):
 : RST_STREAM frame data is malformed.
 
-QUIC_INVALID_CONNECTION_CLOSE_DATA (0x07):
+QUIC_INVALID_CONNECTION_CLOSE_DATA (0x8007):
 : CONNECTION_CLOSE frame data is malformed.
 
-QUIC_INVALID_GOAWAY_DATA (0x08):
+QUIC_INVALID_GOAWAY_DATA (0x8008):
 : GOAWAY frame data is malformed.
 
-QUIC_INVALID_WINDOW_UPDATE_DATA (0x39):
+QUIC_INVALID_WINDOW_UPDATE_DATA (0x8039):
 : WINDOW_UPDATE frame data is malformed.
 
-QUIC_INVALID_BLOCKED_DATA (0x3a):
+QUIC_INVALID_BLOCKED_DATA (0x803a):
 : BLOCKED frame data is malformed.
 
-QUIC_INVALID_STOP_WAITING_DATA (0x3c):
+QUIC_INVALID_STOP_WAITING_DATA (0x803c):
 : STOP_WAITING frame data is malformed.
 
-QUIC_INVALID_PATH_CLOSE_DATA (0x4e):
+QUIC_INVALID_PATH_CLOSE_DATA (0x804e):
 : PATH_CLOSE frame data is malformed.
 
-QUIC_INVALID_ACK_DATA (0x09):
+QUIC_INVALID_ACK_DATA (0x8009):
 : ACK frame data is malformed.
 
-QUIC_INVALID_VERSION_NEGOTIATION_PACKET (0x0a):
+QUIC_INVALID_VERSION_NEGOTIATION_PACKET (0x800a):
 : Version negotiation packet is malformed.
 
-QUIC_INVALID_PUBLIC_RST_PACKET (0x0b):
+QUIC_INVALID_PUBLIC_RST_PACKET (0x800b):
 : Public RST packet is malformed.
 
-QUIC_DECRYPTION_FAILURE (0x0c):
+QUIC_DECRYPTION_FAILURE (0x800c):
 : There was an error decrypting.
 
-QUIC_ENCRYPTION_FAILURE (0x0d):
+QUIC_ENCRYPTION_FAILURE (0x800d):
 : There was an error encrypting.
 
-QUIC_PACKET_TOO_LARGE (0x0e):
+QUIC_PACKET_TOO_LARGE (0x800e):
 : The packet exceeded kMaxPacketSize.
 
-QUIC_PEER_GOING_AWAY (0x10):
+QUIC_PEER_GOING_AWAY (0x8010):
 : The peer is going away. May be a client or server.
 
-QUIC_INVALID_STREAM_ID (0x11):
+QUIC_INVALID_STREAM_ID (0x8011):
 : A stream ID was invalid.
 
-QUIC_INVALID_PRIORITY (0x31):
+QUIC_INVALID_PRIORITY (0x8031):
 : A priority was invalid.
 
-QUIC_TOO_MANY_OPEN_STREAMS (0x12):
+QUIC_TOO_MANY_OPEN_STREAMS (0x8012):
 : Too many streams already open.
 
-QUIC_TOO_MANY_AVAILABLE_STREAMS (0x4c):
+QUIC_TOO_MANY_AVAILABLE_STREAMS (0x804c):
 : The peer created too many available streams.
 
-QUIC_PUBLIC_RESET (0x13):
+QUIC_PUBLIC_RESET (0x8013):
 : Received public reset for this connection.
 
-QUIC_INVALID_VERSION (0x14):
+QUIC_INVALID_VERSION (0x8014):
 : Invalid protocol version.
 
-QUIC_INVALID_HEADER_ID (0x16):
+QUIC_INVALID_HEADER_ID (0x8016):
 : The Header ID for a stream was too far from the previous.
 
-QUIC_INVALID_NEGOTIATED_VALUE (0x17):
+QUIC_INVALID_NEGOTIATED_VALUE (0x8017):
 : Negotiable parameter received during handshake had invalid value.
 
-QUIC_DECOMPRESSION_FAILURE (0x18):
+QUIC_DECOMPRESSION_FAILURE (0x8018):
 : There was an error decompressing data.
 
-QUIC_NETWORK_IDLE_TIMEOUT (0x19):
+QUIC_NETWORK_IDLE_TIMEOUT (0x8019):
 : The connection timed out due to no network activity.
 
-QUIC_HANDSHAKE_TIMEOUT (0x43):
+QUIC_HANDSHAKE_TIMEOUT (0x8043):
 : The connection timed out waiting for the handshake to complete.
 
-QUIC_ERROR_MIGRATING_ADDRESS (0x1a):
+QUIC_ERROR_MIGRATING_ADDRESS (0x801a):
 : There was an error encountered migrating addresses.
 
-QUIC_ERROR_MIGRATING_PORT (0x56):
+QUIC_ERROR_MIGRATING_PORT (0x8056):
 : There was an error encountered migrating port only.
 
-QUIC_EMPTY_STREAM_FRAME_NO_FIN (0x32):
+QUIC_EMPTY_STREAM_FRAME_NO_FIN (0x8032):
 : We received a STREAM_FRAME with no data and no fin flag set.
 
-QUIC_FLOW_CONTROL_RECEIVED_TOO_MUCH_DATA (0x3b):
+QUIC_FLOW_CONTROL_RECEIVED_TOO_MUCH_DATA (0x803b):
 : The peer received too much data, violating flow control.
 
-QUIC_FLOW_CONTROL_SENT_TOO_MUCH_DATA (0x3f):
+QUIC_FLOW_CONTROL_SENT_TOO_MUCH_DATA (0x803f):
 : The peer sent too much data, violating flow control.
 
-QUIC_FLOW_CONTROL_INVALID_WINDOW (0x40):
+QUIC_FLOW_CONTROL_INVALID_WINDOW (0x8040):
 : The peer received an invalid flow control window.
 
-QUIC_CONNECTION_IP_POOLED (0x3e):
+QUIC_CONNECTION_IP_POOLED (0x803e):
 : The connection has been IP pooled into an existing connection.
 
-QUIC_TOO_MANY_OUTSTANDING_SENT_PACKETS (0x44):
+QUIC_TOO_MANY_OUTSTANDING_SENT_PACKETS (0x8044):
 : The connection has too many outstanding sent packets.
 
-QUIC_TOO_MANY_OUTSTANDING_RECEIVED_PACKETS (0x45):
+QUIC_TOO_MANY_OUTSTANDING_RECEIVED_PACKETS (0x8045):
 : The connection has too many outstanding received packets.
 
-QUIC_CONNECTION_CANCELLED (0x46):
+QUIC_CONNECTION_CANCELLED (0x8046):
 : The QUIC connection has been cancelled.
 
-QUIC_BAD_PACKET_LOSS_RATE (0x47):
+QUIC_BAD_PACKET_LOSS_RATE (0x8047):
 : Disabled QUIC because of high packet loss rate.
 
-QUIC_PUBLIC_RESETS_POST_HANDSHAKE (0x49):
+QUIC_PUBLIC_RESETS_POST_HANDSHAKE (0x8049):
 : Disabled QUIC because of too many PUBLIC_RESETs post handshake.
 
-QUIC_TIMEOUTS_WITH_OPEN_STREAMS (0x4a):
+QUIC_TIMEOUTS_WITH_OPEN_STREAMS (0x804a):
 : Disabled QUIC because of too many timeouts with streams open.
 
-QUIC_TOO_MANY_RTOS (0x55):
+QUIC_TOO_MANY_RTOS (0x8055):
 : QUIC timed out after too many RTOs.
 
-QUIC_ENCRYPTION_LEVEL_INCORRECT (0x2c):
+QUIC_ENCRYPTION_LEVEL_INCORRECT (0x802c):
 : A packet was received with the wrong encryption level (i.e. it should 
   have been encrypted but was not.)
 
-QUIC_VERSION_NEGOTIATION_MISMATCH (0x37):
+QUIC_VERSION_NEGOTIATION_MISMATCH (0x8037):
 : This connection involved a version negotiation which appears to have been
   tampered with.
 
-QUIC_IP_ADDRESS_CHANGED (0x50):
+QUIC_IP_ADDRESS_CHANGED (0x8050):
 : IP address changed causing connection close.
 
-QUIC_TOO_MANY_FRAME_GAPS (0x5d):
+QUIC_TOO_MANY_FRAME_GAPS (0x805d):
 : Stream frames arrived too discontiguously so that stream sequencer buffer
   maintains too many gaps.
 
-QUIC_TOO_MANY_SESSIONS_ON_SERVER (0x60):
+QUIC_TOO_MANY_SESSIONS_ON_SERVER (0x8060):
 : Connection closed because server hit max number of sessions allowed. 
 
 


### PR DESCRIPTION
Builds on #130 to nearly the same end result as #96, to address #74.

Allocates portions of the error space to QUIC, crypto, and the app-layer. The remote knows the QUIC version (which implies the crypto protocol) and the application -- that means it can figure out what set of error codes to use for interpreting each region. If extensions define new error codes, they would want to do so within the appropriate registries to avoid collisions and thereby confusion.

Congestion control doesn't get a region, because the peer doesn't know what algorithm you're using to interpret anything anyway -- that's just a transport error.

At Jana's suggestion, reserving a range instead for local-only error codes (e.g. the QUIC spec's original "failed to write to socket," "tried to send unencrypted data," etc.) that MUST NOT be sent on the wire, but can be used in logs and APIs to avoid having to use a separate return value for non-protocol errors.