### PR TITLE
Fix build: remove "numbered" attribute from Acknowledgements section

### DIFF
--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -337,7 +337,6 @@ need to be added to the IANA Considerations of {{QUIC-HTTP}}.
 --- back
 
 # Acknowledgments
-{:numbered="false"}
 
 This draft draws heavily on the text of {{!RFC7541}}.  The indirect input of
 those authors is gratefully acknowledged, as well as ideas from:


### PR DESCRIPTION
This attribute does not seem to make a difference to the output.  With it, my build fails:

```
xml2rfc -q draft-ietf-quic-qpack.xml -o draft-ietf-quic-qpack.txt --text
ERROR: Unable to validate the XML document: draft-ietf-quic-qpack.xml
 draft-ietf-quic-qpack.xml: Line 476: Value "false" for attribute numbered of section is not among the enumerated set
lib/main.mk:83: recipe for target 'draft-ietf-quic-qpack.txt' failed
```