### PR TITLE
Encrypt key phase

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -960,6 +960,13 @@ To ensure that this process does not sample the packet number, packet number
 protection algorithms MUST NOT sample more ciphertext than the minimum
 expansion of the corresponding AEAD.
 
+Packet number protection is applied to the packet number encoded as described
+in Section 4.8 of {{QUIC-TRANSPORT}}. Since the length of the packet number is
+stored in the encoded packet number, it is necessary to decrypt the maximum
+length (4 octets) when removing packet number protection. The final 2 or 3
+octets of the plaintext packet number can then be discarded based on the
+packet number length encoded in the first octet, as appropriate.
+
 Before a TLS ciphersuite can be used with QUIC, a packet protection algorithm
 MUST be specifed for the AEAD used with that ciphersuite.  This document defines
 algorithms for AEAD_AES_128_GCM, AEAD_AES_128_CCM, AEAD_AES_256_GCM,

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -941,14 +941,10 @@ Packet number protection is applied after packet protection is applied (see
 {{aead}}).  The ciphertext of the packet is sampled and used as input to an
 encryption algorithm.
 
-For packets with a long header, the ciphertext starting immediately after the
-packet number is used.
-
-For packets with a short header, the packet number length is
-assumed to be the smaller of the maximum possible packet
-number encoding (4 octets), or the size of the protected packet minus the
-minimum expansion for the AEAD. Thus, the sampled ciphertext for a short header
-can be determined by:
+In sampling the packet ciphertext, the packet number length is assumed to be the
+smaller of the maximum possible packet number encoding (4 octets), or the size
+of the protected packet minus the minimum expansion for the AEAD.  For example,
+the sampled ciphertext for a packet with a short header can be determined by:
 
 ```
 sample_offset = min(1 + connection_id_length + 4,

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -962,10 +962,8 @@ expansion of the corresponding AEAD.
 
 Packet number protection is applied to the packet number encoded as described
 in Section 4.8 of {{QUIC-TRANSPORT}}. Since the length of the packet number is
-stored in the encoded packet number, it is necessary to decrypt the maximum
-length (4 octets) when removing packet number protection. The final 2 or 3
-octets of the plaintext packet number can then be discarded based on the
-packet number length encoded in the first octet, as appropriate.
+stored in the first octet of the encoded packet number, it may be necessary to
+progressively decrypt the packet number.
 
 Before a TLS ciphersuite can be used with QUIC, a packet protection algorithm
 MUST be specifed for the AEAD used with that ciphersuite.  This document defines

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -829,13 +829,12 @@ N_MIN set to 12).
 The size of the packet protection key is determined by the packet protection
 algorithm, see {{pn-encrypt}}.
 
-For any secret S, the AEAD key uses a label of "key", the IV uses a label of
-"iv", packet number encryption uses a label of "pn":
+For any secret S, the AEAD key uses a label of "key", and the IV uses a label of
+"iv":
 
 ~~~
 key = QHKDF-Expand(S, "key", key_length)
 iv = QHKDF-Expand(S, "iv", iv_length)
-pn_key = QHKDF-Expand(S, "pn", pn_key_length)
 ~~~
 
 Separate keys are derived for packet protection by clients and servers.  Each
@@ -847,7 +846,6 @@ derived from 1-RTT secrets as follows:
 ~~~
 client_pp_key<i> = QHKDF-Expand(client_pp_secret<i>, "key", 16)
 client_pp_iv<i>  = QHKDF-Expand(client_pp_secret<i>, "iv", 12)
-client_pp_pn<i>  = QHKDF-Expand(client_pp_secret<i>, "pn", 12)
 ~~~
 
 The QUIC packet protection initially starts with keying material derived from
@@ -933,9 +931,25 @@ to QUIC.
 ## Packet Number Protection {#pn-encrypt}
 
 QUIC packets are protected using a key that is derived from the current set of
-secrets.  The key derived using the "pn" label is used to protect the packet
-number from casual observation.  The packet number protection algorithm depends
-on the negotiated AEAD.
+secrets.  A packet protection key is used to protect the packet number from
+casual observation.  The packet number protection key is derived from the first
+packet protection secret using the label "pn".  This key is produced using the
+same process as the AEAD key and IV, but the value is not updated with each key
+update ({{key-update}}).
+
+~~~
+pn_key = QHKDF-Expand(pp_secret<0>, "pn", pn_key_length)
+~~~
+
+That is, for the algorithms defined in this document, the packet protection key
+is determined to be:
+
+~~~
+client_pn_key  = QHKDF-Expand(client_pp_secret<0>, "pn", 16)
+server_pn_key  = QHKDF-Expand(server_pp_secret<0>, "pn", 16)
+~~~
+
+The packet number protection algorithm depends on the negotiated AEAD.
 
 Packet number protection is applied after packet protection is applied (see
 {{aead}}).  The ciphertext of the packet is sampled and used as input to an
@@ -952,9 +966,9 @@ sample_offset = min(1 + connection_id_length + 4,
 sample = packet[sample_offset..sample_offset+sample_length]
 ```
 
-To ensure that this process does not sample the packet number, packet number
-protection algorithms MUST NOT sample more ciphertext than the minimum
-expansion of the corresponding AEAD.
+To ensure that this process does not sample the packet number and key phase,
+packet number protection algorithms MUST NOT sample more ciphertext than the
+minimum expansion of the corresponding AEAD.
 
 Packet number protection is applied to the packet number encoded as described
 in Section 4.8 of {{QUIC-TRANSPORT}}. Since the length of the packet number is

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -806,8 +806,8 @@ result is that one fewer bit from the packet number can be included, as shown in
 | K11xxxxx            | 32 bits        | 29          |
 {: #short-pn-encodings title="Short Header Packet Number Encodings"}
 
-Note that these encodings are similar to those in {{integer-encoding}}, but
-use different values.
+Note that these encodings are superficially similar to those in
+{{integer-encoding}}, but use different prefixes.
 
 The encoded packet number and KEY_PHASE (if present) is protected as described
 in Section 5.6 {{QUIC-TLS}}. Protection of the packet number is removed prior to

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -822,7 +822,7 @@ finding the packet number value that is closest to the next expected packet.
 The next expected packet is the highest received packet number plus one.  For
 example, if the highest successfully authenticated packet had a packet number of
 0xaa82f30e, then a packet containing a 14-bit value of 0x1f94 will be decoded as
-0xaa831f94.
+0xaa831f94; the same value encoded on 13 bits will be decoded as 0xaa82ff94.
 
 The sender MUST use a packet number size able to represent more than twice as
 large a range than the difference between the largest acknowledged packet and
@@ -838,8 +838,8 @@ including the new packet.
 
 For example, if an endpoint has received an acknowledgment for packet 0x6afa2f,
 sending a packet with a number of 0x6b2d79 requires a packet number encoding
-with 14 bits or more; whereas the 30-bit packet number encoding is needed to
-send a packet with a number of 0x6bc107.
+with 13 bits or more; whereas the 29- or 30-bit packet number encoding is needed
+to send a packet with a number of 0x6bc107.
 
 A Version Negotiation packet ({{packet-version}}) does not include a packet
 number.  The Retry packet ({{packet-retry}}) has special rules for populating

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -282,7 +282,7 @@ keys are established.
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                       Payload Length (i)                    ...
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                       Packet Number (32)                      |
+|                     Packet Number (8/16/32)                   |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                          Payload (*)                        ...
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -344,11 +344,10 @@ Payload Length:
 
 Packet Number:
 
-: The Packet Number is a 32-bit field that follows the two connection IDs.
-  Packet numbers are not encrypted as part of packet protection, but instead
-  have additional confidentiality protection. {{packet-numbers}} describes the
-  use of packet numbers.
-
+: The packet number field is 1, 2, or 4 octets long. The packet number has
+confidentiality protection separate from packet protection, as described in
+Section 5.6 of {{QUIC-TLS}}. The length of the packet number field is encoded
+in the plaintext packet number. See {{packet-numbers}} for details.
 
 Payload:
 
@@ -449,8 +448,8 @@ Destination Connection ID:
 
 Packet Number:
 
-: The packet number field is either 1, 2, or 4 bytes long. The packet number
-has confidentiality protection separate from packet protection, as described in
+: The packet number field is 1, 2, or 4 octets long. The packet number has
+confidentiality protection separate from packet protection, as described in
 Section 5.6 of {{QUIC-TLS}}. The length of the packet number field is encoded
 in the plaintext packet number. See {{packet-numbers}} for details.
 
@@ -776,15 +775,10 @@ CONNECTION_CLOSE frame or any further packets; a server MAY send a Stateless
 Reset ({{stateless-reset}}) in response to further packets that it receives.
 
 In the QUIC long and short packet headers, the number of bits required to
-represent the packet number are reduced by including only the least
-significant bits of the packet number.
-
-In the long packet header, the least significant 32 bits of the packet number
-are encoded into the Packet Number field.
-
-In the short packet header, a variable number of significant bits are encoded.
-One or two of the most significant bits of the first octet determine how many
-bits of the packet number are provided, as shown in {{pn-encodings}}.
+represent the packet number are reduced by including only a variable number of
+the least significant bits of the packet number.  One or two of the most
+significant bits of the first octet determine how many bits of the packet
+number are provided, as shown in {{pn-encodings}}.
 
 | First octet pattern | Encoded Length | Bits Present |
 |:--------------------|:---------------|:-------------|
@@ -792,7 +786,6 @@ bits of the packet number are provided, as shown in {{pn-encodings}}.
 | 0b10xxxxxx          | 2              | 14           |
 | 0b11xxxxxx          | 4              | 30           |
 {: #pn-encodings title="Short Header Packet Number Encodings"}
-
 
 Note that these encodings are similar to those in {{integer-encoding}}, but
 use different values.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -779,26 +779,31 @@ In the QUIC long and short packet headers, the number of bits required to
 represent the packet number are reduced by including only the least
 significant bits of the packet number.
 
-In the long packet header, the least significant 32 bits are used. In the
-short packet header, the number of significant bits are encoded in the most
-significant two bits of the first octet of the encoded packet number:
+In the long packet header, the least significant 32 bits of the packet number
+are encoded into the Packet Number field.
+
+In the short packet header, a variable number of significant bits are encoded.
+One or two of the most significant bits of the first octet determine how many
+bits of the packet number are provided, as shown in {{pn-encodings}}.
 
 | First octet pattern | Encoded Length | Bits Present |
 |:--------------------|:---------------|:-------------|
 | 0b0xxxxxxx          | 1 octet        | 7            |
 | 0b10xxxxxx          | 2              | 14           |
 | 0b11xxxxxx          | 4              | 30           |
+{: #pn-encodings title="Short Header Packet Number Encodings"}
+
 
 Note that these encodings are similar to those in {{integer-encoding}}, but
 use different values.
 
-The encoded packet number is protected as described in Section 5.6 {{QUIC-TLS}}.
-Protection of the packet number is removed prior to recovering the full packet
-number.The full packet number is reconstructed at the receiver based on the
-value of the most significant two bits in the first octet (to determine the
-number of least significant bits present), and the largest packet number
-received on a successfully authenticated packet. Recovering the full packet
-number is necessary to successfully remove packet protection.
+The encoded packet number is protected as described in Section 5.6
+{{QUIC-TLS}}. Protection of the packet number is removed prior to recovering
+the full packet number. The full packet number is reconstructed at the
+receiver based on the number of significant bits present, the content of those
+bits, and the largest packet number received on a successfully authenticated
+packet. Recovering the full packet number is necessary to successfully remove
+packet protection.
 
 Once packet number protection is removed, the packet number is decoded by
 finding the packet number value that is closest to the next expected packet.


### PR DESCRIPTION
This is what encrypting the KEY_PHASE might look like, at least to start with.  This builds on #1334.  It's not intended to be merged, just to serve as a discussion point.

@kazuho suggested that we extend the encrypted portion into the type byte.  That's a natural extension of this.  One potential advantage of that is that we might get more bits for packet numbers.

There's also the possibility of making the long and short headers use the same encoding and to use the KEY_PHASE in the long header to indicate use of 0-RTT, which would eliminate the differences I had to introduce here.  I'm sure that there are other options there as well.