### PR TITLE
reword 'cumulative ack' language to avoid tcp confusion

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1581,9 +1581,9 @@ to unnecessarily retransmit some data.  When this is necessary, the receiver
 SHOULD acknowledge newly received packets and stop acknowledging packets
 received in the past.
 
-Unlike TCP SACKs, QUIC ACK blocks are cumulative and therefore irrevocable.
-Once a packet has been acknowledged, even if it does not appear in a future ACK
-frame, it is assumed to be acknowledged.
+Unlike TCP SACKs, QUIC ACK blocks are irrevocable.  Once a packet has
+been acknowledged, even if it does not appear in a future ACK frame,
+it remains acknowledged.
 
 QUIC ACK frames contain a timestamp section with up to 255 timestamps.
 Timestamps enable better congestion control, but are not required for correct
@@ -2241,9 +2241,8 @@ When a packet is detected as lost, the sender re-sends any frames as necessary:
   since subsequent data on this stream is expected to not be delivered by the
   receiver.
 
-* ACK and PADDING frames MUST NOT be retransmitted.  ACK frames are cumulative,
-  so new frames containing updated information will be sent as described in
-  {{frame-ack}}.
+* ACK and PADDING frames MUST NOT be retransmitted.  ACK frames
+ containing updated information will be sent as described in {{frame-ack}}.
 
 * All other frames MUST be retransmitted.
 


### PR DESCRIPTION
I have had the experience of being confused by the "cumulative ack"
langauge in the current draft and then explaining it to others
confused about the same thing.

cumulative' is not used in the tcp sense where
the largest-ack is cumulative for all of the packets previous to
it. It tends to mean non-revokable here (which the draft also uses -
imo to more clarity.) While future acks can incorprate the data from
old ack frames (being in that sense cumulative) they do not have to
and in some cases will not be able to be so for space reasons.

In this case I think it is just the clarifying text that is confusing
- so less is more.