### PR TITLE
More detailed stream states

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -324,13 +324,14 @@ TCP server; data received from the TCP server is packaged into DATA frames by
 the proxy. Note that the size and number of TCP segments is not guaranteed to
 map predictably to the size and number of HTTP DATA or QUIC STREAM frames.
 
-The TCP connection can be closed by either peer. When the client half-closes the
-request stream, the proxy will set the FIN bit on its connection to the TCP
-server. When the proxy receives a packet with the FIN bit set, it will
-half-close the corresponding stream. TCP connections which remain half-closed in
-a single direction are not invalid, but are often handled poorly by servers, so
-clients SHOULD NOT half-close connections on which they are still expecting
-data.
+The TCP connection can be closed by either peer. When the client ends the
+request stream (that is, the receive stream at the proxy enters the "Data Recvd"
+state), the proxy will set the FIN bit on its connection to the TCP server. When
+the proxy receives a packet with the FIN bit set, it will terminate the send
+stream that it sends to client. TCP connections which remain half-closed in a
+single direction are not invalid, but are often handled poorly by servers, so
+clients SHOULD NOT cause send a STREAM frame with a FIN bit for connections on
+which they are still expecting data.
 
 A TCP connection error is signaled with RST_STREAM. A proxy treats any error in
 the TCP connection, which includes receiving a TCP segment with the RST bit set,

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3067,7 +3067,9 @@ the states of the pair of streams.  The simplest model presents the stream as
 {{stream-bidi-mapping}} shows a more complex mapping of bidirectional stream
 states that loosely correspond to the stream states in HTTP/2
 {{?HTTP2=RFC7540}}.  This shows that multiple states on send or receive streams
-are mapped to the same composite state.
+are mapped to the same composite state.  Note that this is just one possibility
+for a mapping, one that requires that data is acknowledged before the transition
+to a closed or half-closed state.
 
 | Send Stream            | Receive Stream         | Composite State      |
 |:-----------------------|:-----------------------|:---------------------|
@@ -3082,7 +3084,7 @@ are mapped to the same composite state.
 | Reset Sent/Reset Recvd | Reset Recvd/Reset Read | closed               |
 | Data Recvd             | Data Recvd/Data Read   | closed               |
 | Data Recvd             | Reset Recvd/Reset Read | closed               |
-{: #stream-bidi-mapping title="Mapping of Stream States to HTTP/2"}
+{: #stream-bidi-mapping title="Possible Mapping of Stream States to HTTP/2"}
 
 Note (*1):
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3127,8 +3127,8 @@ states.
 An endpoint is expected to send another STOP_SENDING frame if a packet
 containing the frame is lost.  However, once either all stream data or a
 RST_STREAM frame has been received for the stream - that is, the stream is in
-any state other than "Recv" or "Size Known" - sending a STOP_SENDING frame
-is unnecessary.
+any state other than "Recv" or "Size Known" - sending a STOP_SENDING frame is
+unnecessary.
 
 
 ## Stream Concurrency {#stream-concurrency}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2951,6 +2951,7 @@ protocol.
        o
        | Recv STREAM / STREAM_BLOCKED / RST_STREAM
        | Open Paired Stream (bidirectional)
+       | Recv MAX_STREAM_DATA
        v
    +-------+
    | Recv  | Recv RST_STREAM
@@ -2989,6 +2990,11 @@ immediately transition to the "Reset Recvd".
 The receive stream enters the "Recv" state when the sending part of a
 bidirectional stream initiated by the endpoint (type 0 for a client, type 1 for
 a server) enters the "Open" state.
+
+A bidirectional stream also opens when a MAX_STREAM_DATA frame is received.
+Receiving a MAX_STREAM_DATA frame implies that the remote peer has opened the
+stream and is providing flow control credit.  A MAX_STREAM_DATA frame might
+arrive before a STREAM or STREAM_BLOCKED frame if packets are lost or reordered.
 
 In the "Recv" state, the endpoint receives STREAM and STREAM_BLOCKED frames.
 Incoming data is buffered and reassembled into the correct order for delivery to

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3032,6 +3032,30 @@ stream was reset, the receive stream transitions to the "Reset Read" state,
 which is a terminal state.
 
 
+### Permitted Frame Types
+
+The sender of a stream sends just three frame types that affect the state of a
+stream at either sender or receiver: STREAM ({{frame-stream}}), STREAM_BLOCKED
+({{frame-stream-blocked}}), and RST_STREAM ({{frame-rst-stream}}).
+
+A sender MUST NOT send any of these frames from a terminal state ("Data Recvd"
+or "Reset Recvd").  A sender MUST NOT send STREAM or STREAM_BLOCKED after
+sending a RST_STREAM; that is, in the "Reset Sent" state in addition to the
+terminal states.  A receiver could receive any of these frames in any state, but
+only due to the possibility of delayed delivery of packets carrying them.
+
+The receiver of a stream sends MAX_STREAM_DATA ({{frame-max-stream-data}}) and
+STOP_SENDING frames ({{frame-stop-sending}}) to allow the sender to write stream
+data and to request stream cancellation.
+
+The receiver only sends MAX_STREAM_DATA in the "Recv" state.  A receiver can
+send STOP_SENDING in any state where it has not received a RST_STREAM frame;
+that is states other than "Reset Recvd" or "Reset Read".  However there is
+little value in sending a STOP_SENDING frame after all stream data has been
+received in the "Data Recvd" state.  A sender could receive these frames in any
+state as a result of delayed delivery of packets.
+
+
 ### Bidirectional Stream States {#stream-bidi-states}
 
 A bidirectional stream is composed of a send stream and a receive stream.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3045,8 +3045,7 @@ terminal states.  A receiver could receive any of these frames in any state, but
 only due to the possibility of delayed delivery of packets carrying them.
 
 The receiver of a stream sends MAX_STREAM_DATA ({{frame-max-stream-data}}) and
-STOP_SENDING frames ({{frame-stop-sending}}) to allow the sender to write stream
-data and to request stream cancellation.
+STOP_SENDING frames ({{frame-stop-sending}}).
 
 The receiver only sends MAX_STREAM_DATA in the "Recv" state.  A receiver can
 send STOP_SENDING in any state where it has not received a RST_STREAM frame;


### PR DESCRIPTION
This takes the state machines that @MikeBishop showed at the Seattle interim
and turns them into text and ASCII art.

I made a few changes in the process.  The state where all data is available
didn't turn out to be any different to the state preceding it, so I removed it.
I also found it valuable to recognize that streams might be created for sending
before any frames are sent (I considered doing the same for receive streams,
but it complicated the transitions more than I liked, I could be convinced to
add this still, it just seems less valuable).

I added a section on composite states, showing how this mess all maps to stuff
you already know (h2).

This is still work-in-progress.  I have changed the main chunk of text on
states, but I haven't changed any of the rest of the document, which still
talks about "idle" and all that.  I'll do that next if people are generally
happy with the direction this is headed.

There are probably a few minor regressions here.  In particular, I need to look at
what retransmissions can be received after they are no longer needed.  But it's
late enough already.

Closes #634.