### PR TITLE
Cover some corner cases in version negotiation

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -819,7 +819,10 @@ initial packets sent from the client to the server MUST use the long header
 format and MUST specify the version of the protocol being used.
 
 When the server receives a packet from a client with the long header format, it
-compares the client's version to the versions it supports.
+compares the client's version to the versions it supports.  Packets MUST be
+discarded if they appear to use the short header format, or if they are too
+short to contain a complete packet header and at least one octet of payload.
+That is, packets that are fewer than 18 octets long are too short to be valid.
 
 If the version selected by the client is not acceptable to the server, the
 server discards the incoming packet and responds with a Version Negotiation


### PR DESCRIPTION
In dealing with #497, I expected that it would be possible to reject initial
packets that are too small.  I also expected that you could reject packets that
weren't of the right type.  However, in order to be able to do that we would
have to create a minimum size requirement for all QUIC versions, and make the
packet types (or at least some of them) version independent also.

That seemed unwise so instead I just described a couple of corner cases.  Short
header packets get thrown away, as do packets that are too small.

Closes #497.