### PR TITLE
Expand connection management text 

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -195,11 +195,13 @@ Once a connection exists to a server endpoint, this connection MAY be reused for
 requests with multiple different URI authority components.  The client MAY send
 any requests for which the client considers the server authoritative.
 
-This typically means that the client has received an Alt-Svc record from the
-request's origin in question which nominates the server endpoint as a valid HTTP
-Alternative Service for that origin.  Clients SHOULD NOT assume that an
-HTTP/QUIC endpoint is authoritative for other origins without an explicit
-signal.
+An authoritative HTTP/QUIC endpoint is typically discovered because the client
+has received an Alt-Svc record from the request's origin which nominates the
+endpoint as a valid HTTP Alternative Service for that origin.  As required by
+{{RFC7838}}, clients MUST validate that the nominated server can present a
+validated certificate for the origin before considering it authoritative.
+Clients SHOULD NOT assume that an HTTP/QUIC endpoint is authoritative for other
+origins without an explicit signal.
 
 A server that does not wish clients to reuse connections for a particular origin
 can indicate that it is not authoritative for a request by sending a 421

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -200,9 +200,9 @@ An authoritative HTTP/QUIC endpoint is typically discovered because the client
 has received an Alt-Svc record from the request's origin which nominates the
 endpoint as a valid HTTP Alternative Service for that origin.  As required by
 {{RFC7838}}, clients MUST check that the nominated server can present a valid
-certificate for the origin before considering it authoritative. Clients SHOULD
-NOT assume that an HTTP/QUIC endpoint is authoritative for other origins without
-an explicit signal.
+certificate for the origin before considering it authoritative. Clients MUST NOT
+assume that an HTTP/QUIC endpoint is authoritative for other origins without an
+explicit signal.
 
 A server that does not wish clients to reuse connections for a particular origin
 can indicate that it is not authoritative for a request by sending a 421

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -153,12 +153,13 @@ MAY omit supported versions for any reason.
 
 HTTP/QUIC relies on QUIC as the underlying transport.  The QUIC version being
 used MUST use TLS version 1.3 or greater as its handshake protocol.  The Server
-Name Indication extension {{!RFC6066}} MUST be included in the TLS handshake.
+Name Indication (SNI) extension {{!RFC6066}} MUST be included in the TLS
+handshake.
 
 QUIC connections are established as described in {{QUIC-TRANSPORT}}. During
 connection establishment, HTTP/QUIC support is indicated by selecting the ALPN
-token "hq" in the crypto handshake.  Support for other application-layer
-protocols MAY be offered in the same handshake.
+token "hq" in the TLS handshake.  Support for other application-layer protocols
+MAY be offered in the same handshake.
 
 While connection-level options pertaining to the core QUIC protocol are set in
 the initial crypto handshake, HTTP-specific settings are conveyed
@@ -198,10 +199,10 @@ any requests for which the client considers the server authoritative.
 An authoritative HTTP/QUIC endpoint is typically discovered because the client
 has received an Alt-Svc record from the request's origin which nominates the
 endpoint as a valid HTTP Alternative Service for that origin.  As required by
-{{RFC7838}}, clients MUST validate that the nominated server can present a
-validated certificate for the origin before considering it authoritative.
-Clients SHOULD NOT assume that an HTTP/QUIC endpoint is authoritative for other
-origins without an explicit signal.
+{{RFC7838}}, clients MUST check that the nominated server can present a valid
+certificate for the origin before considering it authoritative. Clients SHOULD
+NOT assume that an HTTP/QUIC endpoint is authoritative for other origins without
+an explicit signal.
 
 A server that does not wish clients to reuse connections for a particular origin
 can indicate that it is not authoritative for a request by sending a 421


### PR DESCRIPTION
(Fixes #940, #794)

Adds the requirement for TLS as the handshake protocol (agreed in Chicago, but never added to draft), use of SNI, and discusses connection reuse aspects we've probably all been assuming but never wrote down.

I feel like we might still need a stronger text than "QUIC as the underlying transport," since HTTP/QUIC technically has a dependency on the ability for the client to initiate bidirectional streams and the server to initiate unidirectional streams.  There's no guarantee that arbitrary QUIC versions would include that, so we perhaps should state it.