### PR TITLE
Don't ignore TLS draft...?

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,3 @@ venv/
 issues.json
 lib
 .targets.mk
-draft-ietf-quic-tls.md


### PR DESCRIPTION
For some reason, the TLS draft is in the .gitignore file.  I can't see a sensible reason for this, and yet the repo obviously does still track the TLS draft.  Am I missing something?

Ordinarily, I'd just fix this, but it's weird enough I'd like the git-template-master to look and confirm.