### PR TITLE
Error Codes at a consistent offset

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1199,25 +1199,25 @@ stream.  The frame is as follows:
  0                   1                   2                   3
  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                        Error Code (32)                        |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                        Stream ID (32)                         |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                                                               |
 +                        Byte Offset (64)                       +
 |                                                               |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                        Error Code (32)                        |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 ~~~
 
 The fields are:
+
+* Error code: A 32-bit error code which indicates why the stream is being
+  closed.
 
 * Stream ID: The 32-bit Stream ID of the stream being terminated.
 
 * Byte offset: A 64-bit unsigned integer indicating the absolute byte offset of
   the end of data written on this stream by the RST_STREAM sender.
-
-* Error code: A 32-bit error code which indicates why the stream is being
-  closed.
 
 ## PADDING Frame {#frame-padding}
 


### PR DESCRIPTION
The Error Code field in RST_STREAM is at the end of the frame, while for GOAWAY and CONNECTION_CLOSE, it's at the beginning of the frame.  @martinthomson had suggested making these consistent, so I went with the majority.