### PR TITLE
Cleanup packet number text

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -499,41 +499,41 @@ The fields in a Regular packet past the Common Header are the following:
 ~~~
 {: #regular-packet-frames title="Contents of Encrypted Payload"}
 
-### Packet Number Compression and Reconstruction
 
-The complete packet number is a 64-bit unsigned number and is used as part of a
-cryptographic nonce for packet encryption.  To reduce the number of bits
-required to represent the packet number over the wire, at most 48 bits of the
-packet number are transmitted over the wire.  A QUIC endpoint MUST NOT reuse a
-complete packet number within the same connection (that is, under the same
-cryptographic keys).  If the total number of packets transmitted in this
-connection reaches 2^64 - 1, the sender MUST close the connection by sending a
+## Packet Numbers
+
+The packet number is a 64-bit unsigned number and is used as part of a
+cryptographic nonce for packet encryption.  Each endpoint maintains a separate
+packet number for sending and receiving.  The packet number for sending MUST
+increase by one after sending any packet.
+
+A QUIC endpoint MUST NOT reuse a packet number within the same connection (that
+is, under the same cryptographic keys).  If the packet number for sending
+reaches 2^64 - 1, the sender MUST close the connection by sending a
 CONNECTION_CLOSE frame with the error code QUIC_SEQUENCE_NUMBER_LIMIT_REACHED
-(connection termination is described in {{termination}}.)  For unambiguous
-reconstruction of the complete packet number by a receiver from the lower-order
-bits, a QUIC sender MUST NOT have more than 2^(packet_number_size - 2) in flight
-at any point in the connection.  In other words,
+(connection termination is described in {{termination}}.)
 
-* If a sender sets PACKET_NUMBER_SIZE bits to 11, it MUST NOT have more than
-  (2^46) packets in flight.
+To reduce the number of bits required to represent the packet number over the
+wire, only the least significant bits of the packet number are transmitted over
+the wire, up to 48 bits.  The actual packet number for each packet is
+reconstructed at the receiver based on the largest packet number received on a
+successfully authenticated packet.
 
-* If a sender sets PACKET_NUMBER_SIZE bits to 10, it MUST NOT have more than
-  (2^30) packets in flight.
+A packet number is decoded by finding the packet number value that is closest to
+the next expected packet.  The next expected packet is the highest received
+packet number plus one.  For example, if the highest successfully authenticated
+packet had a packet number of 0xaa82f30e, then a packet containing a 16-bit
+value of 0x1f94 will be decoded as 0xaa831f94.
 
-* If a sender sets PACKET_NUMBER_SIZE bits to 01, it MUST NOT have more than
-  (2^14) packets in flight.
-
-* If a sender sets PACKET_NUMBER_SIZE bits to 00, it MUST NOT have more than
-  (2^6) packets in flight.
-
-  DISCUSS: Should the receiver be required to enforce this rule that the sender
-  MUST NOT exceed the inflight limit?  Specifically, should the receiver drop
-  packets that are received outside this window?
-
-  Any truncated packet number received from a peer MUST be reconstructed as the
-  value closest to the next expected packet number from that peer.
-
-(TODO: Clarify how packet number size can change mid-connection.)
+To enable unambiguous reconstruction of the packet number, an endpoint MUST use
+a packet number size that is able to represent 4 times more packet numbers than
+the endpoint has currently outstanding.  A packet is outstanding if it sent but
+has neither been acknowledged nor been marked as lost (see {{QUIC-RECOVERY}}).
+As a result, the size of the packet number encoding is at least two more than
+the base 2 logarithm of the number of outstanding packets, rounded up.  For
+example, if an endpoint has 14,389 packets outstanding, the next packet uses a
+16-bit or larger packet number encoding; a 32-bit packet number is needed if
+there are 20,000 packets outstanding.
 
 
 ### Initial Packet Number
@@ -546,7 +546,7 @@ packet number.  Once any packet has been acknowledged, subsequent packets can
 use a shorter packet number encoding.
 
 
-### Frames and Frame Types {#frames}
+## Frames and Frame Types {#frames}
 
 A Regular packet MUST contain at least one frame, and MAY contain multiple
 frames and multiple frame types.  Frames MUST fit within a single QUIC packet
@@ -657,10 +657,10 @@ that the client selected.
 
 When the client receives a Version Negotiation packet from the server, it should
 select an acceptable protocol version.  If the server lists an acceptable
-version, the client selects that version and resends all packets using that
-version. The resent packets MUST use new packet numbers.  These packets MUST
-continue to have the VERSION flag set and MUST include the new negotiated
-protocol version.
+version, the client selects that version and reattempts to created a connection
+using that version.  The client MUST update packet numbers when attempting to
+connect with the updated version.  Packets MUST continue to have the VERSION
+flag set and MUST include the new negotiated protocol version.
 
 The client MUST set the VERSION flag and include its selected version on all
 packets until it has 1-RTT keys and it has received a packet from the server
@@ -1390,12 +1390,7 @@ of the connection if all pairs are affected. In this case, an endpoint SHOULD
 send a Public Reset packet to indicate the failure. The application SHOULD
 attempt to use TLS over TCP instead.
 
-A sender bundles one or more frames in a Regular QUIC packet.  A sender MAY
-bundle any set of frames in a packet.  All QUIC packets MUST contain a packet
-number and MAY contain one or more frames ({{frames}}).  Packet numbers MUST be
-unique within a connection and MUST NOT be reused within the same connection.
-Packet numbers MUST be assigned to packets in a strictly monotonically
-increasing order.
+A sender bundles one or more frames in a Regular QUIC packet (see {{frames}}).
 
 A sender SHOULD minimize per-packet bandwidth and computational costs by
 bundling as many frames as possible within a QUIC packet.  A sender MAY wait for

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -505,7 +505,7 @@ The fields in a Regular packet past the Common Header are the following:
 The packet number is a 64-bit unsigned number and is used as part of a
 cryptographic nonce for packet encryption.  Each endpoint maintains a separate
 packet number for sending and receiving.  The packet number for sending MUST
-increase by one after sending any packet.
+increase by at least one after sending any packet.
 
 A QUIC endpoint MUST NOT reuse a packet number within the same connection (that
 is, under the same cryptographic keys).  If the packet number for sending
@@ -529,8 +529,8 @@ To enable unambiguous reconstruction of the packet number, an endpoint MUST use
 a packet number size that is able to represent 4 times more packet numbers than
 the endpoint has currently outstanding.  A packet is outstanding if it sent but
 has neither been acknowledged nor been marked as lost (see {{QUIC-RECOVERY}}).
-As a result, the size of the packet number encoding is at least two more than
-the base 2 logarithm of the number of outstanding packets, rounded up.  For
+As a result, the size of the packet number encoding is at least two more bits
+than the base 2 logarithm of the number of outstanding packets, rounded up.  For
 example, if an endpoint has 14,389 packets outstanding, the next packet uses a
 16-bit or larger packet number encoding; a 32-bit packet number is needed if
 there are 20,000 packets outstanding.
@@ -658,9 +658,10 @@ that the client selected.
 When the client receives a Version Negotiation packet from the server, it should
 select an acceptable protocol version.  If the server lists an acceptable
 version, the client selects that version and reattempts to created a connection
-using that version.  The client MUST update packet numbers when attempting to
-connect with the updated version.  Packets MUST continue to have the VERSION
-flag set and MUST include the new negotiated protocol version.
+using that version.  Though the contents of a packet might not change in
+response to version negotiation, a client MUST increase the packet number it
+uses on every packet it sends.  Packets MUST continue to have the VERSION flag
+set and MUST include the new negotiated protocol version.
 
 The client MUST set the VERSION flag and include its selected version on all
 packets until it has 1-RTT keys and it has received a packet from the server

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -475,8 +475,8 @@ The fields in a Regular packet past the Common Header are the following:
 
 * Packet Number: The lower 8, 16, 32, or 48 bits of the packet number, based on
   the PACKET_NUMBER_SIZE flag.  Each Regular packet is assigned a packet number
-  by the sender.  The first packet sent by an endpoint MUST have a packet number
-  of 1.
+  by the sender.  The first packet number is randomized (see
+  {{initial-packet-number}}.
 
 * Encrypted Payload: The remainder of a Regular packet is both authenticated and
   encrypted once packet protection keys are available.  {{QUIC-TLS}} describes
@@ -534,6 +534,17 @@ at any point in the connection.  In other words,
   value closest to the next expected packet number from that peer.
 
 (TODO: Clarify how packet number size can change mid-connection.)
+
+
+### Initial Packet Number
+
+The initial value for packet number MUST be a 31-bit random number.  That is,
+the value is selected from an uniform random distribution between 0 and 2^31-1.
+
+The first set of packets sent by an endpoint MUST include the low 32-bits of the
+packet number.  Once any packet has been acknowledged, subsequent packets can
+use a shorter packet number encoding.
+
 
 ### Frames and Frame Types {#frames}
 
@@ -1384,9 +1395,7 @@ bundle any set of frames in a packet.  All QUIC packets MUST contain a packet
 number and MAY contain one or more frames ({{frames}}).  Packet numbers MUST be
 unique within a connection and MUST NOT be reused within the same connection.
 Packet numbers MUST be assigned to packets in a strictly monotonically
-increasing order.  The initial packet number used, at both the client and the
-server, MUST be 0.  That is, the first packet in both directions of the
-connection MUST have a packet number of 0.
+increasing order.
 
 A sender SHOULD minimize per-packet bandwidth and computational costs by
 bundling as many frames as possible within a QUIC packet.  A sender MAY wait for


### PR DESCRIPTION
This builds on #283 and it includes fixes the infidelities I noticed but did not fix during the process of creating that PR.

This is intended to be editorial, but it does remove the use of "in flight" as noted in #286.  I have defined "outstanding packets" to be the packets that aren't acknowledged or lost and made the formula count those packets.  I think that's probably not the right thing, and the definition in https://github.com/quicwg/base-drafts/issues/286#issuecomment-278883235 is probably closer to what is intended, but I was trying my best to avoid changing text and this seemed like the right compromise.

If I'm wrong and this isn't editorial, feel free to tell me what to write so that it can remain so.

Closes #285 by removing the offending text.