### PR TITLE
Avoid failure from spoofed/delayed PATH_RESPONSE

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2784,8 +2784,11 @@ frame.  Its format is identical to the PATH_CHALLENGE frame
 
 If the content of a PATH_RESPONSE frame does not match the content of a
 PATH_CHALLENGE frame previously sent by the endpoint, the endpoint MAY generate
-a connection error of type UNSOLICITED_PATH_RESPONSE.
-
+a connection error of type UNSOLICITED_PATH_RESPONSE. Endpoints MUST NOT
+generate this error in response to a PATH_RESPONSE frame in a Handshake Packet.
+Endpoints SHOULD NOT generate this error if they are not storing the
+PATH_CHALLENGE data well in excess of any plausible packet round-trip time on
+a new path, as a late response would result in connection teardown.
 
 ## STREAM Frames {#frame-stream}
 


### PR DESCRIPTION
Bogus PATH_RESPONSE in a Handshake packet seems like an obvious DoS attack.

Also, I added some language about storing PATH_CHALLENGE data for a really long time if we're going to send an error. I would actually prefer that we get rid of this error code entirely, as it seems like a great way to accidentally tear down connections when the new path's RTT is way higher than expected.