### PR TITLE
Boilerplate and Conventions

### DIFF
--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -121,6 +121,45 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 document are to be interpreted as described in BCP 14 {{!RFC2119}} {{!RFC8174}}
 when, and only when, they appear in all capitals, as shown here.
 
+Definitions of terms that are used in this document:
+
+Header:
+
+: A name-value pair sent as part of an HTTP message.
+
+Header set:
+
+: The full collection of headers associated with an HTTP message.
+
+Header block:
+
+: The compressed representation of a header set.
+
+Encoder:
+
+: An implementation which transforms a header set into a header block.
+
+Decoder:
+
+: An implementation which transforms a header block into a header set.
+
+QPACK is a name, not an acronym.
+
+## Notational Conventions
+
+Diagrams use the format described in Section 3.1 of {{?RFC2360}}, with the
+following additional conventions:
+
+x (A)
+: Indicates that x is A bits long
+
+x (A+)
+: Indicates that x uses the prefixed integer encoding defined in Section 5.1 of
+  [RFC7541], beginning with an A-bit prefix.
+
+x ...
+: Indicates that x is variable-length and extends to the end of the region.
+
 # Wire Format
 
 QPACK instructions occur in three locations, each of which uses a separate

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -114,6 +114,13 @@ field data MUST remain in the blocked stream's flow control window.  When the
 Largest Reference is zero, the frame contains no references to the dynamic table
 and can always be processed immediately.
 
+# Conventions and Definitions
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this
+document are to be interpreted as described in BCP 14 {{!RFC2119}} {{!RFC8174}}
+when, and only when, they appear in all capitals, as shown here.
+
 # Wire Format
 
 QPACK instructions occur in three locations, each of which uses a separate


### PR DESCRIPTION
Changed something to a lower-case "should," and went to verify that QPACK had the updated BCP14 boilerplate.  Turns out it didn't have any; let's fix that.