### PR TITLE
Update TLS draft to track recent changes

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -978,9 +978,9 @@ exchange.  The contents of these messages determines the keys used to protect
 later messages.  If these handshake messages are included in packets that are
 protected with these keys, they will be indecipherable to the recipient.
 
-Even though newer keys could be available when retransmitting, retransmissions of
-these handshake messages MUST be sent in cleartext packets.  An endpoint MUST
-generate ACK frames for these messages and send them in cleartext packets.
+Even though newer keys could be available when retransmitting, retransmissions
+of these handshake messages MUST be sent in cleartext packets.  An endpoint
+MUST generate ACK frames for these messages and send them in cleartext packets.
 
 A HelloRetryRequest handshake message might be used to reject an initial
 ClientHello.  A HelloRetryRequest handshake message is sent in a Server

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -978,9 +978,9 @@ exchange.  The contents of these messages determines the keys used to protect
 later messages.  If these handshake messages are included in packets that are
 protected with these keys, they will be indecipherable to the recipient.
 
-Even though newer keys could be available when retranmitting, retransmissions of
+Even though newer keys could be available when retransmitting, retransmissions of
 these handshake messages MUST be sent in cleartext packets.  An endpoint MUST
-also generate ACK frames for these messages that are sent in cleartext packets.
+generate ACK frames for these messages and send them in cleartext packets.
 
 A HelloRetryRequest handshake message might be used to reject an initial
 ClientHello.  A HelloRetryRequest handshake message is sent in a Server


### PR DESCRIPTION
This tracks the changes in #493 and so forth to ensure that the TLS doc makes sense.  Up until now it still contained discussion of the VERSION bit, which has been gone for some time.

This sits on top of #493.  Any comments with that I'll deal with over there.