### PR TITLE
Enter closing after the idle timeout

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1712,10 +1712,9 @@ These states SHOULD persist for three times the current Retransmission Timeout
 (RTO) interval as defined in {{QUIC-RECOVERY}}.
 
 An endpoint enters a closing period after initiating an immediate close
-({{immediate-close}}) and optionally after an idle timeout ({{idle-timeout}}).
-While closing, an endpoint MUST NOT send packets unless they contain a
-CONNECTION_CLOSE or APPLICATION_CLOSE frame (see {{immediate-close}} for
-details).
+({{immediate-close}}).  While closing, an endpoint MUST NOT send packets unless
+they contain a CONNECTION_CLOSE or APPLICATION_CLOSE frame (see
+{{immediate-close}} for details).
 
 In the closing state, only a packet containing a closing frame can be sent.  An
 endpoint retains only enough information to generate a packet containing a


### PR DESCRIPTION
The draft was a little unclear on this point and its important.  The idle timeout ends without sending CONNECTION_CLOSE, and it can end approximately simultaneously.  If both endpoints send CONNECTION_CLOSE and then go to closing, then they might start a packet storm if neither actually looks at packets they receive before retransmitting their close packet (which is permitted).  We want idle timeout to pass without packets, so this needs to be closing.

Closes #1178.