### PR TITLE
Remove ACKs from draining period

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1461,14 +1461,10 @@ The draining period persists for three times the current Retransmission Timeout
 can be acknowledged, but no new application data can be sent on the connection.
 
 Different treatment is given to packets that are received while a connection is
-in the draining period depending on how the connection was closed.  An endpoint
-that is in a draining period MUST NOT send packets unless they contain a
-CONNECTION_CLOSE or APPLICATION_CLOSE frame.
+in the draining period depending on how the connection was closed.
 
-An endpoint that receives either CONNECTION_CLOSE or APPLICATION_CLOSE while in
-the draining period MAY terminate the draining period immediately.  An endpoint
-that receives either of these frames can send a packet containing a
-CONNECTION_CLOSE to allow its peer to exit the draining period more rapidly.
+An endpoint that is in a draining period MUST NOT send packets unless they
+contain a CONNECTION_CLOSE or APPLICATION_CLOSE frame.
 
 Once the draining period has ended, an endpoint SHOULD discard per-connection
 state.  This results in new packets on the connection being discarded.  An

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1461,18 +1461,21 @@ The draining period persists for three times the current Retransmission Timeout
 can be acknowledged, but no new application data can be sent on the connection.
 
 Different treatment is given to packets that are received while a connection is
-in the draining period depending on how the connection was closed.  In all
-cases, it is possible to acknowledge packets that are received as normal, but
-other reactions might be preferable depending on how the connection was closed.
-An endpoint that is in a draining period MUST NOT send packets containing frames
-other than ACK, PADDING, or CONNECTION_CLOSE.
+in the draining period depending on how the connection was closed.  An endpoint
+that is in a draining period MUST NOT send packets unless they contain a
+CONNECTION_CLOSE or APPLICATION_CLOSE frame.
+
+An endpoint that receives either CONNECTION_CLOSE or APPLICATION_CLOSE while in
+the draining period can terminate the draining period immediately.  An endpoint
+that receives either of these frames can send a packet containing a
+CONNECTION_CLOSE to allow its peer to exit the draining period more rapidly.
 
 Once the draining period has ended, an endpoint SHOULD discard per-connection
 state.  This results in new packets on the connection being discarded.  An
 endpoint MAY send a stateless reset in response to any further incoming packets.
 
 The draining period does not apply when a stateless reset ({{stateless-reset}})
-is used.
+is sent.
 
 
 ### Idle Timeout
@@ -1511,10 +1514,6 @@ Note:
   new packet numbers is primarily of advantage to loss recovery and congestion
   control, which are not expected to be relevant for a closed connection.
   Retransmitting the final packet requires less state.
-
-An endpoint can cease sending CONNECTION_CLOSE or APPLICATION_CLOSE frames if it
-receives either a CONNECTION_CLOSE, APPLICATION_CLOSE or an acknowledgement for
-a packet that contained a either close frame.
 
 An immediate close can be used after an application protocol has arranged to
 close a connection.  This might be after the application protocols negotiates a

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1466,7 +1466,7 @@ that is in a draining period MUST NOT send packets unless they contain a
 CONNECTION_CLOSE or APPLICATION_CLOSE frame.
 
 An endpoint that receives either CONNECTION_CLOSE or APPLICATION_CLOSE while in
-the draining period can terminate the draining period immediately.  An endpoint
+the draining period MAY terminate the draining period immediately.  An endpoint
 that receives either of these frames can send a packet containing a
 CONNECTION_CLOSE to allow its peer to exit the draining period more rapidly.
 


### PR DESCRIPTION
As agreed at the interim, this removes the ability to acknowledge during the
draining period.  An endpoint can use the APPLICATION_CLOSE/CONNECTION_CLOSE
frame to exit this state early (it's a kind of ACK).

Closes #852.