### PR TITLE
read the connection ID from a packet with an unsupported version

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -422,7 +422,7 @@ constant are:
 
 * the location and value of the VERSION bit in the Flags field,
 
-* the existence of a 64-bit field following the Flags field, and
+* the location and size of the Connection ID field, and
 
 * the Version (or Supported Versions, {{version-negotiation-packet}}) field.
 


### PR DESCRIPTION
According to [Section 5.3](https://quicwg.github.io/base-drafts/draft-ietf-quic-transport.html#version-negotiation-packet), a Version Negotiation Packet MUST contain the Connection ID.
[Section 5.1.2](https://quicwg.github.io/base-drafts/draft-ietf-quic-transport.html#handling-packets-from-different-versions), which specifies the fields that are guaranteed to remain constant between different QUIC versions, must therefore define the location and size of the Connection ID.