### PR TITLE
Make it clear that it is cleartext packets that have an FNV hash

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -840,10 +840,10 @@ number gaps on connection ID transitions. That secret is computed as:
 
 # Unprotected Packets
 
-QUIC adds an integrity check to all cleartext packets.  Cleartext packetare not
-protected by the negotiated AEAD (see {{packet-protection}}), but instead
+QUIC adds an integrity check to all cleartext packets.  Cleartext packets are
+not protected by the negotiated AEAD (see {{packet-protection}}), but instead
 include an integrity check.  This check does not prevent the packet from being
-altered, it exists for added resilience against data corruption and to provided
+altered, it exists for added resilience against data corruption and to provide
 added assurance that the sender intends to use QUIC.
 
 Cleartext packets all use the long form of the QUIC header and so will include a

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -840,14 +840,14 @@ number gaps on connection ID transitions. That secret is computed as:
 
 # Unprotected Packets
 
-QUIC adds an integrity check to all unprotected packets.  Any packet that is not
-protected by the negotiated AEAD (see {{packet-protection}}), includes an
-integrity check.  This check does not prevent the packet from being altered, it
-exists for added resilience against data corruption and to provided added
-assurance that the sender intends to use QUIC.
+QUIC adds an integrity check to all cleartext packets.  Cleartext packetare not
+protected by the negotiated AEAD (see {{packet-protection}}), but instead
+include an integrity check.  This check does not prevent the packet from being
+altered, it exists for added resilience against data corruption and to provided
+added assurance that the sender intends to use QUIC.
 
-Unprotected packets all use the long form of the QUIC header and so will include
-a version number.  For this version of QUIC, the integrity check uses the 64-bit
+Cleartext packets all use the long form of the QUIC header and so will include a
+version number.  For this version of QUIC, the integrity check uses the 64-bit
 FNV-1a hash (see {{fnv1a}}).  The output of this hash is appended to the payload
 of the packet.
 


### PR DESCRIPTION
At the hackathon it came out that several people believed that Version Negotiation had integrity protection.  This was understandable.  The transport doc only said that integrity was for cleartext and said nothing about version neogitation, which isn't great.  What was worse was that the TLS doc said that it was for all unprotected packets, which is not the case.