### PR TITLE
TLS 1.3 is the minimum acceptable TLS version

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -473,7 +473,7 @@ could result in a newer version of TLS than 1.3 being negotiated if both
 endpoints support that version.  This is acceptable provided that the features
 of TLS 1.3 that are used by QUIC are supported by the newer version.
 
-A badly configured TLS implementation could negotiate TLS 1.2 or an older
+A badly configured TLS implementation could negotiate TLS 1.2 or another older
 version of TLS.  An endpoint MUST terminate the connection the handshake if a
 version of TLS older than 1.3 is negotiated.
 

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -464,6 +464,20 @@ Get Handshake
 {: #exchange-summary title="Interaction Summary between QUIC and TLS"}
 
 
+## TLS Version
+
+This document describes how TLS 1.3 {{!I-D.ietf-tls-tls13}} is used with QUIC.
+
+In practice, the TLS handshake will negotiate a version of TLS to use.  This
+could result in a newer version of TLS than 1.3 being negotiated if both
+endpoints support that version.  This is acceptable provided that the features
+of TLS 1.3 that are used by QUIC are supported by the newer version.
+
+A badly configured TLS implementation could negotiate TLS 1.2 or an older
+version of TLS.  An endpoint MUST terminate the connection the handshake if a
+version of TLS older than 1.3 is negotiated.
+
+
 # QUIC Packet Protection {#packet-protection}
 
 QUIC packet protection provides authenticated encryption of packets.  This

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -474,8 +474,8 @@ endpoints support that version.  This is acceptable provided that the features
 of TLS 1.3 that are used by QUIC are supported by the newer version.
 
 A badly configured TLS implementation could negotiate TLS 1.2 or another older
-version of TLS.  An endpoint MUST terminate the connection the handshake if a
-version of TLS older than 1.3 is negotiated.
+version of TLS.  An endpoint MUST terminate the connection if a version of TLS
+older than 1.3 is negotiated.
 
 
 # QUIC Packet Protection {#packet-protection}


### PR DESCRIPTION
It was observed that TLS negotiates its version and that a future TLS version might be OK, but an older TLS is definitely not.  We should be explicit about that.