### PR TITLE
Fix stream state machine

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2428,11 +2428,11 @@ From the "open" state, either endpoint can send a frame with the FIN flag set,
 which causes the stream to transition into one of the "half-closed" states.
 This flag can be set on the frame that opens the stream, which causes the stream
 to immediately become "half-closed".  Once an endpoint has completed sending all
-stream data and a STREAM frame with a FIN flag, including any retransmissions,
-the stream state becomes "half-closed (local)".  When an endpoint receives all
-stream data a FIN flag the stream state becomes "half-closed (remote)".  An
-endpoint MUST NOT consider the stream state to have changed until all data has
-been acknowledged, received or discarded.
+stream data and a STREAM frame with a FIN flag, the stream state becomes
+"half-closed (local)".  When an endpoint receives all stream data a FIN flag the
+stream state becomes "half-closed (remote)".  An endpoint MUST NOT consider the
+stream state to have changed until all data has been sent, received or
+discarded.
 
 A RST_STREAM frame on an "open" stream causes the stream to become
 "half-closed".  A stream that becomes "open" as a result of sending or receiving
@@ -2493,8 +2493,7 @@ stream and connection data limits (see {{flow-control}}).
 
 A stream transitions from this state to "closed" by completing transmission of
 all data.  This includes sending all data carried in STREAM frames up including
-the terminal STREAM frame that contains a FIN flag and receiving acknowledgment
-from the peer for packets that included all the data.
+the terminal STREAM frame that contains a FIN flag.
 
 A stream becomes "closed" when the endpoint sends and receives acknowledgment of
 a RST_STREAM frame.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2427,11 +2427,12 @@ order.
 From the "open" state, either endpoint can send a frame with the FIN flag set,
 which causes the stream to transition into one of the "half-closed" states.
 This flag can be set on the frame that opens the stream, which causes the stream
-to immediately become "half-closed".  An endpoint sending an FIN flag causes the
-stream state to become "half-closed (local)".  An endpoint receiving a FIN flag
-causes the stream state to become "half-closed (remote)" once all preceding data
-has arrived.  The receiving endpoint MUST NOT consider the stream state to have
-changed until all data has arrived.
+to immediately become "half-closed".  Once an endpoint has completed sending all
+stream data and a STREAM frame with a FIN flag, including any retransmissions,
+the stream state becomes "half-closed (local)".  When an endpoint receives all
+stream data a FIN flag the stream state becomes "half-closed (remote)".  An
+endpoint MUST NOT consider the stream state to have changed until all data has
+either been acknowledged or received.
 
 A RST_STREAM frame on an "open" stream causes the stream to become
 "half-closed".  A stream that becomes "open" as a result of sending or receiving

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2432,7 +2432,7 @@ stream data and a STREAM frame with a FIN flag, including any retransmissions,
 the stream state becomes "half-closed (local)".  When an endpoint receives all
 stream data a FIN flag the stream state becomes "half-closed (remote)".  An
 endpoint MUST NOT consider the stream state to have changed until all data has
-either been acknowledged or received.
+been acknowledged, received or discarded.
 
 A RST_STREAM frame on an "open" stream causes the stream to become
 "half-closed".  A stream that becomes "open" as a result of sending or receiving


### PR DESCRIPTION
This corrects a few infidelities about the way that stream states
update.  This includes Subodh's excellent suggestion to limit
transitions from idle to only go through open.

Fixes #572, #571.