### PR TITLE
Adding a description of stream commitment attacks in security section

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2706,13 +2706,13 @@ large number of connections, in a manner similar to
 SYN flooding attacks in TCP.
 
 Normally, clients will open streams sequentially,
-as explained in {{stream-identifiers}}. 
+as explained in {{stream-identifiers}}.
 However, when several streams are initiated at short intervals,
 transmission error may cause STREAM DATA frames opening streams to be
 received out of sequence. A receiver is obligated to open intervening
 streams if a higher-numbered stream ID is received. Thus, on a
 new connection, opening stream 2000001 opens 1 million streams,
-as required by the specification. 
+as required by the specification.
 
 The number of active streams is limited
 by the concurrent stream limit transport

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2697,35 +2697,22 @@ also be forward-secure encrypted.  Since the attacker will not have the forward
 secure key, the attacker will not be able to generate forward-secure encrypted
 packets with ACK frames.
 
-## Stream commitment attack
+## Stream Commitment Attack
 
-An adversarial client may try to use the
-stream creation process to open a large
-number of streams and induce the server to
-commit memory resource for the various
-streams. The adversarial client, or clients, would repeat the process on a
-large number of connections, in an attempt to exhaust the server memory. This
-attack is in some ways similar to SYN flooding attack in TCP, in which the
-attackers try to exhaust a server memory by creating a large number of half
-open TCP connections. It is less potent than the SYN flooding attack, since
-stream creation is much lighter weight than the creation of TCP-IP connections,
-and stream control data presumably requires less
-memory resource than a TCP protocol
-control block. However, the attack can be amplified if the adversarial
-client can open multiple streams with a single message.
+An adversarial endpoint can open lots of streams,
+exhausting state on the server.
+The adversarial endpoint, or endpoint, could repeat the process on a
+large number of connections, in a manner similar to
+SYN flooding attacks in TCP.
 
 Normally, clients will open streams sequentially,
-as explained in {{stream-identifiers}}.
+as explained in {{stream-identifiers}}. 
 However, when several streams are initiated at short intervals,
 transmission error may cause STREAM DATA frames opening streams to be
-received out of sequence. Some implementations will have provisions to
-open all intermediate streams in case of out-of-sequence arrival. For example,
-a server that receive STREAM DATA for streams 3 and then 9 may decide to
-open stream 5 and 7 immediately. An adversarial client
-would for example exploit that
-design by sending STREAM DATA for streams 3 and the 2,000,001, causing the
-server to open 1 million connections, and contributing to server resource
-exhaustion.
+received out of sequence. A receiver is obligated to open intervening
+streams if a higher-numbered stream ID is received. Thus, on a
+new connection, opening stream 2000001 opens 1 million streams,
+as required by the specification. 
 
 The number of active streams is limited
 by the concurrent stream limit transport

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2707,23 +2707,27 @@ attack is in some ways similar to SYN flooding attack in TCP, in which the
 attackers try to exhaust a server memory by creating a large number of half 
 open TCP connections. It is less potent than the SYN flooding attack, since
 stream creation is much lighter weight than the creation of TCP-IP connections,
-and stream control data presumably requires less memory resource than a TCP protocol
+and stream control data presumably requires less 
+memory resource than a TCP protocol
 control block. However, the attack can be amplified if the adversarial
 client can open multiple streams with a single message.
 
-Normally, clients will open streams sequentially, as explained in {{stream-identifiers}}. 
+Normally, clients will open streams sequentially, 
+as explained in {{stream-identifiers}}. 
 However, when several streams are initiated at short intervals,
 transmission error may cause STREAM DATA frames opening streams to be
 received out of sequence. Some implementations will have provisions to 
 open all intermediate streams in case of out-of-sequence arrival. For example,
 a server that receive STREAM DATA for streams 3 and then 9 may decide to
-open stream 5 and 7 immediately. An adversarial client would for example exploit that
+open stream 5 and 7 immediately. An adversarial client 
+would for example exploit that
 design by sending STREAM DATA for streams 3 and the 2,000,001, causing the 
 server to open 1 million connections, and contributing to server resource
 exhaustion.
 
 The number of active streams is limited by the concurrent stream limit transport 
-parameter, as explained in {{stream-concurrency}}. If chosen judisciously, this limit 
+parameter, as explained in {{stream-concurrency}}. 
+If chosen judisciously, this limit 
 mitigates the effect of the stream commitment attack. However, setting the limit
 too low could affect performance when applications expect to open large number
 of streams.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2699,45 +2699,43 @@ packets with ACK frames.
 
 ## Stream commitment attack
 
-An adversarial client may try to use the 
+An adversarial client may try to use the
 stream creation process to open a large
-number of streams and induce the server to 
+number of streams and induce the server to
 commit memory resource for the various
-streams. The adversarial client, or clients, would repeat the process on a 
+streams. The adversarial client, or clients, would repeat the process on a
 large number of connections, in an attempt to exhaust the server memory. This
 attack is in some ways similar to SYN flooding attack in TCP, in which the
-attackers try to exhaust a server memory by creating a large number of half 
+attackers try to exhaust a server memory by creating a large number of half
 open TCP connections. It is less potent than the SYN flooding attack, since
 stream creation is much lighter weight than the creation of TCP-IP connections,
-and stream control data presumably requires less 
+and stream control data presumably requires less
 memory resource than a TCP protocol
 control block. However, the attack can be amplified if the adversarial
 client can open multiple streams with a single message.
 
-Normally, clients will open streams sequentially, 
-as explained in {{stream-identifiers}}. 
+Normally, clients will open streams sequentially,
+as explained in {{stream-identifiers}}.
 However, when several streams are initiated at short intervals,
 transmission error may cause STREAM DATA frames opening streams to be
-received out of sequence. Some implementations will have provisions to 
+received out of sequence. Some implementations will have provisions to
 open all intermediate streams in case of out-of-sequence arrival. For example,
 a server that receive STREAM DATA for streams 3 and then 9 may decide to
-open stream 5 and 7 immediately. An adversarial client 
+open stream 5 and 7 immediately. An adversarial client
 would for example exploit that
-design by sending STREAM DATA for streams 3 and the 2,000,001, causing the 
+design by sending STREAM DATA for streams 3 and the 2,000,001, causing the
 server to open 1 million connections, and contributing to server resource
 exhaustion.
 
-The number of active streams is limited 
-by the concurrent stream limit transport 
-parameter, as explained in {{stream-concurrency}}. 
-If chosen judisciously, this limit 
-mitigates the effect of the stream commitment attack. 
+The number of active streams is limited
+by the concurrent stream limit transport
+parameter, as explained in {{stream-concurrency}}.
+If chosen judisciously, this limit
+mitigates the effect of the stream commitment attack.
 However, setting the limit
-too low could affect performance when 
+too low could affect performance when
 applications expect to open large number
 of streams.
-
-
 
 # IANA Considerations
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2699,8 +2699,10 @@ packets with ACK frames.
 
 ## Stream commitment attack
 
-An adversarial client may try to use the stream creation process to open a large
-number of streams and induce the server to commit memory resource for the various
+An adversarial client may try to use the 
+stream creation process to open a large
+number of streams and induce the server to 
+commit memory resource for the various
 streams. The adversarial client, or clients, would repeat the process on a 
 large number of connections, in an attempt to exhaust the server memory. This
 attack is in some ways similar to SYN flooding attack in TCP, in which the
@@ -2725,11 +2727,14 @@ design by sending STREAM DATA for streams 3 and the 2,000,001, causing the
 server to open 1 million connections, and contributing to server resource
 exhaustion.
 
-The number of active streams is limited by the concurrent stream limit transport 
+The number of active streams is limited 
+by the concurrent stream limit transport 
 parameter, as explained in {{stream-concurrency}}. 
 If chosen judisciously, this limit 
-mitigates the effect of the stream commitment attack. However, setting the limit
-too low could affect performance when applications expect to open large number
+mitigates the effect of the stream commitment attack. 
+However, setting the limit
+too low could affect performance when 
+applications expect to open large number
 of streams.
 
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2209,7 +2209,7 @@ MUST terminate the connection with an error of type QUIC_TOO_MANY_OPEN_STREAMS
 ({{error-handling}}).
 
 
-## Stream Concurrency
+## Stream Concurrency {#stream-concurrency}
 
 An endpoint limits the number of concurrently active incoming streams by setting
 the concurrent stream limit (see {{transport-parameter-definitions}}) in the
@@ -2696,6 +2696,38 @@ forward-secure key, then any acknowledgments that are received for them MUST
 also be forward-secure encrypted.  Since the attacker will not have the forward
 secure key, the attacker will not be able to generate forward-secure encrypted
 packets with ACK frames.
+
+## Stream commitment attack
+
+An adversarial client may try to use the stream creation process to open a large
+number of streams and induce the server to commit memory resource for the various
+streams. The adversarial client, or clients, would repeat the process on a 
+large number of connections, in an attempt to exhaust the server memory. This
+attack is in some ways similar to SYN flooding attack in TCP, in which the
+attackers try to exhaust a server memory by creating a large number of half 
+open TCP connections. It is less potent than the SYN flooding attack, since
+stream creation is much lighter weight than the creation of TCP-IP connections,
+and stream control data presumably requires less memory resource than a TCP protocol
+control block. However, the attack can be amplified if the adversarial
+client can open multiple streams with a single message.
+
+Normally, clients will open streams sequentially, as explained in {{stream-identifiers}}. 
+However, when several streams are initiated at short intervals,
+transmission error may cause STREAM DATA frames opening streams to be
+received out of sequence. Some implementations will have provisions to 
+open all intermediate streams in case of out-of-sequence arrival. For example,
+a server that receive STREAM DATA for streams 3 and then 9 may decide to
+open stream 5 and 7 immediately. An adversarial client would for example exploit that
+design by sending STREAM DATA for streams 3 and the 2,000,001, causing the 
+server to open 1 million connections, and contributing to server resource
+exhaustion.
+
+The number of active streams is limited by the concurrent stream limit transport 
+parameter, as explained in {{stream-concurrency}}. If chosen judisciously, this limit 
+mitigates the effect of the stream commitment attack. However, setting the limit
+too low could affect performance when applications expect to open large number
+of streams.
+
 
 
 # IANA Considerations


### PR DESCRIPTION
See discussion of issue #435: Stream ID sequential order may create head of queue blocking.