### PR TITLE
HTTP/2 Guidance and Extensions

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -758,7 +758,6 @@ HTTP_MULTIPLE_SETTINGS (0x10):
 HTTP_RST_CONTROL_STREAM (0x11):
 : A message control stream closed abruptly.
 
-<<<<<<< HEAD
 
 # Considerations for Transitioning from HTTP/2
 
@@ -839,9 +838,6 @@ to the IANA registry in {{iana-settings}}.
 QUIC has the same concepts of "stream" and "connection" errors that HTTP/2
 provides. However, because the error code space is shared between multiple
 components, there is no direct portability of HTTP/2 error codes.
-=======
-## Mapping HTTP/2 Error Codes
->>>>>>> origin/master
 
 The HTTP/2 error codes defined in Section 7 of {{!RFC7540}} map to QUIC error
 codes as follows:

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1078,6 +1078,8 @@ The original authors of this specification were Robbie Shade and Mike Warres.
 
 - 0-RTT guidance added
 
+- Guide to differences from HTTP/2 and porting HTTP/2 extensions added
+
 ## Since draft-ietf-quic-http-00:
 
 - Changed "HTTP/2-over-QUIC" to "HTTP/QUIC" throughout

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -970,11 +970,87 @@ required if the frame is supported over HTTP/2.
 
 ## Settings Parameters {#iana-settings}
 
-TODO:  Register settings
+This document adds two new columns to the "HTTP/2 Settings" registry defined
+in {{!RFC7540}}:
+
+  Supported Protocols:
+  : Indicates which associated protocols use the setting.  Values MUST be one
+    of:
+
+    - "HTTP/2 only"
+    - "HTTP/QUIC only"
+    - "Both"
+
+  HTTP/QUIC Specification:
+  : Indicates where this setting's behavior over QUIC is defined; required
+    if the frame is supported over QUIC.
+
+Values for existing registrations are assigned by this document:
+
+|----------------------------|---------------------|-------------------------|
+| Setting Name               | Supported Protocols | HTTP/QUIC Specification |
+|----------------------------|:-------------------:|-------------------------|
+| HEADER_TABLE_SIZE          | Both                | {{settings-parameters}} |
+| ENABLE_PUSH / DISABLE_PUSH | Both                | {{settings-parameters}} |
+| MAX_CONCURRENT_STREAMS     | HTTP/2 Only         | N/A                     |
+| INITIAL_WINDOW_SIZE        | HTTP/2 Only         | N/A                     |
+| MAX_FRAME_SIZE             | HTTP/2 Only         | N/A                     |
+| MAX_HEADER_LIST_SIZE       | Both                | {{settings-parameters}} |
+|----------------------------|---------------------|-------------------------|
+
+The "Specification" column is renamed to "HTTP/2 Specification" and is only
+required if the setting is supported over HTTP/2.
 
 ## Error Codes {#iana-error-codes}
 
-TODO:  Register error codes
+This document establishes a registry for HTTP/QUIC error codes.  The
+"HTTP/QUIC Error Code" registry manages a 30-bit space.  The "HTTP/QUIC
+Error Code" registry operates under the "Expert Review" policy
+{{?RFC5226}}.
+
+Registrations for error codes are required to include a description
+of the error code.  An expert reviewer is advised to examine new
+registrations for possible duplication with existing error codes.
+Use of existing registrations is to be encouraged, but not mandated.
+
+New registrations are advised to provide the following information:
+
+Name:
+: A name for the error code.  Specifying an error code name is optional.
+
+Code:
+: The 30-bit error code value.
+
+Description:
+: A brief description of the error code semantics, longer if no detailed
+  specification is provided.
+
+Specification:
+: An optional reference for a specification that defines the error code.
+
+The entries in the following table are registered by this document.
+
+|-----------------------------------|--------|----------------------------------------------|------------------------|
+| Name                              | Code   | Description                                  | Specification          |
+|-----------------------------------|--------|----------------------------------------------|------------------------|
+|  HTTP_PUSH_REFUSED                |  0x01  |  Client refused pushed content               |  {{http-error-codes}}  |
+|  HTTP_INTERNAL_ERROR              |  0x02  |  Internal error                              |  {{http-error-codes}}  |
+|  HTTP_PUSH_ALREADY_IN_CACHE       |  0x03  |  Pushed content already cached               |  {{http-error-codes}}  |
+|  HTTP_REQUEST_CANCELLED           |  0x04  |  Data no longer needed                       |  {{http-error-codes}}  |
+|  HTTP_HPACK_DECOMPRESSION_FAILED  |  0x05  |  HPACK cannot continue                       |  {{http-error-codes}}  |
+|  HTTP_CONNECT_ERROR               |  0x06  |  TCP reset or error on CONNECT request       |  {{http-error-codes}}  |
+|  HTTP_EXCESSIVE_LOAD              |  0x07  |  Peer generating excessive load              |  {{http-error-codes}}  |
+|  HTTP_VERSION_FALLBACK            |  0x08  |  Retry over HTTP/2                           |  {{http-error-codes}}  |
+|  HTTP_MALFORMED_HEADERS           |  0x09  |  Invalid HEADERS frame                       |  {{http-error-codes}}  |
+|  HTTP_MALFORMED_PRIORITY          |  0x0A  |  Invalid PRIORITY frame                      |  {{http-error-codes}}  |
+|  HTTP_MALFORMED_SETTINGS          |  0x0B  |  Invalid SETTINGS frame                      |  {{http-error-codes}}  |
+|  HTTP_MALFORMED_PUSH_PROMISE      |  0x0C  |  Invalid PUSH_PROMISE frame                  |  {{http-error-codes}}  |
+|  HTTP_INTERRUPTED_HEADERS         |  0x0E  |  Incomplete HEADERS block                    |  {{http-error-codes}}  |
+|  HTTP_SETTINGS_ON_WRONG_STREAM    |  0x0F  |  SETTINGS frame on a request control stream  |  {{http-error-codes}}  |
+|  HTTP_MULTIPLE_SETTINGS           |  0x10  |  Multiple SETTINGS frames                    |  {{http-error-codes}}  |
+|  HTTP_RST_CONTROL_STREAM          |  0x11  |  Message control stream was RST              |  {{http-error-codes}}  |
+|-----------------------------------|--------|----------------------------------------------|------------------------|
+
 
 --- back
 


### PR DESCRIPTION
Collates the HTTP/2 migration guidance from various places into a single section, and expands on details about how HTTP/2 extensions can be used/ported.  In the process, I added more IANA stuff, which should address the HTTP portion of #359.

Builds on #274; Closes #242.