### PR TITLE
Packet number encryption

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1636,10 +1636,11 @@ effectively random.
 All the AEAD functions used meet indistinguishability under (adaptive) chosen
 plaintext attack (IND-CPA, IND-CPA2) goals and produce minimal expansion of the
 plaintext, adding only an authentication tag.  Therefore, this document assumes
-that the sampled AEAD output is unpredictable and not subject to influence by an
-attacker.  Based on this assumption, the odds of producing identical input to a
-packet protection algorithm approach the birthday bound on the size of the input
-(that is, one divided by the square root of the number of possible values).
+that each bit of sampled AEAD output contains one bit of entropy and that an
+attacker is unable to reduce this without knowledge of the key.  Based on this
+assumption, the odds of producing identical input to a packet protection
+algorithm approach the birthday bound on the size of the input (that is, one
+divided by the square root of the number of possible values).
 
 Note:
 

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1654,11 +1654,12 @@ removed.
 
 An attacker can guess values for packet numbers and have an endpoint confirm
 guesses through timing side channels.  If the recipient of a packet discards
-duplicate packets without attempting to remove packet protection they will
-reveal through timing side-channels that the packet number matches a received
-packet.  For authentication to be free from side-channels, the entire process of
-packet number protection removal, packet number recovery, and packet protection
-removal MUST be applied together without timing and other side-channels.
+packets with duplicate packet numbers without attempting to remove packet
+protection they could reveal through timing side-channels that the packet number
+matches a received packet.  For authentication to be free from side-channels,
+the entire process of packet number protection removal, packet number recovery,
+and packet protection removal MUST be applied together without timing and other
+side-channels.
 
 For the sending of packets, construction and protection of packet payloads and
 packet numbers MUST be free from side-channels that would reveal the packet

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -944,8 +944,8 @@ encryption algorithm.
 For packets with a long header, the ciphertext starting immediately after the
 packet number is used.
 
-For packets with a short header, the packet number length is not known before
-decryption, so it is assumed to be the smaller of the maximum possible packet
+For packets with a short header, the packet number length is
+assumed to be the smaller of the maximum possible packet
 number encoding (4 octets), or the size of the protected packet minus the
 minimum expansion for the AEAD. Thus, the sampled ciphertext for a short header
 can be determined by:

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1638,9 +1638,9 @@ plaintext attack (IND-CPA, IND-CPA2) goals and produce minimal expansion of the
 plaintext, adding only an authentication tag.  Therefore, this document assumes
 that each bit of sampled AEAD output contains one bit of entropy and that an
 attacker is unable to reduce this without knowledge of the key.  Based on this
-assumption, the odds of producing identical input to a packet protection
-algorithm approach the birthday bound on the size of the input (that is, one
-divided by the square root of the number of possible values).
+assumption, the odds of two samples of ciphertext approach the birthday bound
+for the size of the sample (that is, two to the negative power of half the
+number of sampled bits).
 
 Note:
 

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -971,7 +971,7 @@ In summary, packet protection with AES uses the following pseudocode:
 encoded = EncodePacketNumber(packet_number)
 len = Length(encoded)
 sample = ZeroPadSlice(ciphertext, offset, 16)
-encrypted_pn = encoded XOR AES(pn_key, sample)[0..len]
+encrypted_pn = encoded XOR AES(pn_key, sample)[0..len-1]
 ~~~
 
 

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -972,20 +972,14 @@ AEAD_CHACHA20_POLY1305 ({{!CHACHA=RFC7539}}).
 This section defines the packet protection algorithm for AEAD_AES_128_GCM,
 AEAD_AES_128_CCM, AEAD_AES_256_GCM, and AEAD_AES_256_CCM. AEAD_AES_128_GCM and
 AEAD_AES_128_CCM use 128-bit AES {{!AES=DOI.10.6028/NIST.FIPS.197}} in
-Electronic Code-Book (ECB) mode. AEAD_AES_256_GCM, and AEAD_AES_256_CCM use
-256-bit AES in ECB mode.
+counter (CTR) mode. AEAD_AES_256_GCM, and AEAD_AES_256_CCM use
+256-bit AES in CTR mode.
 
 This algorithm samples 16 octets from the packet ciphertext. This value is
-input to AES that is keyed using the packet protection key.
-
-The output of AES is truncated to the length of the encoded packet number.  The
-protected packet number is the exclusive-OR (XOR) of the encoded packet number
-and the truncated output.
-
-In summary, packet protection with AES uses the following form:
+used as the counter input to AES-CTR.
 
 ~~~
-encrypted_pn = packet_number XOR AES(pn_key, sample)
+encrypted_pn = AES-CTR(pn_key, sample, packet_number)
 ~~~
 
 

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1623,11 +1623,11 @@ Packet number protection relies on the randomness of the AEAD output, which is a
 property that AEAD algorithms do not guarantee.  Therefore, no strong assurances
 about the general security of this mechanism can be proven.
 
-Use of the same key and nonce for encryption for encryption can weaken
-encryption.  For the schemes described, protecting two different packet numbers
-with the same key and nonce reveals the exclusive OR of those packet numbers,
-which might be used to compromise confidentiality.  For packet number protection
-to be effective, the output of the packet protection AEAD needs to be
+Use of the same key and nonce more than once can weaken the guarantees provided
+by this protection.  For the schemes described, protecting two different packet
+numbers with the same key and nonce reveals the exclusive OR of those packet
+numbers, which might be used to compromise confidentiality.  For packet number
+protection to be effective, the output of the packet protection AEAD needs to be
 effectively random.
 
 All the AEAD functions used meet indistinguishability under (adaptive) chosen

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1638,9 +1638,9 @@ plaintext attack (IND-CPA, IND-CPA2) goals and produce minimal expansion of the
 plaintext, adding only an authentication tag.  Therefore, this document assumes
 that each bit of sampled AEAD output contains one bit of entropy and that an
 attacker is unable to reduce this without knowledge of the key.  Based on this
-assumption, the odds of two samples of ciphertext approach the birthday bound
-for the size of the sample (that is, two to the negative power of half the
-number of sampled bits).
+assumption, the odds of two samples of ciphertext being identical approach the
+birthday bound for the size of the sample (that is, two to the negative power of
+half the number of sampled bits).
 
 Note:
 
@@ -1648,9 +1648,9 @@ Note:
   protection algorithm might be used.
 
 To prevent an attacker from modifying packet numbers, values of packet numbers
-are transitively authenticated using the packet number protection.  A falsified
-or modified packet number can only be detected once the packet protection is
-removed.
+are transitively authenticated using packet protection; packet numbers are part
+of the authenticated additional data.  A falsified or modified packet number can
+only be detected once the packet protection is removed.
 
 An attacker can guess values for packet numbers and have an endpoint confirm
 guesses through timing side channels.  If the recipient of a packet discards

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1624,8 +1624,9 @@ property that AEAD algorithms do not guarantee.  Therefore, no strong assurances
 about the general security of this mechanism can be proven.
 
 Use of the same key and nonce for encryption for encryption can weaken
-encryption.  For the schemes described, protecting two packet numbers with the
-same key and nonce would reveal the packet number.  For packet number protection
+encryption.  For the schemes described, protecting two different packet numbers
+with the same key and nonce reveals the exclusive OR of those packet numbers,
+which might be used to compromise confidentiality.  For packet number protection
 to be effective, the output of the packet protection AEAD needs to be
 effectively random.
 

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -978,7 +978,7 @@ encrypted_pn = encoded XOR AES(pn_key, sample)[0..len]
 ### ChaCha20-Based Packet Number Protection
 
 When AEAD_CHACHA20_POLY1305 is in use, packet number protection uses the
-ChaCha20 block function as defined in Section 2.3 of {{!CHACHA}}.  This uses a
+raw ChaCha20 function as defined in Section 2.4 of {{!CHACHA}}.  This uses a
 256-bit key and 16 octets sampled from the packet protection output.
 
 The first 4 octets of the sampled ciphertext are interpreted as a 32-bit number
@@ -986,17 +986,13 @@ in little-endian order and are used as the block count.  The remaining 12 octets
 are interpreted as three concatenated 32-bit numbers in little-endian order and
 used as the nonce.
 
-The output of the ChaCha20 block function is truncated to the length of the
-encoded packet number.  The protected packet number is the exclusive-OR (XOR) of
-the encoded packet number and the truncated output.
-
-In summary, packet protection with ChaCha20 uses the following pseudocode:
+The encoded packet number is encrypted with ChaCha20 directly.  In pseudocode:
 
 ~~~
 encoded = EncodePacketNumber(packet_number)
-len = Length(encoded)
-sample = ZeroPadSlice(ciphertext, offset, 16)
-encrypted_pn = encoded XOR ChaCha20(pn_key, sample)[0..len]
+counter = DecodeLE(sample[0..3])
+nonce = DecodeLE(sample[4..7], sample[8..11], sample[12..15])
+encrypted_pn = ChaCha20(pn_key, counter, nonce, encoded)
 ~~~
 
 

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1651,11 +1651,17 @@ are transitively authenticated using the packet number protection.  A falsified
 or modified packet number can only be detected once the packet protection is
 removed.
 
-For authentication to be effective, packet number protection MUST be applied and
-removed without timing or other side-channels.  For a recipient of a packet, the
-process for recovering the full packet number also needs to free from
-side-channels.  This includes recovery of variable-length packet numbers.
+An attacker can guess values for packet numbers and have an endpoint confirm
+guesses through timing side channels.  If the recipient of a packet discards
+duplicate packets without attempting to remove packet protection they will
+reveal through timing side-channels that the packet number matches a received
+packet.  For authentication to be free from side-channels, the entire process of
+packet number protection removal, packet number recovery, and packet protection
+removal MUST be applied together without timing and other side-channels.
 
+For the sending of packets, construction and protection of packet payloads and
+packet numbers MUST be free from side-channels that would reveal the packet
+number or its encoded size.
 
 
 # Error Codes {#errors}

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -866,9 +866,9 @@ connection.  For example, if TLS is using the TLS_AES_128_GCM_SHA256, the
 AEAD_AES_128_GCM function is used.
 
 QUIC packets are protected prior to applying packet number encryption
-({{pn-encrypt}}).  Thus, the unprotected packet number is part of the AAD.  When
-removing packet protection, an endpoint first removes the protection from the
-packet number.
+({{pn-encrypt}}).  The unprotected packet number is part of the associated data
+(A).  When removing packet protection, an endpoint first removes the protection
+from the packet number.
 
 All QUIC packets other than Version Negotiation and Stateless Reset packets are
 protected with an AEAD algorithm {{!AEAD}}. Prior to establishing a shared
@@ -941,8 +941,8 @@ Packet number protection is applied after packet protection is applied (see
 {{aead}}).  The ciphertext of the packet is sampled and used as input to an
 encryption algorithm.
 
-For packets with a long header, the ciphertext starting
-immediately after the packet number is used (that is, octet 17 onwards).
+For packets with a long header, the ciphertext starting immediately after the
+packet number is used.
 
 For packets with a short header, the packet number length is not known before
 decryption, so it is assumed to be the smaller of the maximum possible packet

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1766,26 +1766,28 @@ restart the alarm for a longer period of time.
 ### Privacy Implications of Connection Migration {#migration-linkability}
 
 Using a stable connection ID on multiple network paths allows a passive observer
-to correlate activity between those paths.  A client that moves between networks
-might not wish to have their activity correlated by any entity other than a
-server. The NEW_CONNECTION_ID message can be sent by a server to provide an
-unlinkable connection ID for use in case the client wishes to explicitly break
+to correlate activity between those paths.  An endpoint that moves between
+networks might not wish to have their activity correlated by any entity other
+than their peer. The NEW_CONNECTION_ID message can be sent to provide an
+unlinkable connection ID for use in case a peer wishes to explicitly break
 linkability between two points of network attachment.
 
 An endpoint that does not require the use of a connection ID should not request
 that its peer use a connection ID.  Such an endpoint does not need to provide
 new connection IDs using the NEW_CONNECTION_ID frame.
 
-A client might need to send packets on multiple networks without receiving any
-response from the server.  To ensure that the client is not linkable across each
-of these changes, a new connection ID is needed for each network.  To support
-this, a server sends multiple NEW_CONNECTION_ID messages.  Each
+An endpoint might need to send packets on multiple networks without receiving
+any response from its peer.  To ensure that the endpoint is not linkable across
+each of these changes, a new connection ID is needed for each network.  To
+support this, multiple NEW_CONNECTION_ID messages are needed.  Each
 NEW_CONNECTION_ID is marked with a sequence number.  Connection IDs MUST be used
 in the order in which they are numbered.
 
-A client which wishes to break linkability upon changing networks MUST use the
-connection ID provided by the server.  Protection of packet numbers ensures that
-packet numbers cannot be used to correlate connections.
+An endpoint that to break linkability upon changing networks MUST use a
+previously unused connection ID provided by its peer.  Protection of packet
+numbers ensures that packet numbers cannot be used to correlate connections.
+Other properties of packets, such as timing and size, might be used to correlate
+activity, but no explicit correlation can be used to link activity across paths.
 
 Clients MAY change connection ID at any time based on implementation-specific
 concerns.  For example, after a period of network inactivity NAT rebinding might

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -345,8 +345,9 @@ Payload Length:
 Packet Number:
 
 : The Packet Number is a 32-bit field that follows the two connection IDs.
-  {{packet-numbers}} describes the use of packet numbers.  Packet numbers are
-  protected separately to the packet payload.
+  Packet numbers are not encrypted as part of packet protection, but instead
+  have additional confidentiality protection. {{packet-numbers}} describes the
+  use of packet numbers.
 
 
 Payload:
@@ -454,7 +455,8 @@ Packet Number:
 
 : The length of the packet number field depends on the packet type.  This field
   can be 1, 2 or 4 octets long depending on the short packet type.  Packet
-  numbers are protected separate to the packet payload.
+  numbers are not encrypted as part of packet protection, but instead have
+  additional confidentiality protection.
 
 Protected Payload:
 
@@ -696,10 +698,10 @@ continue to use the same Destination Connection ID for 0-RTT packets, see
 
 The version field for protected packets is the current QUIC version.
 
-The packet number field contains a packet number, which is protected separately
-from the rest of the packet (see {{QUIC-TLS}} for details).  The underlying
-packet number increases with each packet sent, see {{packet-numbers}} for
-details.
+The packet number field contains a packet number, which has additional
+confidentiality protection that is applied after packet protection is applied
+(see {{QUIC-TLS}} for details).  The underlying packet number increases with
+each packet sent, see {{packet-numbers}} for details.
 
 The payload is protected using authenticated encryption.  {{QUIC-TLS}} describes
 packet protection in detail.  After decryption, the plaintext consists of a

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -346,7 +346,7 @@ Packet Number:
 
 : The Packet Number is a 32-bit field that follows the two connection IDs.
   {{packet-numbers}} describes the use of packet numbers.  Packet numbers are
-  protected separate to the packet payload.
+  protected separately to the packet payload.
 
 
 Payload:

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2541,11 +2541,11 @@ Unlike TCP SACKs, QUIC acknowledgements are irrevocable.  Once a packet has
 been acknowledged, even if it does not appear in a future ACK frame,
 it remains acknowledged.
 
-A client MUST NOT acknowledge Retry packets.  Version
-Negotiation packets don't contain a packet number and Retry packets include the
-packet number from the Initial packet it responds to.  Rather than relying on
-ACK frames, these packets are implicitly acknowledged by the next Initial packet
-sent by the client.
+A client MUST NOT acknowledge Retry packets.  Retry packets include the packet
+number from the Initial packet it responds to.  Version Negotiation packets
+cannot be acknowledged because they do not contain a packet number.  Rather than
+relying on ACK frames, these packets are implicitly acknowledged by the next
+Initial packet sent by the client.
 
 An ACK frame is shown below.
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -580,8 +580,8 @@ The client populates the Source Connection ID field with a value of its choosing
 and sets the low bits of the ConnID Len field to match.
 
 The first Initial packet that is sent by a client contains a packet number of 0.
-All subsequent packets contain a packet number that is incremented by one, see
-({{packet-numbers}}).
+All subsequent packets contain a packet number that is incremented by at least
+one, see ({{packet-numbers}}).
 
 The payload of an Initial packet conveys a STREAM frame (or frames) for stream
 0 containing a cryptographic handshake message.  The stream in this packet
@@ -775,7 +775,7 @@ response to connection migration ({{migration}}). NEW_CONNECTION_ID frames
 The packet number is an integer in the range 0 to 2^62-1. The value is used in
 determining the cryptographic nonce for packet encryption.  Each endpoint
 maintains a separate packet number for sending and receiving.  The packet number
-for sending MUST starts at zero for the first packet set and MUST increase by at
+for sending MUST start at zero for the first packet sent and MUST increase by at
 least one after sending a packet.
 
 A QUIC endpoint MUST NOT reuse a packet number within the same connection (that

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -786,10 +786,13 @@ Reset ({{stateless-reset}}) in response to further packets that it receives.
 
 For the packet header, the number of bits required to represent the packet
 number are reduced by including only the least significant bits of the packet
-number.  The encoded packet number is protected as described in {{QUIC-TLS}}.
-Protection of the packet number is removed prior to recovering the full packet
-number.  The full packet number is reconstructed at the receiver based on the
-largest packet number received on a successfully authenticated packet.
+number.
+
+The encoded packet number is protected as described in {{QUIC-TLS}}. Protection
+of the packet number is removed prior to recovering the full packet number. The
+full packet number is reconstructed at the receiver based on the largest packet
+number received on a successfully authenticated packet. Recovering the full
+packet number is necessary to successfully remove packet protection.
 
 Once packet number protection is removed, the packet number is decoded by
 finding the packet number value that is closest to the next expected packet.


### PR DESCRIPTION
This is a little rough, but I think that the bones are here.  I'm not all that proud of my analysis of the security of this hack, but I couldn't think of a way of disclaiming its value without also having it seem like we were throwing unlinkability for connection migrations under the bus.

I know that we discussed removing short packet types in favor of putting the lengths under encryption.  I will do that separately, just to keep the size of this changeset to something more manageable.

- Closes #1174
- Closes #1043
- Closes #1048
- Closes #1034
- Closes #850
- Closes #990
- Closes #734 

Enables #598 