### PR TITLE
No timestamps in unprotected packets

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1397,6 +1397,7 @@ loss recovery, and old timestamps are less valuable, so it is not guaranteed
 every timestamp will be received by the sender.  A receiver SHOULD send a
 timestamp exactly once for each received packet containing retransmittable
 frames. A receiver MAY send timestamps for non-retransmittable packets.
+A receiver MUST not send timestamps in unprotected packets.
 
 A sender MAY intentionally skip packet numbers to introduce entropy into the
 connection, to avoid opportunistic acknowledgement attacks.  The sender MUST


### PR DESCRIPTION
Unprotected packets are only used for handshakes, and timestamps are not necessary for proper recovery during the handshake.