### PR TITLE
Update note well in CONTRIBUTING.md for 8179

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,15 +114,13 @@ addressed to:
  * The RFC Editor or the Internet-Drafts function
  * All IETF Contributions are subject to the rules of
    [RFC 5378](https://tools.ietf.org/html/rfc5378) and
-   [RFC 3979](https://tools.ietf.org/html/rfc3979)
-   (updated by [RFC 4879](https://tools.ietf.org/html/rfc4879)).
+   [RFC 8179](https://tools.ietf.org/html/rfc8179).
 
 Statements made outside of an IETF session, mailing list or other function, that are clearly not
 intended to be input to an IETF activity, group or function, are not IETF Contributions in the
 context of this notice.
 
-Please consult [RFC 5378](https://tools.ietf.org/html/rfc5378) and [RFC
-3979](https://tools.ietf.org/html/rfc3979) for details.
+Please consult [RFC 5378](https://tools.ietf.org/html/rfc5378) and [RFC 8179](https://tools.ietf.org/html/rfc8179) for details.
 
 A participant in any IETF activity is deemed to accept all IETF rules of process, as documented in
 Best Current Practices RFCs and IESG Statements.


### PR DESCRIPTION
With the publication of RFC 8179, the Note Well has been updated to refer to it. 