### PR TITLE
stateless_reset_token is server only

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1084,10 +1084,16 @@ idle_timeout (0x0003):
 : The idle timeout is a value in seconds that is encoded as an unsigned 16-bit
   integer.  The maximum value is 600 seconds (10 minutes).
 
-stateless_reset_token (0x0005):
+A server MUST include the following transport parameters:
+
+stateless_reset_token (0x0006):
 
 : The Stateless Reset Token is used in verifying a stateless reset, see
   {{stateless-reset}}.  This parameter is a sequence of 16 octets.
+
+A client MUST NOT include a stateless reset token.  A server MUST treat receipt
+of a stateless_reset_token transport parameter as a connection error of type
+TRANSPORT_PARAMETER_ERROR.
 
 An endpoint MAY use the following transport parameters:
 


### PR DESCRIPTION
This also corrects the number used in prose.

Closes #726.