### PR TITLE
Define the payload size of the initial packet rather than the total packet size

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -533,9 +533,8 @@ older than 1.3 is negotiated.
 ## ClientHello Size
 
 QUIC requires that the initial handshake packet from a client fit within the
-payload of a single packet.  A minimum-sized initial packet in IPv6 has space
-for a single TLS record of 1197 octets once the QUIC header and minimal framing
-is added.
+payload of a single packet.  The size limits on QUIC packets mean that a record
+containing a ClientHello needs to fit within 1197 octets.
 
 A TLS ClientHello can fit within this limit with ample space remaining.
 However, there are several variables that could cause this limit to be exceeded.
@@ -549,9 +548,9 @@ extension can have an effect on a client's ability to connect.  Choosing a small
 value increases the probability that these values can be successfully used by a
 client.
 
-A TLS implementation does not need to enforce this size constraint.  QUIC
-padding can be used to reach this size, meaning that a TLS server is unlikely to
-receive a large ClientHello message.
+The TLS implementation does not need to ensure that the ClientHello is
+sufficiently large.  QUIC PADDING frames are added to increase the size of the
+packet as necessary.
 
 
 ## Peer Authentication

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -532,9 +532,10 @@ older than 1.3 is negotiated.
 
 ## ClientHello Size
 
-QUIC requires that the initial handshake packet from a client fit within a
-single packet of at least 1280 octets.  With framing and packet overheads this
-value could be reduced.
+QUIC requires that the initial handshake packet from a client fit within the
+payload of a single packet.  A minimum-sized initial packet in IPv6 has space
+for a single TLS record of 1197 octets once the QUIC header and minimal framing
+is added.
 
 A TLS ClientHello can fit within this limit with ample space remaining.
 However, there are several variables that could cause this limit to be exceeded.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1137,7 +1137,7 @@ on its own.
 
 Several methods are used in QUIC to mitigate this attack.  Firstly, the initial
 handshake packet is padded to at least 1280 octets.  This allows a server to
-send a similar amount of data without risking causing an amplication attack
+send a similar amount of data without risking causing an amplification attack
 toward an unproven remote address.
 
 A server eventually confirms that a client has received its messages when the

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1957,7 +1957,7 @@ appropriately, and storing the result of previous PMTU determinations.
 
 In the absence of these mechanisms, QUIC endpoints SHOULD NOT send IP packets
 larger than 1280 octets. Assuming the minimum IP header size, this results in
-a UDP payload length of 1232 octets for IPv6 and 1252 octets for IPv4.
+a QUIC packet size of 1232 octets for IPv6 and 1252 octets for IPv4.
 
 QUIC endpoints that implement any kind of PMTU discovery SHOULD maintain an
 estimate for each combination of local and remote IP addresses (as each pairing
@@ -1969,10 +1969,10 @@ An endpoint MUST NOT reduce their MTU below this number, even if it receives
 signals that indicate a smaller limit might exist.
 
 Clients MUST ensure that the first packet in a connection, and any
-retransmissions of those octets, has a payload of least 1232 octets for an IPv6
-datagram and 1252 octets for an IPv4 datagram.  In the absence of extensions to
-the IP header, padding to exactly these values will result in a packet that is
-1280 octets.
+retransmissions of those octets, has a QUIC packet size of least 1232 octets for
+an IPv6 packet and 1252 octets for an IPv4 packet.  In the absence of extensions
+to the IP header, padding to exactly these values will result in an IP packet
+that is 1280 octets.
 
 The initial client packet SHOULD be padded to exactly these values unless the
 client has a reasonable assurance that the PMTU is larger.  Sending a packet of

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -913,7 +913,7 @@ prior to establishing a connection, exposing the server to a denial of service
 risk.
 
 The first client packet of the cryptographic handshake protocol MUST fit within
-a 1280 octet QUIC packet.  This includes overheads that reduce the space
+a 1200 octet QUIC packet.  This includes overheads that reduce the space
 available to the cryptographic handshake protocol.
 
 Details of how TLS is integrated with QUIC is provided in more detail in
@@ -1136,9 +1136,9 @@ use the server to send more data toward the victim than it would be able to send
 on its own.
 
 Several methods are used in QUIC to mitigate this attack.  Firstly, the initial
-handshake packet from a client is padded to at least 1280 octets.  This allows a
-server to send a similar amount of data without risking causing an amplication
-attack toward an unproven remote address.
+handshake packet is padded to at least 1280 octets.  This allows a server to
+send a similar amount of data without risking causing an amplication attack
+toward an unproven remote address.
 
 A server eventually confirms that a client has received its messages when the
 cryptographic handshake successfully completes.  This might be insufficient,
@@ -1969,16 +1969,19 @@ An endpoint MUST NOT reduce their MTU below this number, even if it receives
 signals that indicate a smaller limit might exist.
 
 Clients MUST ensure that the first packet in a connection, and any
-retransmissions of those octets, has a total size (including IP and UDP headers)
-of at least 1280 bytes. This might require inclusion of PADDING frames. It is
-RECOMMENDED that a packet be padded to exactly 1280 octets unless the client has
-a reasonable assurance that the PMTU is larger. Sending a packet of this size
-ensures that the network path supports an MTU of this size and helps mitigate
-amplification attacks caused by server responses toward an unverified client
-address.
+retransmissions of those octets, has a payload of least 1232 octets for an IPv6
+datagram and 1252 octets for an IPv4 datagram.  In the absence of extensions to
+the IP or UDP header, padding to exactly these values will result in a packet
+that is 1280 octets.
 
-Servers MUST reject the first plaintext packet received from a client if it its
-total size is less than 1280 octets, to mitigate amplification attacks.
+The initial client packet SHOULD be padded to exactly these values unless the
+client has a reasonable assurance that the PMTU is larger.  Sending a packet of
+this size ensures that the network path supports an MTU of this size and helps
+reduce the amplitude of amplification attacks caused by server responses toward
+an unverified client address.
+
+Servers MUST ignore an initial plaintext packet from a client if its total size
+is less than 1232 octets for IPv6 or 1252 octets for IPv4.
 
 If a QUIC endpoint determines that the PMTU between any pair of local and remote
 IP addresses has fallen below 1280 octets, it MUST immediately cease sending

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1971,8 +1971,8 @@ signals that indicate a smaller limit might exist.
 Clients MUST ensure that the first packet in a connection, and any
 retransmissions of those octets, has a payload of least 1232 octets for an IPv6
 datagram and 1252 octets for an IPv4 datagram.  In the absence of extensions to
-the IP or UDP header, padding to exactly these values will result in a packet
-that is 1280 octets.
+the IP header, padding to exactly these values will result in a packet that is
+1280 octets.
 
 The initial client packet SHOULD be padded to exactly these values unless the
 client has a reasonable assurance that the PMTU is larger.  Sending a packet of

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -913,7 +913,7 @@ prior to establishing a connection, exposing the server to a denial of service
 risk.
 
 The first client packet of the cryptographic handshake protocol MUST fit within
-a 1200 octet QUIC packet.  This includes overheads that reduce the space
+a 1232 octet QUIC packet payload.  This includes overheads that reduce the space
 available to the cryptographic handshake protocol.
 
 Details of how TLS is integrated with QUIC is provided in more detail in


### PR DESCRIPTION
The entity that creates the packet is not always aware of the existence of header extensions.  That makes hitting the 1280 octet limit hard.  Worse, if they are aware of extensions, they might reduce the size and then encounter a server that enforces the limit.  That server will discard the packet.  That makes enforcement risky.

This change places the limit on the payload.  It mandates 1232/1252 for v6/v4.

This is the uncomplicated version.  The complicated version that I didn't write up allows a client that knows more about overheads to reduce the payload size as long as they keep above some floor value (e.g., 1180).  We might consider doing that later if we want to allow QUIC to operate on paths with a much tighter MTU overhead.  Evidence suggests that we don't need this though (open an issue if you disagree).

Closes #267