### PR TITLE
Change Index-Duplicate instruction code point

### DIFF
--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -253,17 +253,17 @@ Indexed-Duplicate representation instead (see {{indexed-duplicate}}).
 ~~~~~~~~~~  drawing
     0 1 2 3 4 5 6 7
    +-+-+-+-+-+-+-+-+
-   |1|Index(7+)    |
+   |1|  Index (7+) |
    +-+-+-+---------+
 ~~~~~~~~~~
 {:#fig-index-with-duplication title="Indexed Header Field with Duplication"}
 
-*Indexed-Duplicates* insert a new entry into the dynamic table which duplicates
+*Indexed-Duplicate* inserts a new entry into the dynamic table which duplicates
 an existing entry. {{RFC7541}} allows duplicate HPACK table entries, that is
 entries that have the same name and value.
 
 This repurposes the HPACK instruction for Indexed Header Field (see Section
-6.1 of {{RFC7541}}.
+6.1 of {{RFC7541}} in the context of the control stream.
 
 # Performance considerations
 

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -253,7 +253,7 @@ Indexed-Duplicate representation instead (see {{indexed-duplicate}}).
 ~~~~~~~~~~  drawing
     0 1 2 3 4 5 6 7
    +-+-+-+-+-+-+-+-+
-   |0|0|1|Index(5+)|
+   |1|Index(7+)    |
    +-+-+-+---------+
 ~~~~~~~~~~
 {:#fig-index-with-duplication title="Indexed Header Field with Duplication"}
@@ -262,8 +262,8 @@ Indexed-Duplicate representation instead (see {{indexed-duplicate}}).
 an existing entry. {{RFC7541}} allows duplicate HPACK table entries, that is
 entries that have the same name and value.
 
-This replaces the HPACK instruction for Dynamic Table Size Update (see Section
-6.3 of {{RFC7541}}, which is not supported by HTTP over QUIC.
+This repurposes the HPACK instruction for Indexed Header Field (see Section
+6.1 of {{RFC7541}}.
 
 # Performance considerations
 


### PR DESCRIPTION
Changed the instruction for duplicate from 001/5+ to 1/7+.  This is because Table Size Update is otherwise a valid QPACK instruction

Fixes #1142