### PR TITLE
Clarify the In Effect a new Connection language in Stateless Retry

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -606,9 +606,9 @@ Server Stateless Retry packet.
 After receiving a Server Stateless Retry packet, the client uses a new Client
 Initial packet containing the next cryptographic handshake message.  The client
 retains the state of its cryptographic handshake, but discards all transport
-state.  The new Client Initial packet is sent in a packet with a newly
-randomized packet number and starting at a stream offset of 0 and the
-original connection ID.
+state.  The new Client Initial packet includes a newly randomized packet number,
+STREAM frames on stream 0 that start again at an offset of 0, and the original
+connection ID.
 
 Continuing the cryptographic handshake is necessary to ensure that an attacker
 cannot force a downgrade of any cryptographic parameters.  In addition to

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -606,9 +606,9 @@ Server Stateless Retry packet.
 After receiving a Server Stateless Retry packet, the client uses a new Client
 Initial packet containing the next cryptographic handshake message.  The client
 retains the state of its cryptographic handshake, but discards all transport
-state.  In effect, the next cryptographic handshake message is sent on a new
-connection.  The new Client Initial packet is sent in a packet with a newly
-randomized packet number and starting at a stream offset of 0.
+state.  The new Client Initial packet is sent in a packet with a newly
+randomized packet number and starting at a stream offset of 0 and the
+original connection ID.
 
 Continuing the cryptographic handshake is necessary to ensure that an attacker
 cannot force a downgrade of any cryptographic parameters.  In addition to


### PR DESCRIPTION
Regarding client processing of Server Stateless Retry:

Remove language of "In effect, the next cryptographic handshake message is sent on a new
connection" as its pretty much not true if for no other reason that the crypto state is not the same as a new connection.

Of particular concern here was an interop issue where the second client hello used a new connection ID because of the "new connection" language, but the server rejected the HRR cookie because the address validation within it was bound to the old connection ID which seems like a legitimate thing to do when making those tokens opaque. 2 other implementations have chosen to keep the connID constant across CI.