### PR TITLE
Keep-alive requirements

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -848,9 +848,9 @@ QUIC connections are persistent.  All of the considerations in Section 9.1 of
 
 HTTP clients are expected to use QUIC PING frames to keep connections open.
 Servers SHOULD NOT use PING frames to keep a connection open.  A client SHOULD
-NOT use PING frames for this purpose unless there are no responses outstanding
-for requests or server pushes.  If the client is not expecting a response from
-the server, allowing an idle connection to time out (based on the idle_timeout
+NOT use PING frames for this purpose unless there are responses outstanding for
+requests or server pushes.  If the client is not expecting a response from the
+server, allowing an idle connection to time out (based on the idle_timeout
 transport parameter) is preferred over expending effort maintaining a connection
 that might not be needed.  A gateway MAY use PING to maintain connections in
 anticipation of need rather than incur the latency cost of connection

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -841,6 +841,22 @@ A server MUST treat a MAX_PUSH_ID frame payload that is other than 4 octets in
 length as a connection error of type HTTP_MALFORMED_MAX_PUSH_ID.
 
 
+# Connection Management
+
+QUIC connections are persistent.  All of the considerations in Section 9.1 of
+{{?RFC7540}} apply to the management of QUIC connections.
+
+HTTP clients are expected to use QUIC PING frames to keep connections open.
+Servers SHOULD NOT use PING frames to keep a connection open.  A client SHOULD
+NOT use PING frames for this purpose unless there are no responses outstanding
+for requests or server pushes.  If the client is not expecting a response from
+the server, allowing an idle connection to time out (based on the idle_timeout
+transport parameter) is preferred over expending effort maintaining a connection
+that might not be needed.  A gateway MAY use PING to maintain connections in
+anticipation of need rather than incur the latency cost of connection
+establishment to servers.
+
+
 # Error Handling {#errors}
 
 QUIC allows the application to abruptly terminate (reset) individual streams or

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1845,9 +1845,24 @@ than it has sent, unless this is a result of a change in the initial limits (see
 Endpoints can use PING frames (type=0x07) to verify that their peers are still
 alive or to check reachability to the peer. The PING frame contains no
 additional fields. The receiver of a PING frame simply needs to acknowledge the
-packet containing this frame. The PING frame SHOULD be used to keep a connection
-alive when a stream is open. The default is to send a PING frame after 15
-seconds of quiescence. A PING frame has no additional fields.
+packet containing this frame.
+
+A PING frame has no additional fields.
+
+The PING frame can be used to keep a connection alive when an application or
+application protocol wishes to avoid the connection from timing out.  An
+application protocol SHOULD provide guidance about the conditions under which
+generating a PING is recommended.  This guidance SHOULD indicate whether it is
+the client or the server that is expected to send the PING.  Having both
+endpoints send PING frames without coordination can cause excessive number of
+packets and poor performance.
+
+A connection will time out if no packets are for a period longer than the time
+specified in the idle_timeout transport parameter (see {{termination}}).
+However, state in middleboxes might time out earlier than that.  Though REQ-5 in
+{{?RFC4787}} recommends a 2 minute timeout interval, experience shows that
+sending packets every 15 to 30 seconds is necessary to prevent the majority of
+middleboxes from losing state for UDP flows.
 
 
 ## BLOCKED Frame {#frame-blocked}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1854,8 +1854,8 @@ application protocol wishes to prevent the connection from timing out.  An
 application protocol SHOULD provide guidance about the conditions under which
 generating a PING is recommended.  This guidance SHOULD indicate whether it is
 the client or the server that is expected to send the PING.  Having both
-endpoints send PING frames without coordination can cause excessive number of
-packets and poor performance.
+endpoints send PING frames without coordination can produce an excessive number
+of packets and poor performance.
 
 A connection will time out if no packets are sent or received for a period
 longer than the time specified in the idle_timeout transport parameter (see

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1850,19 +1850,19 @@ packet containing this frame.
 A PING frame has no additional fields.
 
 The PING frame can be used to keep a connection alive when an application or
-application protocol wishes to avoid the connection from timing out.  An
+application protocol wishes to prevent the connection from timing out.  An
 application protocol SHOULD provide guidance about the conditions under which
 generating a PING is recommended.  This guidance SHOULD indicate whether it is
 the client or the server that is expected to send the PING.  Having both
 endpoints send PING frames without coordination can cause excessive number of
 packets and poor performance.
 
-A connection will time out if no packets are for a period longer than the time
-specified in the idle_timeout transport parameter (see {{termination}}).
-However, state in middleboxes might time out earlier than that.  Though REQ-5 in
-{{?RFC4787}} recommends a 2 minute timeout interval, experience shows that
-sending packets every 15 to 30 seconds is necessary to prevent the majority of
-middleboxes from losing state for UDP flows.
+A connection will time out if no packets are sent or received for a period
+longer than the time specified in the idle_timeout transport parameter (see
+{{termination}}).  However, state in middleboxes might time out earlier than
+that.  Though REQ-5 in {{?RFC4787}} recommends a 2 minute timeout interval,
+experience shows that sending packets every 15 to 30 seconds is necessary to
+prevent the majority of middleboxes from losing state for UDP flows.
 
 
 ## BLOCKED Frame {#frame-blocked}


### PR DESCRIPTION
This removes the bad advice in PING about keeping connections alive and goes
for a more nuanced description.  The transport contains generic advice and a
recommendation that application protocols provide further guidance.  The HTTP
mapping specifies that the client is the one that performs keep-alives and that
it should only do so if it is waiting on responses from the server.

Closes #729.