### PR TITLE
Mention GQUIC versions

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -316,6 +316,9 @@ MAY use one of these version numbers with the expectation that the server will
 initiate version negotiation; a server MAY advertise support for one of these
 versions and can expect that clients ignore the value.
 
+Version numbers with the lower 24 bits clearted were used to identify
+pre-standards versions of QUIC.
+
 \[\[RFC editor: please remove the remainder of this section before
 publication.]]
 


### PR DESCRIPTION
This should help avoid the case where people reuse the numbers that Google are
currently using.

I would like to be able to say "Prior to <some date>" here, but we can add that
if/once Google switches to implementing the IETF protocol.

Closes #51.  Again.