### PR TITLE
Fix initial_max_streams transport param

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1125,12 +1125,12 @@ language from Section 3 of {{!I-D.ietf-tls-tls13}}.
    enum {
       initial_max_stream_data(0),
       initial_max_data(1),
-      initial_max_stream_id_bidi(2),
+      initial_max_streams_bidi(2),
       idle_timeout(3),
       max_packet_size(5),
       stateless_reset_token(6),
       ack_delay_exponent(7),
-      initial_max_stream_id_uni(8),
+      initial_max_streams_uni(8),
       (65535)
    } TransportParameterId;
 
@@ -1213,7 +1213,7 @@ initial_max_streams_bidi (0x0002):
   equivalent to receiving a MAX_STREAM_ID containing 20 when received by a
   client or 17 when received by a server.
 
-initial_max_stream_id_uni (0x0008):
+initial_max_streams_uni (0x0008):
 
 : The initial maximum unidirectional streams parameter contains the initial
   maximum number of application-owned unidirectional streams the peer may
@@ -1275,12 +1275,12 @@ might be violated by the client with its 0-RTT data.  In particular, a server
 that accepts 0-RTT data MUST NOT set values for initial_max_data or
 initial_max_stream_data that are smaller than the remembered value of those
 parameters.  Similarly, a server MUST NOT reduce the value of
-initial_max_stream_id_bidi or initial_max_stream_id_uni.
+initial_max_streams_bidi or initial_max_streams_uni.
 
 Omitting or setting a zero value for certain transport parameters can result in
 0-RTT data being enabled, but not usable.  The following transport parameters
-SHOULD be set to non-zero values for 0-RTT: initial_max_stream_id_bidi,
-initial_max_stream_id_uni, initial_max_data, initial_max_stream_data.
+SHOULD be set to non-zero values for 0-RTT: initial_max_streams_bidi,
+initial_max_streams_uni, initial_max_data, initial_max_stream_data.
 
 A server MUST reject 0-RTT data or even abort a handshake if the implied values
 for transport parameters cannot be supported.
@@ -2031,11 +2031,12 @@ this value differs from previous packets.  Ths results in two problems:
   about this.
 
 The Packet Number field is set to a randomized value.  The server SHOULD send a
-packet with a short header and a packet number length of 1 octet. Using the
-shortest possible packet number encoding minimizes the perceived gap between the
-last packet that the server sent and this packet.  A server MAY indicate a
-different packet number length, but a longer packet number encoding might allow
-this message to be identified as a stateless reset more easily using heuristics.
+packet with a short header and a type of 0x1F.  This produces the shortest
+possible packet number encoding, which minimizes the perceived gap between the
+last packet that the server sent and this packet.  A server MAY use a different
+short header type, indicating a different packet number length, but a longer
+packet number encoding might allow this message to be identified as a stateless
+reset more easily using heuristics.
 
 After the Packet Number, the server pads the message with an arbitrary
 number of octets containing random values.
@@ -4095,12 +4096,12 @@ The initial contents of this registry are shown in {{iana-tp-table}}.
 |:-------|:---------------------------|:------------------------------------|
 | 0x0000 | initial_max_stream_data    | {{transport-parameter-definitions}} |
 | 0x0001 | initial_max_data           | {{transport-parameter-definitions}} |
-| 0x0002 | initial_max_stream_id_bidi | {{transport-parameter-definitions}} |
+| 0x0002 | initial_max_streams_bidi | {{transport-parameter-definitions}} |
 | 0x0003 | idle_timeout               | {{transport-parameter-definitions}} |
 | 0x0005 | max_packet_size            | {{transport-parameter-definitions}} |
 | 0x0006 | stateless_reset_token      | {{transport-parameter-definitions}} |
 | 0x0007 | ack_delay_exponent         | {{transport-parameter-definitions}} |
-| 0x0008 | initial_max_stream_id_uni  | {{transport-parameter-definitions}} |
+| 0x0008 | initial_max_streams_uni  | {{transport-parameter-definitions}} |
 {: #iana-tp-table title="Initial QUIC Transport Parameters Entries"}
 
 
@@ -4239,7 +4240,7 @@ Issue and pull request numbers are listed with a leading octothorp.
 - Reserved versions don't need to be generated deterministically (#831, #931)
 - You don't always need the draining period (#871)
 - Stateless reset clarified as version-specific (#930, #986)
-- initial_max_stream_id_x transport parameters are optional (#970, #971)
+- initial_max_streams_x transport parameters are optional (#970, #971)
 - Ack Delay assumes a default value during the handshake (#1007, #1009)
 - Removed transport parameters from NewSessionTicket (#1015)
 


### PR DESCRIPTION
This was renamed in one place in draft-11 (for bidi), but uni wasn't renamed. The change also missed numerous references in the document.