### PR TITLE
Enter draining after receiving a stateless reset

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1472,7 +1472,7 @@ state.  This results in new packets on the connection being discarded.  An
 endpoint MAY send a stateless reset in response to any further incoming packets.
 
 The draining period does not apply when a stateless reset ({{stateless-reset}})
-is used.
+is sent.
 
 
 ### Idle Timeout
@@ -1601,7 +1601,7 @@ A client detects a potential stateless reset when a packet with a short header
 either cannot be decrypted or is marked as a duplicate packet.  The client then
 compares the last 16 octets of the packet with the Stateless Reset Token
 provided by the server in its transport parameters.  If these values are
-identical, the client MUST discard all connection state and not send any further
+identical, the client MUST enter the draining period and not send any further
 packets on this connection.  If the comparison fails, the packet can be
 discarded.
 


### PR DESCRIPTION
If a client receives a stateless reset, it makes sense for it to stick around
in the draining period so that you can absorb any further stateless reset
packets that might have been sent by the server.  The server might have
received multiple packets, so it might also generate multiple resets.

Closes #867.