### PR TITLE
Shorten line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ lint::
 	  fi; \
 	  if cat "$$f" | (l=0; while read -r a; do l=$$(($$l + 1)); echo -E "$$l:$$a"; done) | \
 	     sed -e '/^[0-9]*:~~~/,/^[0-9]*:~~~/p;/^[0-9]*:```/,/^[0-9]*:```/p;d' | \
-	     tr -d '\r' | grep '^[0-9]*:.\{70\}'; then \
-	    echo "$$f contains a figure with >69 characters"; err=1; \
+	     tr -d '\r' | grep '^[0-9]*:.\{66\}'; then \
+	    echo "$$f contains a figure with >65 characters"; err=1; \
 	  fi; \
 	done; [ "$$err" -eq 0 ]

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -766,10 +766,10 @@ Pseudocode for DetectLostPackets follows:
        delay_until_lost = 9/8 * max(latest_rtt, smoothed_rtt)
      foreach (unacked < largest_acked.packet_number):
        time_since_sent = now() - unacked.time_sent
-       packet_delta = largest_acked.packet_number - unacked.packet_number
+       delta = largest_acked.packet_number - unacked.packet_number
        if (time_since_sent > delay_until_lost):
          lost_packets.insert(unacked)
-       else if (packet_delta > reordering_threshold)
+       else if (delta > reordering_threshold)
          lost_packets.insert(unacked)
        else if (loss_time == 0 && delay_until_lost != infinite):
          loss_time = now() + delay_until_lost - time_since_sent


### PR DESCRIPTION
I ran idnits on the drafts and this one line tripped their warning.  Turns out that we were too generous by a few characters on the width of figures.