### PR TITLE
Attempt to make the packet number encoding text clearer

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -769,8 +769,9 @@ The sender MUST use a packet number size able to represent more than twice as
 large a range than the difference between the largest acknowledged packet and
 packet number being sent.  A peer receiving the packet will then correctly
 decode the packet number, unless the packet is delayed in transit such that it
-arrives after many higher-numbered packets have been received.  An endpoint MAY
-use a larger packet number size to safeguard against such reordering.
+arrives after many higher-numbered packets have been received.  An endpoint
+SHOULD use a large enough packet number encoding to allow the packet number to
+be recovered even if the packet arrives after packets that are sent afterwards.
 
 As a result, the size of the packet number encoding is at least one more than
 the base 2 logarithm of the number of contiguous unacknowledged packet numbers,


### PR DESCRIPTION
Based on @ianswett's text recommendation in #605.

Closes #605.