### PR TITLE
Expand source address validation text

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -436,11 +436,11 @@ response, QUIC provides one of three responses:
 
 If QUIC requests source address validation, it also provides a new address
 validation token.  TLS includes that along with any information it requires in
-the cookie extension of the TLS HelloRetryRequest message.  In the other cases,
+the cookie extension of a TLS HelloRetryRequest message.  In the other cases,
 the connection either proceeds or terminates with a handshake error.
 
 The client echoes the cookie extension in a second ClientHello.  A ClientHello
-that contains a cookie extension will be always be in response to a
+that contains a valid cookie extension will be always be in response to a
 HelloRetryRequest.  If address validation was requested by QUIC, then this will
 include an address validation token.  TLS makes a second address validation
 request of QUIC, including the value extracted from the cookie extension.  In
@@ -1054,6 +1054,9 @@ ticket.  This might be done to refresh the ticket or token, or it might be
 generated in response to changes in the state of the connection.  QUIC can
 request that a NewSessionTicket be sent by providing a new address validation
 token.
+
+A server that intends to support 0-RTT SHOULD provide an address validation
+token immediately after completing the TLS handshake.
 
 
 ## Address Validation Token Integrity {#validation-token-integrity}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -936,9 +936,9 @@ validation is performed by the core transport protocol.
 ### Client Address Validation Procedure
 
 QUIC uses token-based address validation.  Any time the server wishes to
-validate a client address, it provides the client with a token.  If the client
-is able to return that token, it proves to the server that it received the
-token.
+validate a client address, it provides the client with a token.  As long as the
+token cannot be easily guessed (see {{token-integrity}}), if the client is able
+to return that token, it proves to the server that it received the token.
 
 During the processing of the cryptographic handshake messages from a client, TLS
 will request that the transport make a decision about whether to proceed based
@@ -988,12 +988,18 @@ client with the token.  In TLS the token is included in the ticket that is used
 for resumption and 0-RTT, which is carried in a NewSessionTicket message.
 
 
-### Address Validation Token Integrity
+### Address Validation Token Integrity {#token-integrity}
+
+An address validation token MUST be difficult to guess.  Including a large
+enough random value in the token would be sufficient, but this depends on the
+server remembering the value it sends to clients.
 
 A token-based scheme allows the server to offload any state associated with
 validation to the client.  For this design to work, the token MUST be covered by
-integrity protection.  Without integrity protection, malicious clients could
-generate or guess values for tokens that would be accepted by the server.
+integrity protection against modification or falsification by clients.  Without
+integrity protection, malicious clients could generate or guess values for
+tokens that would be accepted by the server.  Only the server requires access to
+the integrity protection key for tokens.
 
 In TLS the address validation token is often bundled with the information that
 TLS requires, such as the resumption secret.  In this case, adding integrity

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -941,24 +941,24 @@ token cannot be easily guessed (see {{token-integrity}}), if the client is able
 to return that token, it proves to the server that it received the token.
 
 During the processing of the cryptographic handshake messages from a client, TLS
-will request that the transport make a decision about whether to proceed based
-on the information it has.  TLS will provide the transport with any token that
-was provided by the client.  For an initial packet, the transport can decide to
-abort the connection, allow it to proceed, or request address validation.
+will request that QUIC make a decision about whether to proceed based on the
+information it has.  TLS will provide QUIC with any token that was provided by
+the client.  For an initial packet, QUIC can decide to abort the connection,
+allow it to proceed, or request address validation.
 
-If the transport decides to request address validation, it provides the
-cryptographic handshake with a token.  The contents of this token are consumed
-by the server that generates the token, so there is no need for a single
-well-defined format.  A token could include information about the claimed client
-address (IP and port), and any other supplementary information the server will
-need to validate the token in the future.
+If QUIC decides to request address validation, it provides the cryptographic
+handshake with a token.  The contents of this token are consumed by the server
+that generates the token, so there is no need for a single well-defined format.
+A token could include information about the claimed client address (IP and
+port), a timestamp, and any other supplementary information the server will need
+to validate the token in the future.
 
 The cryptographic handshake is responsible for enacting validation by sending
 the address validation token to the client.  A legitimate client will include a
-copy of the token when they attempt to continue the handshake.  The
-cryptographic handshake extracts the token then asks the transport a second time
-whether the token is acceptable.  In response, the transport can either abort
-the connection or permit it to proceed.
+copy of the token when it attempts to continue the handshake.  The cryptographic
+handshake extracts the token then asks QUIC a second time whether the token is
+acceptable.  In response, QUIC can either abort the connection or permit it to
+proceed.
 
 A connection MAY be accepted without address validation - or with only limited
 validation - but a server SHOULD limit the data it sends toward an unvalidated
@@ -981,8 +981,8 @@ number is the same on two different connections; validating the port is
 therefore unlikely to be successful.
 
 This token can be provided to the cryptographic handshake immediately after
-establishing a connection.  The transport might also generate an updated token
-if significant time passes or the client address changes for any reason (see
+establishing a connection.  QUIC might also generate an updated token if
+significant time passes or the client address changes for any reason (see
 {{migration}}).  The cryptographic handshake is responsible for providing the
 client with the token.  In TLS the token is included in the ticket that is used
 for resumption and 0-RTT, which is carried in a NewSessionTicket message.
@@ -1006,8 +1006,9 @@ TLS requires, such as the resumption secret.  In this case, adding integrity
 protection can be delegated to the cryptographic handshake protocol, avoiding
 redundant protection.  If integrity protection is delegated to the cryptographic
 handshake, an integrity failure will result in immediate cryptographic handshake
-failure.  If integrity protection is performed by the transport, the transport
-MUST abort the connection if the integrity check fails with a TBD error code.
+failure.  If integrity protection is performed by QUIC, QUIC MUST abort the
+connection if the integrity check fails with a QUIC_ADDRESS_VALIDATION_FAILURE
+error code.
 
 
 ## Connection Migration {#migration}
@@ -2265,6 +2266,9 @@ QUIC_VERSION_NEGOTIATION_MISMATCH (0x80000037):
 
 QUIC_IP_ADDRESS_CHANGED (0x80000050):
 : IP address changed causing connection close.
+
+QUIC_ADDRESS_VALIDATION_FAILURE (0x80000051):
+: Client address validation failed.
 
 QUIC_TOO_MANY_FRAME_GAPS (0x8000005d):
 : Stream frames arrived too discontiguously so that stream sequencer buffer

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -947,9 +947,11 @@ was provided by the client.  For an initial packet, the transport can decide to
 abort the connection, allow it to proceed, or request address validation.
 
 If the transport decides to request address validation, it provides the
-cryptographic handshake with a token.  This token SHOULD include information
-about the claimed client address (IP and port), and any other supplementary
-information the server will need to validate the token in the future.
+cryptographic handshake with a token.  The contents of this token are consumed
+by the server that generates the token, so there is no need for a single
+well-defined format.  A token could include information about the claimed client
+address (IP and port), and any other supplementary information the server will
+need to validate the token in the future.
 
 The cryptographic handshake is responsible for enacting validation by sending
 the address validation token to the client.  A legitimate client will include a

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -962,7 +962,7 @@ the connection or permit it to proceed.
 
 A connection MAY be accepted without address validation - or with only limited
 validation - but a server SHOULD limit the data it sends toward an unvalidated
-address.  Successful Completion of the cryptographic handshake implicitly
+address.  Successful completion of the cryptographic handshake implicitly
 provides proof that the client has received packets from the server.
 
 


### PR DESCRIPTION
This completes the changes that were started in #120.  As agreed at the interim, TLS will host the source address validation packets, but the transport will be responsible for constructing and validating the token.  I've expanded the detailed interface section to cover this.

There's some finessing in the text around which part adds the integrity check, with the recognition that - because the token will likely be put alongside other TLS information that needs integrity checks - TLS is probably the best place to do that.

This builds on #122 because to do otherwise would be to invite merge conflict hell.  Once that is merged, this will be much easier to review.

Closes #174, #52, #118.