### PR TITLE
Use the VERSION flag to identify 0-RTT packets

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -646,13 +646,11 @@ version. The resent packets MUST use new packet numbers.  These packets MUST
 continue to have the VERSION flag set and MUST include the new negotiated
 protocol version.
 
-The client MUST set the VERSION flag on all packets until version negotiation
-concludes. Version negotiation successfully concludes when the client receives a
-packet from the server with the VERSION flag unset. All subsequent packets sent
-by the client SHOULD have the VERSION flag unset.
-
-Once the server receives a packet from the client with the VERSION flag unset,
-it MUST ignore the flag in subsequently received packets.
+The client MUST set the VERSION flag and include its selected version on all
+packets until it starts protecting packets with 1-RTT keys.  Only unprotected
+packets and 0-RTT protected packets can include a version.  A client MUST NOT
+change the version it uses unless it is in response to a version negotiation
+packet from the server.
 
 Version negotiation uses unprotected data. The result of the negotiation MUST
 be revalidated once the cryptographic handshake has completed (see

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -647,10 +647,14 @@ continue to have the VERSION flag set and MUST include the new negotiated
 protocol version.
 
 The client MUST set the VERSION flag and include its selected version on all
-packets until it starts protecting packets with 1-RTT keys.  Only unprotected
-packets and 0-RTT protected packets can include a version.  A client MUST NOT
-change the version it uses unless it is in response to a version negotiation
-packet from the server.
+packets until it has 1-RTT keys and it has received a packet from the server
+that does not have the VERSION flag set.  With TLS, this means that unprotected
+packets and 0-RTT protected packets all include a version field.
+
+A client MUST NOT change the version it uses unless it is in response to a
+version negotiation packet from the server.  Once a client receives a packet
+from the server with the VERSION flag unset, it MUST ignore the flag in
+subsequently received packets.
 
 Version negotiation uses unprotected data. The result of the negotiation MUST
 be revalidated once the cryptographic handshake has completed (see


### PR DESCRIPTION
This aligns the transport draft with the tls draft.

The primary reason for using this identification is that there are three types
of keys that are in concurrent use during a 0-RTT handshake: unprotected
(cleartext), 0-RTT and 1-RTT.  Identifying 0-RTT packets this way allows the
server to avoid trial decryption.