### PR TITLE
Remove unnecessary text from #1253

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1594,9 +1594,6 @@ other frames are "non-probing frames".  A packet containing only probing frames
 is a "probing packet", and a packet containing any other frame is a "non-probing
 packet".
 
-A server MUST NOT send non-probing frames to a client's address until the server
-receives a non-probing packet from that address.
-
 
 ### Initiating Connection Migration {#initiating-migration}
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1569,12 +1569,11 @@ An endpoint MUST NOT initiate connection migration before the handshake is
 finished and the endpoint has 1-RTT keys.
 
 This document limits migration of connections to new client addresses.
-Additionally, clients are responsible for initiating all migrations.  Servers
-do not send non-probing packets (see {{probing}}) toward a client address until
-it sees a non-probing packet from that address.  Additionally, if a client
-receives packets from an unknown server address, the client MAY discard these
-packets.  Migrating a connection to a new server address is left for future
-work.
+Clients are responsible for initiating all migrations.  Servers do not send
+non-probing packets (see {{probing}}) toward a client address until it sees a
+non-probing packet from that address.  If a client receives packets from an
+unknown server address, the client MAY discard these packets.  Migrating a
+connection to a new server address is left for future work.
 
 
 ### Probing a New Path {#probing}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1569,12 +1569,15 @@ An endpoint MUST NOT initiate connection migration before the handshake is
 finished and the endpoint has 1-RTT keys.
 
 This document limits migration of connections to new client addresses.
-Migrating a connection to a new server address is left for future work. If a
-client receives packets from an unknown server address, the client MAY discard
-these packets.
+Additionally, clients are responsible for initiating all migrations.  Servers
+do not send non-probing packets (see {{probing}}) toward a client address until
+it sees a non-probing packet from that address.  Additionally, if a client
+receives packets from an unknown server address, the client MAY discard these
+packets.  Migrating a connection to a new server address is left for future
+work.
 
 
-### Probing a New Path
+### Probing a New Path {#probing}
 
 An endpoint MAY probe for peer reachability from a new local address using path
 validation {{migrate-validate}} prior to migrating the connection to the new


### PR DESCRIPTION
This paragraph:

> A server MUST NOT send non-probing frames to a client's address until the server
> receives a non-probing packet from that address.

Is true only with the restriction of migration to client addresses.  It
complicates the server migration story if we ever want to do that (as we
already have with the proposal for preferred addresses).