### PR TITLE
Explain that NST.max_stream_data is needed for 0-RTT.

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1424,9 +1424,10 @@ compatible.  The client indicates which ALPN label it has chosen by placing that
 ALPN label first in the ALPN extension. In order to be usable for 0-RTT,
 the NewSessionTicket MUST contain the "max_early_data" extension with the
 value 0xffffffff; the amount of data which the client can send in 0-RTT
-is controlled by the "initial_max_data" and "initial_max_stream_data"
-parameters supplied by the server. It is an error for the server to provide
-any other value for "max_early_data".
+is controlled by the "initial_max_data" transport parameter supplied by the
+server. A client MUST treat receipt of a NewSessionTicket that contains a
+"max_early_data" extension with any other value as a connection error of type
+PROTOCOL_VIOLATION.
 
 The certificate that the server uses MUST be considered valid for both
 connections, which will use different protocol stacks and could use different

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1421,7 +1421,12 @@ enable 0-RTT in TCP.
 All the restrictions on the use of 0-RTT apply, with the exception of the ALPN
 label, which MUST only change to a label that is explicitly designated as being
 compatible.  The client indicates which ALPN label it has chosen by placing that
-ALPN label first in the ALPN extension.
+ALPN label first in the ALPN extension. In order to be usable for 0-RTT,
+the NewSessionTicket MUST contain the "max_early_data" extension with the
+value 0xffffffff; the amount of data which the client can send in 0-RTT
+is controlled by the "initial_max_data" and "initial_max_stream_data"
+parameters supplied by the server. It is an error for the server to provide
+any other value for "max_early_data".
 
 The certificate that the server uses MUST be considered valid for both
 connections, which will use different protocol stacks and could use different


### PR DESCRIPTION
Note that we require 0xffffffff in order to keep things consistent.