### PR TITLE
Fix wrong spin bit in spin-exp text

### DIFF
--- a/draft-ietf-quic-spin-exp.md
+++ b/draft-ietf-quic-spin-exp.md
@@ -131,7 +131,7 @@ version negotiation and connection establishment are completed.
 ## Proposed Short Header Format Including Spin Bit
 
 As of the current editor's version of {{QUIC-TRANSPORT}}, this proposal
-specifies using the fifth most significant bit (0x08) of the first octet in
+specifies using the sixth most significant bit (0x04) of the first octet in
 the short header for the spin bit.
 
 ~~~~~


### PR DESCRIPTION
The text specifying which bit spins (see @ilhar's comment on #1290) did not agree either with the diagram, nor with the reservation in -transport. This PR fixes that.