### PR TITLE
Don't imply that Version Negotiation is always sent

### DIFF
--- a/draft-ietf-quic-invariants.md
+++ b/draft-ietf-quic-invariants.md
@@ -230,7 +230,7 @@ order.  Version 0 is reserved for version negotiation (see
 # Version Negotiation {#version-negotiation}
 
 A QUIC endpoint that receives a packet with a long header and a version it
-either does not understand or does not support sends a Version Negotiation
+either does not understand or does not support might send a Version Negotiation
 packet in response.  Packets with a short header do not trigger version
 negotiation and are always associated with an existing connection.
 


### PR DESCRIPTION
...even by a client.  Leave the details up to the specific version of
QUIC.

FWIW, I don't see us changing this part of the protocol, but the
invariants don't require that we specify behaviour, only format, so this
keeps the separation clean.

Closes #1197.