### PR TITLE
Describe QPACK Feedback mechanisms

### DIFF
--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -508,7 +508,7 @@ already reached the decoder's limit for blocked streams.
 | 1 |     Insert Count (7+)     |
 +---+---------------------------+
 ~~~~~~~~~~
-{:#fig-size-sync title="Table Size Synchronize"}
+{:#fig-size-sync title="Table State Synchronize"}
 
 ### Header Acknowledgement
 
@@ -534,7 +534,7 @@ blocks within a stream have been fully processed.
 
 An encoder MUST treat receipt of a Header Acknowledgment as also acknowledging
 any dynamic table entries that the header block referenced.  That is, this
-instruction is also processed as a Table Size Synchronize instruction with a
+instruction is also processed as a Table State Synchronize instruction with a
 value matching the Largest Reference of the corresponding header block.
 
 A decoder MUST track increases to the largest acknowledged dynamic table entry

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -529,14 +529,14 @@ entries might cause a stream to become blocked, as described in
 ~~~~~~~~~~
 {:#fig-size-sync title="Table State Synchronize"}
 
-A decoder SHOULD emit a Table State Synchronize after receiving new dynamic
-table entries if the most recently inserted entry was not the Largest Reference
-of a blocked stream.  Decoders which support blocking MAY delay this instruction
-briefly to see if new header blocks arrive which reference the new entries, but
-this leads to reduced compression efficiency if the encoder waits for an entry
-to be acknowledged before using it.  This happens if the encoder wants to avoid
-the risk of blocking at the decoder, or the encoder has already reached the
-decoder's limit for blocked streams.
+A decoder chooses when to emit Table State Synchronize instructions. Emitting a
+Table State Synchronize after adding each new dynamic table entry will provide
+the most timely feedback to the encoder, but could be redundant with other
+decoder feedback. By delaying a Table State Synchronize, a decoder might be able
+to coalesce multiple Table State Synchronize instructions, or replace them
+entirely with Header Acknowledgements. However, delaying too long may lead to
+compression inefficiencies if the encoder waits for an entry to be acknowledged
+before using it.
 
 ### Header Acknowledgement
 

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -491,7 +491,14 @@ instruction begins with the '1' one-bit pattern. The instruction specifies the
 total number of dynamic table inserts and duplications since the last Table
 State Synchronize, encoded as a 7-bit prefix integer.  The encoder uses this
 value to determine which table entries are vulnerable to head-of-line blocking.
-A decoder MAY coalesce multiple synchronization updates into a single update.
+
+A decoder MAY coalesce multiple synchronization updates into a single update.  A
+decoder MAY rely on Header Acknowledgement instructions to indirectly
+acknowledge changes to the dynamic table.  Relying on Header Acknowledgment
+instructions exclusively leads to blocking if the encoder waits for an entry to
+be acknowledged before using it.  This happens if the encoder wants to avoid the
+risk of blocking at the decoder, or the decoder sets the
+SETTINGS_QPACK_BLOCKED_STREAMS lower than the number of active streams.
 
 ~~~~~~~~~~ drawing
   0   1   2   3   4   5   6   7
@@ -522,6 +529,12 @@ blocks within a stream have been fully processed.
 +---+---------------------------+
 ~~~~~~~~~~
 {:#fig-header-ack title="Header Acknowledgement"}
+
+An encoder MUST treat receipt of a Header Acknowledgment as also acknowledging
+any dynamic table entries that the header block referenced.  That is, this
+instruction is also processed as a Table Size Synchronize instruction with a
+value matching the Largest Reference of the corresponding header block.
+
 
 ## Request and Push Streams
 

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -487,10 +487,10 @@ server's header blocks and table updates.
 
 After processing a set of instructions on the encoder stream, the decoder will
 emit a Table State Synchronize instruction on the decoder stream.  The
-instruction begins with the '1' one-bit pattern. The instruction specifies the
+instruction begins with the '10' two-bit pattern. The instruction specifies the
 total number of dynamic table inserts and duplications since the last Table
 State Synchronize or Header Acknowledgement that increased the largest
-acknolwedged dynamic table entry.  This is encoded as a 7-bit prefix integer.
+acknowledged dynamic table entry.  This is encoded as a 6-bit prefix integer.
 The encoder uses this value to determine which table entries are vulnerable to
 head-of-line blocking.
 
@@ -505,8 +505,8 @@ already reached the decoder's limit for blocked streams.
 ~~~~~~~~~~ drawing
   0   1   2   3   4   5   6   7
 +---+---+---+---+---+---+---+---+
-| 1 |     Insert Count (7+)     |
-+---+---------------------------+
+| 1 | 0 |   Insert Count (6+)   |
++---+---+-----------------------+
 ~~~~~~~~~~
 {:#fig-size-sync title="Table State Synchronize"}
 
@@ -540,6 +540,28 @@ value matching the Largest Reference of the corresponding header block.
 A decoder MUST track increases to the largest acknowledged dynamic table entry
 caused by acknowledging a header block so that it can correctly generate the
 Table State Synchronize instruction.
+
+
+### Stream Reset Acknowledgement
+
+A stream that is reset might have multiple outstanding header blocks.  A decoder
+that receives a stream reset before the end of a stream generates a Stream Reset
+Acknowledgment instruction on the decoder stream.  This signals to the encoder
+that any references to the dynamic table are no longer outstanding.
+
+An encoder cannot infer from this acknowledgement that any dynamic table entries
+referenced have been received.
+
+The instruction begins with the '11' two-bit pattern. The instruction includes
+the request stream's stream ID, encoded as a 6-bit prefix integer.
+
+~~~~~~~~~~ drawing
+  0   1   2   3   4   5   6   7
++---+---+---+---+---+---+---+---+
+| 1 | 0 |     Stream ID (6+)    |
++---+---+-----------------------+
+~~~~~~~~~~
+{:#fig-stream-reset title="Stream Reset Acknowledgement"}
 
 
 ## Request and Push Streams

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -551,8 +551,8 @@ abandons reading of a stream needs to signal this using the Stream Cancellation
 instruction.  This signals to the encoder that all references to the dynamic
 table on that stream are no longer outstanding.
 
-An encoder cannot infer from this acknowledgement that any dynamic table entries
-referenced have been received.
+An encoder cannot infer from this acknowledgement that any updates to the
+dynamic table have been received.
 
 The instruction begins with the '11' two-bit pattern. The instruction includes
 the stream ID of the affected stream - a request or push stream - encoded as a

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -489,16 +489,18 @@ After processing a set of instructions on the encoder stream, the decoder will
 emit a Table State Synchronize instruction on the decoder stream.  The
 instruction begins with the '1' one-bit pattern. The instruction specifies the
 total number of dynamic table inserts and duplications since the last Table
-State Synchronize, encoded as a 7-bit prefix integer.  The encoder uses this
-value to determine which table entries are vulnerable to head-of-line blocking.
+State Synchronize or Header Acknowledgement that increased the largest
+acknolwedged dynamic table entry.  This is encoded as a 7-bit prefix integer.
+The encoder uses this value to determine which table entries are vulnerable to
+head-of-line blocking.
 
 A decoder MAY coalesce multiple synchronization updates into a single update.  A
 decoder MAY rely on Header Acknowledgement instructions to indirectly
 acknowledge changes to the dynamic table.  Relying on Header Acknowledgment
-instructions exclusively leads to blocking if the encoder waits for an entry to
-be acknowledged before using it.  This happens if the encoder wants to avoid the
-risk of blocking at the decoder, or the decoder sets the
-SETTINGS_QPACK_BLOCKED_STREAMS lower than the number of active streams.
+instructions exclusively leads to poor compression efficiency if the encoder
+waits for an entry to be acknowledged before using it.  This happens if the
+encoder wants to avoid the risk of blocking at the decoder, or the encoder has
+already reached the decoder's limit for blocked streams.
 
 ~~~~~~~~~~ drawing
   0   1   2   3   4   5   6   7

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -537,6 +537,10 @@ any dynamic table entries that the header block referenced.  That is, this
 instruction is also processed as a Table Size Synchronize instruction with a
 value matching the Largest Reference of the corresponding header block.
 
+A decoder MUST track increases to the largest acknowledged dynamic table entry
+caused by acknowledging a header block so that it can correctly generate the
+Table State Synchronize instruction.
+
 
 ## Request and Push Streams
 

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -265,6 +265,34 @@ might not actually become blocked on every stream which risks becoming blocked.
 If the decoder encounters more blocked streams than it promised to support, it
 SHOULD treat this as a stream error of type HTTP_QPACK_DECOMPRESSION_FAILED.
 
+### State Synchronization
+
+The decoder stream signals key events at the decoder that permit the encoder to
+track the decoder's state.  These events are:
+
+- Successful processing of a header block
+- Abandonment of a stream which might have remaining header blocks
+- Receipt of new dynamic table entries
+
+Regardless of whether a header block contained blocking references, the
+knowledge that it was processed successfully permits the encoder to avoid
+evicting entries while references remain outstanding; see {{blocked-eviction}}.
+When a stream is reset or abandoned, the indication that these header blocks
+will never be processed serves a similar function; see {{stream-cancellation}}.
+
+For the encoder to identify which dynamic table entries can be safely used
+without a stream becoming blocked, the encoder tracks the absolute index of the
+decoder's Largest Known Received entry.
+
+When blocking references are permitted, the encoder uses acknowledgement of
+header blocks to identify the Largest Known Received index, as described in
+{{header-acknowledgement}}.
+
+To acknowledge dynamic table entries which are not referenced by header blocks,
+for example because the encoder or the decoder have chosen not to risk blocked
+streams, the decoder sends a Table State Synchronize instruction (see
+{{table-state-synchronize}}).
+
 # Conventions and Definitions
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
@@ -485,22 +513,13 @@ server's header blocks and table updates.
 
 ### Table State Synchronize
 
-After processing a set of instructions on the encoder stream, the decoder will
-emit a Table State Synchronize instruction on the decoder stream.  The
-instruction begins with the '10' two-bit pattern. The instruction specifies the
-total number of dynamic table inserts and duplications since the last Table
-State Synchronize or Header Acknowledgement that increased the largest
-acknowledged dynamic table entry.  This is encoded as a 6-bit prefix integer.
-The encoder uses this value to determine which table entries are vulnerable to
-head-of-line blocking.
-
-A decoder MAY coalesce multiple synchronization updates into a single update.  A
-decoder MAY rely on Header Acknowledgement instructions to indirectly
-acknowledge changes to the dynamic table.  Relying on Header Acknowledgment
-instructions exclusively leads to poor compression efficiency if the encoder
-waits for an entry to be acknowledged before using it.  This happens if the
-encoder wants to avoid the risk of blocking at the decoder, or the encoder has
-already reached the decoder's limit for blocked streams.
+The Table State Synchronize instruction begins with the '10' two-bit pattern.
+The instruction specifies the total number of dynamic table inserts and
+duplications since the last Table State Synchronize or Header Acknowledgement
+that increased the Largest Known Received dynamic table entry.  This is encoded
+as a 6-bit prefix integer. The encoder uses this value to determine which table
+entries might cause a stream to become blocked, as described in
+{{state-synchronization}}.
 
 ~~~~~~~~~~ drawing
   0   1   2   3   4   5   6   7
@@ -509,6 +528,15 @@ already reached the decoder's limit for blocked streams.
 +---+---+-----------------------+
 ~~~~~~~~~~
 {:#fig-size-sync title="Table State Synchronize"}
+
+A decoder SHOULD emit a Table State Synchronize after receiving new dynamic
+table entries if the most recently inserted entry was not the Largest Reference
+of a blocked stream.  Decoders which support blocking MAY delay this instruction
+briefly to see if new header blocks arrive which reference the new entries, but
+this leads to reduced compression efficiency if the encoder waits for an entry
+to be acknowledged before using it.  This happens if the encoder wants to avoid
+the risk of blocking at the decoder, or the encoder has already reached the
+decoder's limit for blocked streams.
 
 ### Header Acknowledgement
 
@@ -532,14 +560,13 @@ blocks within a stream have been fully processed.
 ~~~~~~~~~~
 {:#fig-header-ack title="Header Acknowledgement"}
 
-An encoder MUST treat receipt of a Header Acknowledgment as also acknowledging
-any dynamic table entries that the header block referenced.  That is, this
-instruction is also processed as a Table State Synchronize instruction with a
-value matching the Largest Reference of the corresponding header block.
-
-A decoder MUST track increases to the largest acknowledged dynamic table entry
-caused by acknowledging a header block so that it can correctly generate the
-Table State Synchronize instruction.
+When blocking references are permitted, the encoder uses acknowledgement of
+header blocks to update the Largest Known Received index.  If a header block was
+potentially blocking, the acknowledgement implies that the decoder has received
+all dynamic table state necessary to process the header block.  If the Largest
+Reference of an acknowledged header block was greater than the encoder's current
+Largest Known Received index, the block's Largest Reference becomes the new
+Largest Known Received.
 
 
 ### Stream Cancellation

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -558,7 +558,7 @@ the request stream's stream ID, encoded as a 6-bit prefix integer.
 ~~~~~~~~~~ drawing
   0   1   2   3   4   5   6   7
 +---+---+---+---+---+---+---+---+
-| 1 | 0 |     Stream ID (6+)    |
+| 1 | 1 |     Stream ID (6+)    |
 +---+---+-----------------------+
 ~~~~~~~~~~
 {:#fig-stream-reset title="Stream Reset Acknowledgement"}

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -542,18 +542,21 @@ caused by acknowledging a header block so that it can correctly generate the
 Table State Synchronize instruction.
 
 
-### Stream Reset Acknowledgement
+### Stream Cancellation
 
 A stream that is reset might have multiple outstanding header blocks.  A decoder
-that receives a stream reset before the end of a stream generates a Stream Reset
-Acknowledgment instruction on the decoder stream.  This signals to the encoder
-that any references to the dynamic table are no longer outstanding.
+that receives a stream reset before the end of a stream generates a Stream
+Cancellation instruction on the decoder stream.  Similarly, a decoder that
+abandons reading of a stream need to signal this using the Stream Cancellation
+instruction.  This signals to the encoder that all references to the dynamic
+table on that stream are no longer outstanding.
 
 An encoder cannot infer from this acknowledgement that any dynamic table entries
 referenced have been received.
 
 The instruction begins with the '11' two-bit pattern. The instruction includes
-the request stream's stream ID, encoded as a 6-bit prefix integer.
+the stream ID of the affected stream - a request or push stream - encoded as a
+6-bit prefix integer.
 
 ~~~~~~~~~~ drawing
   0   1   2   3   4   5   6   7
@@ -561,7 +564,7 @@ the request stream's stream ID, encoded as a 6-bit prefix integer.
 | 1 | 1 |     Stream ID (6+)    |
 +---+---+-----------------------+
 ~~~~~~~~~~
-{:#fig-stream-reset title="Stream Reset Acknowledgement"}
+{:#fig-stream-cancel title="Stream Cancellation"}
 
 
 ## Request and Push Streams

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -547,7 +547,7 @@ Table State Synchronize instruction.
 A stream that is reset might have multiple outstanding header blocks.  A decoder
 that receives a stream reset before the end of a stream generates a Stream
 Cancellation instruction on the decoder stream.  Similarly, a decoder that
-abandons reading of a stream need to signal this using the Stream Cancellation
+abandons reading of a stream needs to signal this using the Stream Cancellation
 instruction.  This signals to the encoder that all references to the dynamic
 table on that stream are no longer outstanding.
 

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -551,8 +551,8 @@ abandons reading of a stream needs to signal this using the Stream Cancellation
 instruction.  This signals to the encoder that all references to the dynamic
 table on that stream are no longer outstanding.
 
-An encoder cannot infer from this acknowledgement that any updates to the
-dynamic table have been received.
+An encoder cannot infer from this instruction that any updates to the dynamic
+table have been received.
 
 The instruction begins with the '11' two-bit pattern. The instruction includes
 the stream ID of the affected stream - a request or push stream - encoded as a


### PR DESCRIPTION
This feels like a huge wall of text, and I could use some help making it more readable.  However, it attempts to pull out the text from #1399 into its own section and describe the process of making sure encoder and decoder are on the same page.

Closes #1399 and closes #1400 because I have those commits in here.