### PR TITLE
Making quic-recovery self-contained

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -288,7 +288,7 @@ and Retransmission Timeout mechanisms.
 ### Tail Loss Probe {#tlp}
 
 The algorithm described in this section is an adaptation of the Tail Loss Probe
-algorithm proposed for TCP {{?TLP==I-D.dukkipati-tcpm-tcp-loss-probe}}.
+algorithm proposed for TCP {{?TLP=I-D.dukkipati-tcpm-tcp-loss-probe}}.
 
 A packet sent at the tail is particularly vulnerable to slow loss detection,
 since acks of subsequent packets are needed to trigger ack-based detection. To

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -288,7 +288,7 @@ and Retransmission Timeout mechanisms.
 ### Tail Loss Probe {#tlp}
 
 The algorithm described in this section is an adaptation of the Tail Loss Probe
-algorithm proposed for TCP {{TLP}}.
+algorithm proposed for TCP {{?TLP}}.
 
 A packet sent at the tail is particularly vulnerable to slow loss detection,
 since acks of subsequent packets are needed to trigger ack-based detection. To
@@ -316,8 +316,7 @@ regardless of the number of packets outstanding.  TCP's TLP assumes if at least
 2 packets are outstanding, acks will not be delayed.
 
 A PTO value of at least 1.5*SRTT ensures that the ACK is overdue.  The 1.5
-is based on {{?LOSS-PROBE=I-D.dukkipati-tcpm-tcp-loss-probe}}, but
-implementations MAY experiment with other constants.
+is based on {{?TLP}}, but implementations MAY experiment with other constants.
 
 To reduce latency, it is RECOMMENDED that the sender set and allow the TLP alarm
 to fire twice before setting an RTO alarm. In other words, when the TLP alarm
@@ -739,7 +738,7 @@ response to 0RTT packets.
 
 #### Tail Loss Probe and Retransmission Alarm
 
-Tail loss probes {{?LOSS-PROBE=I-D.dukkipati-tcpm-tcp-loss-probe}} and
+Tail loss probes {{?TLS}} and
 retransmission timeouts {{?RFC6298}} are an alarm based mechanism to recover
 from cases when there are outstanding retransmittable packets, but an
 acknowledgement has not been received in a timely manner.

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -288,7 +288,7 @@ and Retransmission Timeout mechanisms.
 ### Tail Loss Probe {#tlp}
 
 The algorithm described in this section is an adaptation of the Tail Loss Probe
-algorithm proposed for TCP {{?TLP}}.
+algorithm proposed for TCP {{?TLP==I-D.dukkipati-tcpm-tcp-loss-probe}}.
 
 A packet sent at the tail is particularly vulnerable to slow loss detection,
 since acks of subsequent packets are needed to trigger ack-based detection. To

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -738,7 +738,7 @@ response to 0RTT packets.
 
 #### Tail Loss Probe and Retransmission Alarm
 
-Tail loss probes {{?TLS}} and
+Tail loss probes {{?TLP}} and
 retransmission timeouts {{?RFC6298}} are an alarm based mechanism to recover
 from cases when there are outstanding retransmittable packets, but an
 acknowledgement has not been received in a timely manner.

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -203,8 +203,8 @@ the RTT as long as the result is larger than the Min RTT.  If the result is
 smaller than the min_rtt, the RTT should be used, but the ack delay field
 should be ignored.
 
-Like TCP, QUIC calculates both smoothed RTT and RTT variance as specified in
-{{?RFC6298}}.
+Like TCP, QUIC calculates both smoothed RTT and RTT variance similar to those
+specified in {{?RFC6298}}.
 
 Min RTT is the minimum RTT measured over the connection, prior to adjusting
 by ack delay.  Ignoring ack delay for min RTT prevents intentional or
@@ -214,8 +214,8 @@ underestimating smoothed RTT.
 ## Ack-based Detection
 
 Ack-based loss detection implements the spirit of TCP's Fast Retransmit
-{{!RFC5681}}, Early Retransmit {{!RFC5827}}, FACK, and SACK loss recovery
-{{!RFC6675}}. This section provides an overview of how these algorithms are
+{{?RFC5681}}, Early Retransmit {{?RFC5827}}, FACK, and SACK loss recovery
+{{?RFC6675}}. This section provides an overview of how these algorithms are
 implemented in QUIC.
 
 (TODO: Define unacknowledged packet, ackable packet, outstanding bytes.)
@@ -230,13 +230,13 @@ reordering of packets in the network.
 
 The RECOMMENDED initial value for kReorderingThreshold is 3.
 
-We derive this default from recommendations for TCP loss recovery {{!RFC5681}}
-{{!RFC6675}}. It is possible for networks to exhibit higher degrees of
+We derive this default from recommendations for TCP loss recovery {{?RFC5681}}
+{{?RFC6675}}. It is possible for networks to exhibit higher degrees of
 reordering, causing a sender to detect spurious losses. Detecting spurious
 losses leads to unnecessary retransmissions and may result in degraded
 performance due to the actions of the congestion controller upon detecting
 loss. Implementers MAY use algorithms developed for TCP, such as TCP-NCR
-{{!RFC4653}}, to improve QUIC's reordering resilience, though care should be
+{{?RFC4653}}, to improve QUIC's reordering resilience, though care should be
 taken to map TCP specifics to QUIC correctly. Similarly, using time-based loss
 detection to deal with reordering, such as in PR-TCP, should be more readily
 usable in QUIC. Making QUIC deal with such networks is important open research,
@@ -273,8 +273,8 @@ with using other multipliers, bearing in mind that a lower multiplier reduces
 reordering resilience and increases spurious retransmissions, and a higher
 multipler increases loss recovery delay.
 
-This mechanism is based on Early Retransmit for TCP {{!RFC5827}}. However,
-{{!RFC5827}} does not include the alarm described above. Early Retransmit is
+This mechanism is based on Early Retransmit for TCP {{?RFC5827}}. However,
+{{?RFC5827}} does not include the alarm described above. Early Retransmit is
 prone to spurious retransmissions due to its reduced reordering resilence
 without the alarm. This observation led Linux TCP implementers to implement an
 alarm for TCP as well, and this document incorporates this advancement.
@@ -344,13 +344,13 @@ ackable packet.
 
 A Retransmission Timeout (RTO) alarm is the final backstop for loss
 detection. The algorithm used in QUIC is based on the RTO algorithm for TCP
-{{!RFC5681}} and is additionally resilient to spurious RTO events {{!RFC5682}}.
+{{?RFC5681}} and is additionally resilient to spurious RTO events {{?RFC5682}}.
 
 When the last TLP packet is sent, an alarm is scheduled for the RTO period. When
 this alarm fires, the sender sends two packets, to evoke acknowledgements from
 the receiver, and restarts the RTO alarm.
 
-Similar to TCP {{!RFC6298}}, the RTO period is set based on the following
+Similar to TCP {{?RFC6298}}, the RTO period is set based on the following
 conditions:
 
 * When the final TLP packet is sent, the RTO period is set to max(SRTT +
@@ -431,7 +431,7 @@ enforce a maximum ack delay to avoid causing the peer spurious
 timeouts.  The default maximum ack delay in QUIC is 25ms.
 
 An acknowledgement MAY be sent for every second full-sized packet,
-as TCP does {{!RFC5681}}, or may be sent less frequently, as long as
+as TCP does {{?RFC5681}}, or may be sent less frequently, as long as
 the delay does not exceed the maximum ack delay.  QUIC recovery algorithms
 do not assume the peer generates an acknowledgement immediately when
 receiving a second full-sized packet.


### PR DESCRIPTION
The references should have been informational because recovery is intended to entirely self-contained.

Closes #858.