### PR TITLE
Identify streams unidirectional vs bidirectional based on stream ID

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2542,7 +2542,7 @@ shown in the following figure and described below.
    recv:   endpoint receives this frame
 
    STREAM: a STREAM frame
-   UNI:    a unidirectional stream
+   UNI:    a STREAM frame with a unidirectional stream ID
    FIN:    FIN flag in a STREAM frame
    RST:    RST_STREAM frame
    MSD:    MAX_STREAM_DATA frame

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2630,7 +2630,8 @@ A stream that is in the "half-closed (local)" state MUST NOT be used for sending
 on new STREAM frames.  Retransmission of data that has already been sent on
 STREAM frames is permitted.  An endpoint MAY also send MAX_STREAM_DATA and
 STOP_SENDING in this state. Unidirectional streams created by the peer are
-immediately half-closed (local) to the receiver.
+immediately half-closed (local) to the receiver and are subsequently treated
+identically to a half-closed bidirectional stream.
 
 An application can decide to abandon a stream in this state. An endpoint can
 send RST_STREAM for a stream that was closed with the FIN flag. The final offset

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1857,8 +1857,10 @@ The frame is as follows:
 The fields in the MAX_STREAM_ID frame are as follows:
 
 Maximum Stream ID:
-: ID of the maximum unidirectional or bidirectional (based on the second least
-  signification bit of the stream id) peer-initiated stream ID for the connection.
+: ID of the maximum unidirectional or bidirectional peer-initiated stream ID
+  for the connection. The limit applies to unidirectional steams if the second
+  least signification bit of the stream id is 0, and applies to bidirectional
+  streams if it is 1.
 
 Loss or reordering can mean that a MAX_STREAM_ID frame can be received which
 states a lower stream limit than the client has previously received.
@@ -2442,7 +2444,7 @@ Streams in QUIC provide a lightweight, ordered, and bidirectional byte-stream
 abstraction modeled closely on HTTP/2 streams {{?RFC7540}}.
 
 Streams can be created either by the client or the server, can concurrently send
-data interleaved with other streams, and can be cancelled, and can be opened in
+data interleaved with other streams, can be cancelled, and can be opened in
 unidirectional mode.
 
 Data that is received on a stream is delivered in order within that stream, but
@@ -2654,7 +2656,7 @@ after a frame bearing the FIN flag is sent.
 A stream is "half-closed (remote)" when the stream is no longer being used by
 the peer to send any data.  An endpoint will have either received all data that
 a peer has sent or will have received a RST_STREAM frame and discarded any
-received data. Unidirectional streams created by the locally are immediately
+received data. Unidirectional streams created locally are immediately
 half-closed (remote) to the creator.
 
 Once all data has been either received or discarded, a sender is no longer

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1859,8 +1859,8 @@ The fields in the MAX_STREAM_ID frame are as follows:
 Maximum Stream ID:
 : ID of the maximum unidirectional or bidirectional peer-initiated stream ID
   for the connection. The limit applies to unidirectional steams if the second
-  least signification bit of the stream id is 0, and applies to bidirectional
-  streams if it is 1.
+  least signification bit of the stream id is 1, and applies to bidirectional
+  streams if it is 0.
 
 Loss or reordering can mean that a MAX_STREAM_ID frame can be received which
 states a lower stream limit than the client has previously received.
@@ -2478,15 +2478,15 @@ created, it MUST close the connection with error code STREAM_STATE_ERROR.
 
 The second least significant bit differentiates between unidirectional streams
 and bidirectional streams. Unidirectional streams always have this bit set to
-0 and bidirectional streams have this bit set to 1. As a result the initial
+1 and bidirectional streams have this bit set to 0. As a result the initial
 stream ID for various stream types is listed below:
 
 | Stream ID   | Type                          |
 |:------------|:------------------------------|
-| 0x01        | Client Unidirectional         |
-| 0x02        | Server Unidirectional         |
-| 0x03        | Client Bidirectional          |
-| 0x04        | Server Bidirectional          |
+| 0x01        | Client Bidirectional          |
+| 0x02        | Server Bidirectional          |
+| 0x03        | Client Unidirectional         |
+| 0x04        | Server Unidirectional         |
 
 Stream ID 0 (0x0) is reserved for the cryptographic handshake.  Stream 0 MUST
 NOT be used for application data, and is the first client-initiated stream.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2562,12 +2562,6 @@ coordinate the creation of streams; they are created unilaterally by either
 endpoint.  Endpoints can use acknowledgments to understand the peer's subjective
 view of stream state at any given time.
 
-Only the initiator of a stream may send a STREAM frame without receiving one
-unless otherwise specified by the application.  All implicitly opened streams
-must remain in the IDLE state until a STREAM frame has been received.  If a
-RST is received on a stream reserved for the peer before any STREAM frame
-has been received, it will immediately transition to the closed state.
-
 In the absence of more specific guidance elsewhere in this document,
 implementations SHOULD treat the receipt of a frame that is not expressly
 permitted in the description of a state as a connection error (see


### PR DESCRIPTION
Identify streams unidirectional vs bidirectional based on stream ID, much like how client vs server created is identified.