### PR TITLE
Stream correlation in Transport

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -552,7 +552,9 @@ All frames have the following format:
 The HAS_BODY frame indicates that the HTTP message contains a payload body.  It
 is sent after the initial header block on a request, response, or push stream.
 
-The HAS_BODY frame has no flags and is always empty.
+The HAS_BODY frame has no flags and is always empty.  A HAS_BODY frame with a
+non-empty payload or flags that are set MUST be treated as a
+HTTP_MALFORMED_HAS_BODY error.
 
 
 ### HEADERS {#frame-headers}
@@ -797,10 +799,9 @@ SETTINGS frames always apply to a connection, never a single stream.  A SETTINGS
 frame MUST be sent as the first frame of the connection control stream (see
 {{stream-mapping}}) by each peer, and MUST NOT be sent subsequently or on any
 other stream. If an endpoint receives an SETTINGS frame on a different stream,
-the endpoint MUST respond with a connection error of type
-HTTP_SETTINGS_ON_WRONG_STREAM.  If an endpoint receives a second SETTINGS frame,
-the endpoint MUST respond with a connection error of type
-HTTP_MULTIPLE_SETTINGS.
+the endpoint MUST respond with a connection error of type HTTP_WRONG_STREAM.  If
+an endpoint receives a second SETTINGS frame, the endpoint MUST respond with a
+connection error of type HTTP_MULTIPLE_SETTINGS.
 
 The SETTINGS frame affects connection state. A badly formed or incomplete
 SETTINGS frame MUST be treated as a connection error (Section 5.4.1) of type
@@ -937,24 +938,27 @@ HTTP_VERSION_FALLBACK (0x08):
 : The requested operation cannot be served over HTTP/QUIC.  The peer should
   retry over HTTP/2.
 
-HTTP_MALFORMED_HEADERS (0x09):
+HTTP_MALFORMED_HAS_BODY (0x09):
+: A HAS_BODY frame with a non-empty payload or set flags was received.
+
+HTTP_MALFORMED_HEADERS (0x0A):
 : A HEADERS frame has been received with an invalid format.
 
-HTTP_MALFORMED_PRIORITY (0x0A):
+HTTP_MALFORMED_PRIORITY (0x0B):
 : A PRIORITY frame has been received with an invalid format.
 
-HTTP_MALFORMED_SETTINGS (0x0B):
+HTTP_MALFORMED_SETTINGS (0x0C):
 : A SETTINGS frame has been received with an invalid format.
 
-HTTP_MALFORMED_PUSH_PROMISE (0x0C):
+HTTP_MALFORMED_PUSH_PROMISE (0x0D):
 : A PUSH_PROMISE frame has been received with an invalid format.
 
-HTTP_INTERRUPTED_HEADERS (0x0E):
+HTTP_MALFORMED_CANCEL_REQUEST (0x0E):
+: A PUSH_PROMISE frame has been received with an invalid format.
+
+HTTP_INTERRUPTED_HEADERS (0x0F):
 : A HEADERS frame without the End Header Block flag was followed by a frame
   other than HEADERS.
-
-HTTP_SETTINGS_ON_WRONG_STREAM (0x0F):
-: A SETTINGS frame was received on a request control stream.
 
 HTTP_MULTIPLE_SETTINGS (0x10):
 : More than one SETTINGS frame was received.
@@ -1320,12 +1324,13 @@ The entries in the following table are registered by this document.
 |  HTTP_CONNECT_ERROR               |  0x06  |  TCP reset or error on CONNECT request       |  {{http-error-codes}}  |
 |  HTTP_EXCESSIVE_LOAD              |  0x07  |  Peer generating excessive load              |  {{http-error-codes}}  |
 |  HTTP_VERSION_FALLBACK            |  0x08  |  Retry over HTTP/2                           |  {{http-error-codes}}  |
-|  HTTP_MALFORMED_HEADERS           |  0x09  |  Invalid HEADERS frame                       |  {{http-error-codes}}  |
-|  HTTP_MALFORMED_PRIORITY          |  0x0A  |  Invalid PRIORITY frame                      |  {{http-error-codes}}  |
-|  HTTP_MALFORMED_SETTINGS          |  0x0B  |  Invalid SETTINGS frame                      |  {{http-error-codes}}  |
-|  HTTP_MALFORMED_PUSH_PROMISE      |  0x0C  |  Invalid PUSH_PROMISE frame                  |  {{http-error-codes}}  |
-|  HTTP_INTERRUPTED_HEADERS         |  0x0E  |  Incomplete HEADERS block                    |  {{http-error-codes}}  |
-|  HTTP_SETTINGS_ON_WRONG_STREAM    |  0x0F  |  SETTINGS frame on a request control stream  |  {{http-error-codes}}  |
+|  HTTP_MALFORMED_HEADERS           |  0x09  |  Invalid HAS_BODY frame                      |  {{http-error-codes}}  |
+|  HTTP_MALFORMED_HEADERS           |  0x0A  |  Invalid HEADERS frame                       |  {{http-error-codes}}  |
+|  HTTP_MALFORMED_PRIORITY          |  0x0B  |  Invalid PRIORITY frame                      |  {{http-error-codes}}  |
+|  HTTP_MALFORMED_SETTINGS          |  0x0C  |  Invalid SETTINGS frame                      |  {{http-error-codes}}  |
+|  HTTP_MALFORMED_PUSH_PROMISE      |  0x0D  |  Invalid PUSH_PROMISE frame                  |  {{http-error-codes}}  |
+|  HTTP_MALFORMED_CANCEL_REQUEST    |  0x0E  |  Invalid CANCEL_REQUEST frame                |  {{http-error-codes}}  |
+|  HTTP_INTERRUPTED_HEADERS         |  0x0F  |  Incomplete HEADERS block                    |  {{http-error-codes}}  |
 |  HTTP_MULTIPLE_SETTINGS           |  0x10  |  Multiple SETTINGS frames                    |  {{http-error-codes}}  |
 |  HTTP_RST_CONTROL_STREAM          |  0x11  |  Message control stream was RST              |  {{http-error-codes}}  |
 |  HTTP_INVALID_STREAM_HEADER       |  0x12  |  Invalid stream header                       |  {{http-error-codes}}  |

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -492,6 +492,8 @@ response stream ({{frame-push-promise}}, {{stream-response}}).  Other than the
 means of identifying requests, the prioritization system is identical to that in
 HTTP/2.
 
+Only a client can prioritize requests.  A server MUST NOT sent a PRIORITY frame.
+
 
 ## Server Push
 

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -492,7 +492,7 @@ response stream ({{frame-push-promise}}, {{stream-response}}).  Other than the
 means of identifying requests, the prioritization system is identical to that in
 HTTP/2.
 
-Only a client can prioritize requests.  A server MUST NOT sent a PRIORITY frame.
+Only a client can prioritize requests.  A server MUST NOT send a PRIORITY frame.
 
 
 ## Server Push

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -398,6 +398,7 @@ Pseudocode for OnPacketAcked follows:
 
 ~~~
    OnPacketAcked(acked_packet_number):
+     OnPacketAckedCC(acked_packet_number)
      // If a packet sent prior to RTO was acked, then the RTO
      // was spurious.  Otherwise, inform congestion control.
      if (rto_count > 0 &&
@@ -652,13 +653,13 @@ follows:
 
 ## On Packet Acknowledgement
 
-Invoked at the same time loss detection's OnPacketAcked is called and
-supplied with the acked_packet from sent_packets.
+Invoked from loss detection's OnPacketAcked and is supplied with
+acked_packet from sent_packets.
 
-Pseudocode for OnPacketAcked follows:
+Pseudocode for OnPacketAckedCC follows:
 
 ~~~
-   OnPacketAcked(acked_packet):
+   OnPacketAckedCC(acked_packet):
      if (acked_packet.packet_number < end_of_recovery):
        return
      if (congestion_window < ssthresh):

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2723,9 +2723,9 @@ the RST_STREAM frame.  Otherwise, the final offset is the offset of the end of
 the data carried in STREAM frame marked with a FIN flag.
 
 An endpoint will know the final offset for a stream when it receives a STREAM
-frame with a FIN flag or a RST_STREAM frame.  If there is reordering or loss,
-an endpoint receive a STREAM frame with a FIN flag prior to the stream entering
-the "closed" state.
+frame with a FIN flag or a RST_STREAM frame.  If there is reordering or loss, an
+endpoint might receive a STREAM frame with a FIN flag prior to the stream
+entering the "closed" state.
 
 An endpoint MUST NOT send data on a stream at or beyond the final offset.
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2430,7 +2430,7 @@ All streams start in the "idle" state.
 The following transitions are valid from this state:
 
 Sending a STREAM or RST_STREAM frame causes the identified stream to become
-"open" for a sending endpoint.  New streams use the next stream available
+"open" for a sending endpoint.  New streams use the next available stream
 identifier, as described in {{stream-id}}.  An endpoint MUST NOT send a STREAM
 or RST_STREAM frame for a stream ID that is higher than the peers advertised
 maximum stream ID (see {{frame-max-stream-id}}).

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1510,6 +1510,10 @@ A STREAM frame is shown below.
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                      Offset (0/16/32/64)                    ...
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|  [Flags (8)]  |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|              [Associated Stream ID (8/16/24/32)]            ...
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |       [Data Length (16)]      |        Stream Data (*)      ...
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 ~~~
@@ -1529,6 +1533,16 @@ Offset:
   on a stream - the sum of the re-constructed offset and data length - MUST be
   less than 2^64.
 
+Flags:
+
+: Indicates properties of the stream.  Present only when the offset length is 0.
+  See {{stream-flags}}.
+
+Associated Stream ID:
+
+: The stream ID of the stream to which this stream responds.  See
+  {{stream-flags}} for details on the field's length and presence.
+
 Data Length:
 
 : An optional 16-bit unsigned number specifying the length of the Stream Data
@@ -1538,6 +1552,10 @@ Data Length:
 Stream Data:
 
 : The bytes from the designated stream to be delivered.
+
+The first STREAM frame on a given stream MUST use an Offset length of zero and
+a corresponding Flags field describing the stream.  A value of zero in a
+non-zero-length Offset field MUST NOT be used.
 
 A STREAM frame MUST have either non-zero data length or the FIN bit set.  When
 the FIN flag is sent on an empty STREAM frame, the offset in the STREAM frame
@@ -1556,6 +1574,28 @@ blocks all those streams from making progress.  An implementation is therefore
 advised to bundle as few streams as necessary in outgoing packets without losing
 transmission efficiency to underfilled packets.
 
+### Stream Flags {#stream-flags}
+
+The Flags field indicates properties of a newly-opened stream.  The use of these
+properties are controlled by the application, but are carried by the QUIC
+transport to ease reuse by multiple applications.
+
+The flags are formatted as `TTAARRRR`.  These bits are interpreted as follows:
+
+  - The `TT` bits indicate the type of the stream:
+      - `00` indicates a unidirectional stream (no response expected)
+      - `01` indicates the initial leg of a bidirectional stream (one response
+        expected)
+      - `10` indicates the initial leg of a one-to-many stream (one or more
+        responses expected)
+      - `11` indicates a response stream, and signals the presence of an
+        Associated Stream ID field
+  - The `AA` bits encode the length of the Associated Stream ID field.
+    The values 00, 01, 02, and 03 indicate lengths of 8, 16, 24, and 32 bits
+    long respectively.  These bits are ignored if the `TT` bits have any value
+    other than `11`.
+  - The `RRRR` bits are reserved to indicate additional stream properties in
+    future versions, and MUST be set to zero in this version.
 
 ## ACK Frame {#frame-ack}
 
@@ -2297,7 +2337,9 @@ actually lost.
 Streams in QUIC provide a lightweight, ordered, and unidirectional byte-stream.
 
 Streams can be created either by the client or the server, can concurrently send
-data interleaved with other streams, and can be cancelled.
+data interleaved with other streams, and can be cancelled.  Streams can be
+associated with each other to enable bidirectional communication, including
+many-to-one relationships, as needed by the application protocol.
 
 Data that is received on a stream is delivered in order within that stream, but
 there is no particular delivery order across streams.  Transmit ordering among
@@ -2584,6 +2626,22 @@ sending new data, unless application priorities indicate otherwise.
 Retransmitting lost STREAM frames can fill in gaps, which allows the peer to
 consume already received data and free up flow control window.
 
+## Stream Correlation {#correlation}
+
+The first STREAM frame on a stream identifies whether the stream will be
+stand-alone, expects one or more responding streams, or is a response.
+Responding streams additionally identify the stream in the opposite direction
+with which they are correlated.  Correlated streams can be used to present
+bidirectional channels, subscriptions, or other useful abstractions to the
+application layer.
+
+Receipt of a stream associated to a parent which did not expect a response
+(unidirectional), or receipt of additional streams associated to a parent which
+expected only one response (bidirectional) MUST be treated as a stream error of
+type QUIC_CORRELATION_FAILED ({{error-handling}}).
+
+The client's stream 0 MUST request a bidirectional stream.  The server MUST
+use its stream 0 to respond.
 
 # Flow Control {#flow-control}
 
@@ -2843,6 +2901,9 @@ QUIC_STREAM_CANCELLED (0x80000006):
 
 QUIC_CLOSED_CRITICAL_STREAM (0x80000007):
 : A stream that is critical to the protocol was closed.
+
+QUIC_CORRELATION_FAILED (0x80000008):
+: A stream declared an association which could not be matched.
 
 QUIC_MISSING_PAYLOAD (0x80000030):
 : The packet contained no payload.


### PR DESCRIPTION
This is an augmentation of @martinthomson's PR to add stream correlation, as promised.

# Major changes

Leveraging @igorlord's insight that OO=00 only occurs on the first STREAM frame of a stream, I used that as the trigger for a Stream Properties byte.  Two bits of that byte describe the directionality of the stream:

- Unidirectional (no response expected)
- Initial bidirectional (one response expected)
- Initial multi-response (one or more responses expected; needs a better name)
- Response

If the type is Response, there's an Associated Stream ID field, length given by two more bits following the same pattern as the SS bits in the STREAM frame ID.

# Personal Opinion

On the plus side, these stream types seem to cover the abstractions I can envision for most applications.  You can unilaterally send something (unidirectional), do request/response (bidirectional), or pub/sub (single subscription stream, series of update streams).

I don't care for the fact that I still need the stream type header in HTTP after putting this in the transport.  That will be ameliorated if we go back to one stream per request, since all unidirectional streams will be push streams.  (As a side-note, I considered using the multiple-response option in the HTTP mapping, but then I need a stream header again to indicate which is the response and which the pushes.)

I particularly don't like that you now have to look at the frame type header to find out whether a field exists which tells you the length of something else in the header.  I'd like to simplify that.  I went with this model over a CREATE_STREAM frame because of @mikkelfj's use-case of very small messages -- this adds only one byte to the first frame on a stream in one direction and 2-5 bytes to the first frame of response streams.  A separate frame type would be somewhat larger, but could be cleaner in that respect.