### PR TITLE
 reflect changes to short header from #1334 

### DIFF
--- a/draft-ietf-quic-spin-exp.md
+++ b/draft-ietf-quic-spin-exp.md
@@ -181,7 +181,7 @@ as follows:
 This procedure will cause the spin bit to change value in each direction once
 per round trip. Observation points can estimate the network latency by
 observing these changes in the latency spin bit, as described in {{usage}}.
-See {{QUIC-SPIN}} for further illustration of this
+See {{?QUIC-SPIN=I-D.trammell-quic-spin}} for further illustration of this
 mechanism in action.
 
 ## Resetting Spin Value State

--- a/draft-ietf-quic-spin-exp.md
+++ b/draft-ietf-quic-spin-exp.md
@@ -139,7 +139,7 @@ the short header for the spin bit.
  0                   1                   2                   3
  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
 +-+-+-+-+-+-+-+-+
-|0|K|1|1|0|S|T T|
+|0|K|1|1|0|S|R R|
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                Destination Connection ID (0..144)           ...
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -153,6 +153,8 @@ the short header for the spin bit.
 
 S: The Spin bit is set 0 or 1 depending on the stored spin value that is
 updated on packet reception as explained in {{spinbit}}.
+
+R: Two additional bits are reserved for experimentation in the short header.
 
 ## Setting the Spin Bit on Outgoing Packets {#spinbit}
 
@@ -179,7 +181,7 @@ as follows:
 This procedure will cause the spin bit to change value in each direction once
 per round trip. Observation points can estimate the network latency by
 observing these changes in the latency spin bit, as described in {{usage}}.
-See {{?QUIC-SPIN=I-D.trammell-quic-spin}} for further illustration of this
+See {{QUIC-SPIN}} for further illustration of this
 mechanism in action.
 
 ## Resetting Spin Value State
@@ -253,7 +255,7 @@ on-path devices is therefore negligible.
 
 # Acknowledgments
 
-This document is derived from {{?I-D.trammell-quic-spin}}, which was the work
+This document is derived from {{QUIC-SPIN}}, which was the work
 of the following authors in addition to the editor of this document:
 
 - Piet De Vaere, ETH Zurich


### PR DESCRIPTION
Tracks changes to the short header due to varint PN size (and the bits used by the VEC in https://tools.ietf.org/html/draft-trammell-quic-spin). Fixes problem with double refs.