### PR TITLE
Add a section on stream prioritization

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1762,17 +1762,17 @@ of connection flow control or the current congestion controller state.
 Giving preference to the transmission of its own management frames ensures that
 the protocol functions efficiently.  That is, prioritizing frames other than
 STREAM frames ensures that loss recovery, congestion control, and flow control
-operate effectively.  Prioritizing stream 1 over other streams ensures that the
-cryptographic handshake can complete.
+operate effectively.
 
-Choosing to retransmit data that was already sent and determined to be lost can
-help ensure that flow control doesn't cause underutilization or temporary
-stalling of a connection.  Data sent in STREAM frames counts toward flow control
-limits from the instant it is initially transmitted, and preferring repair of
-lost data over sending new data ensures that receiver memory can be freed more
-quickly.  This is more valuable if the retransmission will repair a gap in a
-stream; retransmitting a gap in stream data potentially allows more octets of
-the stream to be made available.
+Stream 1 MUST be prioritized over other streams prior to the completion of the
+cryptographic handshake.  This includes the retransmission of the second flight
+of client handshake messages, that is, the TLS Finished and any client
+authentication messages.
+
+STREAM frames that are determined to be lost SHOULD be retransmitted before
+sending new data, unless application priorities indicate otherwise.
+Retransmitting lost STREAM frames can fill in gaps, which allows the peer to
+consume already received data and free up flow control window.
 
 
 # Flow Control {#flow-control}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1739,15 +1739,15 @@ is described in the companion document {{QUIC-RECOVERY}}.
 
 Stream multiplexing has a significant effect on application performance if
 resources allocated to streams are correctly prioritized.  Experience with other
-multiplexed protocols, such as HTTP/2 {{?RFC7540}} shows that effective
-prioritization strategies have a significant impact on performance.
+multiplexed protocols, such as HTTP/2 {{?RFC7540}}, shows that effective
+prioritization strategies have a significant positive impact on performance.
 
 QUIC does not provide frames for exchanging priotization information.  Instead
 it relies on receiving priority information from the application that uses QUIC.
 Protocols that use QUIC are able to define any prioritization scheme that suits
 their application semantics.  A protocol might define explicit messages for
-signaling priority, such as those defined in HTTP/2, it could define rules that
-allow an endpoint to determine priority based on context, or it could leave the
+signaling priority, such as those defined in HTTP/2; it could define rules that
+allow an endpoint to determine priority based on context; or it could leave the
 determination to the application.
 
 A QUIC implementation SHOULD provide ways in which an application can indicate


### PR DESCRIPTION
We decided that the transport would need priority but that it would rely on the application (protocol) to provide that information.  This attempts to capture that decision and provides a little guidance on what to prioritize (management stuff over STREAM, STREAM 1 over other streams, retransmissions, and then the rest of the streams according to application-layer priority).

Closes #114, #104.