### PR TITLE
Rewrite text about Version Negotiation

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -930,10 +930,11 @@ that is mutually supported. A server sends a Version Negotiation packet in
 response to a packet that might initiate a new connection, see
 {{packet-handling}} for details.
 
-Clients that support multiple QUIC versions SHOULD pad their Initial packets
-to reflect the largest minimum Initial packet size of all their versions.
-This ensures that that the server responds if there are any mutually supported
-versions.
+The size of the first packet sent by a client will determine whether a server
+sends a Version Negotiation packet. Clients that support multiple QUIC
+versions SHOULD pad their Initial packets to reflect the largest minimum
+Initial packet size of all their versions. This ensures that that the server
+responds if there are any mutually supported versions.
 
 ### Sending Version Negotiation Packets {#send-vn}
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -867,7 +867,7 @@ Incoming packets are classified on receipt.  Packets can either be associated
 with an existing connection, or - for servers - potentially create a new
 connection.
 
-First, hosts try to associate the packet with an existing connection. If the
+Hosts try to associate the packet with an existing connection. If the
 packet has a connection ID corresponding to an existing connection, QUIC
 processes that packet accordingly. Note that a NEW_CONNECTION_ID frame
 ({{frame-new-connection-id}}) would associate more than one connection ID
@@ -879,7 +879,7 @@ the packet as part of that connection. Endpoints MUST drop packets that omit
 connection IDs if they do not meet both of these criteria.
 
 
-### Client-Specific Behaviors {#client-specific-behaviors}
+### Client Packet Handling {#client-pkt-handling}
 
 If a client receives a packet with an unknown connection ID, and it matches
 the tuple of a connection with no received packets, it is a reply to an
@@ -896,24 +896,29 @@ these packets, or MAY buffer them in anticipation of later packets that
 allow it to compute the key.
 
 
-### Server-Specific Behaviors {#server-specific-behaviors}
+### Server Packet Handling {#server-pkt-handling}
 
-If a server receives a packet that has an unknown connection ID, an
-unsupported version, and a sufficient length to be an Initial packet for
-some version supported by the server, it SHOULD send a Version Negotiation
-packet as described in {{send-vn}}.
+If a server receives a packet that has an unsupported version. and a
+sufficient length to be an Initial packet for some version supported
+by the server, it SHOULD send a Version Negotiation packet as
+described in {{send-vn}}. Servers MAY rate control these packets to
+avoid storms of Version Negotiaion packets.
 
 Servers MUST drop other packets that contain unsupported versions.
 
-If the packet is a supported version, and an Initial packet fully
-conforming with the specification, the server proceeds with the handshake
-({{handshake}}).  This commits the server to the version that the client
-selected.
+Packets with a supported version, or no version field, are matched to
+a connection as described in {{packet-handling}}. If not matched, the
+server continues below.
 
-If the packet is a supported version and a 0-RTT packet, the server MAY
-buffer a limited number of these packets in anticipation of a late-arriving
-Initial Packet. Clients are forbidden from sending Handshake packets prior
-to receiving a server response, so servers SHOULD ignore any such packets.
+If the packet is an Initial packet fully conforming with the
+specification, the server proceeds with the handshake ({{handshake}}).
+This commits the server to the version that the client
+selected. 
+
+If the packet is a 0-RTT packet, the server MAY buffer a limited
+number of these packets in anticipation of a late-arriving Initial
+Packet. Clients are forbidden from sending Handshake packets prior to 
+receiving a server response, so servers SHOULD ignore any such packets.
 
 Servers MUST drop incoming packets under all other circumstances.
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -898,11 +898,11 @@ allow it to compute the key.
 
 ### Server Packet Handling {#server-pkt-handling}
 
-If a server receives a packet that has an unsupported version. and a
+If a server receives a packet that has an unsupported version and
 sufficient length to be an Initial packet for some version supported
 by the server, it SHOULD send a Version Negotiation packet as
 described in {{send-vn}}. Servers MAY rate control these packets to
-avoid storms of Version Negotiaion packets.
+avoid storms of Version Negotiation packets.
 
 Servers MUST drop other packets that contain unsupported versions.
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -868,13 +868,14 @@ Incoming packets are classified on receipt.  Packets can either be associated
 with an existing connection, or - for servers - potentially create a new
 connection.
 
-Packets that can be associated with an existing connection are handled according
-to the current state of that connection.  Packets are associated with existing
-connections using connection ID if it is present; this might include connection
-IDs that were advertised using NEW_CONNECTION_ID ({{frame-new-connection-id}}).
-Packets without connection IDs and long-form packets for connections that have
-incomplete cryptographic handshakes are associated with an existing connection
-using the tuple of source and destination IP addresses and ports.
+Host handle packets that can be associated with an existing connection
+according to the current state of that connection. Short form packets without
+connection IDs, and long-form packets for connections that have incomplete
+cryptographic handshakes, are associated with an existing connection using the
+tuple of source and destination IP addresses and ports. Other packets are
+associated with existing connections using connection ID the connection ID
+in the header; this might include connection IDs that were advertised using
+NEW_CONNECTION_ID ({{frame-new-connection-id}}).
 
 Clients SHOULD discard any packet that cannot be associated with an existing
 connection.  Discarded packets MAY be logged for diagnostic or security

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -888,33 +888,32 @@ accordingly. Clients SHOULD discard any packets with new connection IDs that
 do not meet these criteria.
 
 Note that a successfully associated packet may be a Version Negotiation
-packet, which is handled in accordance with {{handle-vn}}. 
+packet, which is handled in accordance with {{handle-vn}}.
 
-Due to packet reordering or loss, clients might receive packets associated
-with a connection for which it does not yet have the keys to decrypt it.
-Clients MAY drop these packets, or MAY buffer them in anticipation of
-later packets that allow it to compute the key.
+Due to packet reordering or loss, clients might receive packets for a
+connection encrypted with a key it has not yet computed. Clients MAY drop
+these packets, or MAY buffer them in anticipation of later packets that
+allow it to compute the key.
 
 
 ### Server-Specific Behaviors {#server-specific-behaviors}
 
-If a server receives a packet with an unknown connection ID, an unsupported
-version, and is long enough to be an Initial packet for some version
-supported by the server, it SHOULD send a Version Negotiation packet as
-described in {{send-vn}}.
+If a server receives a packet that has an unknown connection ID, an
+unsupported version, and a sufficient length to be an Initial packet for
+some version supported by the server, it SHOULD send a Version Negotiation
+packet as described in {{send-vn}}.
 
 Servers MUST drop other packets that contain unsupported versions.
 
-If the packet is a supported version, and an Initial Packet fully
-conforming with the specification, the server MUST proceed with the
-handshake ({{handshake}}).  This commits the server to the version that the
-client selected.
+If the packet is a supported version, and an Initial packet fully
+conforming with the specification, the server proceeds with the handshake
+({{handshake}}).  This commits the server to the version that the client
+selected.
 
-If the packet is a supported version, and a Handshake or 0RTT packet, the
-server MAY buffer a limited number of these packets in anticipation of
-a late-arriving Initial Packet. In the event the server later generates
-a RETRY packet, this buffer should be purged. Servers MUST NOT send packets
-in response to these buffered packets until the Initial packet arrives.
+If the packet is a supported version and a 0-RTT packet, the server MAY
+buffer a limited number of these packets in anticipation of a late-arriving
+Initial Packet. Clients are forbidden from sending Handshake packets prior
+to receiving a server response, so servers SHOULD ignore any such packets.
 
 Servers MUST drop incoming packets under all other circumstances.
 
@@ -922,7 +921,7 @@ Servers MUST drop incoming packets under all other circumstances.
 
 Version negotiation ensures that client and server agree to a QUIC version
 that is mutually supported. A server sends a Version Negotiation packet in
-response to a packet that might initiate a new connection, see
+response to each packet that might initiate a new connection, see
 {{packet-handling}} for details.
 
 The size of the first packet sent by a client will determine whether a server
@@ -938,7 +937,7 @@ server responds with a Version Negotiation packet ({{packet-version}}).  This
 includes a list of versions that the server will accept.
 
 This system allows a server to process packets with unsupported versions without
-retaining state.  Though either the Initial packet or the version negotiation
+retaining state.  Though either the Initial packet or the Version Negotiation
 packet that is sent in response could be lost, the client will send new packets
 until it successfully receives a response or it abandons the connection attempt.
 


### PR DESCRIPTION
This is meant to resolve #1038.

I made the following changes:
1) Explicitly state the conditions for each possible server action on receipt of the first packet
2) Use IETF terms like "MUST" when missing.
3) Eliminate redundant text
4) Eliminate all explicit mentions of the 1200-byte limit, as this is defined later in the text, where it also explains exactly how to measure packet size. I'm concerned that just saying "1200 bytes" here might cause people to count IP headers or something. Make them read the definition!

I don't believe there's any substantive change to the spec.