### PR TITLE
Invert connection ID

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1127,9 +1127,26 @@ validation was not requested originally.  In such cases, the cookie extension
 could either be absent or it could indicate that an address validation token is
 not present.
 
+
+### Stateless Address Validation
+
 A server can use the cookie extension to store all state necessary to continue
 the connection.  This allows a server to avoid committing state for clients that
 have unvalidated source addresses.
+
+For instance, a server could use a statically-configured key to encrypt the
+information that it requires and include that information in the cookie.  In
+addition to address validation information, a server that uses encryption also
+needs to be able recover the hash of the ClientHello and its length, plus any
+information it needs in order to reconstruct the HelloRetryRequest.
+
+A client proceeds as though the server were stateful.  It constructs a second
+ClientHello and sends it following the initial ClientHello.  Note that this
+means a server that doesn't maintain state between the intial and second
+ClientHello will receive the second ClientHello in STREAM frames with a non-zero
+offset.  The resulting gap in the received stream data needs to be ignored and
+data passed to TLS; if a valid cookie is found, the size of the gap SHOULD be
+validated prior to generating a response.
 
 
 ## NewSessionTicket Address Validation

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1151,8 +1151,10 @@ stream 0, the packet number that the server selects, and any opportunity to
 measure round trip time.
 
 A server MUST send a TLS HelloRetryRequest in a Server Stateless Retry packet.
-Using a Server Stateless Retry packet causes the client to reset stream offsets
-and avoids the need to commit to an initial packet number.
+Using a Server Stateless Retry packet causes the client to reset stream offsets.
+It also avoids the need for the server select an initial packet number, which
+would need to be remembered so that subsequent packets could be correctly
+numbered.
 
 A HelloRetryRequest message MUST NOT be split between multiple Server Stateless
 Retry packets.  This means that HelloRetryRequest is subject to the same size

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1127,6 +1127,10 @@ validation was not requested originally.  In such cases, the cookie extension
 could either be absent or it could indicate that an address validation token is
 not present.
 
+A server can use the cookie extension to store all state necessary to continue
+the connection.  This allows a server to avoid committing state for clients that
+have unvalidated source addresses.
+
 
 ## NewSessionTicket Address Validation
 

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -530,7 +530,7 @@ version of TLS.  An endpoint MUST terminate the connection if a version of TLS
 older than 1.3 is negotiated.
 
 
-## ClientHello Size
+## ClientHello Size {#clienthello-size}
 
 QUIC requires that the initial handshake packet from a client fit within the
 payload of a single packet.  The size limits on QUIC packets mean that a record
@@ -1140,13 +1140,23 @@ addition to address validation information, a server that uses encryption also
 needs to be able recover the hash of the ClientHello and its length, plus any
 information it needs in order to reconstruct the HelloRetryRequest.
 
-A client proceeds as though the server were stateful.  It constructs a second
-ClientHello and sends it following the initial ClientHello.  Note that this
-means a server that doesn't maintain state between the intial and second
-ClientHello will receive the second ClientHello in STREAM frames with a non-zero
-offset.  The resulting gap in the received stream data needs to be ignored and
-data passed to TLS; if a valid cookie is found, the size of the gap SHOULD be
-validated prior to generating a response.
+
+### Sending HelloRetryRequest
+
+A server does not need to maintain state for the connection when sending a
+HelloRetryRequest message.  This might be necessary to avoid creating a denial
+of service exposure for the server.  However, this means that information about
+the transport will be lost at the server.  This includes the stream offset of
+stream 0, the packet number that the server selects, and any opportunity to
+measure round trip time.
+
+A server MUST send a TLS HelloRetryRequest in a Server Stateless Retry packet.
+Using a Server Stateless Retry packet causes the client to reset stream offsets
+and avoids the need to commit to an initial packet number.
+
+A HelloRetryRequest message MUST NOT be split between multiple Server Stateless
+Retry packets.  This means that HelloRetryRequest is subject to the same size
+constraints as a ClientHello (see {{clienthello-size}}).
 
 
 ## NewSessionTicket Address Validation

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -725,7 +725,7 @@ packets ({{packet-client-initial}}).  If the client has received any packet from
 the server, it uses the connection ID it received from the server.
 
 When the server receives a Client Initial packet, it chooses a new value for the
-connection ID and sends that in its response.  The server can send a new
+connection ID and sends that in its response.  The server MUST send a new
 connection ID in any packet that is sent in response to a Client Initial packet.
 This includes Version Negotiation ({{packet-version}}), Server Stateless Retry
 ({{packet-server-stateless}}), and the first Server Cleartext packet

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -716,8 +716,7 @@ as load balancers, to locate and use it.
 
 The client MUST choose a random connection ID and use it in Client Initial
 packets ({{packet-client-initial}}).  If the client has received any packet from
-the server, the uses the connection ID it received from the server in that
-packet.
+the server, it uses the connection ID it received from the server.
 
 When the server receives a Client Initial packet, it chooses a new value for the
 connection ID and sends that in its response.  The server can send a new


### PR DESCRIPTION
This defines a new packet type for the initial client cleartext packet, and stateless rejects.  The remaining packets that carry cleartext messages remain the same.  The final packet from the server is removed; instead the server cleartext packet carries the server-selected connection ID.  The server can propose a new connection ID in any of its cleartext packets, including the version negotiation packet.

This rolls in the changes from #482 and so addresses the issues raised there.

Things that I might do differently: 

1. Require the client to send an initial packet after version negotiation on the basis that version negotiation is a complete do-over.  

2. Maybe also after a stateless reject, which would mean that all packets containing the ClientHello would use that "initial" type.  That would mean that only the initial type would have packet size restrictions,
which is nice.

Those alternatives give the server more options for changing connection ID as well, but it also removes the ability for a server-side load balancer to easily distinguish between connection IDs that the client proposes and those that the server has provided.  Not sure which way that goes, I've opted to keep the signal in place until we've had some more discussion.

Closes #482, #442.