### PR TITLE
clarify 5.2.2 frame type enumerations

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -559,16 +559,16 @@ document.
 +------------------|--------------------|----------------------------+
 | Type-field value |     Frame type     | Definition                 |
 +------------------|--------------------|----------------------------+
-| `1FDOOOSS`       |  STREAM            | {{frame-stream}}           |
-| `01NULLMM`       |  ACK               | {{frame-ack}}              |
-| 00000000 (0x00)  |  PADDING           | {{frame-padding}}          |
-| 00000001 (0x01)  |  RST_STREAM        | {{frame-rst-stream}}       |
-| 00000010 (0x02)  |  CONNECTION_CLOSE  | {{frame-connection-close}} |
-| 00000011 (0x03)  |  GOAWAY            | {{frame-goaway}}           |
-| 00000100 (0x04)  |  WINDOW_UPDATE     | {{frame-window-update}}    |
-| 00000101 (0x05)  |  BLOCKED           | {{frame-blocked}}          |
-| 00000110 (0x06)  |  STOP_WAITING      | {{frame-stop-waiting}}     |
-| 00000111 (0x07)  |  PING              | {{frame-ping}}             |
+| 0x00             |  PADDING           | {{frame-padding}}          |
+| 0x01             |  RST_STREAM        | {{frame-rst-stream}}       |
+| 0x02             |  CONNECTION_CLOSE  | {{frame-connection-close}} |
+| 0x03             |  GOAWAY            | {{frame-goaway}}           |
+| 0x04             |  WINDOW_UPDATE     | {{frame-window-update}}    |
+| 0x05             |  BLOCKED           | {{frame-blocked}}          |
+| 0x06             |  STOP_WAITING      | {{frame-stop-waiting}}     |
+| 0x07             |  PING              | {{frame-ping}}             |
+| 0x40 - 0x7f      |  ACK               | {{frame-ack}}              |
+| 0x80 - 0xff      |  STREAM            | {{frame-stream}}           |
 +------------------|--------------------|----------------------------+
 
 ## Version Negotiation Packet


### PR DESCRIPTION
I've always found 5.2.2's use of 1fdoooss and 01nullmm more confusing than helpful when trying to figure out what the frame type enumerations are. They are well defined later on in the STREAM and ACK frame definitions, but in the general frame type section it reads a bit unclear to me. This PR just enumerates the type ranges of each frame type and forgoes the bit level definitions.