### PR TITLE
Make lint faster.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,9 @@ jobs:
           keys:
             - refcache
       - run:
+          name: "Lint Drafts"
+          command: "make 'CLONE_ARGS=--reference ~/i-d-template' -k lint"
+      - run:
           name: "Build Drafts"
           command: "make 'CLONE_ARGS=--reference ~/i-d-template'"
       - save_cache:

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ pulls.json
 lib
 .targets.mk
 *.upload
+*.lint

--- a/Makefile
+++ b/Makefile
@@ -12,17 +12,18 @@ else
 	    -b master https://github.com/martinthomson/i-d-template $(LIBDIR)
 endif
 
-latest:: lint
 .PHONY: lint
-lint::
-	@err=0; for f in draft-*.md ; do \
-	  if cat "$$f" | (l=0; while read -r a; do l=$$(($$l + 1)); echo -E "$$l:$$a"; done) | \
-	     sed -e '1,/--- abstract/d;/^[0-9]*: *|/d' | tr -d '\r' | grep '^[0-9]*:.\{81\}'; then \
-	    echo "$$f contains a line with >80 characters"; err=1; \
-	  fi; \
-	  if cat "$$f" | (l=0; while read -r a; do l=$$(($$l + 1)); echo -E "$$l:$$a"; done) | \
-	     sed -e '/^[0-9]*:~~~/,/^[0-9]*:~~~/p;/^[0-9]*:```/,/^[0-9]*:```/p;d' | \
-	     tr -d '\r' | grep '^[0-9]*:.\{66\}'; then \
-	    echo "$$f contains a figure with >65 characters"; err=1; \
-	  fi; \
-	done; [ "$$err" -eq 0 ]
+lint:: $(addprefix .,$(addsuffix .lint,$(drafts)))
+
+.%.lint: %.md
+	@err=0; \
+	if cat "$<" | (l=0; while read -r a; do l=$$(($$l + 1)); echo -E "$$l:$$a"; done) | \
+	   sed -e '1,/--- abstract/d;/^[0-9]*: *|/d' | tr -d '\r' | grep '^[0-9]*:.\{81\}'; then \
+	  echo "$< contains a line with >80 characters"; err=1; \
+	fi; \
+	if cat "$<" | (l=0; while read -r a; do l=$$(($$l + 1)); echo -E "$$l:$$a"; done) | \
+	   sed -e '/^[0-9]*:~~~/,/^[0-9]*:~~~/p;/^[0-9]*:```/,/^[0-9]*:```/p;d' | \
+	   tr -d '\r' | grep '^[0-9]*:.\{66\}'; then \
+	  echo "$< contains a figure with >65 characters"; err=1; \
+	fi; \
+	[ "$$err" -eq 0 ] && touch $@


### PR DESCRIPTION
This makes files to track what has been linted.  It runs `make -k lint`
in CI to avoid having partial results reported in CI.

BTW, I had no idea that this was so slow on windows until I ran it on my Windows box.  Wow.  I appreciate now that 25s is a little slow.  This restores it to 1s on that same machine, which isn't perfect, but certainly is better.  This could probably be improved with a python script for linting rather than the current kludge, but I don't have the cycles for that right now.

Closes #938.