### PR TITLE
Rewrite the section about experimentation to make clear that you

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -314,7 +314,8 @@ Version numbers used to identify IETF drafts are created by adding the draft
 number to 0xff000000.  For example, draft-ietf-quic-transport-13 would be
 identified as 0xff00000D.
 
-Versions of QUIC that are used for experimentation are coordinated on the
+Implementors are encouraged to register version numbers of QUIC that they
+are using for private experimentation on the
 [github wiki](https://github.com/quicwg/base-drafts/wiki/QUIC-Versions).
 
 


### PR DESCRIPTION
are registering your private experimental versions, not that you
are registering the versions people are using for interop testing.