### PR TITLE
Narrow lint target to just the drafts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ endif
 
 ifneq ($(PYTHON),)
 lint::
-	@$(PYTHON) ./.lint.py draft-*.md
+	@$(PYTHON) ./.lint.py $(addsuffix .md,$(drafts))
 endif
 
 show-next:


### PR DESCRIPTION
Note that this doesn't filter out non-markdown drafts, so this will fail in the general case, but I don't think that we'll have that problem here.

Fixes martinthomson/i-d-template#143 for @MikeBishop.  I hope.