### PR TITLE
Address validation for connection migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ issues.json
 pulls.json
 lib
 .targets.mk
+*.upload

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1533,7 +1533,8 @@ sufficient to ensure that it is easier to receive the packet than it is to guess
 the value correctly.
 
 If the PING frame is determined to be lost, a new PING frame SHOULD be
-generated.  This frame MUST include a new payload that is difficult to guess.
+generated.  This PING frame MUST include a new Data field that is similarly
+difficult to guess.
 
 If validation of the new remote address fails, after allowing enough time for
 possible loss and recovery of packets carrying PING and PONG frames, the

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1435,8 +1435,9 @@ recover such as outstanding requests, which might otherwise be lost with no easy
 way to retry them.
 
 An endpoint that receives packets that contain a source IP address and port that
-has not yet been used MUST start sending new packets with those as a destination
-IP address and port.  Packets exchanged between endpoints now follow a new path.
+has not yet been used can start sending new packets with those as a destination
+IP address and port.  Packets exchanged between endpoints can then follow the
+new path.
 
 Due to variations in path latency or packet reordering, packets from different
 source addresses might be reordered.  The packet with the highest packet number

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1503,9 +1503,9 @@ as described in Section 5.6 of {{QUIC-TLS}}.
 
 ### Address Validation for Migrated Connections {#migrate-validate}
 
-An endpoint that see a new source IP address and port (or just a new source
-port) on packets from its peer is likely seeing a connection migration at the
-peer.
+An endpoint that receives a packet from a new remote IP address and port (or
+just a new remote port) on packets from its peer is likely seeing a connection
+migration at the peer.
 
 However, it is also possible that the peer is spoofing its source address in
 order to cause the endpoint to send excessive amounts of data to an unwilling
@@ -1515,7 +1515,7 @@ generate toward a victim.
 
 Thus, when seeing a new remote transport address, an endpoint MUST verify that
 its peer can receive and respond to packets at that new address.  By providing
-copies of the frames that it receives, the peer proves that it is receiving
+copies of the data that it receives, the peer proves that it is receiving
 packets at the new address and consents to receive data.
 
 Prior to validating the new remote address, and endpoint MUST limit the amount

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1532,6 +1532,10 @@ return.  A PING frame containing 12 randomly generated {{?RFC4086}} octets is
 sufficient to ensure that it is easier to receive the packet than it is to guess
 the value correctly.
 
+Note:
+
+: Retransmissions of the PING frame MUST also use the same remote address.
+
 If validation of the new remote address fails, after allowing enough time for
 possible loss and recovery of packets carrying PING and PONG frames, the
 endpoint MUST terminate the connection.  When setting this timer,
@@ -1558,6 +1562,49 @@ longer valid based on the changed address.
 Address validation using the PING frame MAY be used at any time by either peer.
 For instance, an endpoint might check that a peer is still in possession of its
 address after a period of quiescence.
+
+Upon seeing a connection migration, an endpoint that sees a new address MUST
+abandon any address validation it is performing with other addresses on the
+expectation that the validation is likely to fail.  Abandoning address
+validation primarily means not closing the connection when a PONG frame is not
+received, but it could also mean ceasing retransmissions of the PING frame.  An
+endpoint that doesn't retransmit a PING frame might receive a PONG frame, which
+it MUST ignore.
+
+
+## Spurious Connection Migrations
+
+A connection migration could be triggered by an attacker that is able to capture
+and forward a packet such that it arrives before the legitimate copy of that
+packet.  Such a packet will appear to be a legitimate connection migration and
+the legitimate copy will be dropped as a duplicate.
+
+After a spurious migration, validation of the source address will fail because
+the entity at the source address does not have the necessary cryptographic keys
+to read or respond to the PING frame that is sent to it, even if it wanted to.
+Such a spurious connection migration could result in the connection being
+dropped when the source address validation fails.  This grants an attacker the
+ability to terminate the connection.
+
+Receipt of packets with higher packet numbers from the legitimate address will
+trigger another connection migration.  This will cause the validation of the
+address of the spurious migration to be abandoned.
+
+To ensure that a peer sends packets from the legitimate address before the
+validation of the new address can fail, an endpoint SHOULD attempt to validate
+the old remote address before attempting to validate the new address.  If the
+connection migration is spurious, then the legitimate address will be used to
+respond and the connection will migrate back to the old address.
+
+As with any address validation, packets containing retransmissions of the PING
+frame validating an address MUST be sent to the address being validated.
+Consequently, during a migration of a peer, an endpoint could be sending to
+multiple remote addresses.
+
+An endpoint MAY abandon address validation for an address that it considers to
+be already valid.  That is, if successive connection migrations occur in quick
+succession with the final remote address being identical to the initial remote
+address, the endpoint MAY abandon address validation for that address.
 
 
 ## Connection Termination {#termination}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1532,9 +1532,8 @@ return.  A PING frame containing 12 randomly generated {{?RFC4086}} octets is
 sufficient to ensure that it is easier to receive the packet than it is to guess
 the value correctly.
 
-Note:
-
-: Retransmissions of the PING frame MUST also use the same remote address.
+If the PING frame is determined to be lost, a new PING frame SHOULD be
+generated.  This frame MUST include a new payload that is difficult to guess.
 
 If validation of the new remote address fails, after allowing enough time for
 possible loss and recovery of packets carrying PING and PONG frames, the


### PR DESCRIPTION
This has been much-discussed, and it's a relatively isolated change, so I did it.

This modifies PING to have an optional payload and adds a PONG frame to echo
the PING.  An empty PING generates an ACK; a PING with a payload demands a
PONG.

Generating an unguessable PING is the basis of mid-connection address
validation.  If the PING is sent on the new path, and the PONG comes back, then
the remote address is probably OK to use.

I've taken the discussion in the issue into consideration here.  There's a lot
of potential nuance to capture in terms of how an endpoint might reduce and
restore send rates, but I've done what I can to thread the gap between allowing
unbounded sending along new and untested paths and allowing connections to get
back to doing business.

It's annoying that this makes PING and PONG so disparate.  I think that we have
a re-ordering of frames in our near future to correct minor infidelities like
this.  I didn't want to do that here and pollute this PR though.

Closes #161.