### PR TITLE
Renumber packet types and invert Connection ID Flag

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -416,11 +416,11 @@ The following packet types are defined:
 
 | Type | Name                          | Section                     |
 |:-----|:------------------------------|:----------------------------|
-| 0x01 | Version Negotiation           | {{packet-version}}          |
-| 0x02 | Initial                       | {{packet-initial}}          |
-| 0x03 | Retry                         | {{packet-retry}}            |
-| 0x04 | Handshake                     | {{packet-handshake}}        |
-| 0x05 | 0-RTT Protected               | {{packet-protected}}        |
+| 0x7F | Version Negotiation           | {{packet-version}}          |
+| 0x7E | Initial                       | {{packet-initial}}          |
+| 0x7D | Retry                         | {{packet-retry}}            |
+| 0x7C | Handshake                     | {{packet-handshake}}        |
+| 0x7B | 0-RTT Protected               | {{packet-protected}}        |
 {: #long-packet-types title="Long Header Packet Types"}
 
 The header form, packet type, connection ID, packet number and version fields of
@@ -459,10 +459,10 @@ Header Form:
 
 : The most significant bit (0x80) of octet 0 is set to 0 for the short header.
 
-Connection ID Flag:
+Omit Connection ID Flag:
 
 : The second bit (0x40) of octet 0 indicates whether the Connection ID field is
-  present.  If set to 1, then the Connection ID field is present; if set to 0,
+  omitted.  If set to 0, then the Connection ID field is present; if set to 1,
   the Connection ID field is omitted.  The Connection ID field can
   only be omitted if the omit_connection_id transport parameter
   ({{transport-parameter-definitions}}) is specified by the intended recipient
@@ -481,8 +481,8 @@ Short Packet Type:
 
 Connection ID:
 
-: If the Connection ID Flag is set, a connection ID occupies octets 1 through 8
-  of the packet.  See {{connection-id}} for more details.
+: If the Omit Connection ID Flag is not set, a connection ID occupies octets
+  1 through 8 of the packet.  See {{connection-id}} for more details.
 
 Packet Number:
 
@@ -499,20 +499,20 @@ other fields.
 
 | Type | Packet Number Size |
 |:-----|:-------------------|
-| 0x01 | 1 octet            |
-| 0x02 | 2 octets           |
-| 0x03 | 4 octets           |
+| 0x1F | 1 octet            |
+| 0x1E | 2 octets           |
+| 0x1D | 4 octets           |
 {: #short-packet-types title="Short Header Packet Types"}
 
-The header form, connection ID flag and connection ID of a short header packet
-are version-independent.  The remaining fields are specific to the selected QUIC
-version.  See {{version-specific}} for details on how packets from different
-versions of QUIC are interpreted.
+The header form, omit connection ID flag, and connection ID of a short header
+packet are version-independent.  The remaining fields are specific to the
+selected QUIC version.  See {{version-specific}} for details on how packets
+from different versions of QUIC are interpreted.
 
 
 ## Version Negotiation Packet {#packet-version}
 
-A Version Negotiation packet has long headers with a type value of 0x01 and is
+A Version Negotiation packet has long headers with a type value of 0x7F and is
 sent only by servers.  The Version Negotiation packet is a response to a client
 packet that contains a version that is not supported by the server.
 
@@ -566,7 +566,7 @@ off-path attackers.
 
 ### Initial Packet {#packet-initial}
 
-The Initial packet uses long headers with a type value of 0x02.  It carries the
+The Initial packet uses long headers with a type value of 0x7E.  It carries the
 first cryptographic handshake message sent by the client.
 
 The client populates the connection ID field with randomly selected values,
@@ -594,7 +594,7 @@ Retry packet ({{packet-retry}}).
 
 ### Retry Packet {#packet-retry}
 
-A Retry packet uses long headers with a type value of 0x03.  It carries
+A Retry packet uses long headers with a type value of 0x7D.  It carries
 cryptographic handshake messages and acknowledgments.  It is used by a server
 that wishes to perform a stateless retry (see {{stateless-retry}}).
 
@@ -627,7 +627,7 @@ the server will also start at stream offset 0.
 
 ### Handshake Packet {#packet-handshake}
 
-A Handshake packet uses long headers with a type value of 0x04.  It is
+A Handshake packet uses long headers with a type value of 0x7C.  It is
 used to carry acknowledgments and cryptographic handshake messages from the
 server and client.
 
@@ -651,7 +651,7 @@ packets protected with 1-RTT keys are sent with short headers.  The different
 packet types explicitly indicate the encryption level and therefore the keys
 that are used to remove packet protection.
 
-Packets protected with 0-RTT keys use a type value of 0x05.  The connection ID
+Packets protected with 0-RTT keys use a type value of 0x7B.  The connection ID
 field for a 0-RTT packet is selected by the client.
 
 The client can send 0-RTT packets after receiving a Handshake packet
@@ -674,9 +674,9 @@ sequence of frames, as described in {{frames}}.
 
 QUIC connections are identified by their 64-bit Connection ID.  All long headers
 contain a Connection ID.  Short headers indicate the presence of a Connection ID
-using the CONNECTION_ID flag.  When present, the Connection ID is in the same
-location in all packet headers, making it straightforward for middleboxes, such
-as load balancers, to locate and use it.
+using the Omit Connection ID flag.  When present, the Connection ID is in the
+same location in all packet headers, making it straightforward for middleboxes,
+such as load balancers, to locate and use it.
 
 The client MUST choose a random connection ID and use it in Initial packets
 ({{packet-initial}}) and 0-RTT packets ({{packet-protected}}).
@@ -760,7 +760,7 @@ constant:
 
 * the location of the header form flag,
 
-* the location of the Connection ID flag in short headers,
+* the location of the Omit Connection ID flag in short headers,
 
 * the location and size of the Connection ID field in both header forms,
 
@@ -1733,7 +1733,7 @@ stateless reset.  A server omits the connection ID if explicitly configured to
 do so, or if the client packet did not include a connection ID.
 
 The Packet Number field is set to a randomized value.  The server SHOULD send a
-packet with a short header and a type of 0x01.  This produces the shortest
+packet with a short header and a type of 0x1F.  This produces the shortest
 possible packet number encoding, which minimizes the perceived gap between the
 last packet that the server sent and this packet.  A server MAY use a different
 short header type, indicating a different packet number length, but a longer


### PR DESCRIPTION
This commit makes the following changes:

- Renumber long header packet types to count from 0x7f downwards, rather than from 0x01 upwards
- Renumber short header packet types to count from 0x1f downward, rather than from 0x01 upward
- Invert the sense of the Connection ID Flag in the short header packets, to become an Omit Connection ID Flag

This is a purely syntactic change, with no semantic impact on QUIC.

The purpose of the changes is to make it possible to easily demultiplex QUIC and STUN packets running on a single UDP port, to enable peer to peer use of QUIC. It also enables demultiplexing of WebRTC packets and QUIC packets on a single UDP port.

Discussed in QUIC and AVTCORE working groups at IETF 100 (draft-aboba-avtcore-quic-multiplexing-01) and on QUIC mailing list.

Addresses issue #426 