### PR TITLE
Stateless Reset during Path Migration

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1485,6 +1485,11 @@ path validation with other frames.  For instance, an endpoint may pad a packet
 carrying a PATH_CHALLENGE for PMTU discovery, or an endpoint may bundle a
 PATH_RESPONSE with its own PATH_CHALLENGE.
 
+Differences in routing on the Internet might cause the same destination address
+and connection ID to reach a different server instance which does not posses the
+necessary connection state. Receiving a Stateless Reset in response to a probing
+packet SHOULD NOT terminate the connection, but MUST cause the endpoint to
+consider path validation to have failed.
 
 ### Initiation
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1490,8 +1490,8 @@ and connection ID to reach a different server instance which does not posses the
 necessary connection state. Receiving a Stateless Reset in response to a probing
 packet SHOULD NOT terminate the connection, but MUST cause the endpoint to
 consider path validation to have failed.  After receiving a Stateless Reset, the
-client MUST NOT send additional packets with the Connection ID used on the
-probing packet.
+client MUST NOT send additional packets on the same connection the Connection ID
+used on the probing packet.
 
 ### Initiation
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1490,8 +1490,8 @@ and connection ID to reach a different server instance which does not posses the
 necessary connection state. Receiving a Stateless Reset in response to a probing
 packet SHOULD NOT terminate the connection, but MUST cause the endpoint to
 consider path validation to have failed.  After receiving a Stateless Reset, the
-client MUST NOT send additional packets on the same connection the Connection ID
-used on the probing packet.
+client MUST NOT send additional packets on the same connection using the
+Connection ID used on the probing packet.
 
 ### Initiation
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1489,7 +1489,9 @@ Differences in routing on the Internet might cause the same destination address
 and connection ID to reach a different server instance which does not posses the
 necessary connection state. Receiving a Stateless Reset in response to a probing
 packet SHOULD NOT terminate the connection, but MUST cause the endpoint to
-consider path validation to have failed.
+consider path validation to have failed.  After receiving a Stateless Reset, the
+client MUST NOT send additional packets with the Connection ID used on the
+probing packet.
 
 ### Initiation
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1486,11 +1486,11 @@ carrying a PATH_CHALLENGE for PMTU discovery, or an endpoint may bundle a
 PATH_RESPONSE with its own PATH_CHALLENGE.
 
 Differences in routing on the Internet might cause the same destination address
-and connection ID to reach a different server instance which does not posses the
-necessary connection state. Receiving a Stateless Reset in response to a probing
-packet SHOULD NOT terminate the connection, but MUST cause the endpoint to
-consider path validation to have failed.  After receiving a Stateless Reset, the
-client MUST NOT send additional packets on the same connection using the
+and connection ID to reach a different server instance which does not possess
+the necessary connection state. Receiving a Stateless Reset in response to a
+probing packet SHOULD NOT terminate the connection, but MUST cause the endpoint
+to consider path validation to have failed.  After receiving a Stateless Reset,
+the client MUST NOT send additional packets on the same connection using the
 Connection ID used on the probing packet.
 
 ### Initiation


### PR DESCRIPTION
Extracted from #1251 at @martinthomson's request.  Fixes #1258.