### PR TITLE
Remove encrypted notation

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -166,9 +166,6 @@ Packet and frame diagrams use the format described in Section 3.1 of
 \[x\]
 : Indicates that x is optional
 
-\{x\}
-: Indicates that x is encrypted
-
 x (A)
 : Indicates that x is A bits long
 


### PR DESCRIPTION
{x} is apparently an encrypted thing, but we don't use it.