### PR TITLE
Permit CONNECTION_CLOSE in Handshake

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -644,7 +644,8 @@ but could involve additional computational effort depending on implementation
 choices.
 
 The payload of this packet contains STREAM frames and could contain PADDING,
-ACK, PATH_CHALLENGE, or PATH_RESPONSE frames.
+ACK, PATH_CHALLENGE, or PATH_RESPONSE frames.  Handshake packets MAY contain
+CONNECTION_CLOSE frames if the handshake is unsuccessful.
 
 
 ## Protected Packets {#packet-protected}


### PR DESCRIPTION
Closes #1270.

@janaiyengar, anyone, can you remember why we allow PATH_* frames in Handshake messages?  They don't seem to serve any particular purpose.