### PR TITLE
Remove requirement to send public reset if PMTU drops

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1965,10 +1965,8 @@ total size is less than 1280 octets, to mitigate amplification attacks.
 
 If a QUIC endpoint determines that the PMTU between any pair of local and remote
 IP addresses has fallen below 1280 octets, it MUST immediately cease sending
-QUIC packets between those IP addresses. This may result in abrupt termination
-of the connection if all pairs are affected. In this case, an endpoint SHOULD
-send a Public Reset packet to indicate the failure. The application SHOULD
-attempt to use TLS over TCP instead.
+QUIC packets on the affected path.  This could result in termination of the
+connection if an alternative path cannot be found.
 
 A sender bundles one or more frames in a Regular QUIC packet (see {{frames}}).
 


### PR DESCRIPTION
I didn't recommend a specific error code for this.  One of the generic ones will suffice.  I expect this to be rare enough that no implementation will bother reacting to a specific error code.

Closes #290