### PR TITLE
Stream1 is not that special

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2213,11 +2213,6 @@ ordered byte-stream.  Data received out of order MUST be buffered for later
 delivery, as long as it is not in violation of the receiver's flow control
 limits.
 
-The cryptographic handshake stream, Stream 1, MUST NOT be subject to congestion
-control or connection-level flow control, but MUST be subject to stream-level
-flow control. An endpoint MUST NOT send data on any other stream without
-consulting the congestion controller and the flow controller.
-
 Flow control is described in detail in {{flow-control}}, and congestion control
 is described in the companion document {{QUIC-RECOVERY}}.
 


### PR DESCRIPTION
This stream simply isn't that important.  We should definitely be able to function without the congestion control exemption.  I also removed the flow control exemption in line with other decisions we have made not to exempt stream 1 (it counts toward the concurrent stream limit, for example).  That was harder, but all it takes is realizing that we have default values for flow control that can be used prior to handshake completion.  Those defaults are so abundantly generous that only the most perverse certificate (or PQ key exchange) will get close to overflowing.

Closes #248.