### PR TITLE
closed streams

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1283,7 +1283,10 @@ A packet may contain frames and/or application data, only some of which may
 require reliability.  When a packet is detected as lost, the sender re-sends any
 frames as necessary:
 
-* All application data sent in STREAM frames MUST be retransmitted.
+* All application data sent in STREAM frames MUST be retransmitted, with one
+  exception.  When an endpoint sends a RST_STREAM frame, data outstanding on
+  that stream SHOULD NOT be retransmitted, since subsequent data on this stream
+  is expected to not be delivered by the receiver.
 
 * ACK, STOP_WAITING, and PADDING frames MUST NOT be retransmitted.  New frames
   of these types may however be bundled with any outgoing packet.
@@ -1486,8 +1489,7 @@ the highest data offset it already received on that stream.
 An endpoint that receives a RST_STREAM frame (and which has not sent a FIN or a
 RST_STREAM) MUST immediately respond with a RST_STREAM frame, and MUST NOT send
 any more data on the stream.  This endpoint may continue receiving frames for
-the stream on which a RST_STREAM is received, and MUST deliver the received
-data up to the final offset to the application.
+the stream on which a RST_STREAM is received.
 
 If this state is reached as a result of sending a RST_STREAM frame, the peer
 that receives the RST_STREAM might have already sent -- or enqueued for sending

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1283,10 +1283,7 @@ A packet may contain frames and/or application data, only some of which may
 require reliability.  When a packet is detected as lost, the sender re-sends any
 frames as necessary:
 
-* All application data sent in STREAM frames MUST be retransmitted, with one
-  exception.  When an endpoint sends a RST_STREAM frame, data outstanding on
-  that stream SHOULD NOT be retransmitted, since subsequent data on this stream
-  is expected to not be delivered by the receiver.
+* All application data sent in STREAM frames MUST be retransmitted.
 
 * ACK, STOP_WAITING, and PADDING frames MUST NOT be retransmitted.  New frames
   of these types may however be bundled with any outgoing packet.
@@ -1489,7 +1486,8 @@ the highest data offset it already received on that stream.
 An endpoint that receives a RST_STREAM frame (and which has not sent a FIN or a
 RST_STREAM) MUST immediately respond with a RST_STREAM frame, and MUST NOT send
 any more data on the stream.  This endpoint may continue receiving frames for
-the stream on which a RST_STREAM is received.
+the stream on which a RST_STREAM is received, and MUST deliver the received
+data up to the final offset to the application.
 
 If this state is reached as a result of sending a RST_STREAM frame, the peer
 that receives the RST_STREAM might have already sent -- or enqueued for sending

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1473,18 +1473,18 @@ contains a FIN flag or when either peer sends a RST_STREAM frame.
 
 The "closed" state is the terminal state.
 
-A final offset is present in both a frame bearing a FIN flag and in a RST_STREAM
-frame.  Upon sending either of these frames for a stream, the endpoint MUST NOT
-send a STREAM frame carrying data beyond the final offset.
+A final offset is present in both a STREAM frame bearing a FIN flag and in a
+RST_STREAM frame.  Upon sending either of these frames for a stream, the
+endpoint MUST NOT send a STREAM frame carrying data beyond the final offset.
 
-An endpoint that receives a FIN flag or a RST_STREAM frames knows the final
+An endpoint that receives a FIN flag or a RST_STREAM frame knows the final
 offset for this stream. If a STREAM frame carrying data beyond the received
 final offset is received, the endpoint MUST close the connection with a
 QUIC_STREAM_DATA_AFTER_TERMINATION error ({{error-handling}}).
 
 An endpoint MUST close the connection with a QUIC_STREAM_DATA_AFTER_TERMINATION
-error if it receives a RST_STREAM or a FIN flag with a lower final offset than
-the highest data offset it already received on that stream.
+error if it receives a RST_STREAM frame or a FIN flag with a lower final offset
+than the highest data offset it already received on that stream.
 
 An endpoint that receives a RST_STREAM frame (and which has not sent a FIN or a
 RST_STREAM) MUST immediately respond with a RST_STREAM frame, and MUST NOT send
@@ -1492,11 +1492,11 @@ any more data on the stream.  This endpoint may continue receiving frames for
 the stream on which a RST_STREAM is received.
 
 If this state is reached as a result of sending a RST_STREAM frame, the peer
-that receives the RST_STREAM might have already sent -- or enqueued for sending
--- frames on the stream that cannot be withdrawn.  An endpoint MUST ignore
-frames that it receives on closed streams after it has sent a RST_STREAM frame.
-An endpoint MAY choose to limit the period over which it ignores frames and
-treat frames that arrive after this time as being in error.
+that receives the RST_STREAM frame might have already sent -- or enqueued for
+sending -- frames on the stream that cannot be withdrawn.  An endpoint MUST
+ignore frames that it receives on closed streams after it has sent a RST_STREAM
+frame. An endpoint MAY choose to limit the period over which it ignores frames
+and treat frames that arrive after this time as being in error.
 
 STREAM frames received after sending RST_STREAM are counted toward the
 connection and stream flow-control windows.  Even though these frames might be

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1477,11 +1477,14 @@ A final offset is present in both a frame bearing a FIN flag and in a RST_STREAM
 frame.  Upon sending either of these frames for a stream, the endpoint MUST NOT
 send a STREAM frame carrying data beyond the final offset.
 
-An endpoint that receives any frame for this stream after receiving either a FIN
-flag and all stream data preceding it, or a RST_STREAM frame, MUST quietly
-discard the frame, with one exception.  If a STREAM frame carrying data beyond
-the received final offset is received, the endpoint MUST close the connection
-with a QUIC_STREAM_DATA_AFTER_TERMINATION error ({{error-handling}}).
+An endpoint that receives a FIN flag or a RST_STREAM frames knows the final
+offset for this stream. If a STREAM frame carrying data beyond the received
+final offset is received, the endpoint MUST close the connection with a
+QUIC_STREAM_DATA_AFTER_TERMINATION error ({{error-handling}}).
+
+An endpoint MUST close the connection with a QUIC_STREAM_DATA_AFTER_TERMINATION
+error if it receives a RST_STREAM or a FIN flag with a lower final offset than
+the highest data offset it already received on that stream.
 
 An endpoint that receives a RST_STREAM frame (and which has not sent a FIN or a
 RST_STREAM) MUST immediately respond with a RST_STREAM frame, and MUST NOT send


### PR DESCRIPTION
I added two commits regarding the closing of streams.

The current version of the draft already states that a peer that received stream data beyond the final offset (received either in STREAM frame with the FIN flag set or in a RST_STREAM frame) MUST close the connection with a QUIC_STREAM_DATA_AFTER_TERMINATION error. 
However, due to packet reordering, the packet carrying the final offset might be delayed, such that the peer first receives STREAM frames up to a certain offset, and then receives the final offset, and notices that the final offset is smaller than the offset it received before. In this case, it MUST also terminate the connection with a QUIC_STREAM_DATA_AFTER_TERMINATION error.

The second commit is concerned with what happens when a RST_STREAM is received. A common use case is the following: A client sends a POST request to a server and already begins sending data, but the Request URI doesn't accept data (e.g. there's an error 403 or 404). In those cases, the server will send a HTTP response (note that a 404 has a non-empty response body), and immediately after sending the last byte of the 404 response, it will send a RST_STREAM in order to stop the client from sending more data. In this case, QUIC needs to make sure the data sent by the server is delivered to the client (i.e. the server MUST retransmit any lost data, even after receiving the RST_STREAM response from the client), and the client MUST deliver the data received to the application, even if the packets containing the response body are delayed such that they arrive after the RST_STREAM sent by the server.