### PR TITLE
tls: use QHKDF-Expand instead of QHKDF-Update

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -800,9 +800,9 @@ the PRF hash function.
 
 ~~~
 client_pp_secret_<N+1> =
-  QHKDF-Update(client_pp_secret_<N>, "client 1rtt", Hash.length)
+  QHKDF-Expand(client_pp_secret_<N>, "client 1rtt", Hash.length)
 server_pp_secret_<N+1> =
-  QHKDF-Update(server_pp_secret_<N>, "server 1rtt", Hash.length)
+  QHKDF-Expand(server_pp_secret_<N>, "server 1rtt", Hash.length)
 ~~~
 
 This allows for a succession of new secrets to be created as needed.


### PR DESCRIPTION
QHKDF-Update was specific to PR #1043 (not merged) and included the
Connection ID in the info structure, but the actual merged PR (#1077)
does not use this, nor does it define QHKDF-Update.