### PR TITLE
First pass at 7, 14, and 30-bit varint packet numbers

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -960,6 +960,13 @@ To ensure that this process does not sample the packet number, packet number
 protection algorithms MUST NOT sample more ciphertext than the minimum
 expansion of the corresponding AEAD.
 
+Packet number protection is applied to the packet number encoded as described
+in Section 4.8 of {{QUIC-TRANSPORT}}. Since the length of the packet number is
+stored in the encoded packet number, it is necessary to decrypt the maximum
+length (4 octets) when removing packet number protection. The final 2 or 3
+octets of the plaintext packet number can then be discarded based on the
+packet number length encoded in the first octet, as appropriate.
+
 Before a TLS ciphersuite can be used with QUIC, a packet protection algorithm
 MUST be specifed for the AEAD used with that ciphersuite.  This document defines
 algorithms for AEAD_AES_128_GCM, AEAD_AES_128_CCM, AEAD_AES_256_GCM,

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -962,10 +962,8 @@ expansion of the corresponding AEAD.
 
 Packet number protection is applied to the packet number encoded as described
 in Section 4.8 of {{QUIC-TRANSPORT}}. Since the length of the packet number is
-stored in the encoded packet number, it is necessary to decrypt the maximum
-length (4 octets) when removing packet number protection. The final 2 or 3
-octets of the plaintext packet number can then be discarded based on the
-packet number length encoded in the first octet, as appropriate.
+stored in the first octet of the encoded packet number, it may be necessary to
+progressively decrypt the packet number.
 
 Before a TLS ciphersuite can be used with QUIC, a packet protection algorithm
 MUST be specifed for the AEAD used with that ciphersuite.  This document defines

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -282,7 +282,7 @@ keys are established.
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                       Payload Length (i)                    ...
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                       Packet Number (32)                      |
+|                     Packet Number (8/16/32)                   |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                          Payload (*)                        ...
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -344,11 +344,10 @@ Payload Length:
 
 Packet Number:
 
-: The Packet Number is a 32-bit field that follows the two connection IDs.
-  Packet numbers are not encrypted as part of packet protection, but instead
-  have additional confidentiality protection. {{packet-numbers}} describes the
-  use of packet numbers.
-
+: The packet number field is 1, 2, or 4 octets long. The packet number has
+confidentiality protection separate from packet protection, as described in
+Section 5.6 of {{QUIC-TLS}}. The length of the packet number field is encoded
+in the plaintext packet number. See {{packet-numbers}} for details.
 
 Payload:
 
@@ -449,8 +448,8 @@ Destination Connection ID:
 
 Packet Number:
 
-: The packet number field is either 1, 2, or 4 bytes long. The packet number
-has confidentiality protection separate from packet protection, as described in
+: The packet number field is 1, 2, or 4 octets long. The packet number has
+confidentiality protection separate from packet protection, as described in
 Section 5.6 of {{QUIC-TLS}}. The length of the packet number field is encoded
 in the plaintext packet number. See {{packet-numbers}} for details.
 
@@ -776,15 +775,10 @@ CONNECTION_CLOSE frame or any further packets; a server MAY send a Stateless
 Reset ({{stateless-reset}}) in response to further packets that it receives.
 
 In the QUIC long and short packet headers, the number of bits required to
-represent the packet number are reduced by including only the least
-significant bits of the packet number.
-
-In the long packet header, the least significant 32 bits of the packet number
-are encoded into the Packet Number field.
-
-In the short packet header, a variable number of significant bits are encoded.
-One or two of the most significant bits of the first octet determine how many
-bits of the packet number are provided, as shown in {{pn-encodings}}.
+represent the packet number are reduced by including only a variable number of
+the least significant bits of the packet number.  One or two of the most
+significant bits of the first octet determine how many bits of the packet
+number are provided, as shown in {{pn-encodings}}.
 
 | First octet pattern | Encoded Length | Bits Present |
 |:--------------------|:---------------|:-------------|
@@ -792,7 +786,6 @@ bits of the packet number are provided, as shown in {{pn-encodings}}.
 | 0b10xxxxxx          | 2              | 14           |
 | 0b11xxxxxx          | 4              | 30           |
 {: #pn-encodings title="Short Header Packet Number Encodings"}
-
 
 Note that these encodings are similar to those in {{integer-encoding}}, but
 use different values.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -779,26 +779,31 @@ In the QUIC long and short packet headers, the number of bits required to
 represent the packet number are reduced by including only the least
 significant bits of the packet number.
 
-In the long packet header, the least significant 32 bits are used. In the
-short packet header, the number of significant bits are encoded in the most
-significant two bits of the first octet of the encoded packet number:
+In the long packet header, the least significant 32 bits of the packet number
+are encoded into the Packet Number field.
+
+In the short packet header, a variable number of significant bits are encoded.
+One or two of the most significant bits of the first octet determine how many
+bits of the packet number are provided, as shown in {{pn-encodings}}.
 
 | First octet pattern | Encoded Length | Bits Present |
 |:--------------------|:---------------|:-------------|
 | 0b0xxxxxxx          | 1 octet        | 7            |
 | 0b10xxxxxx          | 2              | 14           |
 | 0b11xxxxxx          | 4              | 30           |
+{: #pn-encodings title="Short Header Packet Number Encodings"}
+
 
 Note that these encodings are similar to those in {{integer-encoding}}, but
 use different values.
 
-The encoded packet number is protected as described in Section 5.6 {{QUIC-TLS}}.
-Protection of the packet number is removed prior to recovering the full packet
-number.The full packet number is reconstructed at the receiver based on the
-value of the most significant two bits in the first octet (to determine the
-number of least significant bits present), and the largest packet number
-received on a successfully authenticated packet. Recovering the full packet
-number is necessary to successfully remove packet protection.
+The encoded packet number is protected as described in Section 5.6
+{{QUIC-TLS}}. Protection of the packet number is removed prior to recovering
+the full packet number. The full packet number is reconstructed at the
+receiver based on the number of significant bits present, the content of those
+bits, and the largest packet number received on a successfully authenticated
+packet. Recovering the full packet number is necessary to successfully remove
+packet protection.
 
 Once packet number protection is removed, the packet number is decoded by
 finding the packet number value that is closest to the next expected packet.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -345,9 +345,9 @@ Payload Length:
 Packet Number:
 
 : The packet number field is 1, 2, or 4 octets long. The packet number has
-confidentiality protection separate from packet protection, as described in
-Section 5.6 of {{QUIC-TLS}}. The length of the packet number field is encoded
-in the plaintext packet number. See {{packet-numbers}} for details.
+  confidentiality protection separate from packet protection, as described
+  in Section 5.6 of {{QUIC-TLS}}. The length of the packet number field is
+  encoded in the plaintext packet number. See {{packet-numbers}} for details.
 
 Payload:
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -785,7 +785,7 @@ number are provided, as shown in {{pn-encodings}}.
 | 0b0xxxxxxx          | 1 octet        | 7            |
 | 0b10xxxxxx          | 2              | 14           |
 | 0b11xxxxxx          | 4              | 30           |
-{: #pn-encodings title="Short Header Packet Number Encodings"}
+{: #pn-encodings title="Packet Number Encodings for Packet Headers"}
 
 Note that these encodings are similar to those in {{integer-encoding}}, but
 use different values.


### PR DESCRIPTION
Initial attempt at adding variable-length-ness to encrypted packet numbers, addressing #989. The encoding here is header-type-dependent, and inspired-by-but-not-compatible-with varint encoding.

This also assigns the two bits recovered from the short header Type field to experimentation.