### PR TITLE
Symbolic labels for some references

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -61,10 +61,8 @@ informative:
 
   RFC3782:
   RFC6582:
-  RFC5827:
   RFC5682:
   RFC6937:
-  I-D.dukkipati-tcpm-tcp-loss-probe:
 
 --- abstract
 
@@ -195,6 +193,10 @@ latency before a userspace QUIC receiver processes a received packet.
 We now describe QUIC's loss detection as functions that should be called on
 packet transmission, when a packet is acked, and timer expiration events.
 
+TODO need an extended discussion of
+{{?I-D.dukkipati-tcpm-tcp-loss-probe LOSS-PROBE}}.
+
+
 ## Constants of interest
 
 Constants used in loss recovery and congestion control are based on a
@@ -308,7 +310,7 @@ Pseudocode for SetLossDetectionAlarm follows:
                          << handshake_count
       handshake_count++;
     else if (largest sent packet is acked):
-      // Early retransmit {{!RFC 5827}}
+      // Early retransmit {{!RFC5827}}
       // with an alarm to reduce spurious retransmits.
       alarm_duration = 0.25 * smoothed_rtt
     else if (tlp_count < kMaxTLPs):
@@ -465,7 +467,7 @@ Pseudocode for SetLossDetectionAlarm follows:
       alarm_duration = alarm_duration << handshake_count
       handshake_count++;
     else if (largest sent packet is acked):
-      // Early retransmit {{!RFC 5827}}
+      // Early retransmit {{!RFC5827}}
       // with an alarm to reduce spurious retransmits.
       alarm_duration = 0.25 * smoothed_rtt
     else if (tlp_count < kMaxTLPs):

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -59,14 +59,6 @@ normative:
 
 informative:
 
-  SST:
-    title: "Structured Streams: A New Transport Abstraction"
-    author:
-      - ins: B. Ford
-    date: 2007-08
-    seriesinfo:
-      ACM SIGCOMM 2007
-
   EARLY-DESIGN:
     title: "QUIC: Multiplexed Transport Over UDP"
     author:
@@ -1600,8 +1592,9 @@ Streams are individually flow controlled, allowing an endpoint to limit memory
 commitment and to apply back pressure.
 
 An alternative view of QUIC streams is as an elastic "message" abstraction,
-similar to the way ephemeral streams are used in SST {{SST}}, which may be a
-more appealing description for some applications.
+similar to the way ephemeral streams are used in SST
+{{?DOI.10.1145/1282427.1282421 SST}}, which may be a more appealing description
+for some applications.
 
 ## Life of a Stream
 


### PR DESCRIPTION
This depends on https://github.com/cabo/kramdown-rfc2629/pull/35, so it won't build right now.