### PR TITLE
Spin Bit Reservation

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -89,6 +89,16 @@ informative:
     target:
      "https://web.archive.org/web/20150315054838/http://ha.ckers.org/slowloris/"
 
+  SPIN-BIT-EXP:
+    title: "The QUIC Latency Spin Bit"
+    date: {DATE}
+    seriesinfo:
+      Internet-Draft: draft-ietf-quic-spin-exp
+    author:
+      -
+        ins: B. Trammell
+      -
+        ins: M. Kuehlewind
 
 --- abstract
 
@@ -369,7 +379,7 @@ following sections.
  0                   1                   2                   3
  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
 +-+-+-+-+-+-+-+-+
-|0|K|1|1|0|T T T|
+|0|K|1|1|0|S|T T|
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                Destination Connection ID (0..144)           ...
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -420,9 +430,14 @@ Google QUIC Demultipexing Bit:
   specification when Google QUIC has finished transitioning to the new header
   format.
 
+Spin Bit Reservation:
+
+: The sixth bit (0x4) of octet 0 is reserved for experimentation with the
+Latency Spin Bit, as described in {{SPIN-BIT-EXP}}.
+
 Short Packet Type:
 
-: The remaining 3 bits of octet 0 include one of 8 packet types.
+: The remaining 2 bits of octet 0 include one of 4 packet types.
   {{short-packet-types}} lists the types that are defined for short packets.
 
 Destination Connection ID:

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -89,16 +89,6 @@ informative:
     target:
      "https://web.archive.org/web/20150315054838/http://ha.ckers.org/slowloris/"
 
-  QUIC-SPIN-EXP:
-    title: "The QUIC Latency Spin Bit"
-    date: {DATE}
-    seriesinfo:
-      Internet-Draft: draft-ietf-quic-spin-exp
-    author:
-      -
-        ins: B. Trammell
-      -
-        ins: M. Kuehlewind
 
 --- abstract
 
@@ -379,7 +369,7 @@ following sections.
  0                   1                   2                   3
  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
 +-+-+-+-+-+-+-+-+
-|0|K|1|1|0|S|T T|
+|0|K|1|1|0|R|T T|
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                Destination Connection ID (0..144)           ...
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -430,10 +420,9 @@ Google QUIC Demultipexing Bit:
   specification when Google QUIC has finished transitioning to the new header
   format.
 
-Spin Bit Reservation:
+Reserved:
 
-: The sixth bit (0x4) of octet 0 is reserved for experimentation with the
-Latency Spin Bit, as described in {{QUIC-SPIN-EXP}}.
+: The sixth bit (0x4) of octet 0 is reserved for experimentation.
 
 Short Packet Type:
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -89,7 +89,7 @@ informative:
     target:
      "https://web.archive.org/web/20150315054838/http://ha.ckers.org/slowloris/"
 
-  SPIN-BIT-EXP:
+  QUIC-SPIN-EXP:
     title: "The QUIC Latency Spin Bit"
     date: {DATE}
     seriesinfo:
@@ -433,7 +433,7 @@ Google QUIC Demultipexing Bit:
 Spin Bit Reservation:
 
 : The sixth bit (0x4) of octet 0 is reserved for experimentation with the
-Latency Spin Bit, as described in {{SPIN-BIT-EXP}}.
+Latency Spin Bit, as described in {{QUIC-SPIN-EXP}}.
 
 Short Packet Type:
 


### PR DESCRIPTION
As discussed in London and confirmed on the list, this PR reserves bit 0x04 of the first octet of the short header for the spin bit, referencing a [draft](https://britram.github.io/draft-trammell-quic-spin/draft-ietf-quic-spin-exp.html) to be submitted shortly for the details of the spin bit.