### PR TITLE
Revise text on ACK frames prior to handshake completion

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1262,25 +1262,25 @@ able to inject these packets.  Timing and packet retransmission information from
 `ACK` frames is critical to the functioning of the protocol, but these frames
 might be spoofed or altered.
 
-Endpoints MUST NOT use an unprotected `ACK` frame to acknowledge data that was
-protected by 0-RTT or 1-RTT keys.  An endpoint MUST ignore an unprotected `ACK`
-frame if it claims to acknowledge data that was sent in a protected packet.
-Such an acknowledgement can only serve as a denial of service, since an endpoint
-that can read protected data is always able to send protected data.
+Endpoints MUST NOT use an `ACK` frame in an unprotected packet to acknowledge
+packets that were protected by 0-RTT or 1-RTT keys.  An endpoint MUST ignore an
+`ACK` frame in an unprotected packet if it claims to acknowledge data that was
+sent in a protected packet.  Such an acknowledgement can only serve as a denial
+of service, since an endpoint that can read protected data is always able to
+send protected data.
 
-ISSUE:
+Note:
 
-: What about 0-RTT data?  Should we allow acknowledgment of 0-RTT with
-  unprotected frames?  If we don't, then 0-RTT data will be unacknowledged until
-  the handshake completes.  This isn't a problem if the handshake completes
-  without loss, but it could mean that 0-RTT stalls when a handshake packet
-  disappears for any reason.
+: 0-RTT data can be acknowledged by the server as it receives it, but any
+  packets containing acknowledgments of 0-RTT data cannot have packet protection
+  removed by the client until the entire server handshake is received by the
+  client.
 
-An endpoint SHOULD use data from unprotected or 0-RTT-protected `ACK` frames
-only during the initial handshake and while they have insufficient information
-from 1-RTT-protected `ACK` frames.  Once sufficient information has been
-obtained from protected messages, information obtained from less reliable
-sources can be discarded.
+An endpoint SHOULD use data from `ACK` frames carried in unprotected or
+0-RTT-protected packets only during the initial handshake and while they have
+insufficient information from `ACK` frames in 1-RTT-protected packets.  Once
+sufficient information has been obtained from protected messages, information
+obtained from less reliable sources can be discarded.
 
 
 ### Updates to Data and Stream Limits

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1276,11 +1276,13 @@ Note:
   removed by the client until the entire server handshake is received by the
   client.
 
-An endpoint SHOULD use data from `ACK` frames carried in unprotected or
-0-RTT-protected packets only during the initial handshake and while they have
-insufficient information from `ACK` frames in 1-RTT-protected packets.  Once
-sufficient information has been obtained from protected messages, information
-obtained from less reliable sources can be discarded.
+An endpoint SHOULD use data from `ACK` frames carried in unprotected packets or
+packets protected with 0-RTT keys only during the initial handshake.  All `ACK`
+frames contained in unprotected packets that are received after successful
+receipt of a packet protected with 1-RTT keys MUST be discarded.  An endpoint
+SHOULD therefore include acknowledgments for unprotected and any packets
+protected with 0-RTT keys until it sees an acknowledgment for a packet that is
+both protected with 1-RTT keys and contains an `ACK` frame.
 
 
 ### Updates to Data and Stream Limits

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1263,18 +1263,18 @@ able to inject these packets.  Timing and packet retransmission information from
 might be spoofed or altered.
 
 Endpoints MUST NOT use an `ACK` frame in an unprotected packet to acknowledge
-packets that were protected by 0-RTT or 1-RTT keys.  An endpoint MUST ignore an
-`ACK` frame in an unprotected packet if it claims to acknowledge data that was
-sent in a protected packet.  Such an acknowledgement can only serve as a denial
-of service, since an endpoint that can read protected data is always able to
-send protected data.
+packets that were protected by 0-RTT or 1-RTT keys.  An endpoint MUST treat
+receipt of an `ACK` frame in an unprotected packet that claims to acknowledge
+protected packets as a connection error of type OPTIMISTIC_ACK.  An endpoint
+that can read protected data is always able to send protected data.
 
 Note:
 
 : 0-RTT data can be acknowledged by the server as it receives it, but any
   packets containing acknowledgments of 0-RTT data cannot have packet protection
-  removed by the client until the entire server handshake is received by the
-  client.
+  removed by the client until the TLS handshake is complete.  The 1-RTT keys
+  necessary to remove packet protection cannot be derived until the client
+  receives all server handshake messages.
 
 An endpoint SHOULD use data from `ACK` frames carried in unprotected packets or
 packets protected with 0-RTT keys only during the initial handshake.  All `ACK`


### PR DESCRIPTION
This extensively used language like "protected ACK frames", which is incorrect.
I fixed that here, recognizing that more extensive fixes are probably needed.

I also just made the observation that the server might acknowledge 0-RTT, but
the client might be unable to read those ACK frames, which closes #221.