### PR TITLE
remove incorrect statement about the connection ID in server packet

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -567,7 +567,7 @@ This MUST be at least 8 octets in length.  Until a packet is received from the
 server, the client MUST use the same random value unless it also changes the
 Source Connection ID (which effectively starts a new connection attempt).  The
 randomized Destination Connection ID is used to determine packet protection
-keys, but is not included in server packets.
+keys.
 
 If the client received a Retry packet and is sending a second Initial packet,
 then it sets the Destination Connection ID to the value from the Source


### PR DESCRIPTION
The randomized Destination Connection ID is contained in Retry as well as in Handshake packets sent by the server. Or am I missing something obvious here?