### PR TITLE
Require the client to detect partly bogus version negotiation packets

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -933,7 +933,10 @@ proceeds with the handshake ({{handshake}}).  This commits the server to the
 version that the client selected.
 
 When the client receives a Version Negotiation packet from the server, it should
-select an acceptable protocol version.  If the server lists an acceptable
+select an acceptable protocol version. If the packet contains the version that
+the client initially offered, the client MUST terminate the connection
+using a QUIC_INVALID_VERSION_NEGOTIATION_PACKET error.
+If the server lists an acceptable
 version, the client selects that version and reattempts to create a connection
 using that version.  Though the contents of a packet might not change in
 response to version negotiation, a client MUST increase the packet number it


### PR DESCRIPTION
in which the server sends back the client's version, as servers
aren't supposed to do this.