### PR TITLE
Define requirements for handling packets

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -910,7 +910,7 @@ diagnostic or security purposes.
 For servers, packets that aren't associated with a connection potentially create
 a new connection.  However, only packets that use the long packet header and
 that are at least the minimum size defined for the protocol version can be
-initial packets.  Unless the server is buffering 0-RTT packets, a server MUST
+initial packets.  Unless the server is buffering 0-RTT packets, a server MAY
 discard packets with a short header or packets that are smaller than the
 smallest minimum size for any version that the server supports.  A server that
 discards a packet that cannot be associated with a connection MAY also generate

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -911,9 +911,10 @@ For servers, packets that aren't associated with a connection potentially create
 a new connection.  However, only packets that use the long packet header and
 that are at least the minimum size defined for the protocol version can be
 initial packets.  Unless the server is buffering 0-RTT packets, a server MUST
-discard packets that cannot be associated with a connection if they use the
-short header form, or they are smaller than the smallest minimum size for any
-version that the server supports.
+either discard a packet or generate a stateless reset ({{stateless-reset}}) if
+the packet cannot be associated with a connection if they use the short header
+form, or they are smaller than the smallest minimum size for any version that
+the server supports.
 
 This version of QUIC defines a minimum size for initial packets of 1200 octets.
 Versions of QUIC that define smaller minimum initial packet sizes need to be

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -965,8 +965,9 @@ successfully receives a response or it abandons the connection attempt.
 ### Handling Version Negotiation Packets {#handle-vn}
 
 When the client receives a Version Negotiation packet, it first checks that the
-packet number and connection ID match the values it sent in a Client Initial
-packet.  If this check fails, the packet MUST be discarded.
+packet number and connection ID match the values the client sent in a previous
+packet on the same connection.  If this check fails, the packet MUST be
+discarded.
 
 Once the Version Negotiation packet is determined to be valid, the client then
 selects an acceptable protocol version from the list provided by the server.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -923,7 +923,7 @@ QUIC's connection establishment begins with version negotiation, since all
 communication between the endpoints, including packet and frame formats, relies
 on the two endpoints agreeing on a version.
 
-A QUIC connection begins with a client sending a client initial packet
+A QUIC connection begins with a client sending a Client Initial packet
 ({{packet-client-initial}}). The details of the handshake mechanisms are
 described in {{handshake}}, but all of the initial packets sent from the client
 to the server MUST use the long header format - which includes the version of
@@ -948,7 +948,7 @@ includes a list of versions that the server will accept.
 A server sends a Version Negotiation packet for any packet with an unaccepable
 version if that packet could create a new connection.  This allows a server to
 process packets with unsupported versions without retaining state.  Though
-either the client initial packet or the version negotiation packet that is sent
+either the Client Initial packet or the version negotiation packet that is sent
 in response could be lost, the client will send new packets until it
 successfully receives a response or it abandons the connection attempt.
 
@@ -956,13 +956,13 @@ successfully receives a response or it abandons the connection attempt.
 ### Handling Version Negotiation Packets {#handle-vn}
 
 When the client receives a Version Negotiation packet, it first checks that the
-packet number and connection ID match the values it sent in a client initial
+packet number and connection ID match the values it sent in a Client Initial
 packet.  If this check fails, the packet MUST be discarded.
 
 Once the Version Negotiation packet is determined to be valid, the client then
 selects an acceptable protocol version from the list provided by the server.
 The client then attempts to create a connection using that version.  Though the
-contents of the client initial packet the client sends might not change in
+contents of the Client Initial packet the client sends might not change in
 response to version negotiation, a client MUST increase the packet number it
 uses on every packet it sends.  Packets MUST continue to use long headers and
 MUST include the new negotiated protocol version.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -910,11 +910,10 @@ diagnostic or security purposes.
 For servers, packets that aren't associated with a connection potentially create
 a new connection.  However, only packets that use the long packet header and
 that are at least the minimum size defined for the protocol version can be
-initial packets.  Unless the server is buffering 0-RTT packets, a server MAY
-discard packets with a short header or packets that are smaller than the
-smallest minimum size for any version that the server supports.  A server that
-discards a packet that cannot be associated with a connection MAY also generate
-a stateless reset ({{stateless-reset}}).
+initial packets.  A server MAY discard packets with a short header or packets
+that are smaller than the smallest minimum size for any version that the server
+supports.  A server that discards a packet that cannot be associated with a
+connection MAY also generate a stateless reset ({{stateless-reset}}).
 
 This version of QUIC defines a minimum size for initial packets of 1200 octets
 (see {{packetization}}).  Versions of QUIC that define smaller minimum initial

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -904,17 +904,17 @@ controllers.  However, limiting the number and size of buffered packets might be
 needed to prevent exposure to denial of service.
 
 For clients, any packet that cannot be associated with an existing connection
-SHOULD be discarded if it not buffered.  Discarded packets MAY be logged for
+SHOULD be discarded if it is not buffered.  Discarded packets MAY be logged for
 diagnostic or security purposes.
 
 For servers, packets that aren't associated with a connection potentially create
 a new connection.  However, only packets that use the long packet header and
 that are at least the minimum size defined for the protocol version can be
 initial packets.  Unless the server is buffering 0-RTT packets, a server MUST
-either discard a packet or generate a stateless reset ({{stateless-reset}}) if
-the packet cannot be associated with a connection if they use the short header
-form, or they are smaller than the smallest minimum size for any version that
-the server supports.
+discard packets with a short header or packets that are smaller than the
+smallest minimum size for any version that the server supports.  A server that
+discards a packet that cannot be associated with a connection MAY also generate
+a stateless reset ({{stateless-reset}}).
 
 This version of QUIC defines a minimum size for initial packets of 1200 octets
 (see {{packetization}}).  Versions of QUIC that define smaller minimum initial
@@ -954,7 +954,7 @@ If the version selected by the client is not acceptable to the server, the
 server responds with a Version Negotiation packet ({{packet-version}}).  This
 includes a list of versions that the server will accept.
 
-A server sends a Version Negotiation packet for any packet with an unaccepable
+A server sends a Version Negotiation packet for any packet with an unacceptable
 version if that packet could create a new connection.  This allows a server to
 process packets with unsupported versions without retaining state.  Though
 either the Client Initial packet or the version negotiation packet that is sent

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -916,14 +916,14 @@ the packet cannot be associated with a connection if they use the short header
 form, or they are smaller than the smallest minimum size for any version that
 the server supports.
 
-This version of QUIC defines a minimum size for initial packets of 1200 octets.
-Versions of QUIC that define smaller minimum initial packet sizes need to be
-aware that initial packets will be discarded without action by servers that only
-support versions with larger minimums.  Clients that support multiple QUIC
-versions can avoid this problem by ensuring that they increase the size of their
-initial packets to the largest minimum size across all of the QUIC versions they
-support.  Servers need to recognize initial packets that are the minimum size of
-all QUIC versions they support.
+This version of QUIC defines a minimum size for initial packets of 1200 octets
+(see {{packetization}}).  Versions of QUIC that define smaller minimum initial
+packet sizes need to be aware that initial packets will be discarded without
+action by servers that only support versions with larger minimums.  Clients that
+support multiple QUIC versions can avoid this problem by ensuring that they
+increase the size of their initial packets to the largest minimum size across
+all of the QUIC versions they support.  Servers need to recognize initial
+packets that are the minimum size of all QUIC versions they support.
 
 
 ## Version Negotiation {#version-negotiation}


### PR DESCRIPTION
We never really said how to handle incoming packets.  This adds a section on
that.  This was originally motivated by #570, where the rules for what to
generate a Version Negotiation packet for were a little unclear.

Now though, this is a far more comprehensive description of what to do with
a packet that is received.

For #570, I've chosen to limit packet size.  If the packet is too small, then
this requires the server to drop the packet.  In response to the potential for
a future version of QUIC to define a smaller initial packet (@mikkelfj raised
this point), I've included advice on what might be done to avoid having packets
discarded.

Closes #570, #523, #568.