### PR TITLE
Clarify flow control issues on stream 0

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3428,15 +3428,19 @@ implementations.
 
 ### Handshake Exemption
 
-During the initial handshake, a server could need to send a larger message than
-would ordinarily be permitted by the client's initial stream flow control
-window. Since MAX_STREAM_DATA frames are not permitted in Handshake packets, the
-client cannot respond to server requests for additional flow control window in
-order to complete the handshake.
+During the initial handshake, an endpoint could need to send a larger message on
+stream 0 than would ordinarily be permitted by the peer's initial stream flow
+control window. Since MAX_STREAM_DATA frames are not permitted in these early
+packets, the peer cannot provide additional flow control window in order to
+complete the handshake.
 
-Servers MAY exceed the flow control limits on stream 0 prior to the completion
-of the cryptographic handshake.  However, once the handshake is complete,
-servers MUST NOT send data beyond the client's permitted offset.
+Endpoints MAY exceed the flow control limits on stream 0 prior to the completion
+of the cryptographic handshake.  (That is, in Initial, Retry, and Handshake
+packets.)  However, once the handshake is complete, endpoints MUST NOT send
+additional data beyond the peer's permitted offset.  If the amount of data sent
+during the handshake exceeds the peer's maximum offset, the endpoint cannot send
+additional data until the peer has sent a MAX_STREAM_DATA frame indicating a
+larger maximum offset.
 
 ## Stream Limit Increment
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3439,8 +3439,8 @@ of the cryptographic handshake.  (That is, in Initial, Retry, and Handshake
 packets.)  However, once the handshake is complete, endpoints MUST NOT send
 additional data beyond the peer's permitted offset.  If the amount of data sent
 during the handshake exceeds the peer's maximum offset, the endpoint cannot send
-additional data until the peer has sent a MAX_STREAM_DATA frame indicating a
-larger maximum offset.
+additional data on stream 0 until the peer has sent a MAX_STREAM_DATA frame
+indicating a larger maximum offset.
 
 ## Stream Limit Increment
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -650,11 +650,6 @@ described in {{packet-numbers}}.  The client increments the packet number from
 its previous packet by one for each Handshake packet that it sends (which might
 be an Initial, 0-RTT Protected, or Handshake packet).
 
-Servers MUST NOT send more than three Handshake packets in response to a
-client's Initial packet without validating the client's ownership of the
-address, either via a Retry packet or by receiving packets from the client
-in response to the server's Handshake packets.
-
 The payload of this packet contains STREAM frames and could contain PADDING and
 ACK frames.
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3375,9 +3375,9 @@ one of the packets is lost.
 Connection flow control is a limit to the total bytes of stream data sent in
 STREAM frames on all streams except stream 0.  A receiver advertises credit for
 a connection by sending a MAX_DATA frame.  A receiver maintains a cumulative sum
-of bytes received on all streams, which are used to check for flow control
-violations. A receiver might use a sum of bytes consumed on all contributing
-streams to determine the maximum data limit to be advertised.
+of bytes received on all contributing streams, which are used to check for flow
+control violations. A receiver might use a sum of bytes consumed on all
+contributing streams to determine the maximum data limit to be advertised.
 
 ## Edge Cases and Other Considerations
 


### PR DESCRIPTION
Fixes #1074, #725 - these are similar problems around flow control on stream zero.

Stream 0 isn't bound to obey connection-level flow control, which necessarily means that it can't consume connection-level flow control either.  That was previously incorrect, since the definition of connection flow control repeatedly referred to "all streams."

On the other hand, Stream 0 can get stalled by stream-level flow control and the client isn't allowed to give it more credit.  This permits Stream 0 to "surge" until the end of the handshake, but then it has to wait for the client to give it more credit until it catches up.

~~~Finally, that surge could provoke an amplification attack if a server has a really large handshake message.  The proposed mitigation to that is to require address validation before sending more than N times the client's initial packet size; since the client has an initial minimum packet size, that can be simplified to N Handshake packets from the server.  I've arbitrarily chosen N=3, but happy to bikeshed that.  I'm not certain I've landed that restriction in the best place, so feel free to suggest moving it elsewhere entirely.~~~