### PR TITLE
Add bidirectional streams on top of unidirectional

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -198,6 +198,10 @@ type of stream and to link the stream to another stream as necessary.
 
 Streams MUST be opened sequentially, with no gaps.
 
+HTTP does not use the Related Stream ID field.  Receipt of a QUIC STREAM frame
+that includes a Related Stream ID field MUST be treated as a connection error of
+type INVALID_RELATED_STREAM.
+
 HTTP does not need to do any separate multiplexing when using QUIC. Data sent
 over a QUIC stream always maps to a particular HTTP transaction. Requests and
 responses are considered complete when the corresponding QUIC streams are

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2641,7 +2641,7 @@ stream ID of the first in the Related Stream ID of the first stream.  This
 enables straightforward use of QUIC for request-response protocols or protocols
 that rely on bidirectional channels.
 
-This document doesn't proscribe the use of the Related Stream ID field, leaving
+This document doesn't define how to use the Related Stream ID field, leaving
 decisions about the semantics of related streams to protocols that use QUIC.
 Protocols that use QUIC MUST either define the semantics of related streams or
 prohibit the use of the Related Stream ID field.  Protocols MAY define other
@@ -2652,11 +2652,17 @@ invalid Related Stream ID field values, unless the protocol defines a more
 specific error code for the circumstances.
 
 The Related Stream ID for a stream only needs to be sent once for each stream
-(allowing for retransmissions due to loss).  Sending the field on all stream
-frames with an offset of 0 ensures that the value is received without
-duplicating the field unnecessarily.  If the value of the Related Stream ID
-changes for a stream, the endpoint that receives the conflicting value MUST
-treat this as a connection error of type INVALID_RELATED_STREAM.
+(allowing for retransmissions due to loss).  If a stream is related to another
+stream, then all stream frames with an offset of 0 MUST include the Related
+Stream ID field.  This is generally sufficient to ensure that the relationship
+between streams is correctly received.  However, the field MAY be included on
+other STREAM frames, which ensures that the stream relationship can be
+established even if the packet containing the first octets of a stream is lost.
+If the Related Stream ID is present in a STREAM frame and the value is different
+to the value included in other STREAM frames or a STREAM frame with a non-zero
+offset contains the value and a STREAM frame with offset zero does not, the
+recipient of the conflicting information MUST treat this as a connection error
+of type INVALID_RELATED_STREAM.
 
 A related stream MUST NOT refer to a stream in the "idle" state
 ({{stream-state-idle}}).  Receipt of a STREAM frame that includes a Related

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2223,12 +2223,10 @@ Offset:
 Related Stream ID:
 
 : A 32-bit value containing the stream ID of a stream in the opposite direction.
-  This field is only present if the Offset field is zero length.  Using a
+  This field is only present if the R bit in the frame type is set.  Using a
   Related Stream ID allows an application protocol to create bidirectional
-  streams by having a stream in one direction refer to another.  The identified
-  stream MUST NOT be in the "idle" state; receipt of a STREAM frame that
-  contains a Related Stream ID for an "idle" stream MUST be treated as a
-  connection error of type PROTOCOL_VIOLATION.
+  streams by having a stream in one direction refer to another (see
+  {{related-streams}}).
 
 Data Length:
 
@@ -2653,12 +2651,12 @@ INVALID_RELATED_STREAM error code can be used by protocols to signal receipt of
 invalid Related Stream ID field values, unless the protocol defines a more
 specific error code for the circumstances.
 
-The Related Stream ID for a stream only needs to be sent once for each (allowing
-for retransmissions due to loss).  Sending the field on all stream frames with
-an offset of 0 ensures that the value is received without duplicating the field
-unnecessarily.  If the value of the Related Stream ID changes for a stream, the
-endpoint that receives the conflicting value MUST treat this as a connection
-error of type INVALID_RELATED_STREAM.
+The Related Stream ID for a stream only needs to be sent once for each stream
+(allowing for retransmissions due to loss).  Sending the field on all stream
+frames with an offset of 0 ensures that the value is received without
+duplicating the field unnecessarily.  If the value of the Related Stream ID
+changes for a stream, the endpoint that receives the conflicting value MUST
+treat this as a connection error of type INVALID_RELATED_STREAM.
 
 A related stream MUST NOT refer to a stream in the "idle" state
 ({{stream-state-idle}}).  Receipt of a STREAM frame that includes a Related


### PR DESCRIPTION
This is based on the PR in #643.  It adds the concept of "related streams", which allows for pairing of streams.  It recommends against using the concept for anything else, but notes that any semantics are the responsibility of the application protocol.  This modifies the HTTP draft to prohibit use of this capability - that draft has a superior mechanism for request-response association.

I've kept this separate from #643 so that it can be assessed independently.