### PR TITLE
[transport] disambiguate stream frame 'payload'

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1544,7 +1544,7 @@ Stream Data:
 
 : The bytes from the designated stream to be delivered.
 
-A stream frame's payload MUST NOT be empty, unless the FIN bit is set.  When the
+A stream frame's Stream Data MUST NOT be empty, unless the FIN bit is set.  When the
 FIN flag is sent on an empty STREAM frame, the offset in the STREAM frame MUST
 be one greater than the last data byte sent on this stream.
 


### PR DESCRIPTION
"payload" already means something else, and this seems to be the only instance of it being used this way.

Better words may be available.