### PR TITLE
Integrate QCRAM

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -344,18 +344,9 @@ abort a response in progress as a result of receiving a solicited RST_STREAM.
 
 ### Header Compression
 
-HTTP/QUIC uses HPACK header compression as described in {{!RFC7541}}. HPACK was
-designed for HTTP/2 with the assumption of in-order delivery such as that
-provided by TCP. A sequence of encoded header blocks must arrive (and be
-decoded) at an endpoint in the same order in which they were encoded. This
-ensures that the dynamic state at the two endpoints remains in sync.
-
-QUIC streams provide in-order delivery of data sent on those streams, but there
-are no guarantees about order of delivery between streams. QUIC anticipates
-moving to a modified version of HPACK without this assumption.  In the meantime,
-by fixing the size of the dynamic table at zero, HPACK can be used in an
-unordered environment.
-
+HTTP/QUIC uses QCRAM header compression as described in [QCRAM], a variation of
+HPACK which allows the flexibility to avoid header-compression-induced HoL
+blocking.  See that document for additional details.
 
 ### The CONNECT Method
 
@@ -739,7 +730,7 @@ Settings which are integers use the QUIC variable-length integer encoding.
 The following settings are defined in HTTP/QUIC:
 
   SETTINGS_HEADER_TABLE_SIZE (0x1):
-  : An integer with a maximum value of 2^30 - 1.  This value MUST be zero.
+  : An integer with a maximum value of 2^30 - 1.
 
   SETTINGS_MAX_HEADER_LIST_SIZE (0x6):
   : An integer with a maximum value of 2^30 - 1
@@ -1132,6 +1123,12 @@ HTTP/2 specifies priority assignments in PRIORITY frames and (optionally) in
 HEADERS frames. To achieve in-order delivery of priority changes in HTTP/QUIC,
 PRIORITY frames are sent on the control stream and the PRIORITY section is
 removed from the HEADERS frame.
+
+Likewise, HPACK was designed with the assumption of in-order delivery. A
+sequence of encoded header blocks must arrive (and be decoded) at an endpoint in
+the same order in which they were encoded. This ensures that the dynamic state
+at the two endpoints remains in sync.  As a result, HTTP/QUIC uses a modified
+version of HPACK, described in [QCRAM].
 
 Frame type definitions in HTTP/QUIC often use the QUIC variable-length integer
 encoding.  In particular, Stream IDs use this encoding, which allow for a larger

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -345,8 +345,8 @@ abort a response in progress as a result of receiving a solicited RST_STREAM.
 ### Header Compression
 
 HTTP/QUIC uses QCRAM header compression as described in [QCRAM], a variation of
-HPACK which allows the flexibility to avoid header-compression-induced HoL
-blocking.  See that document for additional details.
+HPACK which allows the flexibility to avoid header-compression-induced
+head-of-line blocking.  See that document for additional details.
 
 ### The CONNECT Method
 
@@ -931,8 +931,9 @@ HTTP_NO_ERROR code.
 The HEADER_ACK frame (type=0x8) is sent from the decoder to the encoder on the
 Control Stream when the decoder has fully processed a header block.  It is used
 by the encoder to determine whether subsequent indexed representations that
-might reference that block are vulnerable to HoL blocking, and to prevent
-eviction races.  See [QCRAM] for more details on the use of this information.
+might reference that block are vulnerable to head-of-line blocking, and to
+prevent eviction races.  See [QCRAM] for more details on the use of this
+information.
 
 The HEADER_ACK frame indicates the stream on which the header block was
 processed by encoding the Stream ID as a variable-length integer. The same

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -951,8 +951,8 @@ feedback on which header blocks within a stream have been fully processed.
 ~~~~~~~~~~
   0   1   2   3   4   5   6   7
 +---+---+---+---+---+---+---+---+
-|        Stream ID [i]          |
-+---+---------------------------+
+|        Stream ID (i)        ...
++---+---+---+---+---+---+---+---+
 ~~~~~~~~~~
 {: title="HEADER_ACK frame"}
 

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -928,12 +928,17 @@ HTTP_NO_ERROR code.
 
 ### HEADER_ACK {#frame-header-ack}
 
-The HEADER_ACK frame (type=0x8) is sent from the decoder to the encoder on the
-Control Stream when the decoder has fully processed a header block.  It is used
-by the encoder to determine whether subsequent indexed representations that
-might reference that block are vulnerable to head-of-line blocking, and to
-prevent eviction races.  See [QCRAM] for more details on the use of this
-information.
+The HEADER_ACK frame (type=0x8) is used by header compression to ensure
+consistency. The frames are sent from the QCRAM decoder to the QCRAM encoder;
+that is, the server sends them to the client to acknowledge processing of the
+client's header blocks, and the client sends them to the server to acknowledge
+processing of the server's header blocks.
+
+The HEADER_ACK frame is sent on the Control Stream when the QCRAM decoder has
+fully processed a header block.  It is used by the peer's QCRAM encoder to
+determine whether subsequent indexed representations that might reference that
+block are vulnerable to head-of-line blocking, and to prevent eviction races.
+See [QCRAM] for more details on the use of this information.
 
 The HEADER_ACK frame indicates the stream on which the header block was
 processed by encoding the Stream ID as a variable-length integer. The same

--- a/draft-ietf-quic-qcram.md
+++ b/draft-ietf-quic-qcram.md
@@ -98,7 +98,7 @@ the reference from being usable.
 The encoder can choose on a per-header-block basis whether to favor higher
 compression ratio (by permitting vulnerable references) or HoL resilience (by
 avoiding them). This is signaled by the BLOCKING flag in HEADERS and
-PUSH_PROMISE frames (see {{hq-frames}}).
+PUSH_PROMISE frames (see {{QUIC-HTTP}}).
 
 If a header block contains no vulnerable header fields, BLOCKING MUST be 0.
 This implies that the header fields are represented either as references
@@ -122,51 +122,9 @@ considered blocked by the decoder and can not be processed until all entries in
 the range `[1, Depends Index]` have been added.  While blocked, header
 field data MUST remain in the blocked stream's flow control window.
 
-# HTTP over QUIC mapping extensions {#hq-frames}
-
-## HEADERS and PUSH_PROMISE
-
-HEADERS and PUSH_PROMISE frames define a new flag.
-
-BLOCKING (0x01):
-: Indicates the stream might need to wait for dependent headers before
-  processing.  If 0, the frame can be processed immediately upon receipt.
-
-HEADERS frames can be sent on the Connection Control Stream as well as on
-request / push streams.  The value of BLOCKING MUST be 0 for HEADERS frames on
-the Connection Control Stream, since they can only depend on previous HEADERS on
-the same stream.
-
-## HEADER_ACK
-
-The HEADER_ACK frame (type=0x8) is sent from the decoder to the encoder on the
-Control Stream when the decoder has fully processed a header block.  It is used
-by the encoder to determine whether subsequent indexed representations that
-might reference that block are vulnerable to HoL blocking, and to prevent
-eviction races (see {{evictions}}).
-
-The HEADER_ACK frame indicates the stream on which the header block was
-processed by encoding the Stream ID as a variable-length integer. The same
-Stream ID can be identified multiple times, as multiple header-containing blocks
-can be sent on a single stream in the case of intermediate responses, trailers,
-pushed requests, etc. as well as on the Control Streams.  Since header frames on
-each stream are received and processed in order, this gives the encoder precise
-feedback on which header blocks within a stream have been fully processed.
-
-~~~~~~~~~~
-  0   1   2   3   4   5   6   7
-+---+---+---+---+---+---+---+---+
-|        Stream ID [i]          |
-+---+---------------------------+
-~~~~~~~~~~
-{: title="HEADER_ACK frame"}
-
-The HEADER_ACK frame does not define any flags.
-
 # HPACK extensions
 
 ## Allowed Instructions
-
 
 HEADERS frames on the Control Stream SHOULD contain only Literal with
 Incremental Indexing and Indexed with Duplication (see {{indexed-duplicate}})


### PR DESCRIPTION
Fixes #228, at long last!

This does two major things, and then I think we're ready to iterate on any changes we'd like to make to QCRAM itself:

- Moves the "Changes to HTTP/QUIC" section from QCRAM and applies them to the HTTP/QUIC spec
- Removes the restriction that HPACK's table size is zero