### PR TITLE
GOAWAY needs a maximum stream number in both directions

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1657,6 +1657,11 @@ data.  A GOAWAY frame indicates that any application layer actions on streams
 with higher numbers than those indicated can be safely retried because no data
 was exchanged.
 
+In addition to initiating a graceful shutdown of a connection, GOAWAY MAY be
+sent immediately prior to sending a CONNECTION_CLOSE frame that is sent as a
+result of detecting a fatal error.  Higher-numbered streams than those indicated
+in the GOAWAY frame can then be retried.
+
 For peer-initiated streams, an endpoint might indicate a lower value for the
 highest stream number than the value that might be sent by a peer.  After
 receiving a GOAWAY frame, an endpoint SHOULD send a GOAWAY frame in response to

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1668,14 +1668,6 @@ sent immediately prior to sending a CONNECTION_CLOSE frame that is sent as a
 result of detecting a fatal error.  Higher-numbered streams than those indicated
 in the GOAWAY frame can then be retried.
 
-For peer-initiated streams, an endpoint might indicate a lower value for the
-highest stream number than the value that might be sent by a peer.  After
-receiving a GOAWAY frame, an endpoint SHOULD send a GOAWAY frame in response and
-update the value for streams that it initiates, if the value is lower than the
-one it receives.  If an endpoint does send a GOAWAY in response to another
-GOAWAY, it SHOULD NOT update the value for peer-initiated streams, unless it
-wishes to cancel those streams.
-
 
 # Packetization and Reliability {#packetization}
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1631,15 +1631,15 @@ Error Code:
 Last Client Stream ID:
 
 : The last client-initiated Stream ID which was accepted by the sender of the
-  GOAWAY frame.  All higher-numbered, client-initiated streams (that is, odd
-  numbered streams) are implicitly reset by sending or receiving the GOAWAY
+  GOAWAY frame.  All higher-numbered, client-initiated streams (that is,
+  odd-numbered streams) are implicitly reset by sending or receiving the GOAWAY
   frame.
 
 Last Server Stream ID:
 
 : The last server-initiated Stream ID which was accepted by the sender of the
-  GOAWAY frame.  All higher-numbered, server-initiated streams (that is, even
-  numbered streams) are implicitly reset by sending or receiving the GOAWAY
+  GOAWAY frame.  All higher-numbered, server-initiated streams (that is,
+  even-numbered streams) are implicitly reset by sending or receiving the GOAWAY
   frame.
 
 Reason Phrase Length:

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1630,17 +1630,17 @@ Error Code:
 
 Last Client Stream ID:
 
-: The last client-initiated Stream ID which was accepted by the sender of the
-  GOAWAY frame.  All higher-numbered, client-initiated streams (that is,
-  odd-numbered streams) are implicitly reset by sending or receiving the GOAWAY
-  frame.
+: The highest-numbered, client-initiated stream on which the endpoint sending
+  the GOAWAY frame either sent data, or received and delivered data.  All
+  higher-numbered, client-initiated streams (that is, odd-numbered streams) are
+  implicitly reset by sending or receiving the GOAWAY frame.
 
 Last Server Stream ID:
 
-: The last server-initiated Stream ID which was accepted by the sender of the
-  GOAWAY frame.  All higher-numbered, server-initiated streams (that is,
-  even-numbered streams) are implicitly reset by sending or receiving the GOAWAY
-  frame.
+: The highest-numbered, server-initiated stream on which the endpoint sending
+  the GOAWAY frame either sent data, or received and delivered data.  All
+  higher-numbered, server-initiated streams (that is, even-numbered streams) are
+  implicitly reset by sending or receiving the GOAWAY frame.
 
 Reason Phrase Length:
 
@@ -1651,11 +1651,16 @@ Reason Phrase:
 
 : An optional, human-readable explanation for why the connection was closed.
 
-An endpoint MUST set the value of the Last Client or Server Stream ID to be at
-least as high as the highest-numbered stream on which it either sent or received
-data.  A GOAWAY frame indicates that any application layer actions on streams
-with higher numbers than those indicated can be safely retried because no data
-was exchanged.
+A GOAWAY frame indicates that any application layer actions on streams with
+higher numbers than those indicated can be safely retried because no data was
+exchanged.  An endpoint MUST set the value of the Last Client or Server Stream
+ID to be at least as high as the highest-numbered stream on which it either sent
+data or received and delivered data to the application protocol that uses QUIC.
+
+An endpoint MAY choose a larger stream identifier if it wishes to allow for a
+number of streams to be created.  This is especially valuable for peer-initiated
+streams where packets creating new streams could be in transit; using a larger
+stream number allows those streams to complete.
 
 In addition to initiating a graceful shutdown of a connection, GOAWAY MAY be
 sent immediately prior to sending a CONNECTION_CLOSE frame that is sent as a

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1613,9 +1613,9 @@ those indicated.  The GOAWAY frame is as follows:
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                        Error Code (32)                        |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                    Last Client Stream ID (32)                 |
+|                  Largest Client Stream ID (32)                |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                    Last Server Stream ID (32)                 |
+|                  Largest Server Stream ID (32)                |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |   Reason Phrase Length (16)   |      [Reason Phrase (*)]    ...
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -1628,14 +1628,14 @@ Error Code:
 : A 32-bit field error code which indicates the reason for closing this
   connection.
 
-Last Client Stream ID:
+Largest Client Stream ID:
 
 : The highest-numbered, client-initiated stream on which the endpoint sending
   the GOAWAY frame either sent data, or received and delivered data.  All
   higher-numbered, client-initiated streams (that is, odd-numbered streams) are
   implicitly reset by sending or receiving the GOAWAY frame.
 
-Last Server Stream ID:
+Largest Server Stream ID:
 
 : The highest-numbered, server-initiated stream on which the endpoint sending
   the GOAWAY frame either sent data, or received and delivered data.  All
@@ -1653,9 +1653,10 @@ Reason Phrase:
 
 A GOAWAY frame indicates that any application layer actions on streams with
 higher numbers than those indicated can be safely retried because no data was
-exchanged.  An endpoint MUST set the value of the Last Client or Server Stream
-ID to be at least as high as the highest-numbered stream on which it either sent
-data or received and delivered data to the application protocol that uses QUIC.
+exchanged.  An endpoint MUST set the value of the Largest Client or Server
+Stream ID to be at least as high as the highest-numbered stream on which it
+either sent data or received and delivered data to the application protocol that
+uses QUIC.
 
 An endpoint MAY choose a larger stream identifier if it wishes to allow for a
 number of streams to be created.  This is especially valuable for peer-initiated
@@ -1669,8 +1670,11 @@ in the GOAWAY frame can then be retried.
 
 For peer-initiated streams, an endpoint might indicate a lower value for the
 highest stream number than the value that might be sent by a peer.  After
-receiving a GOAWAY frame, an endpoint SHOULD send a GOAWAY frame in response to
-indicate its own view of which streams are unused.
+receiving a GOAWAY frame, an endpoint SHOULD send a GOAWAY frame in response and
+update the value for streams that it initiates, if the value is lower than the
+one it receives.  If an endpoint does send a GOAWAY in response to another
+GOAWAY, it SHOULD NOT update the value for peer-initiated streams, unless it
+wishes to cancel those streams.
 
 
 # Packetization and Reliability {#packetization}


### PR DESCRIPTION
I have also taken the liberty of updating the text that surrounds the frame type.

@janaiyengar, @mnot, @larseggert, I believe that this is basically a bugfix and it doesn't need any more discussion that it has already.  If you disagree, then we'll hold off on merging until we've had more discussion.

Closes #347.