### PR TITLE
remove langauge that says how many bits of the packet number are used

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -855,7 +855,7 @@ PROTOCOL_ERROR (0x1):
 : No single mapping.  See new HTTP_MALFORMED_* error codes defined in
   {{http-error-codes}}.
 
-INTERNAL_ERROR (0x2)
+INTERNAL_ERROR (0x2):
 : HTTP_INTERNAL_ERROR in {{http-error-codes}}.
 
 FLOW_CONTROL_ERROR (0x3):

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -755,11 +755,10 @@ reaches 2^64 - 1, the sender MUST close the connection without sending a
 CONNECTION_CLOSE frame or any further packets; the sender MAY send a Public
 Reset packet in response to further packets that it receives.
 
-To reduce the number of bits required to represent the packet number
-over the wire, only the least significant bits of the packet number
-are transmitted.  The actual packet number for each packet is
-reconstructed at the receiver based on the largest packet number
-received on a successfully authenticated packet.
+To reduce the number of bits required to represent the packet number over the
+wire, only the least significant bits of the packet number are transmitted.  The
+actual packet number for each packet is reconstructed at the receiver based on
+the largest packet number received on a successfully authenticated packet.
 
 A packet number is decoded by finding the packet number value that is closest to
 the next expected packet.  The next expected packet is the highest received


### PR DESCRIPTION
issue #566 

in the introduction. It said at most 32, when 48 are used in ack
formats.