### PR TITLE
Change Packet Number Gap to Packet Number Offset

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -934,10 +934,10 @@ used in QUIC can cause packet numbers to be decoded incorrectly if they are
 delayed significantly.
 
 
-## Packet Number Gaps {#packet-number-gaps}
+## Packet Number Offset {#packet-number-offset}
 
 Section 6.8.5.1 of {{QUIC-TRANSPORT}} also requires a secret to compute packet
-number gaps on connection ID transitions. That secret is computed as:
+number offset per connection ID. That secret is computed as:
 
 ~~~
 packet_number_secret =


### PR DESCRIPTION
This is a proposed solution to the privacy/linkability problem by slightly modifying the existing packet number gap solution to make it a per connection ID packet number offset. The offset is used to transform the wire encoding of the packet number, but the connection still uses the same monotonically increasing packet number space (no gaps).

This solution requires very little per packet CPU overhead, compared to PNE.

Unlike the PNE proposal (#1079), this doesn't fix the ossification/greasing problem as well. Instead, I'd like to treat that as a separate problem (and a separate PR) and attempt to solve that with a non-cryptographic solution (shuffle for instance).

Closes:
- #1174
- #1034
- #990
