### PR TITLE
Mitigate amplification attacks during handshake

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1293,6 +1293,13 @@ establishment.  A `STREAM` frame carrying a TLS alert MAY be included in the
 same packet.
 
 
+### Address Verification
+
+In order to perform source-address verification before the handshake is
+complete, `PATH_CHALLENGE` and `PATH_RESPONSE` frames MAY be exchanged
+unprotected.
+
+
 ### Denial of Service with Unprotected Packets
 
 Accepting unprotected - specifically unauthenticated - packets presents a denial

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -651,14 +651,17 @@ its previous packet by one for each Handshake packet that it sends (which might
 be an Initial, 0-RTT Protected, or Handshake packet).
 
 Servers MUST NOT send more than three Handshake packets without receiving a
-packet from a verified source address.  If the server expects to generate more
-than three Handshake packets in response to an Initial packet, it SHOULD include
-a PATH_CHALLENGE frame in each Handshake packet that it sends.  After receiving
-at least one valid PATH_RESPONSE frame in a Handshake packet, the server can
-send its remaining Handshake packets.  (Servers MAY instead perform address
-validation using a Retry packet; this requires less state on the server, but
-could involve additional computational effort depending on implementation
-choices.)
+packet from a verified source address.  Source addresses can be verified
+through an address validation token, receipt of the final cryptographic message
+from the client, or by receiving a valid PATH_RESPONSE frame from the client.
+
+If the server expects to generate more than three Handshake packets in response
+to an Initial packet, it SHOULD include a PATH_CHALLENGE frame in each Handshake
+packet that it sends.  After receiving at least one valid PATH_RESPONSE frame,
+the server can send its remaining Handshake packets. Servers can instead perform
+address validation using a Retry packet; this requires less state on the server,
+but could involve additional computational effort depending on implementation
+choices.
 
 The payload of this packet contains STREAM frames and could contain PADDING,
 ACK, PATH_CHALLENGE, or PATH_RESPONSE frames.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -650,8 +650,18 @@ described in {{packet-numbers}}.  The client increments the packet number from
 its previous packet by one for each Handshake packet that it sends (which might
 be an Initial, 0-RTT Protected, or Handshake packet).
 
-The payload of this packet contains STREAM frames and could contain PADDING and
-ACK frames.
+Servers MUST NOT send more than three Handshake packets without receiving a
+packet from a verified source address.  If the server expects to generate more
+than three Handshake packets in response to an Initial packet, it SHOULD include
+a PATH_CHALLENGE frame in each Handshake packet that it sends.  After receiving
+at least one valid PATH_RESPONSE frame in a Handshake packet, the server can
+send its remaining Handshake packets.  (Servers MAY instead perform address
+validation using a Retry packet; this requires less state on the server, but
+could involve additional computational effort depending on implementation
+choices.)
+
+The payload of this packet contains STREAM frames and could contain PADDING,
+ACK, PATH_CHALLENGE, or PATH_RESPONSE frames.
 
 
 ## Protected Packets {#packet-protected}


### PR DESCRIPTION
Lifted out of #1082 and building on #1086, this attempts to mitigate a potential amplification in which an attacker finds a server with a very large certificate, spoofs a source address, and then uses the server's handshake to generate traffic.  It limits the server from sending more than three Handshake packets to an unvalidated source address.  Suggested ways of validating are Retry packets and PATH_CHALLENGE.

Fixes #38.