### PR TITLE
Make lint fast again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ pulls.json
 lib
 .targets.mk
 *.upload
+.lintcache

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,8 @@ $(LINT_DIR)/%.lint: %.md $(LINT_DIR)
 		echo "Reused lint of $<"; \
 	else \
 		for draft_lint in $(LINT_DIR)/*.lint; do \
-			if [ -r "$$draft_lint" ] && [ "`cat "$$draft_lint"`" == "$$hash" ]; then \
+			if ["$$draft_lint" != "$@" ] && \
+			 [ -r "$$draft_lint" ] && [ "`cat "$$draft_lint"`" == "$$hash" ]; then \
 				cp "$$draft_lint" "$@"; \
 				echo "Reused lint from $$draft_lint"; \
 			fi; \

--- a/Makefile
+++ b/Makefile
@@ -15,14 +15,33 @@ endif
 latest:: lint
 .PHONY: lint
 lint::
-	@err=0; for f in draft-*.md ; do \
-	  if cat "$$f" | (l=0; while read -r a; do l=$$(($$l + 1)); echo -E "$$l:$$a"; done) | \
-	     sed -e '1,/--- abstract/d;/^[0-9]*: *|/d' | tr -d '\r' | grep '^[0-9]*:.\{81\}'; then \
-	    echo "$$f contains a line with >80 characters"; err=1; \
-	  fi; \
-	  if cat "$$f" | (l=0; while read -r a; do l=$$(($$l + 1)); echo -E "$$l:$$a"; done) | \
-	     sed -e '/^[0-9]*:~~~/,/^[0-9]*:~~~/p;/^[0-9]*:```/,/^[0-9]*:```/p;d' | \
-	     tr -d '\r' | grep '^[0-9]*:.\{66\}'; then \
-	    echo "$$f contains a figure with >65 characters"; err=1; \
-	  fi; \
+
+	@err=0; \
+	lint_dir=".lintcache/`git rev-parse --abbrev-ref HEAD`"; \
+	if [ -d "$$lint_dir" ]; then \
+		MAYBE_OBSOLETE=`comm -13 <(git branch | sed -e 's,.*[ /],,' | sort | uniq) <(ls ".lintcache" | sed -e 's,.*/,,')`; \
+		for item in $$MAYBE_OBSOLETE; do \
+				rm -rf ".lintcache/$$item"; \
+		done \
+	fi; \
+	for f in draft-*.md ; do \
+		localerr=0; \
+		hash=`git hash-object "$$f"`; \
+		lint_file="$$lint_dir/$$f"; \
+		mkdir -p "$$lint_dir"; \
+		if [ ! -r "$$lint_file" ] || [ "`cat "$$lint_file"`" != "$$hash" ]; then \
+			if cat "$$f" | (l=0; while read -r a; do l=$$(($$l + 1)); echo -E "$$l:$$a"; done) | \
+				sed -e '1,/--- abstract/d;/^[0-9]*: *|/d' | tr -d '\r' | grep '^[0-9]*:.\{81\}'; then \
+				echo "$$f contains a line with >80 characters"; localerr=1; \
+			fi; \
+			if cat "$$f" | (l=0; while read -r a; do l=$$(($$l + 1)); echo -E "$$l:$$a"; done) | \
+				sed -e '/^[0-9]*:~~~/,/^[0-9]*:~~~/p;/^[0-9]*:```/,/^[0-9]*:```/p;d' | \
+				tr -d '\r' | grep '^[0-9]*:.\{66\}'; then \
+				echo "$$f contains a figure with >65 characters"; localerr=1; \
+			fi; \
+			if [ "$$localerr" -eq 1 ]; then err=1; \
+			else \
+				echo "$$hash" > "$$lint_file"; \
+			fi; \
+		fi; \
 	done; [ "$$err" -eq 0 ]

--- a/Makefile
+++ b/Makefile
@@ -12,36 +12,66 @@ else
 	    -b master https://github.com/martinthomson/i-d-template $(LIBDIR)
 endif
 
-latest:: lint
-.PHONY: lint
-lint::
+CURRENT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
+LINT_DIR := .lintcache/$(CURRENT_BRANCH)
 
-	@err=0; \
-	lint_dir=".lintcache/`git rev-parse --abbrev-ref HEAD`"; \
-	if [ -d "$$lint_dir" ]; then \
-		MAYBE_OBSOLETE=`comm -13 <(git branch | sed -e 's,.*[ /],,' | sort | uniq) <(ls ".lintcache" | sed -e 's,.*/,,')`; \
-		for item in $$MAYBE_OBSOLETE; do \
-				rm -rf ".lintcache/$$item"; \
-		done \
-	fi; \
-	for f in draft-*.md ; do \
-		localerr=0; \
-		hash=`git hash-object "$$f"`; \
-		lint_file="$$lint_dir/$$f"; \
-		mkdir -p "$$lint_dir"; \
-		if [ ! -r "$$lint_file" ] || [ "`cat "$$lint_file"`" != "$$hash" ]; then \
-			if cat "$$f" | (l=0; while read -r a; do l=$$(($$l + 1)); echo -E "$$l:$$a"; done) | \
-				sed -e '1,/--- abstract/d;/^[0-9]*: *|/d' | tr -d '\r' | grep '^[0-9]*:.\{81\}'; then \
-				echo "$$f contains a line with >80 characters"; localerr=1; \
+lint_files:= $(addprefix $(LINT_DIR)/,$(addsuffix .lint,$(drafts)))
+
+latest:: lint
+lint:: lint-purge $(lint_files)
+
+.PHONY: lint lint-purge
+
+$(LINT_DIR)::
+	@mkdir -p $(LINT_DIR)
+
+$(LINT_DIR)/%.lint: %.md $(LINT_DIR)
+	@hash=`git hash-object "$<"`; \
+	if [ -r "$@" ] && [ "`cat '$@'`" == "$$hash" ]; then \
+		touch "$@"; \
+		echo "Reused lint of $<"; \
+	else \
+		for draft_lint in $(LINT_DIR)/*.lint; do \
+			if [ -r "$$draft_lint" ] && [ "`cat "$$draft_lint"`" == "$$hash" ]; then \
+				cp "$$draft_lint" "$@"; \
+				echo "Reused lint from $$draft_lint"; \
 			fi; \
-			if cat "$$f" | (l=0; while read -r a; do l=$$(($$l + 1)); echo -E "$$l:$$a"; done) | \
-				sed -e '/^[0-9]*:~~~/,/^[0-9]*:~~~/p;/^[0-9]*:```/,/^[0-9]*:```/p;d' | \
-				tr -d '\r' | grep '^[0-9]*:.\{66\}'; then \
-				echo "$$f contains a figure with >65 characters"; localerr=1; \
-			fi; \
-			if [ "$$localerr" -eq 1 ]; then err=1; \
-			else \
-				echo "$$hash" > "$$lint_file"; \
+		done; \
+		if [ ! -r "$@" ] || [ "`cat "$@"`" != "$$hash" ]; then \
+			for branch in `git branch --points-at HEAD`; do \
+				old_lintfile=".lintcache/$$branch/$(@F)"; \
+				if [ -r "$$old_lintfile" ]; then \
+					cp "$$old_lintfile" "$@"; \
+					echo "Reused lint of $< from $$branch"; \
+					break; \
+				fi; \
+			done; \
+			if [ ! -r "$@" ] || [ "`cat "$@"`" != "$$hash" ]; then \
+				echo "Linting $<..."; \
+				localerr=0 \
+				f="$<"; \
+				if cat "$<" | (l=0; while read -r a; do l=$$(($$l + 1)); echo -E "$$l:$$a"; done) | \
+					sed -e '1,/--- abstract/d;/^[0-9]*: *|/d' | tr -d '\r' | grep '^[0-9]*:.\{81\}'; then \
+					echo "$< contains a line with >80 characters"; err=1; \
+				fi; \
+				if cat "$<" | (l=0; while read -r a; do l=$$(($$l + 1)); echo -E "$$l:$$a"; done) | \
+					sed -e '/^[0-9]*:~~~/,/^[0-9]*:~~~/p;/^[0-9]*:```/,/^[0-9]*:```/p;d' | \
+					tr -d '\r' | grep '^[0-9]*:.\{66\}'; then \
+					echo "$< contains a figure with >65 characters"; err=1; \
+				fi; \
+				if [ "$$localerr" -eq 1 ]; then false; \
+				else \
+					echo "$$hash" > "$@"; \
+				fi; \
 			fi; \
 		fi; \
-	done; [ "$$err" -eq 0 ]
+	fi;
+
+lint-purge:: $(LINT_DIR)
+	@MAYBE_OBSOLETE=`comm -13 <(git branch | sed -e 's,.*[ /],,' | sort | uniq) <(ls ".lintcache" | sed -e 's,.*/,,')`; \
+	for item in $$MAYBE_OBSOLETE; do \
+			rm -rf ".lintcache/$$item"; \
+	done; \
+	for item in $(filter-out $(lint_files),$(wildcard $(LINT_DIR)/*.lint)); do \
+		rm $$item; \
+	done

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ LINT_DIR := .lintcache/$(CURRENT_BRANCH)
 
 lint_files:= $(addprefix $(LINT_DIR)/,$(addsuffix .lint,$(drafts)))
 
-latest:: lint
-lint:: lint-purge $(lint_files)
+latest:: lint lint-purge
+lint:: $(lint_files)
 
 .PHONY: lint lint-purge
 
@@ -35,7 +35,7 @@ $(LINT_DIR)/%.lint: %.md $(LINT_DIR)
 			if ["$$draft_lint" != "$@" ] && \
 			 [ -r "$$draft_lint" ] && [ "`cat "$$draft_lint"`" == "$$hash" ]; then \
 				cp "$$draft_lint" "$@"; \
-				echo "Reused lint from $$draft_lint"; \
+				echo "Reused lint of $$draft_lint for $@"; \
 			fi; \
 		done; \
 		if [ ! -r "$@" ] || [ "`cat "$@"`" != "$$hash" ]; then \
@@ -68,7 +68,7 @@ $(LINT_DIR)/%.lint: %.md $(LINT_DIR)
 		fi; \
 	fi;
 
-lint-purge:: $(LINT_DIR)
+lint-purge:: $(LINT_DIR) | lint
 	@MAYBE_OBSOLETE=`comm -13 <(git branch | sed -e 's,.*[ /],,' | sort | uniq) <(ls ".lintcache" | sed -e 's,.*/,,')`; \
 	for item in $$MAYBE_OBSOLETE; do \
 			rm -rf ".lintcache/$$item"; \


### PR DESCRIPTION
@ianswett and I were remarking that makes and commits have gotten very slow lately.  Some observation of my machine shows that I'm spending a lot of that time checking for trailing whitespace and long lines.

This updates the `make lint` recipe to cache the hashes per branch of files that have successfully been linted and not re-lint them unless they've been modified (or you're on a new branch -- sorry).  On my machine, lint goes from 12 seconds to 0.75 seconds.