### PR TITLE
QPACK Blocking Setting

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -781,10 +781,10 @@ The following settings are defined in HTTP/QUIC:
   : An integer with a maximum value of 2^30 - 1.
 
   SETTINGS_MAX_HEADER_LIST_SIZE (0x6):
-  : An integer with a maximum value of 2^30 - 1
+  : An integer with a maximum value of 2^30 - 1.
 
   SETTINGS_BLOCKING_HEADER_REFERENCES (0x7):
-  : A Boolean
+  : An integer with a maximum value of 2^16 - 1.
 
 #### Initial SETTINGS Values
 

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -778,13 +778,15 @@ Settings which are integers use the QUIC variable-length integer encoding.
 The following settings are defined in HTTP/QUIC:
 
   SETTINGS_HEADER_TABLE_SIZE (0x1):
-  : An integer with a maximum value of 2^30 - 1.
+  : An integer with a maximum value of 2^30 - 1.  The default value is 4,096
+    bytes.
 
   SETTINGS_MAX_HEADER_LIST_SIZE (0x6):
-  : An integer with a maximum value of 2^30 - 1.
+  : An integer with a maximum value of 2^30 - 1.  The default value is
+    unlimited.
 
   SETTINGS_BLOCKING_HEADER_REFERENCES (0x7):
-  : An integer with a maximum value of 2^16 - 1.
+  : An integer with a maximum value of 2^16 - 1.  The default value is 100.
 
 #### Initial SETTINGS Values
 

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -785,7 +785,7 @@ The following settings are defined in HTTP/QUIC:
   : An integer with a maximum value of 2^30 - 1.  The default value is
     unlimited.
 
-  SETTINGS_BLOCKING_HEADER_REFERENCES (0x7):
+  SETTINGS_QPACK_BLOCKED_STREAMS (0x7):
   : An integer with a maximum value of 2^16 - 1.  The default value is 100.
 
 #### Initial SETTINGS Values
@@ -1454,6 +1454,7 @@ The entries in the following table are registered by this document.
 | Reserved                   | 0x4  | N/A                     |
 | Reserved                   | 0x5  | N/A                     |
 | MAX_HEADER_LIST_SIZE       | 0x6  | {{settings-parameters}} |
+| QPACK_BLOCKED_STREAMS      | 0x7  | {{settings-parameters}} |
 |----------------------------|------|-------------------------|
 
 ## Error Codes {#iana-error-codes}

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -783,6 +783,9 @@ The following settings are defined in HTTP/QUIC:
   SETTINGS_MAX_HEADER_LIST_SIZE (0x6):
   : An integer with a maximum value of 2^30 - 1
 
+  SETTINGS_BLOCKING_HEADER_REFERENCES (0x7):
+  : A Boolean
+
 #### Initial SETTINGS Values
 
 When a 0-RTT QUIC connection is being used, the client's initial requests will

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -100,9 +100,10 @@ which might not yet have been processed by the recipient.  Such references
 are called "vulnerable," because the loss of a different packet can keep
 the reference from being usable.
 
-The encoder can choose on a per-header-block basis whether to favor higher
-compression ratio (by permitting vulnerable references) or HoL resilience (by
-avoiding them).
+The decoder can signal that it is willing to process vulnerable references by
+setting SETTINGS_BLOCKING_HEADER_REFERENCES to true.  In this case, the encoder
+can choose on a per-header-block basis whether to favor higher compression ratio
+(by permitting vulnerable references) or HoL resilience (by avoiding them).
 
 The header block contains a Base Index (see {{absolute-index}}) which is used to
 correctly index entries, regardless of reordering in the transport (see
@@ -112,6 +113,7 @@ least the value of the Base Index.  While blocked, header field data MUST remain
 in the blocked stream's flow control window.  When the Base Index is zero, the
 frame contains no references to the dynamic table and can always be processed
 immediately.
+
 
 # Wire Format
 

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -102,9 +102,9 @@ received.
 Each header block contains a Largest Reference (see {{absolute-index}}) which
 identifies the table state necessary for decoding. If the greatest absolute
 index in the dynamic table is less than the value of the Largest Reference, the
-stream is considered "blocked."  While blocked, header field data MUST remain in
-the blocked stream's flow control window.  When the Largest Reference is zero,
-the frame contains no references to the dynamic table and can always be
+stream is considered "blocked."  While blocked, header field data should remain
+in the blocked stream's flow control window.  When the Largest Reference is
+zero, the frame contains no references to the dynamic table and can always be
 processed immediately.
 
 A decoder can permit the possibility of blocked streams by setting
@@ -115,17 +115,16 @@ An encoder can decide whether to risk having a stream become blocked. If
 permitted by the value of SETTINGS_QPACK_BLOCKED_STREAMS, compression efficiency
 can be improved by referencing dynamic table entries that are still in transit,
 but if there is loss or reordering the stream can become blocked at the decoder.
-An encoder avoids the rist of blocking by only referencing dynamic table entries
+An encoder avoids the risk of blocking by only referencing dynamic table entries
 which have been acknowledged, but this means using literals. Since literals make
 the header block larger, this can result in the encoder becoming blocked on
 congestion or flow control limits.
 
 An encoder MUST limit the number of streams which could become blocked to the
-value of SETTINGS_QPACK_BLOCKED_STREAMS at all times. Note that the decoder's
-count of streams which are actually blocked will be at most the encoder's count
-of streams which could become blocked.  If the decoder encounters more blocked
-streams than it promised to support, it SHOULD treat this as a stream error of
-type HTTP_QPACK_DECOMPRESSION_FAILED.
+value of SETTINGS_QPACK_BLOCKED_STREAMS at all times. Note that the decoder
+might not actually become blocked on every stream which risks becoming blocked.
+If the decoder encounters more blocked streams than it promised to support, it
+SHOULD treat this as a stream error of type HTTP_QPACK_DECOMPRESSION_FAILED.
 
 # Wire Format
 

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -496,7 +496,9 @@ Indexed-Duplicate representation instead (see {{indexed-duplicate}}).
 
 For header blocks encoded in non-blocking mode, the encoder needs to forego
 indexed representations that refer to table updates which have not yet been
-acknowledged with {{feedback}}.
+acknowledged with {{feedback}}.  Since all table updates are processed in
+sequence on the control stream, an index into the dynamic table is sufficient to
+track which entries have been processed.
 
 To track blocked streams, the necessary Base Index value for each stream
 can be used.  Whenever the decoder processes a table update, it can begin

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -105,7 +105,9 @@ index in the dynamic table is less than the value of the Largest Reference, the
 stream is considered "blocked."  While blocked, header field data should remain
 in the blocked stream's flow control window.  When the Largest Reference is
 zero, the frame contains no references to the dynamic table and can always be
-processed immediately.
+processed immediately. A stream becomes unblocked when the greatest absolute
+index in the dynamic table becomes greater than or equal to the Largest
+Reference for all header blocks the decoder has started reading from the stream.
 
 A decoder can permit the possibility of blocked streams by setting
 SETTINGS_QPACK_BLOCKED_STREAMS to a non-zero value.  This setting specifies an

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -98,7 +98,8 @@ reintroduced by HPACK when the loss includes a HEADERS frame.
 In the example above, the header block on the second stream contained a
 reference to data which might not yet have been processed by the recipient. Such
 references are called "vulnerable," because the loss of a different packet can
-keep the reference from being usable.
+keep the reference from being usable.  If the reference cannot be immediately
+processed on receipt, the reference is considered "blocking."
 
 The decoder can signal that it is willing to process vulnerable references by
 setting SETTINGS_BLOCKING_HEADER_REFERENCES to a non-zero value.  In this case,

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -95,25 +95,26 @@ reintroduced by HPACK when the loss includes a HEADERS frame.
 
 ## Avoiding Head-of-Line Blocking in HTTP/QUIC {#overview-hol-avoidance}
 
-In the example above, the header block on the second stream contained a
-reference to data which might not yet have been processed by the recipient. Such
-references are called "vulnerable," because the loss of a different packet can
-keep the reference from being usable.  If the reference cannot be immediately
-processed on receipt, the stream is considered "blocked."
+Because QUIC does not guarantee order between data on different streams, a
+reference might be received on a request stream to an entry which is not yet in
+the dynamic table. References are called "vulnerable" when they refer to entries
+whose receipt has not been confirmed by the peer, because loss or reordering can
+keep the reference from being immediately usable.  If the reference cannot be
+immediately processed on receipt, the stream is considered "blocked."
 
 The decoder can signal that it is willing to process vulnerable references by
-setting SETTINGS_BLOCKING_HEADER_REFERENCES to a non-zero value.  In this case,
-the encoder can choose on a per-header-block basis whether to favor higher
+setting SETTINGS_QPACK_BLOCKED_STREAMS to a non-zero value.  In this case, the
+encoder can choose on a per-header-block basis whether to favor higher
 compression ratio (by permitting vulnerable references) or HoL resilience (by
 avoiding them).
 
 An encoder MUST NOT have header blocks which contain vulnerable references
-outstanding on more streams than the value of
-SETTINGS_BLOCKING_HEADER_REFERENCES at any time. Note that the decoder's count
-of streams which are actually blocked will be less than or equal to the
-encoder's count of references which are vulnerable (potentially blocking).  If
-the decoder encounters more blocked streams than it promised to support, it
-SHOULD treat this as a stream error of type HTTP_QPACK_DECOMPRESSION_FAILED.
+outstanding on more streams than the value of SETTINGS_QPACK_BLOCKED_STREAMS at
+any time. Note that the decoder's count of streams which are actually blocked
+will be less than or equal to the encoder's count of references which are
+vulnerable (potentially blocking).  If the decoder encounters more blocked
+streams than it promised to support, it SHOULD treat this as a stream error of
+type HTTP_QPACK_DECOMPRESSION_FAILED.
 
 The header block contains a Base Index (see {{absolute-index}}) which is used to
 correctly index entries, regardless of reordering in the transport (see

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -99,7 +99,7 @@ In the example above, the header block on the second stream contained a
 reference to data which might not yet have been processed by the recipient. Such
 references are called "vulnerable," because the loss of a different packet can
 keep the reference from being usable.  If the reference cannot be immediately
-processed on receipt, the reference is considered "blocking."
+processed on receipt, the stream is considered "blocked."
 
 The decoder can signal that it is willing to process vulnerable references by
 setting SETTINGS_BLOCKING_HEADER_REFERENCES to a non-zero value.  In this case,
@@ -107,13 +107,13 @@ the encoder can choose on a per-header-block basis whether to favor higher
 compression ratio (by permitting vulnerable references) or HoL resilience (by
 avoiding them).
 
-An encoder MUST NOT have more header blocks which contain vulnerable references
-outstanding than the value of SETTINGS_BLOCKING_HEADER_REFERENCES at any time.
-Note that the decoder's count of references which are actually blocking will be
-less than or equal to the encoder's count of references which are vulnerable
-(potentially blocking).  If the decoder encounters more blocking references than
-it promised to support, it SHOULD treat this as a stream error of type
-HTTP_QPACK_DECOMPRESSION_FAILED.
+An encoder MUST NOT have header blocks which contain vulnerable references
+outstanding on more streams than the value of
+SETTINGS_BLOCKING_HEADER_REFERENCES at any time. Note that the decoder's count
+of streams which are actually blocked will be less than or equal to the
+encoder's count of references which are vulnerable (potentially blocking).  If
+the decoder encounters more blocked streams than it promised to support, it
+SHOULD treat this as a stream error of type HTTP_QPACK_DECOMPRESSION_FAILED.
 
 The header block contains a Base Index (see {{absolute-index}}) which is used to
 correctly index entries, regardless of reordering in the transport (see

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -101,9 +101,13 @@ are called "vulnerable," because the loss of a different packet can keep
 the reference from being usable.
 
 The decoder can signal that it is willing to process vulnerable references by
-setting SETTINGS_BLOCKING_HEADER_REFERENCES to true.  In this case, the encoder
-can choose on a per-header-block basis whether to favor higher compression ratio
-(by permitting vulnerable references) or HoL resilience (by avoiding them).
+setting SETTINGS_BLOCKING_HEADER_REFERENCES to a non-zero value.  In this case,
+the encoder can choose on a per-header-block basis whether to favor higher
+compression ratio (by permitting vulnerable references) or HoL resilience (by
+avoiding them).
+
+An encoder MUST NOT have more header blocks which contain vulnerable references
+outstanding than the value of SETTINGS_BLOCKING_HEADER_REFERENCES at any time.
 
 The header block contains a Base Index (see {{absolute-index}}) which is used to
 correctly index entries, regardless of reordering in the transport (see
@@ -113,7 +117,6 @@ least the value of the Base Index.  While blocked, header field data MUST remain
 in the blocked stream's flow control window.  When the Base Index is zero, the
 frame contains no references to the dynamic table and can always be processed
 immediately.
-
 
 # Wire Format
 

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -507,7 +507,7 @@ For header blocks encoded in non-blocking mode, the encoder needs to forego
 indexed representations that refer to table updates which have not yet been
 acknowledged with {{feedback}}.  Since all table updates are processed in
 sequence on the control stream, an index into the dynamic table is sufficient to
-track which entries have been processed.
+track which entries have been acknowledged.
 
 To track blocked streams, the necessary Base Index value for each stream
 can be used.  Whenever the decoder processes a table update, it can begin


### PR DESCRIPTION
Based on #1141, fixes #1140.  Creates a setting that indicates blocking references are permitted.  We can, if desired, extend this further and make the setting an integer.  0-RTT issues are dealt with by adding this to the existing 0-RTT discussion under the same terms.