### PR TITLE
Allow arbitrary empty STREAM frames (not just Offset=0 or FIN=1)

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2957,9 +2957,8 @@ Stream Data:
 
 : The bytes from the designated stream to be delivered.
 
-A stream frame's Stream Data MUST NOT be empty, unless the offset is 0 or the
-FIN bit is set.  When the FIN flag is sent on an empty STREAM frame, the offset
-in the STREAM frame is the offset of the next byte that would be sent.
+When a Stream Data field has a length of 0, the offset in the STREAM frame is
+the offset of the next byte that would be sent.
 
 The first byte in the stream has an offset of 0.  The largest offset delivered
 on a stream - the sum of the re-constructed offset and data length - MUST be


### PR DESCRIPTION
From the mailing list.

From: Martin Thomson [mailto:martin.thomson@gmail.com] 
Sent: Thursday, May 10, 2018 8:37 PM
Subject: Re: Why allow empty STREAM frames when offset is zero?

That's possible, if someone wants to open a PR.

To be clear, I don't think that there is a valid use case for an empty STREAM frame (other than at the start or end) that isn't satisfied better by other frames.  But we're not necessarily in the business of policing these things and allowing empty STREAM frames is actually easier than creating the exclusions.

Here's a use case: steganography.  A covert channel to the peer that won't manifest as observable activity outside of the QUIC stack.  An empty STREAM frame can carry a surprising amount of entropy if you are clever.

We would then put empty STREAM frames in the same bucket as other frames that could be pointless and wasteful when used excessively.  There's already a bunch of those.

On Fri, May 11, 2018 at 10:11 AM Ian Swett <ianswett= 40google.com@dmarc.ietf.org> wrote:
> I would agree that the restriction here seem unnecessary and I tend to
think we'd be better off removing it.

> On Thu, May 10, 2018 at 5:58 PM Lubashev, Igor <ilubashe=
40akamai.com@dmarc.ietf.org> wrote:
>> Actually, I’ll take an issue with:
>>
>> [draft-ietf-quic-transport-11] says the following:
>>      A stream frame's Stream Data MUST NOT be empty, unless the offset is
>>      0 or the FIN bit is set.
>>
>> Why disallow this?  This may be a signal to the receiver about where 
>> in
the stream the sender is, even if the sender does not have any new data to send.  This signal may be useful in cases of packet loss, when the sender is not ready to declare a packet with stream data lost and retransmit lots of stream data (has not been long enough), but it is very important for the application to know where the sender is in the stream.  Of course, there are workarounds – you can send a STREAM frame, retransmitting a single byte.  But it still seems like an unnecessary restriction.