### PR TITLE
Need to include valeus for the TLS 1.3 colum in the TLS ExtensionType…

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1555,7 +1555,8 @@ values in the following registries:
   {{!TLS-REGISTRIES=I-D.ietf-tls-iana-registry-updates}} - IANA is to register
   the quic_transport_parameters extension found in {{quic_parameters}}.
   Assigning 26 to the extension would be greatly appreciated.  The Recommended
-  column is to be marked Yes.
+  column is to be marked Yes.  The TLS 1.3 Column is to include CH
+  and EE.
 
 * TLS Exporter Label Registry {{!TLS-REGISTRIES}} - IANA is requested to
   register "EXPORTER-QUIC 0rtt" from {{zero-rtt-secrets}}; "EXPORTER-QUIC client


### PR DESCRIPTION
… registry.

TLS 1.3 introduced a new column to the registry and we need to include values.  This extension appears in the ClientHello and EncryptedExtensions so CH, EE are the values.