### PR TITLE
Size limit for Version Negotiation

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -887,12 +887,10 @@ server discards the incoming packet and responds with a Version Negotiation
 packet ({{packet-version}}).  This includes a list of versions that the server
 will accept.
 
-There is no limit to the size of the Version Negotiation packet, other than the
-number of versions that the server supports and the estimated path MTU.  To
-avoid packet amplification attacks a server MUST NOT send a Version Negotiation
-packet that is larger than the packet it responds to.  It is anticipated that
-this is ample space for all QUIC versions that a single server might need to
-advertise.
+To avoid packet amplification attacks a server MUST NOT send a Version
+Negotiation packet that is larger than the packet it responds to.  It is
+anticipated that this is ample space for all QUIC versions that a single server
+might need to advertise.
 
 A server sends a Version Negotiation packet for every packet that it receives
 with an unacceptable version.  This allows a server to process packets with

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -887,6 +887,13 @@ server discards the incoming packet and responds with a Version Negotiation
 packet ({{packet-version}}).  This includes a list of versions that the server
 will accept.
 
+There is no limit to the size of the Version Negotiation packet, other than the
+number of versions that the server supports and the estimated path MTU.  To
+avoid packet amplification attacks a server MUST NOT send a Version Negotiation
+packet that is larger than the packet it responds to.  It is anticipated that
+this is ample space for all QUIC versions that a single server might need to
+advertise.
+
 A server sends a Version Negotiation packet for every packet that it receives
 with an unacceptable version.  This allows a server to process packets with
 unsupported versions without retaining state.  Though either the initial client


### PR DESCRIPTION
As discussed, the limits are largely practical, and there should be enough
incentive to avoid inflation, but it pays to be a little more precise when
defining protocols or you can get odd downstream effects.  I've chosen to limit
the size to the CI.  That's 1200 currently (or more) and should be plenty og
space for many versions.

Closes #585.