### PR TITLE
Allow non-RFC6066 methods for indicating server domain

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -208,7 +208,7 @@ HTTP/QUIC relies on QUIC as the underlying transport.  The QUIC version being
 used MUST use TLS version 1.3 or greater as its handshake protocol.  HTTP/QUIC
 clients MUST indicate the target domain name during the TLS handshake. This may
 be done using the Server Name Indication (SNI) {{!RFC6066}} extension to TLS or
-some other mechanism.
+using some other mechanism.
 
 QUIC connections are established as described in {{QUIC-TRANSPORT}}. During
 connection establishment, HTTP/QUIC support is indicated by selecting the ALPN

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -205,10 +205,10 @@ version in the list which it does support.
 ## Connection Establishment {#connection-establishment}
 
 HTTP/QUIC relies on QUIC as the underlying transport.  The QUIC version being
-used MUST use TLS version 1.3 or greater as its handshake protocol.  The TLS
-implementation MUST support the Server Name Indication (SNI) {{!RFC6066}}
-extension to TLS. HTTP/QUIC clients MUST indicate the target domain name during
-the TLS handshake.
+used MUST use TLS version 1.3 or greater as its handshake protocol.  HTTP/QUIC
+clients MUST indicate the target domain name during the TLS handshake. This may
+be done using the Server Name Indication (SNI) {{!RFC6066}} extension to TLS or
+some other mechanism.
 
 QUIC connections are established as described in {{QUIC-TRANSPORT}}. During
 connection establishment, HTTP/QUIC support is indicated by selecting the ALPN


### PR DESCRIPTION
Closes #1459.