### PR TITLE
Push ID

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -486,7 +486,7 @@ The PRIORITY frame payload has the following fields:
     stream ID of a request stream when the PUSH_DEPENDENT flag is clear, or a
     Push ID when the PUSH_DEPENDENT flag is set.  A request stream ID of 0
     indicates a dependency on the root stream. For details of dependencies,
-    see {{priority}} and {!RFC7540}}, Section 5.3.
+    see {{priority}} and {{!RFC7540}}, Section 5.3.
 
   Weight:
   : An unsigned 8-bit integer representing a priority weight for the stream (see
@@ -499,14 +499,12 @@ when the corresponding PUSH_PRIORITIZED or PUSH_DEPENDENT flag is not set.
 Setting the PUSH or PUSH_DEPENDENT flag causes the frame to identify a
 PUSH_PROMISE using a Push ID (see {{frame-push-promise}} for details).
 
-A PRIORITY frame MAY identify no request in the Prioritized Request field by
-using a stream ID of 0; as in {{!RFC7540}}, this makes the request dependent on
-the root of the dependency tree.
-
-A PRIORITY frame MAY identify a dependent stream with a stream ID of 0; as in
+A PRIORITY frame MAY identify a Stream Dependency with a stream ID of 0; as in
 {{!RFC7540}}, this makes the request dependent on the root of the dependency
-tree.  Stream ID 0 and stream ID 1 cannot be reprioritized; an attempt to
-reprioritize these stream MUST be treated as a connection error of type
+tree.
+
+Stream ID 0 and stream ID 1 cannot be reprioritized. A Prioritized Request that
+identifies Stream 0 or 1 MUST be treated as a connection error of type
 HTTP_MALFORMED_PRIORITY.
 
 A PRIORITY frame that does not reference a request MUST be treated as a
@@ -521,7 +519,7 @@ length MUST be treated as a connection error of type HTTP_MALFORMED_PRIORITY.
 ### CANCEL_PUSH {#frame-cancel-push}
 
 The CANCEL_PUSH frame (type=0x3) is used to request cancellation of server push
-prior to the push stream being created.  The CANCEL_REQUEST frame identifies a
+prior to the push stream being created.  The CANCEL_PUSH frame identifies a
 server push request by Push ID (see {{frame-push-promise}}).
 
 When a server receives this frame, it aborts sending the response for the

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -496,7 +496,7 @@ The PRIORITY frame payload has the following fields:
 
 A PRIORITY frame identifies a request to priotize, and a request upon which that
 request is dependent.  A Prioritized Request ID or Stream Dependency ID
-identifies a client initiated request using the corresponding stream ID when the
+identifies a client-initiated request using the corresponding stream ID when the
 corresponding PUSH_PRIORITIZED or PUSH_DEPENDENT flag is not set.  Setting the
 PUSH_PRIORITIZED or PUSH_DEPENDENT flag causes the Prioritized Request ID or
 Stream Dependency ID (respectively) to identify a server push using a Push ID


### PR DESCRIPTION
As requested, I split this out of the unidirectional PR (#643).

There is a change here, that needs to be highlighted.  @kazuho points out that without inter-stream ordering guarantees, requests might be triggered on multiple streams.  The server then has an awkward choice: either push multiple times, or risk the client triggering requests when streams arrive out of order.  This contains a fix for that bug.

The fix is to allow the same push ID to be used in multiple PUSH_PROMISE frames.  Then, fulfillment happens at most once.

I think that this is a neat fix, but it creates two more problems:

1. How does a client know when the server will stop referencing a push ID in PUSH_PROMISE?  With reordering, the pushed response might arrive and be consumed before a PUSH_PROMISE that references it.  I think that it might be possible to add a counter to the push stream header that says how many times the server promised this response.  The problem with that is that if a stream that carries the PUSH_PROMISE is reset, then that counter will be too high.  I've decided to just explain the issue and add some weasel wording rather than provide a direct fix.

2. What if the server provides different headers for the same Push ID?  I've chosen to fix this by simply forbidding variations in the content of the header block.  I considered only allowing the headers to appear once, but then you have to deal with that stream being reset.  Repetition should be rare enough, and header compression might be able to help with the extra bytes.

I think that those problems are both less serious than the bug this fixes.  Besides, the first is really only an generalized form of a problem we have already: the stream carrying a PUSH_PROMISE can be reset.  What currently happens is that the server more or less has to send a push stream anyway, even though it can't know whether the client got the PUSH_PROMISE.  With this, a server can use CANCEL_REQUEST.

Closes #702, #281.