### PR TITLE
 Unidirectional and bidirectional streams

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3178,8 +3178,8 @@ is increased.
 
 The final offset is the count of the number of octets that are transmitted on a
 stream.  For a stream that is reset, the final offset is carried explicitly in
-the RST_STREAM frame.  Otherwise, the final offset is the offset of the end of
-the data carried in a STREAM frame marked with a FIN flag, or 0 in the case of
+a RST_STREAM frame.  Otherwise, the final offset is the offset of the end of the
+data carried in a STREAM frame marked with a FIN flag, or 0 in the case of
 incoming unidirectional streams.
 
 An endpoint will know the final offset for a stream when the stream enters the

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2739,7 +2739,7 @@ shown in the following figure and described below.
                                  v
                  recv FIN/  +--------+    send FIN/
                  recv RST   |        |    send RST
-                 recv UNI   |        |    send UNI
+                 send UNI   |        |    recv UNI
                   ,---------|  open  |-----------.
                  /          |        |            \
                 v           +--------+             v
@@ -3179,7 +3179,7 @@ is increased.
 The final offset is the count of the number of octets that are transmitted on a
 stream.  For a stream that is reset, the final offset is carried explicitly in
 the RST_STREAM frame.  Otherwise, the final offset is the offset of the end of
-the data carried in STREAM frame marked with a FIN flag, or 0 in the case of
+the data carried in a STREAM frame marked with a FIN flag, or 0 in the case of
 incoming unidirectional streams.
 
 An endpoint will know the final offset for a stream when the stream enters the

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2687,8 +2687,7 @@ identifier.
 
 If an endpoint receives a frame for a stream that it expects to initiate (i.e.,
 odd-numbered for the client or even-numbered for the server), but which it has
-not yet opened but which it has not yet created, it MUST close the connection
-with error code STREAM_STATE_ERROR.
+not yet opened, it MUST close the connection with error code STREAM_STATE_ERROR.
 
 The second least significant bit (0x2) of the Stream ID differentiates between
 unidirectional streams and bidirectional streams. Unidirectional streams always

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2715,7 +2715,7 @@ same direction being counted as open.
 
 Stream IDs are usually encoded as a 32-bit integer, though the STREAM frame
 ({{frame-stream}}) permits a shorter encoding when the leading bits of the
-stream ID are zero.
+Stream ID are zero.
 
 
 ## Life of a Stream {#stream-states}


### PR DESCRIPTION
This is #872 with some additional exposition and one significant change.

Client-initiated streams are now EVEN.

Server initiated streams are now ODD.

This is a pretty noticeable change, because it inverts the current sign, and
might cause some disruption in implementations.  However, it makes stream 0
work within the framework better.  It wasn't clear what Ryan's intent was with
respect to numbering, but I wouldn't have noticed this until I noticed a
conflict between prose and the table.

Closes #643, #656, #720, #872, #175.

This does not close the other issues that were addressed by #643, because this
doesn't include any changes in the HTTP draft.  I'll create a follow-up PR for
that.

(We can argue about bit placement later, I'm just trying to make this as good as it can be.)