### PR TITLE
Packet number echo with variable-length numbering

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,13 +59,13 @@ commits will only be responded to with best effort, and may not be seen.
 
 ## Resolving Issues
 
-The `open` issues in the issues list are those that we are currently or plan to discuss. When an issue is `closed`, it implies that the group has consensus and it is reflected in the draft(s). If substantive new information is brought to our attention, issues can be reopened by the Chairs.
-
-Issues will be labeled by the Chairs as either `editorial` or `design`.
+Issues will be labeled by the Chairs as either `editorial` or `design`:
 
 * **Design** issues require discussion and consensus in the Working Group. This discussion can happen both in the issue and on the [Working Group mailing list](https://www.ietf.org/mailman/listinfo/quic), as outlined below.
 
 * **Editorial** issues can be dealt with by the editor(s) without consensus or notification. Typically, any discussion will take place on the issue itself.
+
+The `open` design issues in the issues list are those that we are currently or plan to discuss. When a design issue is `closed`, it implies that the issue has a proposed resolution that is reflected in the drafts; if a `closed` design issue is labeled with `has-consensus`, it means that the incorporated resolution has Working Group consensus.
 
 Design issues can be discussed on the mailing list or the issues list. The editors can also propose resolutions to design issues for the group's consideration by incorporating them into the draft(s).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,27 +65,21 @@ Issues will be labeled by the Chairs as either `editorial` or `design`.
 
 * **Design** issues require discussion and consensus in the Working Group. This discussion can happen both in the issue and on the [Working Group mailing list](https://www.ietf.org/mailman/listinfo/quic), as outlined below.
 
-* **Editorial** issues can be closed by the editor(s) without consensus or notification. Typically, any discussion will take place on the issue itself.
+* **Editorial** issues can be dealt with by the editor(s) without consensus or notification. Typically, any discussion will take place on the issue itself.
 
-Consensus for the resolution of a design issue can be established in a few different ways:
+Design issues can be discussed on the mailing list or the issues list. The editors can also propose resolutions to design issues for the group's consideration by incorporating them into the draft(s).
 
-* Through discussion on the mailing list. Once a resolution is found, it will be recorded in the issue.
+When a new draft is published, the design issues that have been closed since the last draft will be highlighted on the mailing list, to aid reviewers. Once consensus is confirmed, those issues will be labeled with [`has-consensus`](https://github.com/quicwg/base-drafts/issues?utf8=✓&q=label%3Ahas-consensus%20).
 
-* Through discussion on the issues list. Once a resolution is found, it will be confirmed on the mailing list before consensus is declared.
-
-The editors can also propose resolutions for the group's consideration by incorporating them into the draft(s); when doing so, the issue should not be closed until consensus is declared.
-
-Issues that have consensus but which aren't yet reflected in text will be labelled as `editor-ready`. After the editors have incorporated a resolution into the specification, the issue can be closed.
-
-When a new draft is published, the design issues that have been closed since the last draft will be highlighted on the mailing list, to aid reviewers.
+Note that whether or not a design issue is closed does **not** reflect consensus of the Working Group; an issue's `open`/`closed` state is only used to organise our discussions. If you have a question or problem with an issue in the `closed` state, please comment on it (either in the issues list or mailing list), and we'll adjust its state accordingly. Note that reopening issues with `has-consensus` requires new information.
 
 ### Discretionary Design Issue Labels
 
 We also use the following labels to help understand the state of our design issues:
 
-* **Needs Discussion**: The issue needs significant Working Group discussion before it can progress.
-* **Confirm Consensus**: There is a resolution that the proponents believe reflects a consensus position, needs to be confirmed with the WG.
-* **Notify Consensus**: The WG has achieved consensus in a meeting, needs to be confirmed on the mailing list.
+* [`needs-discussion`](https://github.com/quicwg/base-drafts/labels/needs-discussion): The issue needs significant Working Group discussion before it can progress.
+* [`has-proposal`](https://github.com/quicwg/base-drafts/labels/has-proposal): The issue has a proposal for resolution.
+* [`editor-ready`](https://github.com/quicwg/base-drafts/labels/editor-ready): The Working Group believes it has a viable resolution, but the editors need to incorporate that into the document so we can see it in situ.
 
 
 ## Pull Requests

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -466,8 +466,9 @@ Connection ID:
 
 Packet Number:
 
-: The length of the packet number field depends on the packet type.  This field
-  can be 1, 2 or 4 octets long depending on the short packet type; see {{packet-numbers}}.
+: The length of the packet number field depends on the packet type.
+  This field can be 1, 2 or 4 octets long depending on the short packet type; 
+  see {{packet-numbers}}.
 
 Packet Number Echo:
 
@@ -746,12 +747,18 @@ omitted if a 1-RTT packet containing an ACK frame has already been sent during a
 time interval equal to the sender's current estimate of the RTT.
 
 Since the Packet Number and Packet Number Echo fielda are of the same size, a
-sender sending a packet containing a Packet Number Echo determines the size to use as follows:
+sender sending a packet containing a Packet Number Echo determines the size to
+use as follows:
 
-- Let `SIZE_P` be the size of the packet number to be sent, as determined in {{packet-numbers}} above.
-- Let `SIZE_E` be the size of the packet number sent in the packet whose packet number is to be echoed.
-- Let `SIZE_S` be the size of the packet number dictated by the difference between the packet number echo to be sent and the last packet number echo sent; if no packet number echo has yet been sent, then let SIZE_S be 4.
-- Choose the packet number and packet number echo size to send as `max(SIZE_P, SIZE_E, SIZE_S).
+- Let `SIZE_P` be the size of the packet number to be sent, as determined in
+  {{packet-numbers}} above.
+- Let `SIZE_E` be the size of the packet number sent in the packet whose packet
+  number is to be echoed.
+- Let `SIZE_S` be the size of the packet number dictated by the difference
+  between the packet number echo to be sent and the last packet number echo
+  sent; if no packet number echo has yet been sent, then let SIZE_S be 4.
+- Choose the packet number and packet number echo size to send as `max(SIZE_P,
+  SIZE_E, SIZE_S).
 
 ## Handling Packets from Different Versions {#version-specific}
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -497,7 +497,7 @@ A Public Reset packet contains:
 * Octets 1-8: Echoed data (octets 1-8 of received packet)
 * Octets 9-12: Echoed data (octets 9-12 of received packet)
 * Octets 13-16: Version (server version)
-* Octets 17+: Public Reset Proof (optional, TBD)
+* Octets 17+: Public Reset Proof
 
 For a client that sends a connection ID on every packet, a Public Reset
 packet received in response can be simply interpreted as:
@@ -507,22 +507,18 @@ packet received in response can be simply interpreted as:
   on the packet number size used by the client, followed by 0, 2, or 3
   subsequent bytes from the client packet.
 * Octets 13-16: Version (server version)
-* Octets 17+: Public Reset Proof (optional, TBD)
+* Octets 17+: Public Reset Proof
 
-Whether the Public Reset Proof field is included in a Public Reset packet
-depends on the entity that generates the packet.
-
-A Public Reset packet sent by an endpoint indicates that it does not have the
-state necessary to continue with a connection.  In this case, the endpoint will
+A Public Reset packet sent by a server indicates that it does not have the
+state necessary to continue with a connection.  In this case, the server will
 include the fields that prove that it originally participated in the connection
 (see {{public-reset-proof}} for details).
 
-Upon receipt of a Public Reset packet that contains a valid proof, an endpoint
-MUST tear down state associated with the connection.  The endpoint MUST then
+Upon receipt of a Public Reset packet that contains a valid proof, a client
+MUST tear down state associated with the connection.  The client MUST then
 cease sending packets on the connection and SHOULD discard any subsequent
 packets that arrive. A Public Reset that does not contain a valid proof MUST be
 ignored.
-
 
 ### Public Reset Proof
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -376,7 +376,7 @@ Connection ID:
 
 Packet Number:
 
-: Octets 9 to 12 contain a packet number.  {{packet-numbers} describes the use
+: Octets 9 to 12 contain a packet number.  {{packet-numbers}} describes the use
   of packet numbers.
 
 Version:
@@ -423,10 +423,12 @@ semantics are described in {{version-negotiation-packet}},
 |0|C|K|  Type   |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                                                               |
-+                   Connection ID (optional)                    +
++                        [Connection ID]                        +
 |                                                               |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                     Packet Number (1/2/4)                     |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                  [Packet Number Echo (1/2/4)]                 |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                       Encrypted Payload                     ...
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -465,7 +467,13 @@ Connection ID:
 Packet Number:
 
 : The length of the packet number field depends on the packet type.  This field
-  can be 1, 2 or 4 octets long depending on the short packet type.
+  can be 1, 2 or 4 octets long depending on the short packet type; see {{packet-numbers}}.
+
+Packet Number Echo:
+
+: The packet number echo field, if present, contains the highest packet number
+seen in the opposite direction. This field can be absent, or 1, 2, or 4 octets
+long depending on the short packet type; see {{packet-number-echo}}.
 
 Encrypted Payload:
 
@@ -475,11 +483,14 @@ The packet type in a short header currently determines only the size of the
 packet number field.  Additional types can be used to signal the presence of
 other fields.
 
-| Type | Packet Number Size     |
-|:-----|:-----------------------|
-| 01   | 1 octet                |
-| 02   | 2 octets               |
-| 03   | 4 octets               |
+| Type | Packet Number Size     | Packet Number Echo Size |
+|:-----|:-----------------------|-------------------------|
+| 01   | 1 octet                | not present             |
+| 02   | 2 octets               | not present             |
+| 03   | 4 octets               | not present             |
+| 05   | 1 octet                | 1 octet                 |
+| 06   | 2 octets               | 2 octets                |
+| 07   | 4 octets               | 4 octets                |
 {: #short-packet-types title="Short Header Packet Types"}
 
 The header form, connection ID flag and connection ID of a short header packet
@@ -686,7 +697,7 @@ CONNECTION_CLOSE frame with the error code QUIC_SEQUENCE_NUMBER_LIMIT_REACHED
 
 To reduce the number of bits required to represent the packet number over the
 wire, only the least significant bits of the packet number are transmitted over
-the wire, up to 48 bits.  The actual packet number for each packet is
+the wire, up to 32 bits.  The actual packet number for each packet is
 reconstructed at the receiver based on the largest packet number received on a
 successfully authenticated packet.
 
@@ -720,6 +731,27 @@ The first set of packets sent by an endpoint MUST include the low 32-bits of the
 packet number.  Once any packet has been acknowledged, subsequent packets can
 use a shorter packet number encoding.
 
+### Packet Number Echo {#packet-number-echo}
+
+If present, the Packet Number Echo field contains the least significant 8, 16,
+or 32 bits of the highest packet number seen in the opposite direction before
+this packet was sent. This allows devices along the path to estimate round-trip
+times and observe indications of loss, for passive performance measurement of
+QUIC flows equivalent to present techniques using TCP sequence and
+acknowledgement numbers and/or timestamps.
+
+The Packet Number Echo field SHOULD be present on 1-RTT packets containing at
+least one ACK frame (see {{frame-ack}}). For efficiency's sake, it MAY be
+omitted if a 1-RTT packet containing an ACK frame has already been sent during a
+time interval equal to the sender's current estimate of the RTT.
+
+Since the Packet Number and Packet Number Echo fielda are of the same size, a
+sender sending a packet containing a Packet Number Echo determines the size to use as follows:
+
+- Let `SIZE_P` be the size of the packet number to be sent, as determined in {{packet-numbers}} above.
+- Let `SIZE_E` be the size of the packet number sent in the packet whose packet number is to be echoed.
+- Let `SIZE_S` be the size of the packet number dictated by the difference between the packet number echo to be sent and the last packet number echo sent; if no packet number echo has yet been sent, then let SIZE_S be 4.
+- Choose the packet number and packet number echo size to send as `max(SIZE_P, SIZE_E, SIZE_S).
 
 ## Handling Packets from Different Versions {#version-specific}
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -341,7 +341,7 @@ earlier.
 +                        Connection ID                          +
 |                                                               |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                  Packet Number / Proof                        |
+|                        Packet Number                          |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                           Version                             |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -356,27 +356,35 @@ inefficient, long headers MAY be used for 1-RTT packets. The long form allows
 for special packets, such as the version negotiation and the public reset
 packets to be represented in this uniform fixed-length packet format.
 
-The first octet (octet 0) contains the following fields.
+The Flags field (octet 0) contains the following version-independent fields.
 * Bit 0 (0x80): HEADER_FORM, set to 1 for long headers.
 * Bits 1-7: Packet Type, indicating one of 128 packet types. The following types
   are currently defined.
   * 01: Version Negotiation packet (see {{version-negotiation-packet}}.)
   * 02: Public Reset packet (see {{public-reset-packet}}.)
   * 03: Client Cleartext packet (see {{cleartext-packet}}.)
-  * 04: Server Cleartext packet indicating successful handshake (see 
-  {{cleartext-packet}}.)
+  * 04: Server Cleartext End-of-Handshake packet (see {{cleartext-packet}}.)
   * 05: Other Server Cleartext packet (see {{cleartext-packet}}.)
   * 06: 0-RTT Encrypted packet (see {{encrypted-packet}}.)
   * 07: 1-RTT Encrypted packet with key phase 0 (see {{encrypted-packet}}.)
   * 08: 1-RTT Encrypted packet with key phase 1 (see {{encrypted-packet}}.)
 
-The remainder of the packet layout is the same regardless of type, but the
-semantics of the fields are specific to each type (see corresponding sections
-for type-specific semantics.)
+A long-header packet has the following version-independent fields:
+* Octets 1-9: Connection ID
+* Octets 10-14: Packet Number
+* Octets 15-19: Version
 
-Connection ID considerations are discussed in {{connection-id}}. Each packet is
-assigned a packet number by the sender, as described further in
-{{packet-number}}.
+The remainder of the long-header packet is defined to be specific to a version.
+In this version, the rest of the packet contains:
+* Octets 20+: Payload
+
+The packet layout is the same for all long-header packet types, but the
+semantics of the fields are specific to each packet type. Type-specific
+semantics are described in {{version-negotiation-packet}},
+{{public-reset-packet}}, {{cleartext-packet}}, and {{encrypted-packet}}.
+
+Connection ID considerations are discussed in {{connection-id}} and packet
+number considerations in {{packet-number}}.
 
 ## Short Header
 
@@ -420,7 +428,7 @@ this version, it contains:
 * Remainder of this packet: Encrypted Payload (see {{encrypted-payload}}.)
 
 
-## Version Negotiation Packet {version-negotiation-packet}
+## Version Negotiation Packet {#version-negotiation-packet}
 
 A Version Negotiation packet is sent by only the server and is a response to a
 client packet of an unsupported version. It uses a long header and contains:
@@ -428,7 +436,7 @@ client packet of an unsupported version. It uses a long header and contains:
 * Octet 0: 0x81 (Flags indicating long header and Version Negotiation packet 
   type)
 * Octets 1-8: Connection ID (echoed)
-* Octets 9-12: Proof (first 4 octets of client-selected connection ID)
+* Octets 9-12: Packet Number (echoed)
 * Octets 13-16: Version (echoed)
 * Octets 17+: Payload (version list, containing 0 or more acceptable versions)
 
@@ -524,7 +532,7 @@ Details to be added.
 ## Cleartext Packets {#cleartext-packet}
 
 Cleartext packets are sent during the handshake prior to key negotiation. A 
-client Cleartext packet contains:
+Client Cleartext packet contains:
 
 * Octet 0: 0x83 (Flags indicating long header and client Cleartext packet type)
 * Octets 1-8: Connection ID (randomly chosen)
@@ -532,7 +540,7 @@ client Cleartext packet contains:
 * Octets 13-16: Version
 * Octets 17+: Payload
 
-A server Cleartext packet indicating a successful handshake contains:
+A Server Cleartext End-of-Handshake packet contains:
 
 * Octet 0: 0x84 (Flags indicating Long header and appropriate server Cleartext 
   packet type)
@@ -541,7 +549,7 @@ A server Cleartext packet indicating a successful handshake contains:
 * Octets 13-16: Version (echoed)
 * Octets 17+: Payload
 
-Other server Cleartext packets contain:
+Other Server Cleartext packets contain:
 
 * Octet 0: 0x85 (Flags indicating Long header and appropriate server Cleartext 
   packet type)
@@ -550,15 +558,15 @@ Other server Cleartext packets contain:
 * Octets 13-16: Version (echoed)
 * Octets 17+: Payload
 
-
 The client MUST choose a random value and use it as the Connection ID until the
-server replies with a server-selected Connection ID. The client's Connection ID
-is a suggestion to the server, as described further in {{connection-id}}. A
-server may respond to a client Cleartext packet with one of the two server
-Cleartext packets, using the server-selected Connection ID on only the final
-Cleartext packet that indicates successful handshake completion.
+server replies with a server-selected Connection ID. Server-selected Connection
+IDs are used after a successful handshake, cleanly distinguishing packets that
+use them from packets using client-selected Connection IDs. All packets
+including and following a Server Cleartext End-of-Handshake packet use a
+server-selected Connection ID, as described in {{connection-id}}.
 
 The payload of Cleartext packets contains frames, as described in {{frames}}.
+(TODO: Add hash before frames.)
 
 ## Encrypted Packets {#encrypted-packet}
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -325,7 +325,7 @@ describing the value of fields.
 QUIC packet headers can be separated into long and short headers. Long headers
 are expected to be used for the initial phase of the connection and are used for
 version negotiation, connection establishment, 0-RTT, and public reset
-packets. Short headers are minimal version-specific headers, which MAY be used
+packets. Short headers are minimal version-specific headers, which can be used
 after version negotiation and 1-RTT keys are established, and MUST NOT be used
 earlier.
 
@@ -367,7 +367,8 @@ The first octet (octet 0) contains the following fields.
   {{cleartext-packet}}.)
   * 05: Other Server Cleartext packet (see {{cleartext-packet}}.)
   * 06: 0-RTT Encrypted packet (see {{encrypted-packet}}.)
-  * 07: 1-RTT Encrypted packet (see {{encrypted-packet}}.)
+  * 07: 1-RTT Encrypted packet with key phase 0 (see {{encrypted-packet}}.)
+  * 08: 1-RTT Encrypted packet with key phase 1 (see {{encrypted-packet}}.)
 
 The remainder of the packet layout is the same regardless of type, but the
 semantics of the fields are specific to each type (see corresponding sections
@@ -395,8 +396,8 @@ assigned a packet number by the sender, as described further in
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 ```
 
-The short header is used after the version and 1-RTT keys are negotiated. This
-header has the following version-independent fields:
+The short header can be used after the version and 1-RTT keys are negotiated.
+This header has the following version-independent fields:
 * Octet 0: Flags
   * Bit 0 (0x80): HEADER_FORM, set to 0 for short headers.
   * Bit 1: CONNECTION_ID. Indicates presence of Connection ID field following
@@ -407,8 +408,8 @@ The remainder of the short header is defined to be specific to a version. In
 this version, it contains:
 * Octet 0: Flags
   * Bit 2: KEY_PHASE. Used by the QUIC packet protection to identify
-    the correct packet protection keys after the 1-RTT keys are initially
-    established. See {{QUIC-TLS}}.
+    the correct packet protection keys after the 1-RTT keys are established. 
+    See {{QUIC-TLS}} for more details.
   * Bit 3-7: Packet Type, indicating one of 32 packet types. The following types
     are currently defined.
   * 01: 1-RTT packet (packet number size = 1)
@@ -564,12 +565,17 @@ The payload of Cleartext packets contains frames, as described in {{frames}}.
 Packets encrypted with either 0-RTT or 1-RTT keys may be sent with long headers.
 Different packet types explicitly indicate the encryption level for ease of
 decryption. These packets contain:
-* Octet 0: 0x86 or 0x87 (Flags indicating long header and one of the two 
-  encrypted packet types)
+* Octet 0: 0x86, 0x87 or 0x88 (Flags indicating long header and an encrypted 
+  packet type)
 * Octets 1-8: Connection ID (client or server-selected, see {{connectionid}})
 * Octets 9-12: Packet Number (low 4 octets)
 * Octets 13-16: Version
 * Octets 17+: Encrypted Payload (see {{encrypted-payload}}.)
+
+A flags octet of 0x86 indicates a 0-RTT packet. Key phases are used by the QUIC
+packet protection to identify the correct packet protection keys after the 1-RTT
+keys are established. The default initial value key phase is 0. See {{QUIC-TLS}}
+for more details.
 
 The encrypted payload is both authenticated and encrypted using packet
 protection keys. {{QUIC-TLS}} describes packet protection in detail.  After

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -427,8 +427,7 @@ client packet of an unsupported version. It uses a long header and contains:
 
 * Octet 0: 0x81 (Flags indicating long header and Version Negotiation packet 
   type)
-* Octets 1-8: Connection ID (server-selected value, may be used in a subsequent
-  connection to reach the same server)
+* Octets 1-8: Connection ID (echoed)
 * Octets 9-12: Proof (first 4 octets of client-selected connection ID)
 * Octets 13-16: Version (echoed)
 * Octets 17+: Payload (version list, containing 0 or more acceptable versions)
@@ -484,10 +483,11 @@ outage). A server that wishes to indicate fatal errors with a connection MUST
 use a CONNECTION_CLOSE frame in preference to Public Reset if it has sufficient
 state to do so.
 
-A public reset packet contains:
+A Public Reset packet contains:
 
 * Octet 0: 0x82 (Flags indicating long header and Public Reset packet type) 
-* Octets 1-12: Echoed data (octets 1-12 of received packet)
+* Octets 1-8: Echoed data (octets 1-8 of received packet)
+* Octets 9-12: Echoed data (octets 9-12 of received packet)
 * Octets 13-16: Version (server version)
 * Octets 17+: Public Reset Proof (optional, TBD)
 
@@ -545,7 +545,7 @@ Other server Cleartext packets contain:
 
 * Octet 0: 0x85 (Flags indicating Long header and appropriate server Cleartext 
   packet type)
-* Octets 1-8: Connection ID (client-selected value)
+* Octets 1-8: Connection ID (echoed)
 * Octets 9-12: Packet Number (low 4 octets, random 31-bit initial value)
 * Octets 13-16: Version (echoed)
 * Octets 17+: Payload

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -467,7 +467,7 @@ Connection ID:
 Packet Number:
 
 : The length of the packet number field depends on the packet type.
-  This field can be 1, 2 or 4 octets long depending on the short packet type; 
+  This field can be 1, 2 or 4 octets long depending on the short packet type;
   see {{packet-numbers}}.
 
 Packet Number Echo:

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -322,114 +322,170 @@ all field sizes are in bits.  When discussing individual bits of fields, the
 least significant bit is referred to as bit 0.  Hexadecimal notation is used for
 describing the value of fields.
 
+QUIC packet headers can be separated into long and short headers. Long headers
+are expected to be used for the initial phase of the connection and are used for
+version negotiation, connection establishment, 0-RTT, and public reset
+packets. Short headers are minimal version-specific headers, which MAY be used
+after version negotiation and 1-RTT keys are established, and MUST NOT be used
+earlier.
 
-## Common Header
+## Long Header
 
-All QUIC packets begin with a QUIC Common header, as shown below.
-
-~~~
+```
  0                   1                   2                   3
  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
 +-+-+-+-+-+-+-+-+
-|   Flags (8)   |
+|1|   Type      |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                                                               |
-+                     [Connection ID (64)]                      +
++                        Connection ID                          +
 |                                                               |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                   Type-Dependent Fields (*)                 ...
+|                  Packet Number / Proof                        |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-~~~
+|                           Version                             |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                            Payload                          ...
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+```
 
-The fields in the Common Header are the following:
+Long headers are used for packets that are sent prior to the completion of
+version negotiation or are not encrypted with 1-RTT keys. Once both conditions
+are met, a sender SHOULD switch to sending short-form headers. While
+inefficient, long headers MAY be used for 1-RTT packets. The long form allows
+for special packets, such as the version negotiation and the public reset
+packets to be represented in this uniform fixed-length packet format.
 
-* Flags:
+The first octet (octet 0) contains the following fields.
+* Bit 0 (0x80): Header form. Set to 1 for long headers.
+* Bits 1-7: Packet Type, indicating one of 128 packet types. The following types
+  are currently defined.
+  * 01: Version Negotiation packet
+  * 02: Public Reset packet
+  * 03: 0-RTT packet
+  * 04: Server cleartext packet
+  * 05: Client cleartext packet
+  * 06: 1-RTT packet with version field, connection ID,
+        and 2-byte packet number
 
-   * 0x01 = VERSION.  The semantics of this flag depends on whether the packet
-     is sent by the server or the client.  A client MAY set this flag and
-     include exactly one proposed version.  A server may set this flag when the
-     client-proposed version was unsupported, and may then provide a list (0 or
-     more) of acceptable versions as a part of version negotiation (described in
-     {{version-negotiation}}.)
+The remainder of the packet layout is the same regardless of type, but the
+semantics of the fields are specific to each type, as described next.
 
-   * 0x02 = PUBLIC_RESET.  Set to indicate that the packet is a Public Reset
-     packet.
+### Version Negotiation Packet
 
-   * 0x04 = KEY_PHASE.  This is used by the QUIC packet protection to identify
-     the correct packet protection keys, see {{QUIC-TLS}}.
+A Version Negotiation packet is sent by the server in response to a client
+packet of an unsupported version. It contains:
 
-   * 0x08 = CONNECTION_ID.  Indicates the Connection ID is present in the
-     packet.  This must be set in all packets until negotiated to a different
-     value for a given direction.  For instance, if a client indicates that the
-     5-tuple fully identifies the connection at the client, the connection ID is
-     optional in the server-to-client direction. The negotiation is described in
-     {{transport-parameter-definitions}}.
+* Octets 1-8: Connection ID (server-selected value, may be used in a subsequent
+  connection to reach the same server)
+* Octets 9-12: Proof (first 4 octets of client-selected connection ID)
+* Octets 13-16: Version (echoed)
+* Octets 17+: Payload (version list, containing 0 or more acceptable versions)
 
-   * 0x30 = PACKET_NUMBER_SIZE.  These two bits indicate the number of
-     low-order-bytes of the packet number that are present in each packet.
+See {{version-negotiation}} for a description of the version negotiation
+process.
 
-     + 11 indicates that 6 bytes of the packet number are present
-     + 10 indicates that 4 bytes of the packet number are present
-     + 01 indicates that 2 bytes of the packet number are present
-     + 00 indicates that 1 byte of the packet number is present
+### Public Reset Packet
 
-   * 0x40 = MULTIPATH.  This bit is reserved for multipath use.
+A Public Reset packet is sent when the server has no state for a received
+packet. A server may therefore have to respond to either a long-form or a
+short-form packet. A public reset packet contains:
 
-   * 0x80 is currently unused, and must be set to 0.
+* Octets 1-12: Proof (octets 1-12 of received packet)
+* Octets 13-16: Version (server version)
 
-* Connection ID: An unsigned 64-bit random number chosen by the client, used as
-  the identifier of the connection.  Connection ID is tied to a QUIC connection,
-  and remains consistent across client and/or server IP and port changes.
+For a client that sends a connection ID on every packet, a Public Reset
+packet received in response can be simply interpreted as:
 
+* Octets 1-8: Connection ID (echoed)
+* Octets 9-12: Proof (echoed packet number, which could be 1, 2, or 4 bytes
+  depending on the packet number size used by the client, followed by 0, 2, or 3
+  subsequent bytes from the client packet)
+* Octets 13-16: Version (server version)
 
-### Identifying Packet Types
+### Client Cleartext Packet
 
-While all QUIC packets have the same common header, there are three types of
-packets: Regular packets, Version Negotiation packets, and Public Reset packets.
-The flowchart below shows how a packet is classified into one of these three
-packet types:
+A client cleartext packet may be sent during the handshake. It contains:
+* Octets 1-8: Connection ID (randomly chosen)
+* Octets 9-12: Packet number (low 4 octets, starts at a random 31-bit value)
+* Octets 13-16: Version
+* Octets 17+: Payload
 
-~~~
-Check the flags in the common header
-              |
-              |
-              V
-        +--------------+
-        | PUBLIC_RESET |  YES
-        | flag set?    |-------> Public Reset packet
-        +--------------+
-              |
-              | NO
-              V
-        +------------+         +-------------+
-        | VERSION    |  YES    | Packet sent |  YES     Version
-        | flag set?  |-------->| by server?  |--------> Negotiation
-        +------------+         +-------------+          packet
-              |                       |
-              | NO                    | NO
-              V                       V
-      Regular packet with       Regular packet with
-  no QUIC Version in header    QUIC Version in header
-~~~
-{: #packet-types title="Types of QUIC Packets"}
+The client MUST choose a random value and use it as the Connection ID until the
+server replies with a server-selected Connection ID. The client's Connection ID
+is a suggestion to the server, as described further in {{connection-id}}.
+
+### Server Cleartext Packet
+
+A server cleartext packet may be sent during the handshake. It contains:
+* Octets 1-8: Connection ID (server-selected value)
+* Octets 9-12: Packet Number (low 4 octets, random 31-bit initial value)
+* Octets 13-16: Version (echoed)
+* Octets 17+: Payload
+
+### Encrypted Packet Types
+
+Packets encrypted with either 0-RTT or 1-RTT keys may be sent with long headers.
+Different packet types explicitly indicate the encryption level for ease of
+decryption. These packets contain:
+* Octets 1-8: Connection ID (client or server-selected, see {{connectionid}})
+* Octets 9-12: Packet Number (low 4 octets)
+* Octets 13-16: Version
+* Octets 17+: Payload
+
+## Short Header
+
+```
+ 0                   1                   2                   3
+ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
++-+-+-+-+-+-+-+-+
+|0|C|K|  Type   |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                                                               |
++                   Connection ID (optional)                    +
+|                                                               |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                     Packet Number (1/2/4)                     |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                            Payload                          ...
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+```
+
+The short header is used after the version and 1-RTT keys are negotiated. This
+header has the following version-independent fields:
+* Octet 0: Flags
+  * Bit 0 (0x80): Header form, set to 0 for short headers.
+  * Bit 1: CONNECTION_ID. Indicates presence of Connection ID field following
+    the Flags byte.
+* Octets 1-8: Connection ID (optional)
+
+The remainder of the short header is defined to be specific to a version. In
+this version, it contains:
+* Octet 0: Flags
+  * Bit 2: KEY_PHASE. Used by the QUIC packet protection to identify
+    the correct packet protection keys after the 1-RTT keys are initially
+    established. See {{QUIC-TLS}}.
+  * Bit 3-7: Packet Type, indicating one of 32 packet types. The following types
+    are currently defined.
+  * 01: 1-RTT packet (packet number size = 1)
+  * 02: 1-RTT packet (packet number size = 2)
+  * 03: 1-RTT packet (packet number size = 4)
+* Octets 1-2/3/4 or 9-10/11/12: Packet Number (lower 8, 16, or 32 bits)
+* Remainder of this packet: Payload.
 
 
 ### Handling Packets from Different Versions
 
-Version negotiation ({{version-negotiation}}) is performed using packets that
-have the VERSION bit set.  This bit is always set on packets that are sent prior
-to connection establishment.  When receiving a packet that is not associated
-with an existing connection, packets without a VERSION bit MUST be discarded.
+When receiving a packet that is not associated with an existing connection,
+packets with a short header MUST be discarded.
 
 Implementations MUST assume that an unsupported version uses an unknown packet
-format.
-
-Between different versions the following things are guaranteed to remain
-constant are:
+format with the exception of the following. Between different versions the
+following things are guaranteed to remain constant are:
 
 * the location and size of the Flags field,
 
-* the location and value of the VERSION bit in the Flags field,
+* the location and value of the Version Field
 
 * the location and size of the Connection ID field, and
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -376,8 +376,8 @@ Connection ID:
 
 Packet Number:
 
-: Octets 9 to 12 contain a packet number.  {{packet-numbers} describes the use of
-  packet numbers.
+: Octets 9 to 12 contain a packet number.  {{packet-numbers} describes the use
+  of packet numbers.
 
 Version:
 
@@ -404,9 +404,9 @@ The following packet types are defined:
 {: #long-packet-types title="Long Header Packet Types"}
 
 The header form, long packet type, connection ID, packet number and version
-fields of a long header packet are version independent.  The payload is specific
-to a version.  See {{version-specific}} for details on how packets from
-different versions of QUIC are interpreted.
+fields of a long header packet are version independent. The rest of the packet
+is specific to a version. See {{version-specific}} for details on how packets
+from different versions of QUIC are interpreted.
 
 The packet layout is the same for all long-header packet types, but the
 semantics of the fields are specific to each packet type.  Type-specific


### PR DESCRIPTION
This PR replaces #351, (manually) rebased on #361. It adds packet number echo with the echo taking the same size as the number, with correct guidance as to the packet number echo size (thanks @martinthomson).