### PR TITLE
make payload length 0 special

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -340,7 +340,8 @@ Source Connection ID:
 Payload Length:
 
 : The length of the Payload field in octets, encoded as a variable-length
-  integer ({{integer-encoding}}).
+  integer ({{integer-encoding}}). An encoded length of 0 indicates that the
+  payload consumes all the remaining octets in the UDP datagram.
 
 Packet Number:
 


### PR DESCRIPTION
0 is currently a valid value for the payload length, but sending a packet with no payload is not allowed. By making this value special, we can give it a clearly defined meaning, and save a byte in the common case (and potentially make implementations easier).