### PR TITLE
This is what you get from reading Python docs

### DIFF
--- a/.lint.py
+++ b/.lint.py
@@ -16,7 +16,7 @@ foundError = False
 for inputfile in args.files:
     insideFigure = False
     beforeAbstract = True
-    with open(inputfile, mode='t', newline=None, encoding='utf-8') as draft:
+    with open(inputfile, mode='rt', newline=None, encoding='utf-8') as draft:
         linecounter = 1
         lines = draft.readlines()
 

--- a/.lint.py
+++ b/.lint.py
@@ -16,7 +16,7 @@ foundError = False
 for inputfile in args.files:
     insideFigure = False
     beforeAbstract = True
-    with open(inputfile, 'U') as draft:
+    with open(inputfile, mode='t', newline=None, encoding='utf-8') as draft:
         linecounter = 1
         lines = draft.readlines()
 


### PR DESCRIPTION
The stream 0 design team produced a file with smart quotes, which builds fine on most systems, but not all.  That was valid UTF-8, which is a common default.  However, it turns out that the CI system was configured with a different default encoding.  I read the docs, and it seems like it might be a good idea to be more explicit about the things we care about: text mode, "universal" line endings, and UTF-8.