### PR TITLE
use the 0x8 short header bit for demultiplexing gQUIC

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -486,8 +486,8 @@ Key Phase Bit:
   recipient of a packet to identify the packet protection keys that are used to
   protect the packet.  See {{QUIC-TLS}} for details.
 
-\[\[RFC editor: please remove the Google QUIC Demultipexing bit before
-publication.]]
+\[\[Editor's Note: this section should be removed and the bit definitions
+changed before this draft goes to the IESG.]]
 
 Google QUIC Demultipexing Bit:
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -489,6 +489,13 @@ Key Phase Bit:
 \[\[Editor's Note: this section should be removed and the bit definitions
 changed before this draft goes to the IESG.]]
 
+Fourth bit:
+
+: The fourth bit (0x10) of octet 0 is set to 1.
+
+\[\[Editor's Note: this section should be removed and the bit definitions
+changed before this draft goes to the IESG.]]
+
 Google QUIC Demultipexing Bit:
 
 : The fifth bit (0x8) of octet 0 is set to 0. This allows implementations of

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -524,9 +524,9 @@ other fields.
 
 | Type | Packet Number Size |
 |:-----|:-------------------|
-| 0x7  | 1 octet            |
-| 0x6  | 2 octets           |
-| 0x5  | 4 octets           |
+| 0x0  | 1 octet            |
+| 0x1  | 2 octets           |
+| 0x2  | 4 octets           |
 {: #short-packet-types title="Short Header Packet Types"}
 
 The header form, omit connection ID flag, and connection ID of a short header

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -493,7 +493,8 @@ Google QUIC Demultipexing Bit:
 
 : The fifth bit (0x8) of octet 0 is set to 0. This allows implementations of
   Google QUIC to distinguish Google QUIC packets from short header packets sent
-  by a client.
+  by a client because Google QUIC servers expect the connection ID to always be
+  present.
   The special interpretation of this bit SHOULD be removed from this
   specification when Google QUIC has finished transitioning to the new header
   format.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -451,7 +451,7 @@ following sections.
  0                   1                   2                   3
  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
 +-+-+-+-+-+-+-+-+
-|0|C|K| Type (5)|
+|0|C|K|1|0|T T T|
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                                                               |
 +                     [Connection ID (64)]                      +
@@ -486,9 +486,18 @@ Key Phase Bit:
   recipient of a packet to identify the packet protection keys that are used to
   protect the packet.  See {{QUIC-TLS}} for details.
 
+Google QUIC Demultipexing Bit:
+
+: The fifth bit (0x8) of octet 0 is set to 0. This allows implementations of
+  Google QUIC to distinguish Google QUIC packets from short header packets sent
+  by a client.
+  The special interpretation of this bit SHOULD be removed from this
+  specification when Google QUIC has finished transitioning to the new header
+  format.
+
 Short Packet Type:
 
-: The remaining 5 bits of octet 0 include one of 32 packet types.
+: The remaining 3 bits of octet 0 include one of 8 packet types.
   {{short-packet-types}} lists the types that are defined for short packets.
 
 Connection ID:
@@ -511,9 +520,9 @@ other fields.
 
 | Type | Packet Number Size |
 |:-----|:-------------------|
-| 0x1F | 1 octet            |
-| 0x1E | 2 octets           |
-| 0x1D | 4 octets           |
+| 0x7  | 1 octet            |
+| 0x6  | 2 octets           |
+| 0x5  | 4 octets           |
 {: #short-packet-types title="Short Header Packet Types"}
 
 The header form, omit connection ID flag, and connection ID of a short header

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -486,6 +486,9 @@ Key Phase Bit:
   recipient of a packet to identify the packet protection keys that are used to
   protect the packet.  See {{QUIC-TLS}} for details.
 
+\[\[RFC editor: please remove the Google QUIC Demultipexing bit before
+publication.]]
+
 Google QUIC Demultipexing Bit:
 
 : The fifth bit (0x8) of octet 0 is set to 0. This allows implementations of


### PR DESCRIPTION
This PR changes the code points for the short header packet types, such that the 0x8 bit is always unset. This will allow implementations of gQUIC to demultiplex gQUIC packets with short header packets sent by the client (gQUIC clients will always set the 0x8 bit).

For implementers, the only thing that needs to be changed is the short header packet type:
- 0x1F => 0x17
- 0X1E => 0x16
- 0x1D => 0x15

Apparently Github doesn't allow me to request reviews, but probably @ianswett, @martinthomson, @janaiyengar and @csperkins should have a look at this.