### PR TITLE
Deemphasize TCP SACKs reference in ACK frame description

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2581,9 +2581,9 @@ received and processed.  A sent packet that has never been acknowledged is
 missing. The ACK frame contains any number of ACK blocks.  ACK blocks are
 ranges of acknowledged packets.
 
-QUIC acknowledgements are irrevocable:  Once a packet has been acknowledged,
-even if it does not appear in a future ACK frame, it remains acknowledged.
-(This is unlike TCP SACKs.)
+QUIC acknowledgements are irrevocable.  Once acknowledged, a packet remains
+acknowledged, even if it does not appear in a future ACK frame.  This is unlike
+TCP SACKs ({{?RFC2018}}).
 
 A client MUST NOT acknowledge Retry packets.  Retry packets include the packet
 number from the Initial packet it responds to.  Version Negotiation packets

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2581,9 +2581,9 @@ received and processed.  A sent packet that has never been acknowledged is
 missing. The ACK frame contains any number of ACK blocks.  ACK blocks are
 ranges of acknowledged packets.
 
-Unlike TCP SACKs, QUIC acknowledgements are irrevocable.  Once a packet has
-been acknowledged, even if it does not appear in a future ACK frame,
-it remains acknowledged.
+QUIC acknowledgements are irrevocable:  Once a packet has been acknowledged,
+even if it does not appear in a future ACK frame, it remains acknowledged.
+(This is unlike TCP SACKs.)
 
 A client MUST NOT acknowledge Retry packets.  Retry packets include the packet
 number from the Initial packet it responds to.  Version Negotiation packets


### PR DESCRIPTION
It is odd to describe something by saying what is *not* like.  In
addition, not all readers of the document will be familiar with
TCP SACKs.