### PR TITLE
QPACK:  Updated Static Table

### DIFF
--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -1117,17 +1117,16 @@ Description:
 | 108   | access-control-allow-credentials | FALSE                                                                                                  |
 | 109   | expect-ct                        |                                                                                                        |
 | 110   | content-security-policy          | script-src 'none'; object-src 'none'; base-uri 'none'                                                  |
-| 111   | transfer-encoding                | chunked                                                                                                |
-| 112   | upgrade-insecure-requests        | 1                                                                                                      |
-| 113   | x-served-by                      |                                                                                                        |
-| 114   | x-requested-with                 | xmlhttprequest                                                                                         |
-| 115   | access-control-request-headers   | content-type                                                                                           |
-| 116   | access-control-request-headers   | x-requested-with                                                                                       |
-| 117   | access-control-request-method    | post                                                                                                   |
-| 118   | access-control-request-method    | get                                                                                                    |
-| 119   | purpose                          | prefetch                                                                                               |
-| 120   | x-csrf-token                     | null                                                                                                   |
-| 121   | x-csrf-token                     | undefined                                                                                              |
+| 111   | upgrade-insecure-requests        | 1                                                                                                      |
+| 112   | x-served-by                      |                                                                                                        |
+| 113   | x-requested-with                 | xmlhttprequest                                                                                         |
+| 114   | access-control-request-headers   | content-type                                                                                           |
+| 115   | access-control-request-headers   | x-requested-with                                                                                       |
+| 116   | access-control-request-method    | post                                                                                                   |
+| 117   | access-control-request-method    | get                                                                                                    |
+| 118   | purpose                          | prefetch                                                                                               |
+| 119   | x-csrf-token                     | null                                                                                                   |
+| 120   | x-csrf-token                     | undefined                                                                                              |
 
 # Change Log
 

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -117,9 +117,7 @@ addressed.
 ## Static Table {#table-static}
 
 The static table consists of a predefined static list of header fields, each of
-which has a fixed index over time.  Its entries are defined in Appendix A of
-{{!RFC7541}}. Note that because HPACK did not use zero-based references, there
-is no value at index zero of the static table.
+which has a fixed index over time.  Its entries are defined in {{static-table}}.
 
 ## Dynamic Table {#table-dynamic}
 
@@ -1004,6 +1002,133 @@ Description:
 
 --- back
 
+# Static Table
+
+| Index | Name                             | Value                                                                                                  |
+| ----- | -------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| 0     | :path                            | /                                                                                                      |
+| 1     | referer                          |                                                                                                        |
+| 2     | content-length                   | 0                                                                                                      |
+| 3     | date                             |                                                                                                        |
+| 4     | last-modified                    |                                                                                                        |
+| 5     | :authority                       |                                                                                                        |
+| 6     | expires                          |                                                                                                        |
+| 7     | cookie                           |                                                                                                        |
+| 8     | etag                             |                                                                                                        |
+| 9     | location                         |                                                                                                        |
+| 10    | if-modified-since                |                                                                                                        |
+| 11    | if-none-match                    |                                                                                                        |
+| 12    | if-range                         |                                                                                                        |
+| 13    | set-cookie                       |                                                                                                        |
+| 14    | age                              | 0                                                                                                      |
+| 15    | link                             |                                                                                                        |
+| 16    | content-disposition              | attachment; filename="f.txt"                                                                           |
+| 17    | range                            | bytes=0-                                                                                               |
+| 18    | authorization                    |                                                                                                        |
+| 19    | :scheme                          | https                                                                                                  |
+| 20    | :scheme                          | http                                                                                                   |
+| 21    | :status                          | 200                                                                                                    |
+| 22    | :status                          | 304                                                                                                    |
+| 23    | :path                            | /index.html                                                                                            |
+| 24    | :method                          | GET                                                                                                    |
+| 25    | :method                          | HEAD                                                                                                   |
+| 26    | :method                          | POST                                                                                                   |
+| 27    | :method                          | PUT                                                                                                    |
+| 28    | :method                          | DELETE                                                                                                 |
+| 29    | :method                          | CONNECT                                                                                                |
+| 30    | :method                          | OPTIONS                                                                                                |
+| 31    | content-type                     | application/x-www-form-urlencoded                                                                      |
+| 32    | content-type                     | image/jpeg                                                                                             |
+| 33    | content-type                     | text/plain;charset=utf-8                                                                               |
+| 34    | content-type                     | image/png                                                                                              |
+| 35    | content-type                     | text/plain                                                                                             |
+| 36    | content-type                     | application/json                                                                                       |
+| 37    | content-type                     | application/x-www-form-urlencoded; charset=utf-8                                                       |
+| 38    | content-type                     | image/gif                                                                                              |
+| 39    | content-type                     | text/html; charset=utf-8                                                                               |
+| 40    | content-type                     | application/javascript                                                                                 |
+| 41    | content-type                     | text/css                                                                                               |
+| 42    | content-type                     | text/javascript                                                                                        |
+| 43    | content-type                     | application/json; charset=utf-8                                                                        |
+| 44    | content-type                     | text/javascript; charset=utf-8                                                                         |
+| 45    | content-type                     | application/x-javascript                                                                               |
+| 46    | server                           |                                                                                                        |
+| 47    | user-agent                       |                                                                                                        |
+| 48    | accept                           | \*/\*                                                                                                  |
+| 49    | cache-control                    | max-age=0                                                                                              |
+| 50    | cache-control                    | no-cache                                                                                               |
+| 51    | cache-control                    | max-age=2592000                                                                                        |
+| 52    | cache-control                    | public, max-age=31536000                                                                               |
+| 53    | cache-control                    | no-cache, no-store, must-revalidate                                                                    |
+| 54    | cache-control                    | max-age=604800                                                                                         |
+| 55    | accept-encoding                  | gzip, deflate, br                                                                                      |
+| 56    | accept-encoding                  | gzip, deflate                                                                                          |
+| 57    | vary                             | accept-encoding                                                                                        |
+| 58    | vary                             | origin                                                                                                 |
+| 59    | vary                             | accept-encoding,user-agent                                                                             |
+| 60    | vary                             | accept                                                                                                 |
+| 61    | accept-language                  |                                                                                                        |
+| 62    | strict-transport-security        | max-age=31536000                                                                                       |
+| 63    | strict-transport-security        | max-age=10886400; includesubdomains; preload                                                           |
+| 64    | strict-transport-security        | max-age=31536000; includesubdomains                                                                    |
+| 65    | strict-transport-security        | max-age=31536000; includesubdomains; preload                                                           |
+| 66    | :status                          | 100                                                                                                    |
+| 67    | :status                          | 103                                                                                                    |
+| 68    | :status                          | 204                                                                                                    |
+| 69    | :status                          | 206                                                                                                    |
+| 70    | :status                          | 302                                                                                                    |
+| 71    | :status                          | 400                                                                                                    |
+| 72    | :status                          | 403                                                                                                    |
+| 73    | :status                          | 404                                                                                                    |
+| 74    | :status                          | 421                                                                                                    |
+| 75    | :status                          | 500                                                                                                    |
+| 76    | :status                          | 503                                                                                                    |
+| 77    | p3p                              |                                                                                                        |
+| 78    | content-encoding                 | gzip                                                                                                   |
+| 79    | content-encoding                 | br                                                                                                     |
+| 80    | accept-ranges                    | bytes                                                                                                  |
+| 81    | alt-svc                          | clear                                                                                                  |
+| 82    | x-xss-protection                 | 1; mode=block                                                                                          |
+| 83    | host                             |                                                                                                        |
+| 84    | pragma                           | no-cache                                                                                               |
+| 85    | pragma                           | public                                                                                                 |
+| 86    | x-powered-by                     |                                                                                                        |
+| 87    | via                              |                                                                                                        |
+| 88    | access-control-allow-origin      | \*                                                                                                     |
+| 89    | x-content-type-options           | nosniff                                                                                                |
+| 90    | access-control-allow-headers     | content-type                                                                                           |
+| 91    | access-control-allow-headers     | cache-control                                                                                          |
+| 92    | access-control-allow-headers     | x-requested-with                                                                                       |
+| 93    | access-control-allow-headers     | \*                                                                                                     |
+| 94    | access-control-allow-headers     | origin, x-requested-with, content-type, accept                                                         |
+| 95    | access-control-allow-headers     | dnt,x-customheader,keep-alive,user-agent,x-requested-with,if-modified-since,cache-control,content-type |
+| 96    | access-control-allow-headers     | dnt,x-mx-reqtoken,keep-alive,user-agent,x-requested-with,if-modified-since,cache-control,content-type  |
+| 97    | access-control-allow-methods     | options                                                                                                |
+| 98    | access-control-allow-methods     | get                                                                                                    |
+| 99    | access-control-allow-methods     | get, post, options                                                                                     |
+| 100   | access-control-allow-methods     | get, head, options                                                                                     |
+| 101   | access-control-allow-methods     | get, options                                                                                           |
+| 102   | origin                           |                                                                                                        |
+| 103   | x-frame-options                  | sameorigin                                                                                             |
+| 104   | x-frame-options                  | deny                                                                                                   |
+| 105   | timing-allow-origin              | \*                                                                                                     |
+| 106   | access-control-expose-headers    | content-length                                                                                         |
+| 107   | access-control-allow-credentials | TRUE                                                                                                   |
+| 108   | access-control-allow-credentials | FALSE                                                                                                  |
+| 109   | expect-ct                        |                                                                                                        |
+| 110   | content-security-policy          | script-src 'none'; object-src 'none'; base-uri 'none'                                                  |
+| 111   | transfer-encoding                | chunked                                                                                                |
+| 112   | upgrade-insecure-requests        | 1                                                                                                      |
+| 113   | x-served-by                      |                                                                                                        |
+| 114   | x-requested-with                 | xmlhttprequest                                                                                         |
+| 115   | access-control-request-headers   | content-type                                                                                           |
+| 116   | access-control-request-headers   | x-requested-with                                                                                       |
+| 117   | access-control-request-method    | post                                                                                                   |
+| 118   | access-control-request-method    | get                                                                                                    |
+| 119   | purpose                          | prefetch                                                                                               |
+| 120   | x-csrf-token                     | null                                                                                                   |
+| 121   | x-csrf-token                     | undefined                                                                                              |
+
 # Change Log
 
 > **RFC Editor's Note:** Please remove this section prior to publication of a
@@ -1034,7 +1159,6 @@ Description:
 - Added a setting to control the number of blocked decoders (#238, #1140, #1143)
 - Moved table updates and acknowledgments to dedicated streams (#1121, #1122,
   #1238)
-
 
 # Acknowledgments
 {:numbered="false"}

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -1035,13 +1035,13 @@ Description:
 | 26    | :status                          | 304                                                   |
 | 27    | :status                          | 404                                                   |
 | 28    | :status                          | 503                                                   |
-| 29    | accept                           | */*                                                   |
+| 29    | accept                           | \*/\*                                                 |
 | 30    | accept                           | application/dns-message                               |
 | 31    | accept-encoding                  | gzip, deflate, br                                     |
 | 32    | accept-ranges                    | bytes                                                 |
 | 33    | access-control-allow-headers     | cache-control                                         |
 | 34    | access-control-allow-headers     | content-type                                          |
-| 35    | access-control-allow-origin      | *                                                     |
+| 35    | access-control-allow-origin      | \*                                                    |
 | 36    | cache-control                    | max-age=0                                             |
 | 37    | cache-control                    | max-age=2592000                                       |
 | 38    | cache-control                    | max-age=604800                                        |
@@ -1081,7 +1081,7 @@ Description:
 | 72    | accept-language                  |                                                       |
 | 73    | access-control-allow-credentials | FALSE                                                 |
 | 74    | access-control-allow-credentials | TRUE                                                  |
-| 75    | access-control-allow-headers     | *                                                     |
+| 75    | access-control-allow-headers     | \*                                                    |
 | 76    | access-control-allow-headers     | x-requested-with                                      |
 | 77    | access-control-allow-methods     | get                                                   |
 | 78    | access-control-allow-methods     | get, post, options                                    |
@@ -1101,7 +1101,7 @@ Description:
 | 92    | origin                           |                                                       |
 | 93    | purpose                          | prefetch                                              |
 | 94    | server                           |                                                       |
-| 95    | timing-allow-origin              | *                                                     |
+| 95    | timing-allow-origin              | \*                                                    |
 | 96    | upgrade-insecure-requests        | 1                                                     |
 | 97    | user-agent                       |                                                       |
 | 98    | x-forwarded-for                  |                                                       |

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -1043,7 +1043,7 @@ Description:
 | 34    | cache-control                    | no-cache                                              |
 | 35    | cache-control                    | no-cache, no-store, must-revalidate                   |
 | 36    | cache-control                    | public, max-age=31536000                              |
-| 37    | content-disposition              |                                                       |
+| 37    | content-encoding                 | br                                                    |
 | 38    | content-type                     | application/dns-message                               |
 | 39    | content-type                     | application/javascript                                |
 | 40    | content-type                     | application/json                                      |
@@ -1098,23 +1098,22 @@ Description:
 | 89    | access-control-request-method    | get                                                   |
 | 90    | access-control-request-method    | post                                                  |
 | 91    | alt-svc                          | clear                                                 |
-| 92    | content-encoding                 | br                                                    |
-| 93    | content-encoding                 | gzip                                                  |
-| 94    | content-security-policy          | script-src 'none'; object-src 'none'; base-uri 'none' |
-| 95    | early-data                       | 1                                                     |
-| 96    | expect-ct                        |                                                       |
-| 97    | forwarded                        |                                                       |
-| 98    | if-range                         |                                                       |
-| 99    | origin                           |                                                       |
-| 100   | purpose                          | prefetch                                              |
-| 101   | timing-allow-origin              | *                                                     |
-| 102   | upgrade-insecure-requests        | 1                                                     |
-| 103   | x-content-type-options           | nosniff                                               |
-| 104   | x-forwarded-for                  |                                                       |
-| 105   | x-frame-options                  | deny                                                  |
-| 106   | x-frame-options                  | sameorigin                                            |
-| 107   | x-requested-with                 | xmlhttprequest                                        |
-| 108   | x-xss-protection                 | 1; mode=block                                         |
+| 92    | content-encoding                 | gzip                                                  |
+| 93    | content-security-policy          | script-src 'none'; object-src 'none'; base-uri 'none' |
+| 94    | early-data                       | 1                                                     |
+| 95    | expect-ct                        |                                                       |
+| 96    | forwarded                        |                                                       |
+| 97    | if-range                         |                                                       |
+| 98    | origin                           |                                                       |
+| 99    | purpose                          | prefetch                                              |
+| 100   | timing-allow-origin              | *                                                     |
+| 101   | upgrade-insecure-requests        | 1                                                     |
+| 102   | x-content-type-options           | nosniff                                               |
+| 103   | x-forwarded-for                  |                                                       |
+| 104   | x-frame-options                  | deny                                                  |
+| 105   | x-frame-options                  | sameorigin                                            |
+| 106   | x-requested-with                 | xmlhttprequest                                        |
+| 107   | x-xss-protection                 | 1; mode=block                                         |
 
 # Change Log
 

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -1004,129 +1004,117 @@ Description:
 
 # Static Table
 
-| Index | Name                             | Value                                                                                                  |
-| ----- | -------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| 0     | :path                            | /                                                                                                      |
-| 1     | referer                          |                                                                                                        |
-| 2     | content-length                   | 0                                                                                                      |
-| 3     | date                             |                                                                                                        |
-| 4     | last-modified                    |                                                                                                        |
-| 5     | :authority                       |                                                                                                        |
-| 6     | expires                          |                                                                                                        |
-| 7     | cookie                           |                                                                                                        |
-| 8     | etag                             |                                                                                                        |
-| 9     | location                         |                                                                                                        |
-| 10    | if-modified-since                |                                                                                                        |
-| 11    | if-none-match                    |                                                                                                        |
-| 12    | if-range                         |                                                                                                        |
-| 13    | set-cookie                       |                                                                                                        |
-| 14    | age                              | 0                                                                                                      |
-| 15    | link                             |                                                                                                        |
-| 16    | content-disposition              | attachment; filename="f.txt"                                                                           |
-| 17    | range                            | bytes=0-                                                                                               |
-| 18    | authorization                    |                                                                                                        |
-| 19    | :scheme                          | https                                                                                                  |
-| 20    | :scheme                          | http                                                                                                   |
-| 21    | :status                          | 200                                                                                                    |
-| 22    | :status                          | 304                                                                                                    |
-| 23    | :path                            | /index.html                                                                                            |
-| 24    | :method                          | GET                                                                                                    |
-| 25    | :method                          | HEAD                                                                                                   |
-| 26    | :method                          | POST                                                                                                   |
-| 27    | :method                          | PUT                                                                                                    |
-| 28    | :method                          | DELETE                                                                                                 |
-| 29    | :method                          | CONNECT                                                                                                |
-| 30    | :method                          | OPTIONS                                                                                                |
-| 31    | content-type                     | application/x-www-form-urlencoded                                                                      |
-| 32    | content-type                     | image/jpeg                                                                                             |
-| 33    | content-type                     | text/plain;charset=utf-8                                                                               |
-| 34    | content-type                     | image/png                                                                                              |
-| 35    | content-type                     | text/plain                                                                                             |
-| 36    | content-type                     | application/json                                                                                       |
-| 37    | content-type                     | application/x-www-form-urlencoded; charset=utf-8                                                       |
-| 38    | content-type                     | image/gif                                                                                              |
-| 39    | content-type                     | text/html; charset=utf-8                                                                               |
-| 40    | content-type                     | application/javascript                                                                                 |
-| 41    | content-type                     | text/css                                                                                               |
-| 42    | content-type                     | text/javascript                                                                                        |
-| 43    | content-type                     | application/json; charset=utf-8                                                                        |
-| 44    | content-type                     | text/javascript; charset=utf-8                                                                         |
-| 45    | content-type                     | application/x-javascript                                                                               |
-| 46    | server                           |                                                                                                        |
-| 47    | user-agent                       |                                                                                                        |
-| 48    | accept                           | \*/\*                                                                                                  |
-| 49    | cache-control                    | max-age=0                                                                                              |
-| 50    | cache-control                    | no-cache                                                                                               |
-| 51    | cache-control                    | max-age=2592000                                                                                        |
-| 52    | cache-control                    | public, max-age=31536000                                                                               |
-| 53    | cache-control                    | no-cache, no-store, must-revalidate                                                                    |
-| 54    | cache-control                    | max-age=604800                                                                                         |
-| 55    | accept-encoding                  | gzip, deflate, br                                                                                      |
-| 56    | accept-encoding                  | gzip, deflate                                                                                          |
-| 57    | vary                             | accept-encoding                                                                                        |
-| 58    | vary                             | origin                                                                                                 |
-| 59    | vary                             | accept-encoding,user-agent                                                                             |
-| 60    | vary                             | accept                                                                                                 |
-| 61    | accept-language                  |                                                                                                        |
-| 62    | strict-transport-security        | max-age=31536000                                                                                       |
-| 63    | strict-transport-security        | max-age=10886400; includesubdomains; preload                                                           |
-| 64    | strict-transport-security        | max-age=31536000; includesubdomains                                                                    |
-| 65    | strict-transport-security        | max-age=31536000; includesubdomains; preload                                                           |
-| 66    | :status                          | 100                                                                                                    |
-| 67    | :status                          | 103                                                                                                    |
-| 68    | :status                          | 204                                                                                                    |
-| 69    | :status                          | 206                                                                                                    |
-| 70    | :status                          | 302                                                                                                    |
-| 71    | :status                          | 400                                                                                                    |
-| 72    | :status                          | 403                                                                                                    |
-| 73    | :status                          | 404                                                                                                    |
-| 74    | :status                          | 421                                                                                                    |
-| 75    | :status                          | 500                                                                                                    |
-| 76    | :status                          | 503                                                                                                    |
-| 77    | p3p                              |                                                                                                        |
-| 78    | content-encoding                 | gzip                                                                                                   |
-| 79    | content-encoding                 | br                                                                                                     |
-| 80    | accept-ranges                    | bytes                                                                                                  |
-| 81    | alt-svc                          | clear                                                                                                  |
-| 82    | x-xss-protection                 | 1; mode=block                                                                                          |
-| 83    | host                             |                                                                                                        |
-| 84    | pragma                           | no-cache                                                                                               |
-| 85    | pragma                           | public                                                                                                 |
-| 86    | x-powered-by                     |                                                                                                        |
-| 87    | via                              |                                                                                                        |
-| 88    | access-control-allow-origin      | \*                                                                                                     |
-| 89    | x-content-type-options           | nosniff                                                                                                |
-| 90    | access-control-allow-headers     | content-type                                                                                           |
-| 91    | access-control-allow-headers     | cache-control                                                                                          |
-| 92    | access-control-allow-headers     | x-requested-with                                                                                       |
-| 93    | access-control-allow-headers     | \*                                                                                                     |
-| 94    | access-control-allow-headers     | origin, x-requested-with, content-type, accept                                                         |
-| 95    | access-control-allow-headers     | dnt,x-customheader,keep-alive,user-agent,x-requested-with,if-modified-since,cache-control,content-type |
-| 96    | access-control-allow-headers     | dnt,x-mx-reqtoken,keep-alive,user-agent,x-requested-with,if-modified-since,cache-control,content-type  |
-| 97    | access-control-allow-methods     | options                                                                                                |
-| 98    | access-control-allow-methods     | get                                                                                                    |
-| 99    | access-control-allow-methods     | get, post, options                                                                                     |
-| 100   | access-control-allow-methods     | get, head, options                                                                                     |
-| 101   | access-control-allow-methods     | get, options                                                                                           |
-| 102   | origin                           |                                                                                                        |
-| 103   | x-frame-options                  | sameorigin                                                                                             |
-| 104   | x-frame-options                  | deny                                                                                                   |
-| 105   | timing-allow-origin              | \*                                                                                                     |
-| 106   | access-control-expose-headers    | content-length                                                                                         |
-| 107   | access-control-allow-credentials | TRUE                                                                                                   |
-| 108   | access-control-allow-credentials | FALSE                                                                                                  |
-| 109   | expect-ct                        |                                                                                                        |
-| 110   | content-security-policy          | script-src 'none'; object-src 'none'; base-uri 'none'                                                  |
-| 111   | upgrade-insecure-requests        | 1                                                                                                      |
-| 112   | x-served-by                      |                                                                                                        |
-| 113   | x-requested-with                 | xmlhttprequest                                                                                         |
-| 114   | access-control-request-headers   | content-type                                                                                           |
-| 115   | access-control-request-headers   | x-requested-with                                                                                       |
-| 116   | access-control-request-method    | post                                                                                                   |
-| 117   | access-control-request-method    | get                                                                                                    |
-| 118   | purpose                          | prefetch                                                                                               |
-| 119   | x-csrf-token                     | null                                                                                                   |
-| 120   | x-csrf-token                     | undefined                                                                                              |
+| Index | Name                             | Value                                                 |
+| ----- | -------------------------------- | ----------------------------------------------------- |
+| 0     | :authority                       |                                                       |
+| 1     | :path                            | /                                                     |
+| 2     | age                              | 0                                                     |
+| 3     | content-disposition              |                                                       |
+| 4     | content-length                   | 0                                                     |
+| 5     | cookie                           |                                                       |
+| 6     | date                             |                                                       |
+| 7     | etag                             |                                                       |
+| 8     | if-modified-since                |                                                       |
+| 9     | if-none-match                    |                                                       |
+| 10    | last-modified                    |                                                       |
+| 11    | link                             |                                                       |
+| 12    | location                         |                                                       |
+| 13    | referer                          |                                                       |
+| 14    | set-cookie                       |                                                       |
+| 15    | :method                          | CONNECT                                               |
+| 16    | :method                          | DELETE                                                |
+| 17    | :method                          | GET                                                   |
+| 18    | :method                          | HEAD                                                  |
+| 19    | :method                          | OPTIONS                                               |
+| 20    | :method                          | POST                                                  |
+| 21    | :method                          | PUT                                                   |
+| 22    | :scheme                          | http                                                  |
+| 23    | :scheme                          | https                                                 |
+| 24    | :status                          | 200                                                   |
+| 25    | :status                          | 304                                                   |
+| 26    | accept                           | */*                                                   |
+| 27    | accept                           | application/dns-message                               |
+| 28    | accept-encoding                  | gzip, deflate, br                                     |
+| 29    | accept-language                  |                                                       |
+| 30    | authorization                    |                                                       |
+| 31    | cache-control                    | max-age=0                                             |
+| 32    | cache-control                    | max-age=604800                                        |
+| 33    | cache-control                    | max-age=2592000                                       |
+| 34    | cache-control                    | no-cache                                              |
+| 35    | cache-control                    | no-cache, no-store, must-revalidate                   |
+| 36    | cache-control                    | public, max-age=31536000                              |
+| 37    | content-disposition              |                                                       |
+| 38    | content-type                     | application/dns-message                               |
+| 39    | content-type                     | application/javascript                                |
+| 40    | content-type                     | application/json                                      |
+| 41    | content-type                     | application/json; charset=utf-8                       |
+| 42    | content-type                     | application/x-www-form-urlencoded                     |
+| 43    | content-type                     | application/x-www-form-urlencoded; charset=utf-8      |
+| 44    | content-type                     | image/gif                                             |
+| 45    | content-type                     | image/jpeg                                            |
+| 46    | content-type                     | image/png                                             |
+| 47    | content-type                     | text/css                                              |
+| 48    | content-type                     | text/html; charset=utf-8                              |
+| 49    | content-type                     | text/javascript                                       |
+| 50    | content-type                     | text/javascript; charset=utf-8                        |
+| 51    | content-type                     | text/plain                                            |
+| 52    | content-type                     | text/plain;charset=utf-8                              |
+| 53    | range                            | bytes=0-                                              |
+| 54    | server                           |                                                       |
+| 55    | strict-transport-security        | max-age=10886400; includesubdomains; preload          |
+| 56    | strict-transport-security        | max-age=31536000                                      |
+| 57    | strict-transport-security        | max-age=31536000; includesubdomains                   |
+| 58    | strict-transport-security        | max-age=31536000; includesubdomains; preload          |
+| 59    | user-agent                       |                                                       |
+| 60    | vary                             | accept-encoding                                       |
+| 61    | vary                             | accept-encoding, user-agent                           |
+| 62    | vary                             | origin                                                |
+| 63    | :status                          | 100                                                   |
+| 64    | :status                          | 103                                                   |
+| 65    | :status                          | 204                                                   |
+| 66    | :status                          | 206                                                   |
+| 67    | :status                          | 302                                                   |
+| 68    | :status                          | 400                                                   |
+| 69    | :status                          | 403                                                   |
+| 70    | :status                          | 404                                                   |
+| 71    | :status                          | 421                                                   |
+| 72    | :status                          | 425                                                   |
+| 73    | :status                          | 500                                                   |
+| 74    | :status                          | 503                                                   |
+| 75    | accept-ranges                    | bytes                                                 |
+| 76    | access-control-allow-credentials | FALSE                                                 |
+| 77    | access-control-allow-credentials | TRUE                                                  |
+| 78    | access-control-allow-headers     | *                                                     |
+| 79    | access-control-allow-headers     | cache-control                                         |
+| 80    | access-control-allow-headers     | content-type                                          |
+| 81    | access-control-allow-headers     | x-requested-with                                      |
+| 82    | access-control-allow-methods     | get                                                   |
+| 83    | access-control-allow-methods     | get, post, options                                    |
+| 84    | access-control-allow-methods     | options                                               |
+| 85    | access-control-allow-origin      | *                                                     |
+| 86    | access-control-expose-headers    | content-length                                        |
+| 87    | access-control-request-headers   | content-type                                          |
+| 88    | access-control-request-headers   | x-requested-with                                      |
+| 89    | access-control-request-method    | get                                                   |
+| 90    | access-control-request-method    | post                                                  |
+| 91    | alt-svc                          | clear                                                 |
+| 92    | content-encoding                 | br                                                    |
+| 93    | content-encoding                 | gzip                                                  |
+| 94    | content-security-policy          | script-src 'none'; object-src 'none'; base-uri 'none' |
+| 95    | early-data                       | 1                                                     |
+| 96    | expect-ct                        |                                                       |
+| 97    | forwarded                        |                                                       |
+| 98    | if-range                         |                                                       |
+| 99    | origin                           |                                                       |
+| 100   | purpose                          | prefetch                                              |
+| 101   | timing-allow-origin              | *                                                     |
+| 102   | upgrade-insecure-requests        | 1                                                     |
+| 103   | x-content-type-options           | nosniff                                               |
+| 104   | x-forwarded-for                  |                                                       |
+| 105   | x-frame-options                  | deny                                                  |
+| 106   | x-frame-options                  | sameorigin                                            |
+| 107   | x-requested-with                 | xmlhttprequest                                        |
+| 108   | x-xss-protection                 | 1; mode=block                                         |
 
 # Change Log
 

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -1082,32 +1082,29 @@ Description:
 | 73    | access-control-allow-credentials | FALSE                                                 |
 | 74    | access-control-allow-credentials | TRUE                                                  |
 | 75    | access-control-allow-headers     | \*                                                    |
-| 76    | access-control-allow-headers     | x-requested-with                                      |
-| 77    | access-control-allow-methods     | get                                                   |
-| 78    | access-control-allow-methods     | get, post, options                                    |
-| 79    | access-control-allow-methods     | options                                               |
-| 80    | access-control-expose-headers    | content-length                                        |
-| 81    | access-control-request-headers   | content-type                                          |
-| 82    | access-control-request-headers   | x-requested-with                                      |
-| 83    | access-control-request-method    | get                                                   |
-| 84    | access-control-request-method    | post                                                  |
-| 85    | alt-svc                          | clear                                                 |
-| 86    | authorization                    |                                                       |
-| 87    | content-security-policy          | script-src 'none'; object-src 'none'; base-uri 'none' |
-| 88    | early-data                       | 1                                                     |
-| 89    | expect-ct                        |                                                       |
-| 90    | forwarded                        |                                                       |
-| 91    | if-range                         |                                                       |
-| 92    | origin                           |                                                       |
-| 93    | purpose                          | prefetch                                              |
-| 94    | server                           |                                                       |
-| 95    | timing-allow-origin              | \*                                                    |
-| 96    | upgrade-insecure-requests        | 1                                                     |
-| 97    | user-agent                       |                                                       |
-| 98    | x-forwarded-for                  |                                                       |
-| 99    | x-frame-options                  | deny                                                  |
-| 100   | x-frame-options                  | sameorigin                                            |
-| 101   | x-requested-with                 | xmlhttprequest                                        |
+| 76    | access-control-allow-methods     | get                                                   |
+| 77    | access-control-allow-methods     | get, post, options                                    |
+| 78    | access-control-allow-methods     | options                                               |
+| 79    | access-control-expose-headers    | content-length                                        |
+| 80    | access-control-request-headers   | content-type                                          |
+| 81    | access-control-request-method    | get                                                   |
+| 82    | access-control-request-method    | post                                                  |
+| 83    | alt-svc                          | clear                                                 |
+| 84    | authorization                    |                                                       |
+| 85    | content-security-policy          | script-src 'none'; object-src 'none'; base-uri 'none' |
+| 86    | early-data                       | 1                                                     |
+| 87    | expect-ct                        |                                                       |
+| 88    | forwarded                        |                                                       |
+| 89    | if-range                         |                                                       |
+| 90    | origin                           |                                                       |
+| 91    | purpose                          | prefetch                                              |
+| 92    | server                           |                                                       |
+| 93    | timing-allow-origin              | \*                                                    |
+| 94    | upgrade-insecure-requests        | 1                                                     |
+| 95    | user-agent                       |                                                       |
+| 96    | x-forwarded-for                  |                                                       |
+| 97    | x-frame-options                  | deny                                                  |
+| 98    | x-frame-options                  | sameorigin                                            |
 
 # Change Log
 

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -1030,90 +1030,84 @@ Description:
 | 21    | :method                          | PUT                                                   |
 | 22    | :scheme                          | http                                                  |
 | 23    | :scheme                          | https                                                 |
-| 24    | :status                          | 200                                                   |
-| 25    | :status                          | 304                                                   |
-| 26    | accept                           | */*                                                   |
-| 27    | accept                           | application/dns-message                               |
-| 28    | accept-encoding                  | gzip, deflate, br                                     |
-| 29    | accept-language                  |                                                       |
-| 30    | authorization                    |                                                       |
-| 31    | cache-control                    | max-age=0                                             |
-| 32    | cache-control                    | max-age=604800                                        |
-| 33    | cache-control                    | max-age=2592000                                       |
-| 34    | cache-control                    | no-cache                                              |
-| 35    | cache-control                    | no-cache, no-store, must-revalidate                   |
-| 36    | cache-control                    | public, max-age=31536000                              |
-| 37    | content-encoding                 | br                                                    |
-| 38    | content-type                     | application/dns-message                               |
-| 39    | content-type                     | application/javascript                                |
-| 40    | content-type                     | application/json                                      |
-| 41    | content-type                     | application/json; charset=utf-8                       |
-| 42    | content-type                     | application/x-www-form-urlencoded                     |
-| 43    | content-type                     | application/x-www-form-urlencoded; charset=utf-8      |
-| 44    | content-type                     | image/gif                                             |
-| 45    | content-type                     | image/jpeg                                            |
-| 46    | content-type                     | image/png                                             |
-| 47    | content-type                     | text/css                                              |
-| 48    | content-type                     | text/html; charset=utf-8                              |
-| 49    | content-type                     | text/javascript                                       |
-| 50    | content-type                     | text/javascript; charset=utf-8                        |
-| 51    | content-type                     | text/plain                                            |
-| 52    | content-type                     | text/plain;charset=utf-8                              |
-| 53    | range                            | bytes=0-                                              |
-| 54    | server                           |                                                       |
-| 55    | strict-transport-security        | max-age=10886400; includesubdomains; preload          |
+| 24    | :status                          | 103                                                   |
+| 25    | :status                          | 200                                                   |
+| 26    | :status                          | 304                                                   |
+| 27    | :status                          | 404                                                   |
+| 28    | :status                          | 503                                                   |
+| 29    | accept                           | */*                                                   |
+| 30    | accept                           | application/dns-message                               |
+| 31    | accept-encoding                  | gzip, deflate, br                                     |
+| 32    | accept-ranges                    | bytes                                                 |
+| 33    | access-control-allow-headers     | cache-control                                         |
+| 34    | access-control-allow-headers     | content-type                                          |
+| 35    | access-control-allow-origin      | *                                                     |
+| 36    | cache-control                    | max-age=0                                             |
+| 37    | cache-control                    | max-age=2592000                                       |
+| 38    | cache-control                    | max-age=604800                                        |
+| 39    | cache-control                    | no-cache                                              |
+| 40    | cache-control                    | no-store                                              |
+| 41    | cache-control                    | public, max-age=31536000                              |
+| 42    | content-encoding                 | br                                                    |
+| 43    | content-encoding                 | gzip                                                  |
+| 44    | content-type                     | application/dns-message                               |
+| 45    | content-type                     | application/javascript                                |
+| 46    | content-type                     | application/json                                      |
+| 47    | content-type                     | application/x-www-form-urlencoded                     |
+| 48    | content-type                     | image/gif                                             |
+| 49    | content-type                     | image/jpeg                                            |
+| 50    | content-type                     | image/png                                             |
+| 51    | content-type                     | text/css                                              |
+| 52    | content-type                     | text/html; charset=utf-8                              |
+| 53    | content-type                     | text/plain                                            |
+| 54    | content-type                     | text/plain;charset=utf-8                              |
+| 55    | range                            | bytes=0-                                              |
 | 56    | strict-transport-security        | max-age=31536000                                      |
 | 57    | strict-transport-security        | max-age=31536000; includesubdomains                   |
 | 58    | strict-transport-security        | max-age=31536000; includesubdomains; preload          |
-| 59    | user-agent                       |                                                       |
-| 60    | vary                             | accept-encoding                                       |
-| 61    | vary                             | accept-encoding, user-agent                           |
-| 62    | vary                             | origin                                                |
+| 59    | vary                             | accept-encoding                                       |
+| 60    | vary                             | origin                                                |
+| 61    | x-content-type-options           | nosniff                                               |
+| 62    | x-xss-protection                 | 1; mode=block                                         |
 | 63    | :status                          | 100                                                   |
-| 64    | :status                          | 103                                                   |
-| 65    | :status                          | 204                                                   |
-| 66    | :status                          | 206                                                   |
-| 67    | :status                          | 302                                                   |
-| 68    | :status                          | 400                                                   |
-| 69    | :status                          | 403                                                   |
-| 70    | :status                          | 404                                                   |
-| 71    | :status                          | 421                                                   |
-| 72    | :status                          | 425                                                   |
-| 73    | :status                          | 500                                                   |
-| 74    | :status                          | 503                                                   |
-| 75    | accept-ranges                    | bytes                                                 |
-| 76    | access-control-allow-credentials | FALSE                                                 |
-| 77    | access-control-allow-credentials | TRUE                                                  |
-| 78    | access-control-allow-headers     | *                                                     |
-| 79    | access-control-allow-headers     | cache-control                                         |
-| 80    | access-control-allow-headers     | content-type                                          |
-| 81    | access-control-allow-headers     | x-requested-with                                      |
-| 82    | access-control-allow-methods     | get                                                   |
-| 83    | access-control-allow-methods     | get, post, options                                    |
-| 84    | access-control-allow-methods     | options                                               |
-| 85    | access-control-allow-origin      | *                                                     |
-| 86    | access-control-expose-headers    | content-length                                        |
-| 87    | access-control-request-headers   | content-type                                          |
-| 88    | access-control-request-headers   | x-requested-with                                      |
-| 89    | access-control-request-method    | get                                                   |
-| 90    | access-control-request-method    | post                                                  |
-| 91    | alt-svc                          | clear                                                 |
-| 92    | content-encoding                 | gzip                                                  |
-| 93    | content-security-policy          | script-src 'none'; object-src 'none'; base-uri 'none' |
-| 94    | early-data                       | 1                                                     |
-| 95    | expect-ct                        |                                                       |
-| 96    | forwarded                        |                                                       |
-| 97    | if-range                         |                                                       |
-| 98    | origin                           |                                                       |
-| 99    | purpose                          | prefetch                                              |
-| 100   | timing-allow-origin              | *                                                     |
-| 101   | upgrade-insecure-requests        | 1                                                     |
-| 102   | x-content-type-options           | nosniff                                               |
-| 103   | x-forwarded-for                  |                                                       |
-| 104   | x-frame-options                  | deny                                                  |
-| 105   | x-frame-options                  | sameorigin                                            |
-| 106   | x-requested-with                 | xmlhttprequest                                        |
-| 107   | x-xss-protection                 | 1; mode=block                                         |
+| 64    | :status                          | 204                                                   |
+| 65    | :status                          | 206                                                   |
+| 66    | :status                          | 302                                                   |
+| 67    | :status                          | 400                                                   |
+| 68    | :status                          | 403                                                   |
+| 69    | :status                          | 421                                                   |
+| 70    | :status                          | 425                                                   |
+| 71    | :status                          | 500                                                   |
+| 72    | accept-language                  |                                                       |
+| 73    | access-control-allow-credentials | FALSE                                                 |
+| 74    | access-control-allow-credentials | TRUE                                                  |
+| 75    | access-control-allow-headers     | *                                                     |
+| 76    | access-control-allow-headers     | x-requested-with                                      |
+| 77    | access-control-allow-methods     | get                                                   |
+| 78    | access-control-allow-methods     | get, post, options                                    |
+| 79    | access-control-allow-methods     | options                                               |
+| 80    | access-control-expose-headers    | content-length                                        |
+| 81    | access-control-request-headers   | content-type                                          |
+| 82    | access-control-request-headers   | x-requested-with                                      |
+| 83    | access-control-request-method    | get                                                   |
+| 84    | access-control-request-method    | post                                                  |
+| 85    | alt-svc                          | clear                                                 |
+| 86    | authorization                    |                                                       |
+| 87    | content-security-policy          | script-src 'none'; object-src 'none'; base-uri 'none' |
+| 88    | early-data                       | 1                                                     |
+| 89    | expect-ct                        |                                                       |
+| 90    | forwarded                        |                                                       |
+| 91    | if-range                         |                                                       |
+| 92    | origin                           |                                                       |
+| 93    | purpose                          | prefetch                                              |
+| 94    | server                           |                                                       |
+| 95    | timing-allow-origin              | *                                                     |
+| 96    | upgrade-insecure-requests        | 1                                                     |
+| 97    | user-agent                       |                                                       |
+| 98    | x-forwarded-for                  |                                                       |
+| 99    | x-frame-options                  | deny                                                  |
+| 100   | x-frame-options                  | sameorigin                                            |
+| 101   | x-requested-with                 | xmlhttprequest                                        |
 
 # Change Log
 


### PR DESCRIPTION
Fixes #904.

Takes a snapshot of the current draft on the wiki and turns it into a PR.

One open issue:  The txt output squeezes the "index" column enough that three-digit indices wrap the third digit.  If anyone knows how to coerce the table layout in kramdown-rfc2629, that would be great.

If it's easier for review purposes, you can also view this [here](https://quicwg.github.io/base-drafts/qpack_static/draft-ietf-quic-qpack.html#rfc.appendix.A).