### PR TITLE
transport: frame type does not carry flags for ACK frame

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -823,7 +823,7 @@ followed by additional type-dependent fields:
 {: #frame-layout title="Generic Frame Layout"}
 
 Frame types are listed in {{frame-types}}. Note that the Frame Type byte in
-STREAM and ACK frames is used to carry other frame-specific flags.  For all
+STREAM frames is used to carry other frame-specific flags.  For all
 other frames, the Frame Type byte simply identifies the frame.  These frames are
 explained in more detail as they are referenced later in the document.
 


### PR DESCRIPTION
Since draft -08 (commit 473d9e7fe1845931528c0bbcc039175bd51a3bf5), the frame type for ACK frames no longer have a special interpretation.