### PR TITLE
ClientHello needs to fit in a single packet

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -529,6 +529,29 @@ version of TLS.  An endpoint MUST terminate the connection if a version of TLS
 older than 1.3 is negotiated.
 
 
+## ClientHello Size
+
+QUIC requires that the initial handshake packet from a client fit within a
+single packet of 1280 octets.  With framing and packet overheads this value
+could be reduced.
+
+A TLS ClientHello can fit within this limit with ample space remaining.
+However, there are several variables that could cause this limit to be exceeded.
+Implementations are reminded that large session tickets or HelloRetryRequest
+cookies, multiple or large key shares, and long lists of supported ciphers,
+signature algorithms, versions, and other negotiable parameters and extensions
+could cause this message to grow.
+
+For servers, the size of the session tickets and HelloRetryRequest cookie
+extension can have an effect on a client's ability to connect.  Choosing a small
+value increases the probability that these values can be successfully used by a
+client.
+
+A TLS implementation does not need to enforce this size constraint.  QUIC
+padding can be used to reach this size, meaning that a TLS server is unlikely to
+receive a large ClientHello message.
+
+
 ## Peer Authentication
 
 The requirements for authentication depend on the application protocol that is
@@ -1344,11 +1367,11 @@ by an attacker.
 Certificate caching {{?RFC7924}} can reduce the size of the server's handshake
 messages significantly.
 
-A client SHOULD also pad {{!RFC7685}} its ClientHello to at least 1024 octets.
+QUIC requires that the packet containing a ClientHello be padded to 1280 octets.
 A server is less likely to generate a packet reflection attack if the data it
-sends is a small multiple of the data it receives.  A server SHOULD use a
-HelloRetryRequest if the size of the handshake messages it sends is likely to
-exceed the size of the ClientHello.
+sends is a small multiple of this size.  A server SHOULD use a HelloRetryRequest
+if the size of the handshake messages it sends is likely to significantly exceed
+the size of the packet containing the ClientHello.
 
 
 ## Peer Denial of Service {#useless}

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -532,8 +532,8 @@ older than 1.3 is negotiated.
 ## ClientHello Size
 
 QUIC requires that the initial handshake packet from a client fit within a
-single packet of 1280 octets.  With framing and packet overheads this value
-could be reduced.
+single packet of at least 1280 octets.  With framing and packet overheads this
+value could be reduced.
 
 A TLS ClientHello can fit within this limit with ample space remaining.
 However, there are several variables that could cause this limit to be exceeded.
@@ -1367,11 +1367,12 @@ by an attacker.
 Certificate caching {{?RFC7924}} can reduce the size of the server's handshake
 messages significantly.
 
-QUIC requires that the packet containing a ClientHello be padded to at least
-1280 octets.  A server is less likely to generate a packet reflection attack if
-the data it sends is a small multiple of this size.  A server SHOULD use a
-HelloRetryRequest if the size of the handshake messages it sends is likely to
-significantly exceed the size of the packet containing the ClientHello.
+QUIC requires that the packet containing a ClientHello be padded to the size of
+the maximum transmission unit (MTU).  A server is less likely to generate a
+packet reflection attack if the data it sends is a small multiple of this size.
+A server SHOULD use a HelloRetryRequest if the size of the handshake messages it
+sends is likely to significantly exceed the size of the packet containing the
+ClientHello.
 
 
 ## Peer Denial of Service {#useless}

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -539,8 +539,8 @@ A TLS ClientHello can fit within this limit with ample space remaining.
 However, there are several variables that could cause this limit to be exceeded.
 Implementations are reminded that large session tickets or HelloRetryRequest
 cookies, multiple or large key shares, and long lists of supported ciphers,
-signature algorithms, versions, and other negotiable parameters and extensions
-could cause this message to grow.
+signature algorithms, versions, QUIC transport parameters, and other negotiable
+parameters and extensions could cause this message to grow.
 
 For servers, the size of the session tickets and HelloRetryRequest cookie
 extension can have an effect on a client's ability to connect.  Choosing a small
@@ -1367,11 +1367,11 @@ by an attacker.
 Certificate caching {{?RFC7924}} can reduce the size of the server's handshake
 messages significantly.
 
-QUIC requires that the packet containing a ClientHello be padded to 1280 octets.
-A server is less likely to generate a packet reflection attack if the data it
-sends is a small multiple of this size.  A server SHOULD use a HelloRetryRequest
-if the size of the handshake messages it sends is likely to significantly exceed
-the size of the packet containing the ClientHello.
+QUIC requires that the packet containing a ClientHello be padded to at least
+1280 octets.  A server is less likely to generate a packet reflection attack if
+the data it sends is a small multiple of this size.  A server SHOULD use a
+HelloRetryRequest if the size of the handshake messages it sends is likely to
+significantly exceed the size of the packet containing the ClientHello.
 
 
 ## Peer Denial of Service {#useless}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -758,6 +758,16 @@ the cryptographic handshake provides QUIC with:
   client can receive packets that are addressed with the transport address that
   is claimed by the client (see {{source-address-token}})
 
+The initial cryptographic handshake message needs to be sent in a single packet.
+This avoids having toreassemble a message from multiple packets, which would
+require that servers maintain state prior to establishing a connection.  This
+would expose servers to a denial of service risk.
+
+The first client packet of the cryptographic handshake protocol MUST fit within
+a 1280 octet QUIC packet.  this includes overheads that reduce the space
+available to the cryptographic handshake protocol.  Any second attempt that is
+triggered by address validation MUST also fit within a single packet.
+
 Details of how TLS is integrated with QUIC is provided in more detail in
 {{QUIC-TLS}}.
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -758,15 +758,16 @@ the cryptographic handshake provides QUIC with:
   client can receive packets that are addressed with the transport address that
   is claimed by the client (see {{source-address-token}})
 
-The initial cryptographic handshake message needs to be sent in a single packet.
-This avoids having to reassemble a message from multiple packets. This would
-require that servers maintain state prior to establishing a connection, exposing
-servers to a denial of service risk.
+The initial cryptographic handshake message MUST be sent in a single packet.
+Any second attempt that is triggered by address validation MUST also be sent
+within a single packet.  This avoids having to reassemble a message from
+multiple packets.  Reassembling messages requires that a server maintain state
+prior to establishing a connection, exposing the server to a denial of service
+risk.
 
 The first client packet of the cryptographic handshake protocol MUST fit within
-a 1280 octet QUIC packet.  this includes overheads that reduce the space
-available to the cryptographic handshake protocol.  Any second attempt that is
-triggered by address validation MUST also fit within a single packet.
+a 1280 octet QUIC packet.  This includes overheads that reduce the space
+available to the cryptographic handshake protocol.
 
 Details of how TLS is integrated with QUIC is provided in more detail in
 {{QUIC-TLS}}.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -759,9 +759,9 @@ the cryptographic handshake provides QUIC with:
   is claimed by the client (see {{source-address-token}})
 
 The initial cryptographic handshake message needs to be sent in a single packet.
-This avoids having toreassemble a message from multiple packets, which would
-require that servers maintain state prior to establishing a connection.  This
-would expose servers to a denial of service risk.
+This avoids having to reassemble a message from multiple packets. This would
+require that servers maintain state prior to establishing a connection, exposing
+servers to a denial of service risk.
 
 The first client packet of the cryptographic handshake protocol MUST fit within
 a 1280 octet QUIC packet.  this includes overheads that reduce the space


### PR DESCRIPTION
I'm marking this as editorial.  It touches both TLS and transport.  Anyone who thinks that this is OK can merge it.