### PR TITLE
Move stateless reset token to the end

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1576,9 +1576,9 @@ The Packet Number field is set to a randomized value.  The server SHOULD send a
 packet with a short header and a type of 0x01.  This produces the shortest
 possible packet number encoding, which minimizes the perceived gap between the
 last packet that the server sent and this packet.  A server MAY use a different
-short header type, indicating a different packet number length, but this allows
-for the message to be identified as a stateless reset more easily using
-heuristics.
+short header type, indicating a different packet number length, but a longer
+packet number encoding might allow this message to be identified as a stateless
+reset more easily using heuristics.
 
 After the first short header octet and optional connection ID, the server
 includes the value of the Stateless Reset Token that it included in its

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1572,12 +1572,13 @@ A server copies the connection ID field from the packet that triggers the
 stateless reset.  A server omits the connection ID if explicitly configured to
 do so, or if the client packet did not include a connection ID.
 
-The Packet Number field is set to a randomized value.  This packet SHOULD use
-the short header form with the shortest possible packet number encoding.  This
-minimizes the perceived gap between the last packet that the server sent and
-this packet.  A server MAY use a different short header type, indicating a
-different packet number length, but this allows for the message to be identified
-as a stateless reset more easily using heuristics.
+The Packet Number field is set to a randomized value.  The server SHOULD send a
+packet with a short header and a type of 0x01.  This produces the shortest
+possible packet number encoding, which minimizes the perceived gap between the
+last packet that the server sent and this packet.  A server MAY use a different
+short header type, indicating a different packet number length, but this allows
+for the message to be identified as a stateless reset more easily using
+heuristics.
 
 After the first short header octet and optional connection ID, the server
 includes the value of the Stateless Reset Token that it included in its

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1601,12 +1601,12 @@ CONNECTION_CLOSE or APPLICATION_CLOSE frame if it has sufficient state to do so.
 #### Detecting a Stateless Reset
 
 A client detects a potential stateless reset when a packet with a short header
-either cannot be decrypted or is marked as a potential duplicate.  The client
-then performs a constant-time comparison of the last 16 octets of the packet
-with the Stateless Reset Token provided by the server in its transport
-parameters.  If this comparison is successful, the client MUST discard all
-connection state and not send any further packets on this connection. If the
-comparison is unsuccessful, the packet can be discarded.
+either cannot be decrypted or is marked as a duplicate packet.  The client then
+compares the last 16 octets of the packet with the Stateless Reset Token
+provided by the server in its transport parameters.  If these values are
+identical, the client MUST discard all connection state and not send any further
+packets on this connection.  If the comparison fails, the packet can be
+discarded.
 
 
 #### Calculating a Stateless Reset Token

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1604,10 +1604,9 @@ A client detects a potential stateless reset when a packet with a short header
 either cannot be decrypted or is marked as a potential duplicate.  The client
 then performs a constant-time comparison of the last 16 octets of the packet
 with the Stateless Reset Token provided by the server in its transport
-parameters.  If this comparison is successful, the connection MUST be terminated
-immediately, with the client entering the draining period.  The client MUST NOT
-send any further packets on this connection after receiving a stateless
-reset. If the comparison is unsuccessful, the packet can be discarded.
+parameters.  If this comparison is successful, the client MUST discard all
+connection state and not send any further packets on this connection. If the
+comparison is unsuccessful, the packet can be discarded.
 
 
 #### Calculating a Stateless Reset Token

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1605,7 +1605,9 @@ either cannot be decrypted or is marked as a potential duplicate.  The client
 then performs a constant-time comparison of the last 16 octets of the packet
 with the Stateless Reset Token provided by the server in its transport
 parameters.  If this comparison is successful, the connection MUST be terminated
-immediately.  Otherwise, the packet can be discarded.
+immediately, with the client entering the draining period.  The client MUST NOT
+send any further packets on this connection after receiving a stateless
+reset. If the comparison is unsuccessful, the packet can be discarded.
 
 
 #### Calculating a Stateless Reset Token


### PR DESCRIPTION
This makes the location of the token fixed with respect to the end of
packets, which makes it easier to find.  It also expands the conditions
for checking the token, which now include cases where packets appear
to be duplicated.

Closes #820.