### PR TITLE
Tls error

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3724,10 +3724,6 @@ PROTOCOL_VIOLATION (0xA):
 : An endpoint detected an error with protocol compliance that was not covered by
   more specific error codes.
 
-TLS_NEGOTIATION_FAILURE (0xB):
-
-: An endpoint detected an error during the TLS negotiation.
-
 UNSOLICITED_PATH_RESPONSE (0xB):
 
 : An endpoint received a PATH_RESPONSE frame that did not correspond to any
@@ -3739,7 +3735,9 @@ FRAME_ERROR (0x1XX):
   included as the last octet of the error code.  For example, an error in a
   MAX_STREAM_ID frame would be indicated with the code (0x106).
 
-See {{iana-error-codes}} for details of registering new error codes.
+Codes for error occuring when TLS is used for the crypto handshake are defined
+in Section 11 of {{QUIC-TLS}}.
+See {{iana-error-codes}} for details of registering new error codes. 
 
 
 ## Application Protocol Error Codes {#app-error-codes}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3737,7 +3737,7 @@ FRAME_ERROR (0x1XX):
 
 Codes for errors occuring when TLS is used for the crypto handshake are defined
 in Section 11 of {{QUIC-TLS}}.
-See {{iana-error-codes}} for details of registering new error codes. 
+See {{iana-error-codes}} for details of registering new error codes.
 
 
 ## Application Protocol Error Codes {#app-error-codes}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3724,6 +3724,10 @@ PROTOCOL_VIOLATION (0xA):
 : An endpoint detected an error with protocol compliance that was not covered by
   more specific error codes.
 
+TLS_NEGOTIATION_FAILURE (0xB):
+
+: An endpoint detected an error during the TLS negotiation.
+
 UNSOLICITED_PATH_RESPONSE (0xB):
 
 : An endpoint received a PATH_RESPONSE frame that did not correspond to any

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3735,7 +3735,7 @@ FRAME_ERROR (0x1XX):
   included as the last octet of the error code.  For example, an error in a
   MAX_STREAM_ID frame would be indicated with the code (0x106).
 
-Codes for error occuring when TLS is used for the crypto handshake are defined
+Codes for errors occuring when TLS is used for the crypto handshake are defined
 in Section 11 of {{QUIC-TLS}}.
 See {{iana-error-codes}} for details of registering new error codes. 
 


### PR DESCRIPTION
I would like to add an error code, to use during the handshake when the TLS parameters proposed by the server cannot be accepted by the client. Example would be a bad certificate.