### PR TITLE
Acknowledge stream resets too

### DIFF
--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -508,7 +508,7 @@ already reached the decoder's limit for blocked streams.
 | 1 |     Insert Count (7+)     |
 +---+---------------------------+
 ~~~~~~~~~~
-{:#fig-size-sync title="Table Size Synchronize"}
+{:#fig-size-sync title="Table State Synchronize"}
 
 ### Header Acknowledgement
 
@@ -534,7 +534,7 @@ blocks within a stream have been fully processed.
 
 An encoder MUST treat receipt of a Header Acknowledgment as also acknowledging
 any dynamic table entries that the header block referenced.  That is, this
-instruction is also processed as a Table Size Synchronize instruction with a
+instruction is also processed as a Table State Synchronize instruction with a
 value matching the Largest Reference of the corresponding header block.
 
 A decoder MUST track increases to the largest acknowledged dynamic table entry

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -491,7 +491,14 @@ instruction begins with the '1' one-bit pattern. The instruction specifies the
 total number of dynamic table inserts and duplications since the last Table
 State Synchronize, encoded as a 7-bit prefix integer.  The encoder uses this
 value to determine which table entries are vulnerable to head-of-line blocking.
-A decoder MAY coalesce multiple synchronization updates into a single update.
+
+A decoder MAY coalesce multiple synchronization updates into a single update.  A
+decoder MAY rely on Header Acknowledgement instructions to indirectly
+acknowledge changes to the dynamic table.  Relying on Header Acknowledgment
+instructions exclusively leads to blocking if the encoder waits for an entry to
+be acknowledged before using it.  This happens if the encoder wants to avoid the
+risk of blocking at the decoder, or the decoder sets the
+SETTINGS_QPACK_BLOCKED_STREAMS lower than the number of active streams.
 
 ~~~~~~~~~~ drawing
   0   1   2   3   4   5   6   7
@@ -522,6 +529,12 @@ blocks within a stream have been fully processed.
 +---+---------------------------+
 ~~~~~~~~~~
 {:#fig-header-ack title="Header Acknowledgement"}
+
+An encoder MUST treat receipt of a Header Acknowledgment as also acknowledging
+any dynamic table entries that the header block referenced.  That is, this
+instruction is also processed as a Table Size Synchronize instruction with a
+value matching the Largest Reference of the corresponding header block.
+
 
 ## Request and Push Streams
 

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -487,10 +487,10 @@ server's header blocks and table updates.
 
 After processing a set of instructions on the encoder stream, the decoder will
 emit a Table State Synchronize instruction on the decoder stream.  The
-instruction begins with the '1' one-bit pattern. The instruction specifies the
+instruction begins with the '10' two-bit pattern. The instruction specifies the
 total number of dynamic table inserts and duplications since the last Table
 State Synchronize or Header Acknowledgement that increased the largest
-acknolwedged dynamic table entry.  This is encoded as a 7-bit prefix integer.
+acknowledged dynamic table entry.  This is encoded as a 6-bit prefix integer.
 The encoder uses this value to determine which table entries are vulnerable to
 head-of-line blocking.
 
@@ -505,8 +505,8 @@ already reached the decoder's limit for blocked streams.
 ~~~~~~~~~~ drawing
   0   1   2   3   4   5   6   7
 +---+---+---+---+---+---+---+---+
-| 1 |     Insert Count (7+)     |
-+---+---------------------------+
+| 1 | 0 |   Insert Count (6+)   |
++---+---+-----------------------+
 ~~~~~~~~~~
 {:#fig-size-sync title="Table State Synchronize"}
 
@@ -540,6 +540,28 @@ value matching the Largest Reference of the corresponding header block.
 A decoder MUST track increases to the largest acknowledged dynamic table entry
 caused by acknowledging a header block so that it can correctly generate the
 Table State Synchronize instruction.
+
+
+### Stream Reset Acknowledgement
+
+A stream that is reset might have multiple outstanding header blocks.  A decoder
+that receives a stream reset before the end of a stream generates a Stream Reset
+Acknowledgment instruction on the decoder stream.  This signals to the encoder
+that any references to the dynamic table are no longer outstanding.
+
+An encoder cannot infer from this acknowledgement that any dynamic table entries
+referenced have been received.
+
+The instruction begins with the '11' two-bit pattern. The instruction includes
+the request stream's stream ID, encoded as a 6-bit prefix integer.
+
+~~~~~~~~~~ drawing
+  0   1   2   3   4   5   6   7
++---+---+---+---+---+---+---+---+
+| 1 | 0 |     Stream ID (6+)    |
++---+---+-----------------------+
+~~~~~~~~~~
+{:#fig-stream-reset title="Stream Reset Acknowledgement"}
 
 
 ## Request and Push Streams

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -551,8 +551,8 @@ abandons reading of a stream needs to signal this using the Stream Cancellation
 instruction.  This signals to the encoder that all references to the dynamic
 table on that stream are no longer outstanding.
 
-An encoder cannot infer from this acknowledgement that any dynamic table entries
-referenced have been received.
+An encoder cannot infer from this acknowledgement that any updates to the
+dynamic table have been received.
 
 The instruction begins with the '11' two-bit pattern. The instruction includes
 the stream ID of the affected stream - a request or push stream - encoded as a

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -489,16 +489,18 @@ After processing a set of instructions on the encoder stream, the decoder will
 emit a Table State Synchronize instruction on the decoder stream.  The
 instruction begins with the '1' one-bit pattern. The instruction specifies the
 total number of dynamic table inserts and duplications since the last Table
-State Synchronize, encoded as a 7-bit prefix integer.  The encoder uses this
-value to determine which table entries are vulnerable to head-of-line blocking.
+State Synchronize or Header Acknowledgement that increased the largest
+acknolwedged dynamic table entry.  This is encoded as a 7-bit prefix integer.
+The encoder uses this value to determine which table entries are vulnerable to
+head-of-line blocking.
 
 A decoder MAY coalesce multiple synchronization updates into a single update.  A
 decoder MAY rely on Header Acknowledgement instructions to indirectly
 acknowledge changes to the dynamic table.  Relying on Header Acknowledgment
-instructions exclusively leads to blocking if the encoder waits for an entry to
-be acknowledged before using it.  This happens if the encoder wants to avoid the
-risk of blocking at the decoder, or the decoder sets the
-SETTINGS_QPACK_BLOCKED_STREAMS lower than the number of active streams.
+instructions exclusively leads to poor compression efficiency if the encoder
+waits for an entry to be acknowledged before using it.  This happens if the
+encoder wants to avoid the risk of blocking at the decoder, or the encoder has
+already reached the decoder's limit for blocked streams.
 
 ~~~~~~~~~~ drawing
   0   1   2   3   4   5   6   7

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -537,6 +537,10 @@ any dynamic table entries that the header block referenced.  That is, this
 instruction is also processed as a Table Size Synchronize instruction with a
 value matching the Largest Reference of the corresponding header block.
 
+A decoder MUST track increases to the largest acknowledged dynamic table entry
+caused by acknowledging a header block so that it can correctly generate the
+Table State Synchronize instruction.
+
 
 ## Request and Push Streams
 

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -558,7 +558,7 @@ the request stream's stream ID, encoded as a 6-bit prefix integer.
 ~~~~~~~~~~ drawing
   0   1   2   3   4   5   6   7
 +---+---+---+---+---+---+---+---+
-| 1 | 0 |     Stream ID (6+)    |
+| 1 | 1 |     Stream ID (6+)    |
 +---+---+-----------------------+
 ~~~~~~~~~~
 {:#fig-stream-reset title="Stream Reset Acknowledgement"}

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -542,18 +542,21 @@ caused by acknowledging a header block so that it can correctly generate the
 Table State Synchronize instruction.
 
 
-### Stream Reset Acknowledgement
+### Stream Cancellation
 
 A stream that is reset might have multiple outstanding header blocks.  A decoder
-that receives a stream reset before the end of a stream generates a Stream Reset
-Acknowledgment instruction on the decoder stream.  This signals to the encoder
-that any references to the dynamic table are no longer outstanding.
+that receives a stream reset before the end of a stream generates a Stream
+Cancellation instruction on the decoder stream.  Similarly, a decoder that
+abandons reading of a stream need to signal this using the Stream Cancellation
+instruction.  This signals to the encoder that all references to the dynamic
+table on that stream are no longer outstanding.
 
 An encoder cannot infer from this acknowledgement that any dynamic table entries
 referenced have been received.
 
 The instruction begins with the '11' two-bit pattern. The instruction includes
-the request stream's stream ID, encoded as a 6-bit prefix integer.
+the stream ID of the affected stream - a request or push stream - encoded as a
+6-bit prefix integer.
 
 ~~~~~~~~~~ drawing
   0   1   2   3   4   5   6   7
@@ -561,7 +564,7 @@ the request stream's stream ID, encoded as a 6-bit prefix integer.
 | 1 | 1 |     Stream ID (6+)    |
 +---+---+-----------------------+
 ~~~~~~~~~~
-{:#fig-stream-reset title="Stream Reset Acknowledgement"}
+{:#fig-stream-cancel title="Stream Cancellation"}
 
 
 ## Request and Push Streams

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -547,7 +547,7 @@ Table State Synchronize instruction.
 A stream that is reset might have multiple outstanding header blocks.  A decoder
 that receives a stream reset before the end of a stream generates a Stream
 Cancellation instruction on the decoder stream.  Similarly, a decoder that
-abandons reading of a stream need to signal this using the Stream Cancellation
+abandons reading of a stream needs to signal this using the Stream Cancellation
 instruction.  This signals to the encoder that all references to the dynamic
 table on that stream are no longer outstanding.
 

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -551,8 +551,8 @@ abandons reading of a stream needs to signal this using the Stream Cancellation
 instruction.  This signals to the encoder that all references to the dynamic
 table on that stream are no longer outstanding.
 
-An encoder cannot infer from this acknowledgement that any updates to the
-dynamic table have been received.
+An encoder cannot infer from this instruction that any updates to the dynamic
+table have been received.
 
 The instruction begins with the '11' two-bit pattern. The instruction includes
 the stream ID of the affected stream - a request or push stream - encoded as a


### PR DESCRIPTION
This builds on #1399, because I realized that it would be good to point out that there is no implicit acknowledgment of header table updates here.

Closes #1371.