### PR TITLE
[recovery] Fix some typos

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -422,10 +422,10 @@ below shows how the single timer is set based on the alarm mode.
 The initial flight has no prior RTT sample.  A client SHOULD remember
 the previous RTT it observed when resumption is attempted and use that for an
 initial RTT value.  If no previous RTT is available, the initial RTT defaults
-to 200ms.
+to 100ms.
 
 Endpoints MUST retransmit handshake frames if not acknowledged within a
-time limit. This time limit will start as the largest of twice the rtt value
+time limit. This time limit will start as the largest of twice the RTT value
 and MinTLPTimeout.  Each consecutive handshake retransmission doubles the
 time limit, until an acknowledgement is received.
 
@@ -437,8 +437,8 @@ When stateless rejects are in use, the connection is considered immediately
 closed once a reject is sent, so no timer is set to retransmit the reject.
 
 Version negotiation packets are always stateless, and MUST be sent once per
-per handshake packet that uses an unsupported QUIC version, and MAY be sent
-in response to 0RTT packets.
+handshake packet that uses an unsupported QUIC version, and MAY be sent in
+response to 0RTT packets.
 
 #### Tail Loss Probe and Retransmission Timeout
 


### PR DESCRIPTION
- "per per" -> "per" typo
- "rtt" -> "RTT" for consistency
- 01ad075d8dfae21a changed the initial RTT; I changed a reference in the text that I believe should match `kDefaultInitialRtt`.