### PR TITLE
[transport] add missing 'type' to NEW_CONNECTION_ID frame

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2053,9 +2053,9 @@ seconds of quiescence. A PING frame has no additional fields.
 
 ## NEW_CONNECTION_ID Frame {#frame-new-connection-id}
 
-A server sends a NEW_CONNECTION_ID to provide the client with alternative
-connection IDs that can be used to break linkability when migrating connections
-(see {{migration-linkability}}).
+A server sends a NEW_CONNECTION_ID frame (type=0x0b) to provide the client with
+alternative connection IDs that can be used to break linkability when migrating
+connections (see {{migration-linkability}}).
 
 The NEW_CONNECTION_ID is as follows:
 


### PR DESCRIPTION
... in `-transport`, section 8.12

Tiny editorial tweak, but it saves a bit of jumping back and forth.