### PR TITLE
Stateless reset fixes

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2082,23 +2082,24 @@ of the packet protection AEAD.  More random octets might be necessary if the
 endpoint could have negotiated a packet protection scheme with a larger minimum
 AEAD expansion.
 
-An endpoint cannot determine the source connection ID from a packet with a short
-header, therefore it cannot set the destination connection ID in the stateless
+An endpoint cannot determine the Source Connection ID from a packet with a short
+header, therefore it cannot set the Destination Connection ID in the stateless
 reset packet.  The destination connection ID will therefore differ from the
-value used in previous packets.  A random destination connection ID makes the
+value used in previous packets.  A random Destination Connection ID makes the
 connection ID appear to be the result of moving to new connection ID that was
 provided using the NEW_CONNECTION_ID frame ({{frame-new-connection-id}}).
 
 Using a randomized connection ID results in two problems:
 
 * The packet might not reach the peer.  If the Destination Connection ID is
-  critical for routing toward the client, then this packet could be incorrectly
+  critical for routing toward the peer, then this packet could be incorrectly
   routed.  This causes the stateless reset to be ineffective in causing errors
-  to be quickly detected and recovered.  In this case, clients will need to rely
-  on other methods - such as timers - to detect that the connection has failed.
+  to be quickly detected and recovered.  In this case, endpoints will need to
+  rely on other methods - such as timers - to detect that the connection has
+  failed.
 
 * The randomly generated connection ID can be used by entities other than the
-  client to identify this as a potential stateless reset.  A server that
+  peer to identify this as a potential stateless reset.  An endpoint that
   occasionally uses different connection IDs might introduce some uncertainty
   about this.
 
@@ -2109,9 +2110,9 @@ A stateless reset is not appropriate for signaling error conditions.  An
 endpoint that wishes to communicate a fatal connection error MUST use a
 CONNECTION_CLOSE or APPLICATION_CLOSE frame if it has sufficient state to do so.
 
-This stateless reset design is specific to QUIC version 1.  A server that
+This stateless reset design is specific to QUIC version 1.  An endpoint that
 supports multiple versions of QUIC needs to generate a stateless reset that will
-be accepted by clients that support any version that the server might support
+be accepted by peers that support any version that the endpoint might support
 (or might have supported prior to losing state).  Designers of new versions of
 QUIC need to be aware of this and either reuse this design, or use a portion of
 the packet other than the last 16 octets for carrying data.
@@ -2119,49 +2120,50 @@ the packet other than the last 16 octets for carrying data.
 
 #### Detecting a Stateless Reset
 
-A client detects a potential stateless reset when a packet with a short header
-either cannot be decrypted or is marked as a duplicate packet.  The client then
-compares the last 16 octets of the packet with the Stateless Reset Token
-provided by the server in its transport parameters.  If these values are
-identical, the client MUST enter the draining period and not send any further
-packets on this connection.  If the comparison fails, the packet can be
-discarded.
+An endpoint detects a potential stateless reset when a packet with a short
+header either cannot be decrypted or is marked as a duplicate packet.  The
+endpoint then compares the last 16 octets of the packet with the Stateless Reset
+Token provided by its peer, either from the NEW_CONNECTION_ID frame or the
+server transport parameters.  If these values are identical, the endpoint MUST
+enter the draining period and not send any further packets on this connection.
+If the comparison fails, the packet can be discarded.
 
 
 #### Calculating a Stateless Reset Token
 
 The stateless reset token MUST be difficult to guess.  In order to create a
-Stateless Reset Token, a server could randomly generate {{!RFC4086}} a secret
+Stateless Reset Token, an endpoint could randomly generate {{!RFC4086}} a secret
 for every connection that it creates.  However, this presents a coordination
-problem when there are multiple servers in a cluster or a storage problem for a
-server that might lose state.  Stateless reset specifically exists to handle the
-case where state is lost, so this approach is suboptimal.
+problem when there are multiple instances in a cluster or a storage problem for
+a endpoint that might lose state.  Stateless reset specifically exists to handle
+the case where state is lost, so this approach is suboptimal.
 
 A single static key can be used across all connections to the same endpoint by
 generating the proof using a second iteration of a preimage-resistant function
-that takes three inputs: the static key, the server's connection ID (see
-{{connection-id}}), and an identifier for the server instance.  A server could
-use HMAC {{?RFC2104}} (for example, HMAC(static_key, server_id ||
+that takes three inputs: the static key, the connection ID chosen by the
+endpoint (see {{connection-id}}), and an instance identifier.  An endpoint could
+use HMAC {{?RFC2104}} (for example, HMAC(static_key, instance_id ||
 connection_id)) or HKDF {{?RFC5869}} (for example, using the static key as input
-keying material, with server and connection identifiers as salt).  The output of
-this function is truncated to 16 octets to produce the Stateless Reset Token for
-that connection.
+keying material, with instance and connection identifiers as salt).  The output
+of this function is truncated to 16 octets to produce the Stateless Reset Token
+for that connection.
 
-A server that loses state can use the same method to generate a valid Stateless
-Reset Secret.  The connection ID comes from the packet that the server receives.
+An endpoint that loses state can use the same method to generate a valid
+Stateless Reset Secret.  The connection ID comes from the packet that the
+endpoint receives.
 
-This design relies on the client always sending a connection ID in its packets
-so that the server can use the connection ID from a packet to reset the
-connection.  A server that uses this design cannot allow clients to use a
+This design relies on the peer always sending a connection ID in its packets so
+that the endpoint can use the connection ID from a packet to reset the
+connection.  An endpoint that uses this design cannot allow its peers to use a
 zero-length connection ID.
 
 Revealing the Stateless Reset Token allows any entity to terminate the
 connection, so a value can only be used once.  This method for choosing the
-Stateless Reset Token means that the combination of server instance, connection
-ID, and static key cannot occur for another connection.  A connection ID from a
-connection that is reset by revealing the Stateless Reset Token cannot be
-reused for new connections at the same server without first changing to use a
-different static key or server identifier.
+Stateless Reset Token means that the combination of instance, connection ID, and
+static key cannot occur for another connection.  A connection ID from a
+connection that is reset by revealing the Stateless Reset Token cannot be reused
+for new connections at the same instance without first changing to use a
+different static key or instance identifier.
 
 Note that Stateless Reset messages do not have any cryptographic protection.
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -771,7 +771,7 @@ least one after sending a packet.
 A QUIC endpoint MUST NOT reuse a packet number within the same connection (that
 is, under the same cryptographic keys).  If the packet number for sending
 reaches 2^62 - 1, the sender MUST close the connection without sending a
-CONNECTION_CLOSE frame or any further packets; a server MAY send a Stateless
+CONNECTION_CLOSE frame or any further packets; an endpoint MAY send a Stateless
 Reset ({{stateless-reset}}) in response to further packets that it receives.
 
 In the QUIC long and short packet headers, the number of bits required to
@@ -2032,17 +2032,20 @@ signal closure.
 
 ### Stateless Reset {#stateless-reset}
 
-A stateless reset is provided as an option of last resort for a server that does
-not have access to the state of a connection.  A server crash or outage might
-result in clients continuing to send data to a server that is unable to properly
-continue the connection.  A server that wishes to communicate a fatal connection
-error MUST use a closing frame if it has sufficient state to do so.
+A stateless reset is provided as an option of last resort for an endpoint that
+does not have access to the state of a connection.  A crash or outage might
+result in peers continuing to send data to an endpoint that is unable to
+properly continue the connection.  An endpoint that wishes to communicate a
+fatal connection error MUST use a closing frame if it has sufficient state to do
+so.
 
-To support this process, the server sends a stateless_reset_token value during
-the handshake in the transport parameters.  This value is protected by
-encryption, so only client and server know this value.
+To support this process, a token is sent by endpoints.  The token is carried in
+the NEW_CONNECTION_ID frame sent by either peer, and servers can specify the
+stateless_reset_token transport parameter during the handshake (clients cannot
+because their transport parameters don't have confidentiality protection).  This
+value is protected by encryption, so only client and server know this value.
 
-A server that receives packets that it cannot process sends a packet in the
+An endpoint that receives packets that it cannot process sends a packet in the
 following layout:
 
 ~~~

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2171,13 +2171,6 @@ connection that is reset by revealing the Stateless Reset Token cannot be reused
 for new connections at the same instance without first changing to use a
 different static key or instance identifier.
 
-Any set of instances that share a static key for the purposes of stateless reset
-MUST allocate connection IDs from the same space without reusing connection IDs
-as long as the key is valid.  If instances that share a stateless reset key
-allow connections with the same connection ID to be created, then the stateless
-reset token for one connection could be used to terminate any connection that
-has the same connection ID.
-
 Note that Stateless Reset messages do not have any cryptographic protection.
 
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2160,8 +2160,8 @@ might recover the instance identifier from the connection ID.
 
 This design relies on the peer always sending a connection ID in its packets so
 that the endpoint can use the connection ID from a packet to reset the
-connection.  An endpoint that uses this design cannot allow its peers to use a
-zero-length connection ID.
+connection.  An endpoint that uses this design cannot allow its peers to send
+packets with a zero-length connection ID.
 
 Revealing the Stateless Reset Token allows any entity to terminate the
 connection, so a value can only be used once.  This method for choosing the

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2066,14 +2066,21 @@ following layout:
 This design ensures that a stateless reset packet is - to the extent possible -
 indistinguishable from a regular packet with a short header.
 
+The message consists of a packet header, followed by random octets of arbitrary
+length, followed by a Stateless Reset Token.
+
+The server SHOULD send a packet with a short header and a packet number length
+of 1 octet. Using the hortest possible packet number encoding minimizes the
+perceived gap between the last packet that the server sent and this packet.  A
+server MAY indicate a different packet number length, but a longer packet number
+encoding might allow this message to be identified as a stateless reset more
+easily using heuristics.
+
 The random octets MUST be of a length equal to at least 18 octets plus the
 packet number length implied by the type field. A packet of this length
 simulates a packet with a short header, the maximum-length destination
 connection ID, a packet number of the appropriate length and (with the
 Stateless Reset Token) an authentication trailer, with no packet payload.
-
-Beyond this limit, the server pads the message with an arbitrary number of
-octets containing random values.
 
 In response to a packet with a short header, the server has no means of
 determining the source connection ID and is effectively using a random one
@@ -2091,13 +2098,6 @@ two problems:
   client to identify this as a potential stateless reset.  A server that
   occasionally uses different connection IDs might introduce some uncertainty
   about this.
-
-The server SHOULD send a packet with a short header and a packet number length
-of 1 octet. Using the hortest possible packet number encoding minimizes the
-perceived gap between the last packet that the server sent and this packet.  A
-server MAY indicate a different packet number length, but a longer packet number
-encoding might allow this message to be identified as a stateless reset more
-easily using heuristics.
 
 Finally, the last 16 octets of the packet are set to the value of the Stateless
 Reset Token.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2155,7 +2155,8 @@ for that connection.
 
 An endpoint that loses state can use the same method to generate a valid
 Stateless Reset Secret.  The connection ID comes from the packet that the
-endpoint receives.
+endpoint receives.  An instance that receives a packet for another instance
+might recover the instance identifier from the connection ID.
 
 This design relies on the peer always sending a connection ID in its packets so
 that the endpoint can use the connection ID from a packet to reset the
@@ -2169,6 +2170,13 @@ static key cannot occur for another connection.  A connection ID from a
 connection that is reset by revealing the Stateless Reset Token cannot be reused
 for new connections at the same instance without first changing to use a
 different static key or instance identifier.
+
+Any set of instances that share a static key for the purposes of stateless reset
+MUST allocate connection IDs from the same space without reusing connection IDs
+as long as the key is valid.  If instances that share a stateless reset key
+allow connections with the same connection ID to be created, then the stateless
+reset token for one connection could be used to terminate any connection that
+has the same connection ID.
 
 Note that Stateless Reset messages do not have any cryptographic protection.
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2051,7 +2051,7 @@ following layout:
 +-+-+-+-+-+-+-+-+
 |0|K| Type (6)  |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                        Random Octets (*)                    ...
+|                      Random Octets (160..)                  ...
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                                                               |
 +                                                               +
@@ -2069,26 +2069,26 @@ indistinguishable from a regular packet with a short header.
 The message consists of a packet header, followed by random octets of arbitrary
 length, followed by a Stateless Reset Token.
 
-The server SHOULD send a packet with a short header and a packet number length
-of 1 octet. Using the hortest possible packet number encoding minimizes the
-perceived gap between the last packet that the server sent and this packet.  A
-server MAY indicate a different packet number length, but a longer packet number
-encoding might allow this message to be identified as a stateless reset more
-easily using heuristics.
+The endpoint SHOULD send a packet with a short header.
 
-The random octets MUST be of a length equal to at least 18 octets plus the
-packet number length implied by the type field. A packet of this length
-simulates a packet with a short header, the maximum-length destination
-connection ID, a packet number of the appropriate length and (with the
-Stateless Reset Token) an authentication trailer, with no packet payload.
+Assuming a short header, the Random Octets field needs to include at least 20
+octets of random or unpredictable values.  This is intended to allow for a
+destination connection ID of the maximum length permitted, a packet number, and
+minimal payload.  The Stateless Reset Token corresponds to the minimum expansion
+of the packet protection AEAD.  More random octets might be necessary if the
+endpoint could have negotiated a packet protection scheme with a larger minimum
+AEAD expansion.
 
-In response to a packet with a short header, the server has no means of
-determining the source connection ID and is effectively using a random one
-instead. For a client that depends on the server including a connection ID,
-this will mean that this value differs from previous packets.  Ths results in
-two problems:
+An endpoint cannot determine the source connection ID from a packet with a short
+header, therefore it cannot set the destination connection ID in the stateless
+reset packet.  The destination connection ID will therefore differ from the
+value used in previous packets.  A random destination connection ID makes the
+connection ID appear to be the result of moving to new connection ID that was
+provided using the NEW_CONNECTION_ID frame ({{frame-new-connection-id}}).
 
-* The packet might not reach the client.  If the Destination Connection ID is
+Using a randomized connection ID results in two problems:
+
+* The packet might not reach the peer.  If the Destination Connection ID is
   critical for routing toward the client, then this packet could be incorrectly
   routed.  This causes the stateless reset to be ineffective in causing errors
   to be quickly detected and recovered.  In this case, clients will need to rely

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2052,7 +2052,7 @@ following layout:
  0                   1                   2                   3
  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
 +-+-+-+-+-+-+-+-+
-|0|K| Type (6)  |
+|0|K|1|1|0|0|0|0|
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                      Random Octets (160..)                  ...
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -2069,7 +2069,7 @@ following layout:
 This design ensures that a stateless reset packet is - to the extent possible -
 indistinguishable from a regular packet with a short header.
 
-The message consists of a packet header, followed by random octets of arbitrary
+The message consists of a header octet, followed by random octets of arbitrary
 length, followed by a Stateless Reset Token.
 
 The endpoint SHOULD send a packet with a short header.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2051,10 +2051,6 @@ following layout:
 +-+-+-+-+-+-+-+-+
 |0|K| Type (6)  |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                  Destination Connection ID (144)            ...
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                     Packet Number (8/16/32)                   |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                        Random Octets (*)                    ...
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                                                               |
@@ -2070,9 +2066,20 @@ following layout:
 This design ensures that a stateless reset packet is - to the extent possible -
 indistinguishable from a regular packet with a short header.
 
-A server generates a random 18-octet Destination Connection ID field.  For a
-client that depends on the server including a connection ID, this will mean that
-this value differs from previous packets.  Ths results in two problems:
+The random octets MUST be of a length equal to at least 18 octets plus the
+packet number length implied by the type field. A packet of this length
+simulates a packet with a short header, the maximum-length destination
+connection ID, a packet number of the appropriate length and (with the
+Stateless Reset Token) an authentication trailer, with no packet payload.
+
+Beyond this limit, the server pads the message with an arbitrary number of
+octets containing random values.
+
+In response to a packet with a short header, the server has no means of
+determining the source connection ID and is effectively using a random one
+instead. For a client that depends on the server including a connection ID,
+this will mean that this value differs from previous packets.  Ths results in
+two problems:
 
 * The packet might not reach the client.  If the Destination Connection ID is
   critical for routing toward the client, then this packet could be incorrectly
@@ -2085,15 +2092,12 @@ this value differs from previous packets.  Ths results in two problems:
   occasionally uses different connection IDs might introduce some uncertainty
   about this.
 
-The Packet Number field is set to a randomized value.  The server SHOULD send a
-packet with a short header and a packet number length of 1 octet. Using the
-shortest possible packet number encoding minimizes the perceived gap between the
-last packet that the server sent and this packet.  A server MAY indicate a
-different packet number length, but a longer packet number encoding might allow
-this message to be identified as a stateless reset more easily using heuristics.
-
-After the Packet Number, the server pads the message with an arbitrary
-number of octets containing random values.
+The server SHOULD send a packet with a short header and a packet number length
+of 1 octet. Using the hortest possible packet number encoding minimizes the
+perceived gap between the last packet that the server sent and this packet.  A
+server MAY indicate a different packet number length, but a longer packet number
+encoding might allow this message to be identified as a stateless reset more
+easily using heuristics.
 
 Finally, the last 16 octets of the packet are set to the value of the Stateless
 Reset Token.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2161,7 +2161,7 @@ might recover the instance identifier from the connection ID.
 This design relies on the peer always sending a connection ID in its packets so
 that the endpoint can use the connection ID from a packet to reset the
 connection.  An endpoint that uses this design cannot allow its peers to send
-packets with a zero-length connection ID.
+packets with a zero-length destination connection ID.
 
 Revealing the Stateless Reset Token allows any entity to terminate the
 connection, so a value can only be used once.  This method for choosing the

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2082,6 +2082,11 @@ of the packet protection AEAD.  More random octets might be necessary if the
 endpoint could have negotiated a packet protection scheme with a larger minimum
 AEAD expansion.
 
+An endpoint SHOULD NOT send a stateless reset that is significantly larger than
+the packet it receives.  Endpoints MUST discard packets that are too small to be
+valid QUIC packets.  With the set of AEAD functions defined in {{QUIC-TLS}},
+packets less than 19 octets long are never valid.
+
 An endpoint cannot determine the Source Connection ID from a packet with a short
 header, therefore it cannot set the Destination Connection ID in the stateless
 reset packet.  The destination connection ID will therefore differ from the

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2072,15 +2072,14 @@ indistinguishable from a regular packet with a short header.
 The message consists of a header octet, followed by random octets of arbitrary
 length, followed by a Stateless Reset Token.
 
-The endpoint SHOULD send a packet with a short header.
-
-Assuming a short header, the Random Octets field needs to include at least 20
-octets of random or unpredictable values.  This is intended to allow for a
-destination connection ID of the maximum length permitted, a packet number, and
-minimal payload.  The Stateless Reset Token corresponds to the minimum expansion
-of the packet protection AEAD.  More random octets might be necessary if the
-endpoint could have negotiated a packet protection scheme with a larger minimum
-AEAD expansion.
+A stateless reset will be interpreted by a recipient as a packet with a short
+header.  For the packet to appear as valid, the Random Octets field needs to
+include at least 20 octets of random or unpredictable values.  This is intended
+to allow for a destination connection ID of the maximum length permitted, a
+packet number, and minimal payload.  The Stateless Reset Token corresponds to
+the minimum expansion of the packet protection AEAD.  More random octets might
+be necessary if the endpoint could have negotiated a packet protection scheme
+with a larger minimum AEAD expansion.
 
 An endpoint SHOULD NOT send a stateless reset that is significantly larger than
 the packet it receives.  Endpoints MUST discard packets that are too small to be
@@ -2091,8 +2090,8 @@ An endpoint cannot determine the Source Connection ID from a packet with a short
 header, therefore it cannot set the Destination Connection ID in the stateless
 reset packet.  The destination connection ID will therefore differ from the
 value used in previous packets.  A random Destination Connection ID makes the
-connection ID appear to be the result of moving to new connection ID that was
-provided using the NEW_CONNECTION_ID frame ({{frame-new-connection-id}}).
+connection ID appear to be the result of moving to a new connection ID that was
+provided using a NEW_CONNECTION_ID frame ({{frame-new-connection-id}}).
 
 Using a randomized connection ID results in two problems:
 
@@ -2128,10 +2127,10 @@ the packet other than the last 16 octets for carrying data.
 An endpoint detects a potential stateless reset when a packet with a short
 header either cannot be decrypted or is marked as a duplicate packet.  The
 endpoint then compares the last 16 octets of the packet with the Stateless Reset
-Token provided by its peer, either from the NEW_CONNECTION_ID frame or the
-server transport parameters.  If these values are identical, the endpoint MUST
-enter the draining period and not send any further packets on this connection.
-If the comparison fails, the packet can be discarded.
+Token provided by its peer, either in a NEW_CONNECTION_ID frame or the server's
+transport parameters.  If these values are identical, the endpoint MUST enter
+the draining period and not send any further packets on this connection.  If the
+comparison fails, the packet can be discarded.
 
 
 #### Calculating a Stateless Reset Token
@@ -2154,9 +2153,12 @@ of this function is truncated to 16 octets to produce the Stateless Reset Token
 for that connection.
 
 An endpoint that loses state can use the same method to generate a valid
-Stateless Reset Secret.  The connection ID comes from the packet that the
+Stateless Reset Token.  The connection ID comes from the packet that the
 endpoint receives.  An instance that receives a packet for another instance
-might recover the instance identifier from the connection ID.
+might be able to recover the instance identifier using the connection ID.
+Alternatively, the instance identifier might be omitted from the calculation of
+the Stateless Reset Token so that all instances are equally able to generate a
+stateless reset.
 
 This design relies on the peer always sending a connection ID in its packets so
 that the endpoint can use the connection ID from a packet to reset the


### PR DESCRIPTION
Inspired by @martinduke's #1328, I set to cleaning a few things up.  You can see separate commits here that:

* Take Martin's simplification suggestions
* Reword a few things based on review
* Make stateless reset symmetric
* Add a paragraph limiting the size of stateless reset (for amplification attack reasons)
* Add a point that @kazuho and I discussed somewhere about the scope of the stateless reset key and connection IDs (which opens a different DoS vector if they don't line up correctly).  That's partly addressed by the inclusion of an instance identifier in the calculation of the token, but the point is that you probably want instance X to be able to reset connections for instance Y if Y is out of commission, so you end up with the potential for DoS if you aren't careful to ensure that X and Y use different connection IDs.

Closes #466, #1328.