### PR TITLE
Remove stream reservation

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -202,9 +202,9 @@ this stream to be half-closed in the corresponding direction without
 transferring data.
 
 Pairs of streams must be utilized sequentially, with no gaps.  The data stream
-MUST be reserved with the QUIC implementation when the message control stream
-is opened or reserved, and MUST be closed after transferring the body, or else
-closed immediately after sending the request headers if there is no body.
+is opened at the same time as the message control stream is opened and is closed
+after transferring the body.  The data stream is closed immediately after
+sending the request headers if there is no body.
 
 HTTP does not need to do any separate multiplexing when using QUIC - data sent
 over a QUIC stream always maps to a particular HTTP transaction. Requests and

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1572,9 +1572,10 @@ STREAM frame can also cause a stream to immediately become "half-closed".
 
 Receiving a STREAM frame on a peer-initiated stream (that is, a packet sent by a
 server on an even-numbered stream or a client packet on an odd-numbered stream)
-also causes all idle streams with lower numbers to become "open".  This could
-occur if a peer begins sending on streams in a different order to their
-creation, or it could happen if packets are lost or reordered in transit.
+also causes all lower-numbered "idle" streams in the same direction to become
+"open".  This could occur if a peer begins sending on streams in a different
+order to their creation, or it could happen if packets are lost or reordered in
+transit.
 
 Receiving any frame other than STREAM or RST_STREAM on a stream in this state
 MUST be treated as a connection error ({{error-handling}}) of type YYYY.
@@ -1689,8 +1690,8 @@ used for application data, and MUST be the first client-initiated stream.
 
 A QUIC endpoint cannot reuse a StreamID on a given connection.  Streams MUST be
 created in sequential order.  Open streams can be used in any order.  Streams
-that are used out of order result in lower-numbered streams being counted as
-open.
+that are used out of order result in lower-numbered streams in the same
+direction being counted as open.
 
 All streams, including stream 1, count toward this limit.  Thus, a concurrent
 stream limit of 0 will cause a connection to be unusable.  Application protocols


### PR DESCRIPTION
This PR is based on the outcome of the discussion in #174.  The observation there is that using stream X implicitly opens stream X-2; since all streams are opened in sequence, it must just be that the packets that mention stream X-2 got delayed or lost somehow.

Once you accept that, it's also reasonable to allow a different order of stream creation (the point at which numbers are allocated) and stream *use* (when you send packets on a stream).  This neatly addresses the issue whereby server push can promise use of streams, but not use them in the order in which they were promised.

There's a catch here, and it's not one that was introduced by this change, if a server promises more streams than the client permits in its concurrent streams limit, the server cannot use streams beyond the limit.  I'll open a bug on that.

Closes #182 - that removed only a few of the application actions.  This removes all of them.
Closes #174.