### PR TITLE
AEAD all packets. Fixed #693, Fixes #840.

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -638,8 +638,7 @@ Cleartext packets are protected with secrets derived from the client's
 connection ID. Specifically:
 
 ~~~
-   quic_version_1_salt = ed 1d a2 c6 0b ae 80 03 eb db 17 d8 92 5d 95 92
-                         4a 6e 87 57 cd 48 d9 bf d2 41 c7 19 cb 80 81 ef
+   quic_version_1_salt = afc824ec5fc77eca1e9d36f37fb2d46518c36639
 
    cleartext_secret = HKDF-Extract(quic_version_1_salt,
                                    client_connection_id)
@@ -896,10 +895,10 @@ ensure that TLS handshake messages are sent with the correct packet protection.
 
 ## Packet Protection for the TLS Handshake {#cleartext-hs}
 
-The initial exchange of packets are sent using a cleartext packet type and
-AEAD-protected using the initial key as described in {{cleartext-secrets}}.  All
-TLS handshake messages up to the TLS Finished message sent by either endpoint
-use cleartext packets.
+The initial exchange of packets are sent using a cleartext packet type
+and AEAD-protected using the cleartext key generated as described in
+{{cleartext-secrets}}.  All TLS handshake messages up to the TLS
+Finished message sent by either endpoint use cleartext packets.
 
 Any TLS handshake messages that are sent after completing the TLS handshake do
 not need special packet protection rules.  Packets containing these messages use

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -555,8 +555,11 @@ Cleartext packets are sent during the handshake prior to key negotiation.
 
 All cleartext packets contain the current QUIC version in the version field.
 
-The payload of cleartext packets also includes an integrity check, which is
-described in {{QUIC-TLS}}.
+In order to prevent tampering by version-unaware middleboxes, Cleartext
+packets are protected with a connection and version specific key, as
+described in {{QUIC-TLS}}. This protection does not provide confidentiality
+or integrity against on-path attackers, but provides some level of
+protection against off-path attackers.
 
 
 ### Client Initial Packet {#packet-client-initial}
@@ -926,8 +929,9 @@ Version Negotiation packet.
 A client MUST ignore a Version Negotiation packet that lists the client's chosen
 version.
 
-Version negotiation uses unprotected data. The result of the negotiation MUST be
-revalidated as part of the cryptographic handshake (see {{version-validation}}).
+Version negotiation packets have no cryptographic protection. The
+result of the negotiation MUST be revalidated as part of the
+cryptographic handshake (see {{version-validation}}).
 
 ### Using Reserved Versions
 
@@ -1637,6 +1641,8 @@ ID, and static key cannot occur for another connection.  A connection ID from a
 connection that is reset by revealing the Stateless Reset Token cannot be
 reused for new connections at the same server without first changing to use a
 different static key or server identifier.
+
+Note that Stateless Reset messages do not have any cryptographic protection.
 
 
 # Frame Types and Formats
@@ -3316,7 +3322,7 @@ Issue and pull request numbers are listed with a leading octothorp.
 
 ## Since draft-ietf-quic-transport-06
 
-Nothing yet.
+- Replaced FNV-1a with AES-GCM for all "Cleartext" packets.
 
 ## Since draft-ietf-quic-transport-05
 


### PR DESCRIPTION
This makes the change we discussed in Seattle where all Cleartext
packets are encrypted with AES-GCM using a key derived from the
client connection ID and a random per-version value.

Note: I generated this value using randomness.org.