### PR TITLE
Latency Spin Bit, 2018 edition

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -469,7 +469,7 @@ Key Phase Bit:
   recipient of a packet to identify the packet protection keys that are used to
   protect the packet.  See {{QUIC-TLS}} for details.
 
-Latency Spin Bit: 
+Latency Spin Bit:
 
 : The fourth bit (0x10) of octet 0 is the latency spin bit; which is set as
 described in {{spin-bit}}.
@@ -806,7 +806,7 @@ each endpoint as follows:
   the server, if the packet has a short header and if it increases the
   highest packet number seen by the client from the server, it sets the spin
   value to the opposite of the spin bit in the received packet.
-  
+
   * The server initializes its spin value to 0. When it receives a packet from
   the client, if that packet has a short header and if it increases the
   highest packet number seen by the server from the client, it sets the spin

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -434,7 +434,7 @@ following sections.
  0                   1                   2                   3
  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
 +-+-+-+-+-+-+-+-+
-|0|C|K| Type (5)|
+|0|C|K|S|Type(4)|
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                                                               |
 +                     [Connection ID (64)]                      +
@@ -469,9 +469,14 @@ Key Phase Bit:
   recipient of a packet to identify the packet protection keys that are used to
   protect the packet.  See {{QUIC-TLS}} for details.
 
+Latency Spin Bit: 
+
+: The fourth bit (0x10) of octet 0 is the latency spin bit; which is set as
+described in {{spin-bit}}.
+
 Short Packet Type:
 
-: The remaining 5 bits of octet 0 include one of 32 packet types.
+: The remaining 4 bits of octet 0 include one of 16 packet types.
   {{short-packet-types}} lists the types that are defined for short packets.
 
 Connection ID:
@@ -494,9 +499,9 @@ other fields.
 
 | Type | Packet Number Size |
 |:-----|:-------------------|
-| 0x1F | 1 octet            |
-| 0x1E | 2 octets           |
-| 0x1D | 4 octets           |
+|  0xF | 1 octet            |
+|  0xE | 2 octets           |
+|  0xD | 4 octets           |
 {: #short-packet-types title="Short Header Packet Types"}
 
 The header form, omit connection ID flag, and connection ID of a short header
@@ -788,6 +793,29 @@ Implementations MUST assume that an unsupported version uses an unknown packet
 format. All other fields MUST be ignored when processing a packet that contains
 an unsupported version.
 
+## The Latency Spin Bit {#spin-bit}
+
+The latency spin bit enables latency monitoring from observation points on the
+network path. Each endpoint, client and server, maintains a spin value, 0 or
+1, for each QUIC connection, and sets the spin bit on packets it sends for
+that connection to the appropriate value. It also maintains the highest packet
+number seen from its peer on the connection. The value is then determined at
+each endpoint as follows:
+
+* The server initializes its spin value to 0. When it receives a packet from
+  the client, if that packet has a short header and if it increments the
+  highest packet number seen by the server from the client, it sets the spin
+  value to the spin bit in the received packet.
+
+* The client initializes its spin value to 0. When it receives a packet from
+  the server, if the packet has a short header and if it increments the
+  highest packet number seen by the client from the server, it sets the spin
+  value to the opposite of the spin bit in the received packet.
+
+This procedure will cause the spin bit to change value in each direction once
+per round trip. Observation points can estimate the network latency by
+observing these changes in the latency spin bit, as described in
+{{?QUIC-MAN:I-D.ietf-quic-manageability}}
 
 # Frames and Frame Types {#frames}
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1817,7 +1817,7 @@ following layout:
  0                   1                   2                   3
  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
 +-+-+-+-+-+-+-+-+
-|0|C|K|Type (5) |
+|0|C|K|S|Type(4)|
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                                                               |
 +                     [Connection ID (64)]                      +
@@ -1840,6 +1840,8 @@ following layout:
 A server copies the connection ID field from the packet that triggers the
 stateless reset.  A server omits the connection ID if explicitly configured to
 do so, or if the client packet did not include a connection ID.
+
+The Spin Bit is set to zero.
 
 The Packet Number field is set to a randomized value.  The server SHOULD send a
 packet with a short header and a type of 0x1F.  This produces the shortest

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -802,20 +802,20 @@ that connection to the appropriate value. It also maintains the highest packet
 number seen from its peer on the connection. The value is then determined at
 each endpoint as follows:
 
-* The server initializes its spin value to 0. When it receives a packet from
-  the client, if that packet has a short header and if it increments the
-  highest packet number seen by the server from the client, it sets the spin
-  value to the spin bit in the received packet.
-
 * The client initializes its spin value to 0. When it receives a packet from
-  the server, if the packet has a short header and if it increments the
+  the server, if the packet has a short header and if it increases the
   highest packet number seen by the client from the server, it sets the spin
   value to the opposite of the spin bit in the received packet.
+  
+  * The server initializes its spin value to 0. When it receives a packet from
+  the client, if that packet has a short header and if it increases the
+  highest packet number seen by the server from the client, it sets the spin
+  value to the spin bit in the received packet.
 
 This procedure will cause the spin bit to change value in each direction once
 per round trip. Observation points can estimate the network latency by
 observing these changes in the latency spin bit, as described in
-{{?QUIC-MAN:I-D.ietf-quic-manageability}}
+{{?QUIC-MAN=I-D.ietf-quic-manageability}}
 
 # Frames and Frame Types {#frames}
 


### PR DESCRIPTION
This PR adds a latency spin bit, taking text from [draft-trammell-quic-spin](https://tools.ietf.org/html/draft-trammell-quic-spin). It updates and replaces #609, and addresses #631. Information on usage of the Latency Spin Bit will appear in a separate PR on the manageability draft.

This version of the PR represents the minimum change. It does not grease the spin bit; spin bit greasing is discussed in [Section 6 of draft-trammell-quic-spin](https://tools.ietf.org/html/draft-trammell-quic-spin-01#section-6). It neither proposes a two-bit spin nor a spin-valid bit, the properties of which are explored in [Section 3.3 of draft-trammell-quic-spin](https://tools.ietf.org/html/draft-trammell-quic-spin-01#section-3.3).