### PR TITLE
Fix >80 character line so that Makefiles work

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1386,8 +1386,8 @@ To limit receiver state or the size of ACK frames, a receiver MAY limit the
 number of ACK blocks it sends.  A receiver can do this even without receiving
 acknowledgment of its ACK frames, with the knowledge this could cause the sender
 to unnecessarily retransmit some data.  When this is necessary, the receiver
-SHOULD acknowledge newly received packets and stop acknowledging packets received
-in the past.
+SHOULD acknowledge newly received packets and stop acknowledging packets
+received in the past.
 
 Unlike TCP SACKs, QUIC ACK blocks are cumulative and therefore irrevocable.
 Once a packet has been acknowledged, even if it does not appear in a future ACK


### PR DESCRIPTION
This is breaking in the Makefile sanity checks.