### PR TITLE
Add two error codes from Chromium's RST_STREAM enum

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1885,6 +1885,12 @@ QUIC_INVALID_PACKET_HEADER (0x80000003):
 QUIC_INVALID_FRAME_DATA (0x80000004):
 : Frame data is malformed.
 
+QUIC_MULTIPLE_TERMINATION_OFFSETS (0x80000005):
+: Multiple final offset values were received on the same stream
+
+QUIC_STREAM_CANCELLED (0x80000006):
+: The stream was cancelled
+
 QUIC_MISSING_PAYLOAD (0x80000030):
 : The packet contained no payload.
 


### PR DESCRIPTION
Having gone through the list in #19, almost all of them are host-local or duplicative of error codes we already have (e.g. if the error space is shared, we don't need both `QUIC_TOO_MANY_OPEN_STREAMS` and `QUIC_REFUSED_STREAM`, though we can debate which is the clearer name).  This adds the two that appear to be unique; if there are others that belong in the core docs, please argue for them.

Closes #19.