### PR TITLE
Make initial_max_stream_id_* optional and default to zero

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1159,7 +1159,7 @@ initial_max_stream_id_bidi (0x0002):
   maximum bidirectional stream ID is set to 0 if this parameter is absent,
   preventing the creation of new bidirectional streams until a MAX_STREAM_ID
   frame is sent.  Note that a default value of 0 does not prevent the
-  cryptographic handshake stream (that is, stream 0) to be used.
+  cryptographic handshake stream (that is, stream 0) from being used.
 
 initial_max_stream_id_uni (0x0008):
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1154,12 +1154,12 @@ initial_max_stream_id_bidi (0x0002):
   peer-initiated stream (that is, the two least significant bits are set to 0 by
   a server and to 1 by a client).  If an invalid value is provided, the
   recipient MUST generate a connection error of type TRANSPORT_PARAMETER_ERROR.
-  This is equivalent to sending a MAX_STREAM_ID ({{frame-max-stream-id}})
-  immediately after completing the handshake.  The maximum stream ID is set to 0
-  if this parameter is absent, preventing the creation of new unidirectional
-  streams until a MAX_STREAM_ID frame is sent.  Note that a default value of 0
-  does not prevent the the cryptographic handshake stream (that is, stream 0) to
-  be used.
+  Setting this parameter is equivalent to sending a MAX_STREAM_ID
+  ({{frame-max-stream-id}}) immediately after completing the handshake.  The
+  maximum bidirectional stream ID is set to 0 if this parameter is absent,
+  preventing the creation of new bidirectional streams until a MAX_STREAM_ID
+  frame is sent.  Note that a default value of 0 does not prevent the
+  cryptographic handshake stream (that is, stream 0) to be used.
 
 initial_max_stream_id_uni (0x0008):
 
@@ -1168,11 +1168,11 @@ initial_max_stream_id_uni (0x0008):
   unsigned 32-bit integer.  The value MUST be a valid unidirectional ID for the
   recipient (that is, the two least significant bits are set to 2 by a server
   and to 3 by a client).  If an invalid value is provided, the recipient MUST
-  generate a connection error of type TRANSPORT_PARAMETER_ERROR.  This is
-  equivalent to sending a MAX_STREAM_ID ({{frame-max-stream-id}}) immediately
-  after completing the handshake.  The maximum stream ID is set to 0 if this
-  parameter is absent, preventing the creation of new unidirectional streams
-  until a MAX_STREAM_ID frame is sent.
+  generate a connection error of type TRANSPORT_PARAMETER_ERROR.  Setting this
+  parameter is equivalent to sending a MAX_STREAM_ID ({{frame-max-stream-id}})
+  immediately after completing the handshake.  The maximum unidirectional stream
+  ID is set to 0 if this parameter is absent, preventing the creation of new
+  unidirectional streams until a MAX_STREAM_ID frame is sent.
 
 omit_connection_id (0x0004):
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1128,17 +1128,6 @@ initial_max_data (0x0001):
   sending a MAX_DATA ({{frame-max-data}}) for the connection immediately after
   completing the handshake.
 
-initial_max_stream_id_bidi (0x0002):
-
-: The initial maximum stream ID parameter contains the initial maximum stream
-  number the peer may initiate for bidirectional streams, encoded as an unsigned
-  32-bit integer.  This value MUST be a valid bidirectional stream ID for a
-  peer-initiated stream (that is, the two least significant bits are set to 0 by
-  a server and to 1 by a client).  If an invalid value is provided, the
-  recipient MUST generate a connection error of type TRANSPORT_PARAMETER_ERROR.
-  This is equivalent to sending a MAX_STREAM_ID ({{frame-max-stream-id}})
-  immediately after completing the handshake.
-
 idle_timeout (0x0003):
 
 : The idle timeout is a value in seconds that is encoded as an unsigned 16-bit
@@ -1151,6 +1140,27 @@ stateless_reset_token (0x0006):
 : The Stateless Reset Token is used in verifying a stateless reset, see
   {{stateless-reset}}.  This parameter is a sequence of 16 octets.
 
+A client MUST NOT include a stateless reset token.  A server MUST treat receipt
+of a stateless_reset_token transport parameter as a connection error of type
+TRANSPORT_PARAMETER_ERROR.
+
+An endpoint MAY use the following transport parameters:
+
+initial_max_stream_id_bidi (0x0002):
+
+: The initial maximum stream ID parameter contains the initial maximum stream
+  number the peer may initiate for bidirectional streams, encoded as an unsigned
+  32-bit integer.  This value MUST be a valid bidirectional stream ID for a
+  peer-initiated stream (that is, the two least significant bits are set to 0 by
+  a server and to 1 by a client).  If an invalid value is provided, the
+  recipient MUST generate a connection error of type TRANSPORT_PARAMETER_ERROR.
+  This is equivalent to sending a MAX_STREAM_ID ({{frame-max-stream-id}})
+  immediately after completing the handshake.  The maximum stream ID is set to 0
+  if this parameter is absent, preventing the creation of new unidirectional
+  streams until a MAX_STREAM_ID frame is sent.  Note that a default value of 0
+  does not prevent the the cryptographic handshake stream (that is, stream 0) to
+  be used.
+
 initial_max_stream_id_uni (0x0008):
 
 : The initial maximum stream ID parameter contains the initial maximum stream
@@ -1160,13 +1170,9 @@ initial_max_stream_id_uni (0x0008):
   and to 3 by a client).  If an invalid value is provided, the recipient MUST
   generate a connection error of type TRANSPORT_PARAMETER_ERROR.  This is
   equivalent to sending a MAX_STREAM_ID ({{frame-max-stream-id}}) immediately
-  after completing the handshake.
-
-A client MUST NOT include a stateless reset token.  A server MUST treat receipt
-of a stateless_reset_token transport parameter as a connection error of type
-TRANSPORT_PARAMETER_ERROR.
-
-An endpoint MAY use the following transport parameters:
+  after completing the handshake.  The maximum stream ID is set to 0 if this
+  parameter is absent, preventing the creation of new unidirectional streams
+  until a MAX_STREAM_ID frame is sent.
 
 omit_connection_id (0x0004):
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1223,6 +1223,11 @@ initial_max_stream_data that are smaller than the remembered value of those
 parameters.  Similarly, a server MUST NOT reduce the value of
 initial_max_stream_id_bidi or initial_max_stream_id_uni.
 
+Omitting or setting a zero value for certain transport parameters can result in
+0-RTT data being enabled, but not usable.  The following transport parameters
+SHOULD be set to non-zero values for 0-RTT: initial_max_stream_id_bidi,
+initial_max_stream_id_uni, initial_max_data, initial_max_stream_data.
+
 A server MUST reject 0-RTT data or even abort a handshake if the implied values
 for transport parameters cannot be supported.
 


### PR DESCRIPTION
Out of discussion in #958, this allows an endpoint to omit initial_max_stream_id_x for the type of streams that it doesn't want or expect to receive.

Adds a warning about silly values for 0-RTT.

Closes #970.