### PR TITLE
close connection when receiving unprotected ACKs for protected packets

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -529,7 +529,8 @@ largest acked packet is supplied.
 
 #### Handshake Packets
 
-The receiver MUST ignore unprotected packets that ack protected packets.
+The receiver MUST close the connection with an error of type OPTIMISTIC_ACK
+when receiving an unprotected packet that acks protected packets.
 The receiver MUST trust protected acks for unprotected packets, however.  Aside
 from this, loss detection for handshake packets when an ack is processed is
 identical to other packets.


### PR DESCRIPTION
The TLS draft says in https://quicwg.github.io/base-drafts/draft-ietf-quic-tls.html#rfc.section.9.1.2:

> Endpoints MUST NOT use an ACK frame in an unprotected packet to acknowledge packets that were protected by 0-RTT or 1-RTT keys. An endpoint MUST treat receipt of an ACK frame in an unprotected packet that claims to acknowledge protected packets as a connection error of type OPTIMISTIC_ACK.


The Loss Recovery draft currently says that unprotected packets containing ACKs for protected packets have to be ignored. This PR updates the Loss Recovery draft and makes it consistent with the TLS draft.