### PR TITLE
Transport parameters are stream counts, not IDs

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1167,22 +1167,23 @@ initial_max_streams_bidi (0x0002):
   unsigned 16-bit integer.  If this parameter is absent or zero,
   application-owned bidirectional streams cannot be created until a
   MAX_STREAM_ID frame is sent.  Note that a value of 0 does not prevent the
-  cryptographic handshake stream (that is, stream 0) from being used. For
-  example, a value of 0x05 would be translated to a bidirectional stream ID of
-  20 by a client or 17 by a server.  Setting this parameter is equivalent to
-  sending a MAX_STREAM_ID ({{frame-max-stream-id}}) immediately after completing
-  the handshake containing the resulting Stream ID.
+  cryptographic handshake stream (that is, stream 0) from being used. Setting
+  this parameter is equivalent to sending a MAX_STREAM_ID
+  ({{frame-max-stream-id}}) immediately after completing the handshake
+  containing the resulting Stream ID. For example, a value of 0x05 would be
+  equivalent to receiving a MAX_STREAM_ID containing 20 when received by a
+  client or 17 when received by a server.
 
 initial_max_stream_id_uni (0x0008):
 
 : The initial maximum streams parameter contains the initial maximum number of
   application-owned unidirectional streams the peer may initiate, encoded as an
   unsigned 16-bit integer.  If this parameter is absent or zero, unidirectional
-  streams cannot be created until a MAX_STREAM_ID frame is sent.  For example, a
-  value of 0x05 would be translated to a value of 18 by a client or 19 by a
-  server.  Setting this parameter is equivalent to sending a MAX_STREAM_ID
-  ({{frame-max-stream-id}}) immediately after completing the handshake
-  containing the resulting Stream ID.
+  streams cannot be created until a MAX_STREAM_ID frame is sent.  Setting this
+  parameter is equivalent to sending a MAX_STREAM_ID ({{frame-max-stream-id}})
+  immediately after completing the handshake containing the resulting Stream ID.
+  For example, a value of 0x05 would be equivalent to receiving a MAX_STREAM_ID
+  containing 18 when received by a client or 19 when received by a server.
 
 omit_connection_id (0x0004):
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1162,10 +1162,10 @@ An endpoint MAY use the following transport parameters:
 
 initial_max_streams_bidi (0x0002):
 
-: The initial maximum streams parameter contains the initial maximum number of
-  application-owned bidirectional streams the peer may initiate, encoded as an
-  unsigned 16-bit integer.  If this parameter is absent or zero,
-  application-owned bidirectional streams cannot be created until a
+: The initial maximum bidirectional streams parameter contains the initial
+  maximum number of application-owned bidirectional streams the peer may
+  initiate, encoded as an unsigned 16-bit integer.  If this parameter is absent
+  or zero, application-owned bidirectional streams cannot be created until a
   MAX_STREAM_ID frame is sent.  Note that a value of 0 does not prevent the
   cryptographic handshake stream (that is, stream 0) from being used. Setting
   this parameter is equivalent to sending a MAX_STREAM_ID
@@ -1176,14 +1176,15 @@ initial_max_streams_bidi (0x0002):
 
 initial_max_stream_id_uni (0x0008):
 
-: The initial maximum streams parameter contains the initial maximum number of
-  application-owned unidirectional streams the peer may initiate, encoded as an
-  unsigned 16-bit integer.  If this parameter is absent or zero, unidirectional
-  streams cannot be created until a MAX_STREAM_ID frame is sent.  Setting this
-  parameter is equivalent to sending a MAX_STREAM_ID ({{frame-max-stream-id}})
-  immediately after completing the handshake containing the resulting Stream ID.
-  For example, a value of 0x05 would be equivalent to receiving a MAX_STREAM_ID
-  containing 18 when received by a client or 19 when received by a server.
+: The initial maximum unidirectional streams parameter contains the initial
+  maximum number of application-owned unidirectional streams the peer may
+  initiate, encoded as an unsigned 16-bit integer.  If this parameter is absent
+  or zero, unidirectional streams cannot be created until a MAX_STREAM_ID frame
+  is sent.  Setting this parameter is equivalent to sending a MAX_STREAM_ID
+  ({{frame-max-stream-id}}) immediately after completing the handshake
+  containing the resulting Stream ID. For example, a value of 0x05 would be
+  equivalent to receiving a MAX_STREAM_ID containing 18 when received by a
+  client or 19 when received by a server.
 
 omit_connection_id (0x0004):
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1160,32 +1160,32 @@ TRANSPORT_PARAMETER_ERROR.
 
 An endpoint MAY use the following transport parameters:
 
-initial_max_stream_id_bidi (0x0002):
+initial_max_streams_bidi (0x0002):
 
-: The initial maximum stream ID parameter contains the initial maximum stream
-  number the peer may initiate for bidirectional streams, encoded as an unsigned
-  32-bit integer.  This value MUST be a valid bidirectional stream ID for a
-  peer-initiated stream (that is, the two least significant bits are set to 0 by
-  a server and to 1 by a client).  If an invalid value is provided, the
-  recipient MUST generate a connection error of type TRANSPORT_PARAMETER_ERROR.
-  Setting this parameter is equivalent to sending a MAX_STREAM_ID
-  ({{frame-max-stream-id}}) immediately after completing the handshake.  The
-  maximum bidirectional stream ID is set to 0 if this parameter is absent,
-  preventing the creation of new bidirectional streams until a MAX_STREAM_ID
-  frame is sent.  Note that a default value of 0 does not prevent the
-  cryptographic handshake stream (that is, stream 0) from being used.
+: The initial maximum streams parameter contains the initial maximum number of
+  bidirectional streams the peer may initiate, encoded as an unsigned 32-bit
+  integer.  Upon receipt, this value is converted to a valid bidirectional
+  stream ID for a peer-initiated stream (that is, it is shifted two bits to the
+  left and the two least significant bits are set to 0 by a server and to 1 by a
+  client).  Setting this parameter is equivalent to sending a MAX_STREAM_ID
+  ({{frame-max-stream-id}}) immediately after completing the handshake
+  containing the resulting Stream ID.  The maximum bidirectional stream ID is
+  set to 0 if this parameter is absent, preventing the creation of new
+  bidirectional streams until a MAX_STREAM_ID frame is sent.  Note that a
+  default value of 0 does not prevent the cryptographic handshake stream (that
+  is, stream 0) from being used.
 
 initial_max_stream_id_uni (0x0008):
 
-: The initial maximum stream ID parameter contains the initial maximum stream
-  number the peer may initiate for unidirectional streams, encoded as an
-  unsigned 32-bit integer.  The value MUST be a valid unidirectional ID for the
-  recipient (that is, the two least significant bits are set to 2 by a server
-  and to 3 by a client).  If an invalid value is provided, the recipient MUST
-  generate a connection error of type TRANSPORT_PARAMETER_ERROR.  Setting this
-  parameter is equivalent to sending a MAX_STREAM_ID ({{frame-max-stream-id}})
-  immediately after completing the handshake.  The maximum unidirectional stream
-  ID is set to 0 if this parameter is absent, preventing the creation of new
+: The initial maximum streams parameter contains the initial maximum number of
+  unidirectional streams the peer may initiate, encoded as an unsigned 32-bit
+  integer.  Upon receipt, this value is converted to a valid bidirectional
+  stream ID for a peer-initiated stream (that is, it is shifted two bits to the
+  left and the two least significant bits are set to 2 by a server and to 3 by a
+  client).  Setting this parameter is equivalent to sending a MAX_STREAM_ID
+  ({{frame-max-stream-id}}) immediately after completing the handshake
+  containing the resulting Stream ID.  The maximum unidirectional stream ID is
+  set to 0 if this parameter is absent, preventing the creation of new
   unidirectional streams until a MAX_STREAM_ID frame is sent.
 
 omit_connection_id (0x0004):

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1164,29 +1164,28 @@ initial_max_streams_bidi (0x0002):
 
 : The initial maximum streams parameter contains the initial maximum number of
   bidirectional streams the peer may initiate, encoded as an unsigned 32-bit
-  integer.  Upon receipt, this value is converted to a valid bidirectional
-  stream ID for a peer-initiated stream (that is, it is shifted two bits to the
-  left and the two least significant bits are set to 0 by a server and to 1 by a
-  client).  Setting this parameter is equivalent to sending a MAX_STREAM_ID
-  ({{frame-max-stream-id}}) immediately after completing the handshake
-  containing the resulting Stream ID.  The maximum bidirectional stream ID is
-  set to 0 if this parameter is absent, preventing the creation of new
-  bidirectional streams until a MAX_STREAM_ID frame is sent.  Note that a
-  default value of 0 does not prevent the cryptographic handshake stream (that
-  is, stream 0) from being used.
+  integer.  The maximum bidirectional stream ID is set to 0 if this parameter is
+  absent or zero, preventing the creation of new bidirectional streams until a
+  MAX_STREAM_ID frame is sent.  Note that a value of 0 does not prevent the
+  cryptographic handshake stream (that is, stream 0) from being used. Non-zero
+  values are converted to a valid bidirectional stream ID for a peer-initiated
+  stream (that is, after shifting two bits to the left, clients subtract 0 and
+  servers subtract 3).  Setting this parameter is equivalent to sending a
+  MAX_STREAM_ID ({{frame-max-stream-id}}) immediately after completing the
+  handshake containing the resulting Stream ID.
 
 initial_max_stream_id_uni (0x0008):
 
 : The initial maximum streams parameter contains the initial maximum number of
   unidirectional streams the peer may initiate, encoded as an unsigned 32-bit
-  integer.  Upon receipt, this value is converted to a valid bidirectional
-  stream ID for a peer-initiated stream (that is, it is shifted two bits to the
-  left and the two least significant bits are set to 2 by a server and to 3 by a
-  client).  Setting this parameter is equivalent to sending a MAX_STREAM_ID
+  integer.  The maximum unidirectional stream ID is set to 0 if this parameter
+  is absent or zero, preventing the creation of new unidirectional streams until
+  a MAX_STREAM_ID frame is sent.  Non-zero values are converted to a valid
+  bidirectional stream ID for a peer-initiated stream (that is, after shifting
+  two bits to the left, clients subtract 2 and servers subtract 1).  Setting
+  this parameter is equivalent to sending a MAX_STREAM_ID
   ({{frame-max-stream-id}}) immediately after completing the handshake
-  containing the resulting Stream ID.  The maximum unidirectional stream ID is
-  set to 0 if this parameter is absent, preventing the creation of new
-  unidirectional streams until a MAX_STREAM_ID frame is sent.
+  containing the resulting Stream ID.
 
 omit_connection_id (0x0004):
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1163,7 +1163,7 @@ An endpoint MAY use the following transport parameters:
 initial_max_streams_bidi (0x0002):
 
 : The initial maximum streams parameter contains the initial maximum number of
-  bidirectional streams the peer may initiate, encoded as an unsigned 32-bit
+  bidirectional streams the peer may initiate, encoded as an unsigned 16-bit
   integer.  The maximum bidirectional stream ID is set to 0 if this parameter is
   absent or zero, preventing the creation of new bidirectional streams until a
   MAX_STREAM_ID frame is sent.  Note that a value of 0 does not prevent the
@@ -1177,7 +1177,7 @@ initial_max_streams_bidi (0x0002):
 initial_max_stream_id_uni (0x0008):
 
 : The initial maximum streams parameter contains the initial maximum number of
-  unidirectional streams the peer may initiate, encoded as an unsigned 32-bit
+  unidirectional streams the peer may initiate, encoded as an unsigned 16-bit
   integer.  The maximum unidirectional stream ID is set to 0 if this parameter
   is absent or zero, preventing the creation of new unidirectional streams until
   a MAX_STREAM_ID frame is sent.  Non-zero values are converted to a valid

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1163,27 +1163,24 @@ An endpoint MAY use the following transport parameters:
 initial_max_streams_bidi (0x0002):
 
 : The initial maximum streams parameter contains the initial maximum number of
-  bidirectional streams the peer may initiate, encoded as an unsigned 16-bit
-  integer.  The maximum bidirectional stream ID is set to 0 if this parameter is
-  absent or zero, preventing the creation of new bidirectional streams until a
+  application-owned bidirectional streams the peer may initiate, encoded as an
+  unsigned 16-bit integer.  If this parameter is absent or zero,
+  application-owned bidirectional streams cannot be created until a
   MAX_STREAM_ID frame is sent.  Note that a value of 0 does not prevent the
-  cryptographic handshake stream (that is, stream 0) from being used. Non-zero
-  values are converted to a valid bidirectional stream ID for a peer-initiated
-  stream (that is, after shifting two bits to the left, clients subtract 0 and
-  servers subtract 3).  Setting this parameter is equivalent to sending a
-  MAX_STREAM_ID ({{frame-max-stream-id}}) immediately after completing the
-  handshake containing the resulting Stream ID.
+  cryptographic handshake stream (that is, stream 0) from being used. For
+  example, a value of 0x05 would be translated to a bidirectional stream ID of
+  20 by a client or 17 by a server.  Setting this parameter is equivalent to
+  sending a MAX_STREAM_ID ({{frame-max-stream-id}}) immediately after completing
+  the handshake containing the resulting Stream ID.
 
 initial_max_stream_id_uni (0x0008):
 
 : The initial maximum streams parameter contains the initial maximum number of
-  unidirectional streams the peer may initiate, encoded as an unsigned 16-bit
-  integer.  The maximum unidirectional stream ID is set to 0 if this parameter
-  is absent or zero, preventing the creation of new unidirectional streams until
-  a MAX_STREAM_ID frame is sent.  Non-zero values are converted to a valid
-  bidirectional stream ID for a peer-initiated stream (that is, after shifting
-  two bits to the left, clients subtract 2 and servers subtract 1).  Setting
-  this parameter is equivalent to sending a MAX_STREAM_ID
+  application-owned unidirectional streams the peer may initiate, encoded as an
+  unsigned 16-bit integer.  If this parameter is absent or zero, unidirectional
+  streams cannot be created until a MAX_STREAM_ID frame is sent.  For example, a
+  value of 0x05 would be translated to a value of 18 by a client or 19 by a
+  server.  Setting this parameter is equivalent to sending a MAX_STREAM_ID
   ({{frame-max-stream-id}}) immediately after completing the handshake
   containing the resulting Stream ID.
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1170,7 +1170,7 @@ initial_max_streams_bidi (0x0002):
   cryptographic handshake stream (that is, stream 0) from being used. Setting
   this parameter is equivalent to sending a MAX_STREAM_ID
   ({{frame-max-stream-id}}) immediately after completing the handshake
-  containing the resulting Stream ID. For example, a value of 0x05 would be
+  containing the corresponding Stream ID. For example, a value of 0x05 would be
   equivalent to receiving a MAX_STREAM_ID containing 20 when received by a
   client or 17 when received by a server.
 
@@ -1182,7 +1182,7 @@ initial_max_stream_id_uni (0x0008):
   or zero, unidirectional streams cannot be created until a MAX_STREAM_ID frame
   is sent.  Setting this parameter is equivalent to sending a MAX_STREAM_ID
   ({{frame-max-stream-id}}) immediately after completing the handshake
-  containing the resulting Stream ID. For example, a value of 0x05 would be
+  containing the corresponding Stream ID. For example, a value of 0x05 would be
   equivalent to receiving a MAX_STREAM_ID containing 18 when received by a
   client or 19 when received by a server.
 


### PR DESCRIPTION
Fixes #1023.

Adopts @huitema's suggestion from that issue.  Currently, we send transport parameters which encode max stream IDs for each type.  This forces the other side to then check that we picked an appropriate stream ID for the stream type associated to the parameter.

If you send an initial *count* rather than an initial ID, you not only save two bits, but it's impossible to encode an invalid value.

(Note that this does not in any way revert that we're using maximum stream IDs as our method of limiting open streams; we're not going back to max-concurrent.)