### PR TITLE
Remove a redundant sentence

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2430,12 +2430,10 @@ an endpoint MAY send a PING frame once per RTT to solicit an acknowledgment.
 To limit receiver state or the size of ACK frames, a receiver MAY limit the
 number of ACK blocks it sends.  A receiver can do this even without receiving
 acknowledgment of its ACK frames, with the knowledge this could cause the sender
-to unnecessarily retransmit some data.  When this is necessary, the receiver
-SHOULD acknowledge newly received packets and stop acknowledging packets
-received in the past.  Standard QUIC {{QUIC-RECOVERY}} algorithms declare
-packets lost after sufficiently newer packets are acknowledged.  Therefore,
-receivers SHOULD NOT stop sending an ack block and then start sending it again
-substantially later in an effort to save bytes sent.
+to unnecessarily retransmit some data.  Standard QUIC {{QUIC-RECOVERY}} algorithms
+declare packets lost after sufficiently newer packets are acknowledged.  Therefore,
+the receiver SHOULD repeatedly acknowledge newly received packets in preference to
+packets received in the past.
 
 ### ACK Frames and Packet Protection
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2431,9 +2431,9 @@ To limit receiver state or the size of ACK frames, a receiver MAY limit the
 number of ACK blocks it sends.  A receiver can do this even without receiving
 acknowledgment of its ACK frames, with the knowledge this could cause the sender
 to unnecessarily retransmit some data.  Standard QUIC {{QUIC-RECOVERY}}
-algorithms declare packets lost after sufficiently newer packets are acknowledged.
-Therefore, the receiver SHOULD repeatedly acknowledge newly received packets in
-preference to packets received in the past.
+algorithms declare packets lost after sufficiently newer packets are
+acknowledged.  Therefore, the receiver SHOULD repeatedly acknowledge newly
+received packets in preference to packets received in the past.
 
 ### ACK Frames and Packet Protection
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2430,10 +2430,10 @@ an endpoint MAY send a PING frame once per RTT to solicit an acknowledgment.
 To limit receiver state or the size of ACK frames, a receiver MAY limit the
 number of ACK blocks it sends.  A receiver can do this even without receiving
 acknowledgment of its ACK frames, with the knowledge this could cause the sender
-to unnecessarily retransmit some data.  Standard QUIC {{QUIC-RECOVERY}} algorithms
-declare packets lost after sufficiently newer packets are acknowledged.  Therefore,
-the receiver SHOULD repeatedly acknowledge newly received packets in preference to
-packets received in the past.
+to unnecessarily retransmit some data.  Standard QUIC {{QUIC-RECOVERY}}
+algorithms declare packets lost after sufficiently newer packets are acknowledged.
+Therefore, the receiver SHOULD repeatedly acknowledge newly received packets in
+preference to packets received in the past.
 
 ### ACK Frames and Packet Protection
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2432,7 +2432,10 @@ number of ACK blocks it sends.  A receiver can do this even without receiving
 acknowledgment of its ACK frames, with the knowledge this could cause the sender
 to unnecessarily retransmit some data.  When this is necessary, the receiver
 SHOULD acknowledge newly received packets and stop acknowledging packets
-received in the past.
+received in the past.  Standard QUIC {{QUIC-RECOVERY}} algorithms declare
+packets lost after sufficiently newer packets are acknowledged.  Therefore,
+receivers SHOULD NOT stop sending an ack block and then start sending it again
+substantially later in an effort to save bytes sent.
 
 ### ACK Frames and Packet Protection
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2432,9 +2432,7 @@ number of ACK blocks it sends.  A receiver can do this even without receiving
 acknowledgment of its ACK frames, with the knowledge this could cause the sender
 to unnecessarily retransmit some data.  When this is necessary, the receiver
 SHOULD acknowledge newly received packets and stop acknowledging packets
-received in the past.  Removing ack blocks before the peer has received them
-increases the chances the peer never received an acknowledgement, will declare
-the packet lost, and spuriously retransmit information.
+received in the past.
 
 ### ACK Frames and Packet Protection
 


### PR DESCRIPTION
Also add text on why stopping and then resuming sending older ack blocks is not recommended in response to #917 