### PR TITLE
Limit pushes using MAX_PUSH_ID

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -857,7 +857,7 @@ HTTP_INTERRUPTED_HEADERS (0x0E):
   other than HEADERS.
 
 HTTP_WRONG_STREAM (0x0F):
-: A frame was received on a different stream to where it is permitted.
+: A frame was received on stream where it is not permitted.
 
 HTTP_MULTIPLE_SETTINGS (0x10):
 : More than one SETTINGS frame was received.

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -368,8 +368,8 @@ of type HTTP_MALFORMED_PUSH.
 
 A server SHOULD use Push IDs sequentially, starting at 0.  A client uses the
 MAX_PUSH_ID frame ({{frame-max-push-id}}) to limit the number of pushes that a
-server can promise initiate.  A client MUST treat receipt of a push stream with
-a Push ID that is greater than the maximum Push ID as a connection error of type
+server can promise.  A client MUST treat receipt of a push stream with a Push ID
+that is greater than the maximum Push ID as a connection error of type
 HTTP_MALFORMED_PUSH.
 
 Each Push ID MUST only be used once in a push stream header.  If a push stream

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -367,10 +367,10 @@ receiving a push stream that contains fewer than 4 octets as a connection error
 of type HTTP_MALFORMED_PUSH.
 
 A server SHOULD use Push IDs sequentially, starting at 0.  A client uses the
-MAX_PUSH_ID frame ({{frame-max-push-id}}) and SETTINGS_MAX_PUSH_ID
-({{settings-parameters}}) to limit the number of pushes that a server can
-promise initiate.  A client MUST treat receipt of a push stream with a Push ID
-that is greater than the maximum Push ID as a connection error of type
+SETTINGS_MAX_PUSH_ID ({{settings-parameters}}) setting and the MAX_PUSH_ID frame
+({{frame-max-push-id}}) to limit the number of pushes that a server can promise
+initiate.  A client MUST treat receipt of a push stream with a Push ID that is
+greater than the maximum Push ID as a connection error of type
 HTTP_MALFORMED_PUSH.
 
 Each Push ID MUST only be used once in a push stream header.  If a push stream
@@ -709,9 +709,9 @@ Header Block:
 
 A server MUST NOT use a Push ID that is larger than the client has provided in a
 MAX_PUSH_ID frame ({{frame-max-push-id}}) or the SETTINGS_MAX_PUSH_ID setting
-({{settings-parameters}}).  A client that receives a PUSH_PROMISE that contains
-a larger Push ID than is allowed MUST be treated as a connection error of type
-HTTP_MALFORMED_PUSH_PROMISE.
+({{settings-parameters}}).  A client MUST treat receipt of a PUSH_PROMISE that
+contains a larger Push ID than the client has advertised as a connection error
+of type HTTP_MALFORMED_PUSH_PROMISE.
 
 A server MAY use the same Push ID in multiple PUSH_PROMISE frames.  This allows
 the server to use the same server push in response to multiple concurrent
@@ -816,10 +816,11 @@ This ensures that a connection can be cleanly shut down without losing requests.
 
 # MAX_PUSH_ID {#frame-max-push-id}
 
-The MAX_PUSH_ID frame (type=0xA) is used by clients to control the number of
+The MAX_PUSH_ID frame (type=0xD) is used by clients to control the number of
 server pushes that the server can initiate.  This sets the maximum value for a
 Push ID that the server can use in a PUSH_PROMISE frame.  Consequently, this
-also limits the number of push streams that the server can initiate.
+also limits the number of push streams that the server can initiate in addition
+to the limit set by the QUIC MAX_STREAM_ID frame.
 
 The MAX_PUSH_ID frame is always sent on the control stream.  Receipt of a
 MAX_PUSH_ID frame on any other stream MUST be treated as a connection error of
@@ -1204,7 +1205,7 @@ The entries in the following table are registered by this document.
 | GOAWAY         | 0x7  | {{frame-goaway}}         |
 | Reserved       | 0x8  | N/A                      |
 | Reserved       | 0x9  | N/A                      |
-| MAX_PUSH_ID    | 0xA  | {{frame-max-push-id}}    |
+| MAX_PUSH_ID    | 0xD  | {{frame-max-push-id}}    |
 |----------------|------|--------------------------|
 
 ## Settings Parameters {#iana-settings}

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -821,6 +821,13 @@ server pushes that the server can initiate.  This sets the maximum value for a
 Push ID that the server can use in a PUSH_PROMISE frame.  Consequently, this
 also limits the number of push streams that the server can initiate.
 
+The MAX_PUSH_ID frame is always sent on the control stream.  Receipt of a
+MAX_PUSH_ID frame on any other stream MUST be treated as a connection error of
+type HTTP_WRONG_STREAM.
+
+A server MUST NOT send a MAX_PUSH_ID frame.  A client MUST treat the receipt of
+a MAX_PUSH_ID frame as a connection error of type HTTP_MALFORMED_MAX_PUSH_ID.
+
 The initial value for the maximum Push ID is determined by the
 SETTINGS_MAX_PUSH_ID setting ({{settings-parameters}}).  A client that wishes to
 manage the number of promised server pushes can increase the maximum Push ID by
@@ -829,10 +836,10 @@ sending a MAX_PUSH_ID frame as the server fulfills or cancels server pushes.
 The MAX_PUSH_ID frame has no defined flags.
 
 The MAX_PUSH_ID frame carries a 32-bit Push ID that identifies the maximum value
-for a Push ID that the server can use (see {{frame-push-promise}}).
-
-A server MUST NOT send a MAX_PUSH_ID frame.  A client MUST treat the receipt of
-a MAX_PUSH_ID frame as a connection error of type HTTP_MALFORMED_MAX_PUSH_ID.
+for a Push ID that the server can use (see {{frame-push-promise}}).  A
+MAX_PUSH_ID frame cannot reduce the maximum Push ID; receipt of a MAX_PUSH_ID
+that contains a smaller value than previously received MUST be treated as a
+connection error of type HTTP_MALFORMED_MAX_PUSH_ID.
 
 A server MUST treat a MAX_PUSH_ID frame payload that is other than 4 octets in
 length as a connection error of type HTTP_MALFORMED_MAX_PUSH_ID.
@@ -909,6 +916,9 @@ HTTP_MULTIPLE_SETTINGS (0x10):
 
 HTTP_MALFORMED_PUSH (0x11):
 : A push stream header was malformed or included an invalid Push ID.
+
+HTTP_MALFORMED_MAX_PUSH_ID (0x12):
+: A MAX_STREAM_ID frame has been received with an invalid format.
 
 
 # Considerations for Transitioning from HTTP/2
@@ -1285,6 +1295,7 @@ The entries in the following table are registered by this document.
 |  HTTP_WRONG_STREAM                |  0x0F  |  A frame was sent on the wrong stream  | {{http-error-codes}} |
 |  HTTP_MULTIPLE_SETTINGS           |  0x10  |  Multiple SETTINGS frames              | {{http-error-codes}} |
 |  HTTP_MALFORMED_PUSH              |  0x11  |  Invalid push stream header            | {{http-error-codes}} |
+|  HTTP_MALFORMED_MAX_PUSH_ID       |  0x12  |  Invalid MAX_PUSH_ID frame             | {{http-error-codes}} |
 |-----------------------------------|--------|----------------------------------------|----------------------|
 
 

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -608,10 +608,9 @@ SETTINGS frames always apply to a connection, never a single stream.  A SETTINGS
 frame MUST be sent as the first frame of the control stream (see
 {{stream-mapping}}) by each peer, and MUST NOT be sent subsequently or on any
 other stream. If an endpoint receives an SETTINGS frame on a different stream,
-the endpoint MUST respond with a connection error of type
-HTTP_SETTINGS_ON_WRONG_STREAM.  If an endpoint receives a second SETTINGS frame,
-the endpoint MUST respond with a connection error of type
-HTTP_MULTIPLE_SETTINGS.
+the endpoint MUST respond with a connection error of type HTTP_WRONG_STREAM.  If
+an endpoint receives a second SETTINGS frame, the endpoint MUST respond with a
+connection error of type HTTP_MULTIPLE_SETTINGS.
 
 The SETTINGS frame affects connection state. A badly formed or incomplete
 SETTINGS frame MUST be treated as a connection error ({{errors}}) of type
@@ -851,14 +850,14 @@ HTTP_MALFORMED_PUSH_PROMISE (0x0C):
 : A PUSH_PROMISE frame has been received with an invalid format.
 
 HTTP_MALFORMED_DATA (0x0D):
-: A HEADERS frame has been received with an invalid format.
+: A DATA frame has been received with an invalid format.
 
 HTTP_INTERRUPTED_HEADERS (0x0E):
 : A HEADERS frame without the End Header Block flag was followed by a frame
   other than HEADERS.
 
-HTTP_SETTINGS_ON_WRONG_STREAM (0x0F):
-: A SETTINGS frame was received on a request control stream.
+HTTP_WRONG_STREAM (0x0F):
+: A frame was received on a different stream to where it is permitted.
 
 HTTP_MULTIPLE_SETTINGS (0x10):
 : More than one SETTINGS frame was received.
@@ -1233,6 +1232,7 @@ The entries in the following table are registered by this document.
 |  HTTP_MALFORMED_PRIORITY          |  0x0A  |  Invalid PRIORITY frame                | {{http-error-codes}} |
 |  HTTP_MALFORMED_SETTINGS          |  0x0B  |  Invalid SETTINGS frame                | {{http-error-codes}} |
 |  HTTP_MALFORMED_PUSH_PROMISE      |  0x0C  |  Invalid PUSH_PROMISE frame            | {{http-error-codes}} |
+|  HTTP_MALFORMED_DATA              |  0x0D  |  Invalid DATA frame                    | {{http-error-codes}} |
 |  HTTP_INTERRUPTED_HEADERS         |  0x0E  |  Incomplete HEADERS block              | {{http-error-codes}} |
 |  HTTP_WRONG_STREAM                |  0x0F  |  A frame was sent on the wrong stream  | {{http-error-codes}} |
 |  HTTP_MULTIPLE_SETTINGS           |  0x10  |  Multiple SETTINGS frames              | {{http-error-codes}} |

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -336,9 +336,9 @@ frame.
 ## Server Push
 
 HTTP/QUIC supports server push as described in {{!RFC7540}}. During connection
-establishment, the client indicates whether it is willing to receive server
-pushes via the SETTINGS_ENABLE_PUSH setting in the SETTINGS frame (see
-{{connection-establishment}}), which is disabled by default.
+establishment, the client enables server push by sending a MAX_PUSH_ID frame
+(see {{frame-max-push-id}}).  A server cannot use server push until it receives
+a MAX_PUSH_ID frame.
 
 As with server push for HTTP/2, the server initiates a server push by sending a
 PUSH_PROMISE frame that includes request header fields attributed to the
@@ -367,10 +367,9 @@ receiving a push stream that contains fewer than 4 octets as a connection error
 of type HTTP_MALFORMED_PUSH.
 
 A server SHOULD use Push IDs sequentially, starting at 0.  A client uses the
-SETTINGS_MAX_PUSH_ID ({{settings-parameters}}) setting and the MAX_PUSH_ID frame
-({{frame-max-push-id}}) to limit the number of pushes that a server can promise
-initiate.  A client MUST treat receipt of a push stream with a Push ID that is
-greater than the maximum Push ID as a connection error of type
+MAX_PUSH_ID frame ({{frame-max-push-id}}) to limit the number of pushes that a
+server can promise initiate.  A client MUST treat receipt of a push stream with
+a Push ID that is greater than the maximum Push ID as a connection error of type
 HTTP_MALFORMED_PUSH.
 
 Each Push ID MUST only be used once in a push stream header.  If a push stream
@@ -642,13 +641,6 @@ The following settings are defined in HTTP/QUIC:
   SETTINGS_HEADER_TABLE_SIZE (0x1):
   : An integer with a maximum value of 2^32 - 1.  This value MUST be zero.
 
-  SETTINGS_MAX_PUSH_ID (0x2):
-  : An integer with a maximum value of 2^32 - 1.  This determines the initial
-    maximum Push ID that a server can use.  This setting only has meaning when
-    set by a client; a server MUST NOT provide a value for this setting.  A
-    client MUST treat receipt of this setting from a server as a connection
-    error of type HTTP_MALFORMED_SETTINGS.
-
   SETTINGS_MAX_HEADER_LIST_SIZE (0x6):
   : An integer with a maximum value of 2^32 - 1
 
@@ -708,10 +700,9 @@ Header Block:
 : HPACK-compressed request headers for the promised response.
 
 A server MUST NOT use a Push ID that is larger than the client has provided in a
-MAX_PUSH_ID frame ({{frame-max-push-id}}) or the SETTINGS_MAX_PUSH_ID setting
-({{settings-parameters}}).  A client MUST treat receipt of a PUSH_PROMISE that
-contains a larger Push ID than the client has advertised as a connection error
-of type HTTP_MALFORMED_PUSH_PROMISE.
+MAX_PUSH_ID frame ({{frame-max-push-id}}).  A client MUST treat receipt of a
+PUSH_PROMISE that contains a larger Push ID than the client has advertised as a
+connection error of type HTTP_MALFORMED_PUSH_PROMISE.
 
 A server MAY use the same Push ID in multiple PUSH_PROMISE frames.  This allows
 the server to use the same server push in response to multiple concurrent
@@ -829,8 +820,8 @@ type HTTP_WRONG_STREAM.
 A server MUST NOT send a MAX_PUSH_ID frame.  A client MUST treat the receipt of
 a MAX_PUSH_ID frame as a connection error of type HTTP_MALFORMED_MAX_PUSH_ID.
 
-The initial value for the maximum Push ID is determined by the
-SETTINGS_MAX_PUSH_ID setting ({{settings-parameters}}).  A client that wishes to
+The maximum Push ID is unset when a connection is created, meaning that a server
+cannot push until it receives a MAX_PUSH_ID frame.  A client that wishes to
 manage the number of promised server pushes can increase the maximum Push ID by
 sending a MAX_PUSH_ID frame as the server fulfills or cancels server pushes.
 
@@ -1038,9 +1029,8 @@ SETTINGS_HEADER_TABLE_SIZE:
 : See {{settings-parameters}}.
 
 SETTINGS_ENABLE_PUSH:
-: This is renamed to SETTINGS_MAX_PUSH_ID.  Rather than being a Boolean, this
-  includes an integer that sets an upper bound on the number of server pushes.
-  See {{settings-parameters}}.
+: This is removed in favor of the MAX_PUSH_ID which provides a more granular
+  control over server push.
 
 SETTINGS_MAX_CONCURRENT_STREAMS:
 : QUIC controls the largest open stream ID as part of its flow control logic.
@@ -1240,7 +1230,7 @@ The entries in the following table are registered by this document.
 | Setting Name               | Code | Specification           |
 |----------------------------|:----:|-------------------------|
 | HEADER_TABLE_SIZE          | 0x1  | {{settings-parameters}} |
-| ENABLE_PUSH                | 0x2  | {{settings-parameters}} |
+| Reserved                   | 0x2  | N/A                     |
 | Reserved                   | 0x3  | N/A                     |
 | Reserved                   | 0x4  | N/A                     |
 | Reserved                   | 0x5  | N/A                     |
@@ -1319,8 +1309,7 @@ The original authors of this specification were Robbie Shade and Mike Warres.
 - SETTINGS_ENABLE_PUSH instead of SETTINGS_DISABLE_PUSH (#477)
 - Restored GOAWAY (#696)
 - Identify server push using Push ID rather than a stream ID (#702,#281)
-- Made push ID sequential, rename SETTINGS_ENABLE_PUSH to SETTINGS_MAX_PUSH_ID
-  (#709)
+- Made push ID sequential, add MAX_PUSH_ID, remove SETTINGS_ENABLE_PUSH (#709)
 
 ## Since draft-ietf-quic-http-03
 


### PR DESCRIPTION
This repurposes SETTINGS_ENABLE_PUSH as the initial limit.

A client can use this to limit the number of outstanding pushes.  I've included
advice on increasing the limit, not as the pushes are first used, but as the
pushes are completed (or cancelled).

There wasn't a rule for handling a truncated push stream header, so I added
that as well.  The HTTP_DUPLICATE_PUSH error was reclaimed for signaling all
three types of error with a push stream header: truncation, duplicate Push ID,
and exceeding MAX_PUSH_ID.

Closes #709.