### PR TITLE
Fixing the bit typos in error ranges

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1234,87 +1234,87 @@ packets as indicative of an attack.
 # Error codes {#errors}
 
 The portion of the QUIC error code space allocated for the crypto handshake is
-0xB000-0xFFFF. The following error codes are defined when TLS is used for the
+0xC0000000-0xFFFFFFFF. The following error codes are defined when TLS is used for the
 crypto handshake:
 
-TLS_HANDSHAKE_FAILED (0xB01c):
+TLS_HANDSHAKE_FAILED (0xC000001C):
 : Crypto errors. Handshake failed.
 
-TLS_MESSAGE_OUT_OF_ORDER (0xB01d):
+TLS_MESSAGE_OUT_OF_ORDER (0xC000001D):
 : Handshake message received out of order.
 
-TLS_TOO_MANY_ENTRIES (0xB01e):
+TLS_TOO_MANY_ENTRIES (0xC000001E):
 : Handshake message contained too many entries.
 
-TLS_INVALID_VALUE_LENGTH (0xB01f):
+TLS_INVALID_VALUE_LENGTH (0xC000001F):
 : Handshake message contained an invalid value length.
 
-TLS_MESSAGE_AFTER_HANDSHAKE_COMPLETE (0xB020):
+TLS_MESSAGE_AFTER_HANDSHAKE_COMPLETE (0xC0000020):
 : A handshake message was received after the handshake was complete.
 
-TLS_INVALID_RECORD_TYPE (0xB021):
+TLS_INVALID_RECORD_TYPE (0xC0000021):
 : A handshake message was received with an illegal record type.
 
-TLS_INVALID_PARAMETER (0xB022):
+TLS_INVALID_PARAMETER (0xC0000022):
 : A handshake message was received with an illegal parameter.
 
-TLS_INVALID_CHANNEL_ID_SIGNATURE (0xB034):
+TLS_INVALID_CHANNEL_ID_SIGNATURE (0xC0000034):
 : An invalid channel id signature was supplied.
 
-TLS_MESSAGE_PARAMETER_NOT_FOUND (0xB023):
+TLS_MESSAGE_PARAMETER_NOT_FOUND (0xC0000023):
 : A handshake message was received with a mandatory parameter missing.
 
-TLS_MESSAGE_PARAMETER_NO_OVERLAP (0xB024):
+TLS_MESSAGE_PARAMETER_NO_OVERLAP (0xC0000024):
 : A handshake message was received with a parameter that has no overlap with the
   local parameter.
 
-TLS_MESSAGE_INDEX_NOT_FOUND (0xB025):
+TLS_MESSAGE_INDEX_NOT_FOUND (0xC0000025):
 : A handshake message was received that contained a parameter with too few
   values.
 
-TLS_UNSUPPORTED_PROOF_DEMAND (0xB05e):
+TLS_UNSUPPORTED_PROOF_DEMAND (0xC000005E):
 : A demand for an unsupported proof type was received.
 
-TLS_INTERNAL_ERROR (0xB026):
+TLS_INTERNAL_ERROR (0xC0000026):
 : An internal error occured in handshake processing.
 
-TLS_VERSION_NOT_SUPPORTED (0xB027):
+TLS_VERSION_NOT_SUPPORTED (0xC0000027):
 : A handshake handshake message specified an unsupported version.
 
-TLS_HANDSHAKE_STATELESS_REJECT (0xB048):
+TLS_HANDSHAKE_STATELESS_REJECT (0xC0000048):
 : A handshake handshake message resulted in a stateless reject.
 
-TLS_NO_SUPPORT (0xB028):
+TLS_NO_SUPPORT (0xC0000028):
 : There was no intersection between the crypto primitives supported by the peer
   and ourselves.
 
-TLS_TOO_MANY_REJECTS (0xB029):
+TLS_TOO_MANY_REJECTS (0xC0000029):
 : The server rejected our client hello messages too many times.
 
-TLS_PROOF_INVALID (0xB02a):
+TLS_PROOF_INVALID (0xC000002A):
 : The client rejected the server's certificate chain or signature.
 
-TLS_DUPLICATE_TAG (0xB02b):
+TLS_DUPLICATE_TAG (0xC000002B):
 : A handshake message was received with a duplicate tag.
 
-TLS_ENCRYPTION_LEVEL_INCORRECT (0xB02c):
+TLS_ENCRYPTION_LEVEL_INCORRECT (0xC000002C):
 : A handshake message was received with the wrong encryption level (i.e. it
   should have been encrypted but was not.)
 
-TLS_SERVER_CONFIG_EXPIRED (0xB02d):
+TLS_SERVER_CONFIG_EXPIRED (0xC000002D):
 : The server config for a server has expired.
 
-TLS_SYMMETRIC_KEY_SETUP_FAILED (0xB035):
+TLS_SYMMETRIC_KEY_SETUP_FAILED (0xC0000035):
 : We failed to set up the symmetric keys for a connection.
 
-TLS_MESSAGE_WHILE_VALIDATING_CLIENT_HELLO (0xB036):
+TLS_MESSAGE_WHILE_VALIDATING_CLIENT_HELLO (0xC0000036):
 : A handshake message arrived, but we are still validating the previous
   handshake message.
 
-TLS_UPDATE_BEFORE_HANDSHAKE_COMPLETE (0xB041):
+TLS_UPDATE_BEFORE_HANDSHAKE_COMPLETE (0xC0000041):
 : A server config update arrived before the handshake is complete.
 
-TLS_CLIENT_HELLO_TOO_LARGE (0xB05a):
+TLS_CLIENT_HELLO_TOO_LARGE (0xC000005A):
 : ClientHello cannot fit in one packet.
 
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1748,18 +1748,18 @@ to get blocked.
 Error codes are 32 bits long, with the first two bits indicating the source of
 the error code:
 
-0x0000-0x3FFF:
+0x00000000-0x3FFFFFFF:
 : Application-specific error codes.  Defined by each application-layer protocol.
 
-0x4000-0x7FFF:
+0x40000000-0x7FFFFFFF:
 : Reserved for host-local error codes.  These codes MUST NOT be sent to a peer,
   but MAY be used in API return codes and logs.
 
-0x8000-0xAFFF:
+0x80000000-0xBFFFFFFF:
 : QUIC transport error codes, including packet protection errors.  Applicable to
   all uses of QUIC.
 
-0xB000-0xFFFF:
+0xC0000000-0xFFFFFFFF:
 : Cryptographic error codes.  Defined by the crypto handshake protocol in use.
 
 This section lists the defined QUIC transport error codes that may be used in a
@@ -1767,166 +1767,166 @@ CONNECTION_CLOSE or RST_STREAM frame. Error codes share a common code space.
 Some error codes apply only to either streams or the entire connection and have
 no defined semantics in the other context.
 
-QUIC_INTERNAL_ERROR (0x8001):
+QUIC_INTERNAL_ERROR (0x80000001):
 : Connection has reached an invalid state.
 
-QUIC_STREAM_DATA_AFTER_TERMINATION (0x8002):
+QUIC_STREAM_DATA_AFTER_TERMINATION (0x80000002):
 : There were data frames after the a fin or reset.
 
-QUIC_INVALID_PACKET_HEADER (0x8003):
+QUIC_INVALID_PACKET_HEADER (0x80000003):
 : Control frame is malformed.
 
-QUIC_INVALID_FRAME_DATA (0x8004):
+QUIC_INVALID_FRAME_DATA (0x80000004):
 : Frame data is malformed.
 
-QUIC_MISSING_PAYLOAD (0x8030):
+QUIC_MISSING_PAYLOAD (0x80000030):
 : The packet contained no payload.
 
-QUIC_INVALID_STREAM_DATA (0x802e):
+QUIC_INVALID_STREAM_DATA (0x8000002E):
 : STREAM frame data is malformed.
 
-QUIC_OVERLAPPING_STREAM_DATA (0x8057):
+QUIC_OVERLAPPING_STREAM_DATA (0x80000057):
 : STREAM frame data overlaps with buffered data.
 
-QUIC_UNENCRYPTED_STREAM_DATA (0x803d):
+QUIC_UNENCRYPTED_STREAM_DATA (0x8000003D):
 : Received STREAM frame data is not encrypted.
 
-QUIC_MAYBE_CORRUPTED_MEMORY (0x8059):
+QUIC_MAYBE_CORRUPTED_MEMORY (0x80000059):
 : Received a frame which is likely the result of memory corruption.
 
-QUIC_INVALID_RST_STREAM_DATA (0x8006):
+QUIC_INVALID_RST_STREAM_DATA (0x80000006):
 : RST_STREAM frame data is malformed.
 
-QUIC_INVALID_CONNECTION_CLOSE_DATA (0x8007):
+QUIC_INVALID_CONNECTION_CLOSE_DATA (0x80000007):
 : CONNECTION_CLOSE frame data is malformed.
 
-QUIC_INVALID_GOAWAY_DATA (0x8008):
+QUIC_INVALID_GOAWAY_DATA (0x80000008):
 : GOAWAY frame data is malformed.
 
-QUIC_INVALID_WINDOW_UPDATE_DATA (0x8039):
+QUIC_INVALID_WINDOW_UPDATE_DATA (0x80000039):
 : WINDOW_UPDATE frame data is malformed.
 
-QUIC_INVALID_BLOCKED_DATA (0x803a):
+QUIC_INVALID_BLOCKED_DATA (0x8000003A):
 : BLOCKED frame data is malformed.
 
-QUIC_INVALID_STOP_WAITING_DATA (0x803c):
+QUIC_INVALID_STOP_WAITING_DATA (0x8000003C):
 : STOP_WAITING frame data is malformed.
 
-QUIC_INVALID_PATH_CLOSE_DATA (0x804e):
+QUIC_INVALID_PATH_CLOSE_DATA (0x8000004E):
 : PATH_CLOSE frame data is malformed.
 
-QUIC_INVALID_ACK_DATA (0x8009):
+QUIC_INVALID_ACK_DATA (0x80000009):
 : ACK frame data is malformed.
 
-QUIC_INVALID_VERSION_NEGOTIATION_PACKET (0x800a):
+QUIC_INVALID_VERSION_NEGOTIATION_PACKET (0x8000000A):
 : Version negotiation packet is malformed.
 
-QUIC_INVALID_PUBLIC_RST_PACKET (0x800b):
+QUIC_INVALID_PUBLIC_RST_PACKET (0x8000000b):
 : Public RST packet is malformed.
 
-QUIC_DECRYPTION_FAILURE (0x800c):
+QUIC_DECRYPTION_FAILURE (0x8000000c):
 : There was an error decrypting.
 
-QUIC_ENCRYPTION_FAILURE (0x800d):
+QUIC_ENCRYPTION_FAILURE (0x8000000d):
 : There was an error encrypting.
 
-QUIC_PACKET_TOO_LARGE (0x800e):
+QUIC_PACKET_TOO_LARGE (0x8000000e):
 : The packet exceeded kMaxPacketSize.
 
-QUIC_PEER_GOING_AWAY (0x8010):
+QUIC_PEER_GOING_AWAY (0x80000010):
 : The peer is going away. May be a client or server.
 
-QUIC_INVALID_STREAM_ID (0x8011):
+QUIC_INVALID_STREAM_ID (0x80000011):
 : A stream ID was invalid.
 
-QUIC_INVALID_PRIORITY (0x8031):
+QUIC_INVALID_PRIORITY (0x80000031):
 : A priority was invalid.
 
-QUIC_TOO_MANY_OPEN_STREAMS (0x8012):
+QUIC_TOO_MANY_OPEN_STREAMS (0x80000012):
 : Too many streams already open.
 
-QUIC_TOO_MANY_AVAILABLE_STREAMS (0x804c):
+QUIC_TOO_MANY_AVAILABLE_STREAMS (0x8000004c):
 : The peer created too many available streams.
 
-QUIC_PUBLIC_RESET (0x8013):
+QUIC_PUBLIC_RESET (0x80000013):
 : Received public reset for this connection.
 
-QUIC_INVALID_VERSION (0x8014):
+QUIC_INVALID_VERSION (0x80000014):
 : Invalid protocol version.
 
-QUIC_INVALID_HEADER_ID (0x8016):
+QUIC_INVALID_HEADER_ID (0x80000016):
 : The Header ID for a stream was too far from the previous.
 
-QUIC_INVALID_NEGOTIATED_VALUE (0x8017):
+QUIC_INVALID_NEGOTIATED_VALUE (0x80000017):
 : Negotiable parameter received during handshake had invalid value.
 
-QUIC_DECOMPRESSION_FAILURE (0x8018):
+QUIC_DECOMPRESSION_FAILURE (0x80000018):
 : There was an error decompressing data.
 
-QUIC_NETWORK_IDLE_TIMEOUT (0x8019):
+QUIC_NETWORK_IDLE_TIMEOUT (0x80000019):
 : The connection timed out due to no network activity.
 
-QUIC_HANDSHAKE_TIMEOUT (0x8043):
+QUIC_HANDSHAKE_TIMEOUT (0x80000043):
 : The connection timed out waiting for the handshake to complete.
 
-QUIC_ERROR_MIGRATING_ADDRESS (0x801a):
+QUIC_ERROR_MIGRATING_ADDRESS (0x8000001a):
 : There was an error encountered migrating addresses.
 
-QUIC_ERROR_MIGRATING_PORT (0x8056):
+QUIC_ERROR_MIGRATING_PORT (0x80000056):
 : There was an error encountered migrating port only.
 
-QUIC_EMPTY_STREAM_FRAME_NO_FIN (0x8032):
+QUIC_EMPTY_STREAM_FRAME_NO_FIN (0x80000032):
 : We received a STREAM_FRAME with no data and no fin flag set.
 
-QUIC_FLOW_CONTROL_RECEIVED_TOO_MUCH_DATA (0x803b):
+QUIC_FLOW_CONTROL_RECEIVED_TOO_MUCH_DATA (0x8000003b):
 : The peer received too much data, violating flow control.
 
-QUIC_FLOW_CONTROL_SENT_TOO_MUCH_DATA (0x803f):
+QUIC_FLOW_CONTROL_SENT_TOO_MUCH_DATA (0x8000003f):
 : The peer sent too much data, violating flow control.
 
-QUIC_FLOW_CONTROL_INVALID_WINDOW (0x8040):
+QUIC_FLOW_CONTROL_INVALID_WINDOW (0x80000040):
 : The peer received an invalid flow control window.
 
-QUIC_CONNECTION_IP_POOLED (0x803e):
+QUIC_CONNECTION_IP_POOLED (0x8000003e):
 : The connection has been IP pooled into an existing connection.
 
-QUIC_TOO_MANY_OUTSTANDING_SENT_PACKETS (0x8044):
+QUIC_TOO_MANY_OUTSTANDING_SENT_PACKETS (0x80000044):
 : The connection has too many outstanding sent packets.
 
-QUIC_TOO_MANY_OUTSTANDING_RECEIVED_PACKETS (0x8045):
+QUIC_TOO_MANY_OUTSTANDING_RECEIVED_PACKETS (0x80000045):
 : The connection has too many outstanding received packets.
 
-QUIC_CONNECTION_CANCELLED (0x8046):
+QUIC_CONNECTION_CANCELLED (0x80000046):
 : The QUIC connection has been cancelled.
 
-QUIC_BAD_PACKET_LOSS_RATE (0x8047):
+QUIC_BAD_PACKET_LOSS_RATE (0x80000047):
 : Disabled QUIC because of high packet loss rate.
 
-QUIC_PUBLIC_RESETS_POST_HANDSHAKE (0x8049):
+QUIC_PUBLIC_RESETS_POST_HANDSHAKE (0x80000049):
 : Disabled QUIC because of too many PUBLIC_RESETs post handshake.
 
-QUIC_TIMEOUTS_WITH_OPEN_STREAMS (0x804a):
+QUIC_TIMEOUTS_WITH_OPEN_STREAMS (0x8000004a):
 : Disabled QUIC because of too many timeouts with streams open.
 
-QUIC_TOO_MANY_RTOS (0x8055):
+QUIC_TOO_MANY_RTOS (0x80000055):
 : QUIC timed out after too many RTOs.
 
-QUIC_ENCRYPTION_LEVEL_INCORRECT (0x802c):
+QUIC_ENCRYPTION_LEVEL_INCORRECT (0x8000002c):
 : A packet was received with the wrong encryption level (i.e. it should
   have been encrypted but was not.)
 
-QUIC_VERSION_NEGOTIATION_MISMATCH (0x8037):
+QUIC_VERSION_NEGOTIATION_MISMATCH (0x80000037):
 : This connection involved a version negotiation which appears to have been
   tampered with.
 
-QUIC_IP_ADDRESS_CHANGED (0x8050):
+QUIC_IP_ADDRESS_CHANGED (0x80000050):
 : IP address changed causing connection close.
 
-QUIC_TOO_MANY_FRAME_GAPS (0x805d):
+QUIC_TOO_MANY_FRAME_GAPS (0x8000005d):
 : Stream frames arrived too discontiguously so that stream sequencer buffer
   maintains too many gaps.
 
-QUIC_TOO_MANY_SESSIONS_ON_SERVER (0x8060):
+QUIC_TOO_MANY_SESSIONS_ON_SERVER (0x80000060):
 : Connection closed because server hit max number of sessions allowed.
 
 


### PR DESCRIPTION
As someone pointed out in the interim, my updated version ranges are only 16 bits wide, not 32 bits.  I also incorrectly separated the transport and TLS regions, which means all of the TLS errors were off.  This pull request fixes those typos.