### PR TITLE
Extension frames

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2351,7 +2351,11 @@ The CONNECTION_CLOSE frame is as follows:
  0                   1                   2                   3
  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|           Error Code (16)     |   Reason Phrase Length (i)  ...
+|           Error Code (16)     |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                         Frame Type (i)                      ...
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                    Reason Phrase Length (i)                 ...
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                        Reason Phrase (*)                    ...
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -2365,6 +2369,10 @@ Error Code:
   CONNECTION_CLOSE uses codes from the space defined in {{error-codes}}
   (APPLICATION_CLOSE uses codes from the application protocol error code space,
   see {{app-error-codes}}).
+
+Frame Type:
+
+: The type of frame that triggered the error.
 
 Reason Phrase Length:
 
@@ -2833,8 +2841,8 @@ ACK block that follows the gap using the following formula:
 ~~~
 
 If the calculated value for largest or smallest packet number for any ACK Block
-is negative, an endpoint MUST generate a connection error of type FRAME_ERROR
-indicating an error in an ACK frame (that is, 0x10d).
+is negative, an endpoint MUST generate a connection error of type
+FRAME_FORMAT_ERROR indicating an error in an ACK frame.
 
 The fields in the ACK Block Section are:
 
@@ -4070,12 +4078,6 @@ UNSOLICITED_PATH_RESPONSE (0xB):
 : An endpoint received a PATH_RESPONSE frame that did not correspond to any
   PATH_CHALLENGE frame that it previously sent.
 
-FRAME_ERROR (0x1XX):
-
-: An endpoint detected an error in a specific frame type.  The frame type is
-  included as the last octet of the error code.  For example, an error in a
-  MAX_STREAM_ID frame would be indicated with the code (0x106).
-
 Codes for errors occuring when TLS is used for the crypto handshake are defined
 in Section 11 of {{QUIC-TLS}}. See {{iana-error-codes}} for details of
 registering new error codes.
@@ -4360,25 +4362,22 @@ Specification:
 
 : A reference to a publicly available specification for the value.
 
-The initial contents of this registry are shown in {{iana-error-table}}.  Note
-that FRAME_ERROR takes the range from 0x100 to 0x1FF and private use occupies
-the range from 0xFE00 to 0xFFFF.
+The initial contents of this registry are shown in {{iana-error-table}}.
 
-| Value       | Error                     | Description                   | Specification   |
-|:------------|:--------------------------|:------------------------------|:----------------|
-| 0x0         | NO_ERROR                  | No error                      | {{error-codes}} |
-| 0x1         | INTERNAL_ERROR            | Implementation error          | {{error-codes}} |
-| 0x2         | SERVER_BUSY               | Server currently busy         | {{error-codes}} |
-| 0x3         | FLOW_CONTROL_ERROR        | Flow control error            | {{error-codes}} |
-| 0x4         | STREAM_ID_ERROR           | Invalid stream ID             | {{error-codes}} |
-| 0x5         | STREAM_STATE_ERROR        | Frame received in invalid stream state | {{error-codes}} |
-| 0x6         | FINAL_OFFSET_ERROR        | Change to final stream offset | {{error-codes}} |
-| 0x7         | FRAME_FORMAT_ERROR        | Generic frame format error    | {{error-codes}} |
-| 0x8         | TRANSPORT_PARAMETER_ERROR | Error in transport parameters | {{error-codes}} |
-| 0x9         | VERSION_NEGOTIATION_ERROR | Version negotiation failure   | {{error-codes}} |
-| 0xA         | PROTOCOL_VIOLATION        | Generic protocol violation    | {{error-codes}} |
-| 0xB         | UNSOLICITED_PATH_RESPONSE | Unsolicited PATH_RESPONSE frame | {{error-codes}} |
-| 0x100-0x1FF | FRAME_ERROR               | Specific frame format error   | {{error-codes}} |
+| Value | Error                     | Description                   | Specification   |
+|:------|:--------------------------|:------------------------------|:----------------|
+| 0x0   | NO_ERROR                  | No error                      | {{error-codes}} |
+| 0x1   | INTERNAL_ERROR            | Implementation error          | {{error-codes}} |
+| 0x2   | SERVER_BUSY               | Server currently busy         | {{error-codes}} |
+| 0x3   | FLOW_CONTROL_ERROR        | Flow control error            | {{error-codes}} |
+| 0x4   | STREAM_ID_ERROR           | Invalid stream ID             | {{error-codes}} |
+| 0x5   | STREAM_STATE_ERROR        | Frame received in invalid stream state | {{error-codes}} |
+| 0x6   | FINAL_OFFSET_ERROR        | Change to final stream offset | {{error-codes}} |
+| 0x7   | FRAME_FORMAT_ERROR        | Generic frame format error    | {{error-codes}} |
+| 0x8   | TRANSPORT_PARAMETER_ERROR | Error in transport parameters | {{error-codes}} |
+| 0x9   | VERSION_NEGOTIATION_ERROR | Version negotiation failure   | {{error-codes}} |
+| 0xA   | PROTOCOL_VIOLATION        | Generic protocol violation    | {{error-codes}} |
+| 0xB   | UNSOLICITED_PATH_RESPONSE | Unsolicited PATH_RESPONSE frame | {{error-codes}} |
 {: #iana-error-table title="Initial QUIC Transport Error Codes Entries"}
 
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -938,7 +938,7 @@ a connection error of type PROTOCOL_VIOLATION.
 ## Extension Frames
 
 QUIC frames do not use a self-describing encoding.  An endpoint therefore needs
-to understand the syntax of all frame before it can successfully process a
+to understand the syntax of all frames before it can successfully process a
 packet.  This allows for efficient encoding of frames, but it means that an
 endpoint cannot send a frame of a type that is unknown to its peer.
 
@@ -2372,7 +2372,8 @@ Error Code:
 
 Frame Type:
 
-: The type of frame that triggered the error.
+: The type of frame that triggered the error.  A value of 0 (equivalent to the
+  mention of the PADDING frame) is used when the frame type is unknown.
 
 Reason Phrase Length:
 
@@ -2842,7 +2843,7 @@ ACK block that follows the gap using the following formula:
 
 If the calculated value for largest or smallest packet number for any ACK Block
 is negative, an endpoint MUST generate a connection error of type
-FRAME_FORMAT_ERROR indicating an error in an ACK frame.
+FRAME_ENCODING_ERROR indicating an error in an ACK frame.
 
 The fields in the ACK Block Section are:
 
@@ -4048,13 +4049,11 @@ FINAL_OFFSET_ERROR (0x6):
   that was already received.  Or an endpoint received a RST_STREAM frame
   containing a different final offset to the one already established.
 
-FRAME_FORMAT_ERROR (0x7):
+FRAME_ENCODING_ERROR (0x7):
 
 : An endpoint received a frame that was badly formatted.  For instance, an empty
   STREAM frame that omitted the FIN flag, or an ACK frame that has more
-  acknowledgment ranges than the remainder of the packet could carry.  This is a
-  generic error code; an endpoint SHOULD use the more specific frame format
-  error codes (0x1XX) if possible.
+  acknowledgment ranges than the remainder of the packet could carry.
 
 TRANSPORT_PARAMETER_ERROR (0x8):
 
@@ -4362,7 +4361,8 @@ Specification:
 
 : A reference to a publicly available specification for the value.
 
-The initial contents of this registry are shown in {{iana-error-table}}.
+The initial contents of this registry are shown in {{iana-error-table}}.  Values
+from 0xFF00 to 0xFFFF are reserved for Private Use {{!RFC8126}}.
 
 | Value | Error                     | Description                   | Specification   |
 |:------|:--------------------------|:------------------------------|:----------------|
@@ -4373,7 +4373,7 @@ The initial contents of this registry are shown in {{iana-error-table}}.
 | 0x4   | STREAM_ID_ERROR           | Invalid stream ID             | {{error-codes}} |
 | 0x5   | STREAM_STATE_ERROR        | Frame received in invalid stream state | {{error-codes}} |
 | 0x6   | FINAL_OFFSET_ERROR        | Change to final stream offset | {{error-codes}} |
-| 0x7   | FRAME_FORMAT_ERROR        | Generic frame format error    | {{error-codes}} |
+| 0x7   | FRAME_ENCODING_ERROR      | Frame encoding error          | {{error-codes}} |
 | 0x8   | TRANSPORT_PARAMETER_ERROR | Error in transport parameters | {{error-codes}} |
 | 0x9   | VERSION_NEGOTIATION_ERROR | Version negotiation failure   | {{error-codes}} |
 | 0xA   | PROTOCOL_VIOLATION        | Generic protocol violation    | {{error-codes}} |

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -944,8 +944,8 @@ endpoint cannot send a frame of a type that is unknown to its peer.
 
 An extension to QUIC that wishes to use a new type of frame MUST first ensure
 that a peer is able to understand the frame.  An endpoint can use a transport
-parameter to signal its willingness to receive a new type of frame, or even
-multiple types of frame with the one transport parameter.
+parameter to signal its willingness to receive one or more extension frame types
+with the one transport parameter.
 
 An IANA registry is used to manage the assignment of frame types, see
 {{iana-frames}}.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -931,7 +931,9 @@ encoding.  Though a two-, four- or eight-octet encoding of the frame types
 defined in this document is possible, the Frame Type field for these frames are
 encoded on a single octet.  For instance, though 0x4007 is a legitimate
 two-octet encoding for a variable-length integer with a value of 7, PING frames
-are always encoded as a single octet with the value 0x07.
+are always encoded as a single octet with the value 0x07.  An endpoint MUST
+treat the receipt of a frame type that uses a longer encoding than necessary as
+a connection error of type PROTOCOL_VIOLATION.
 
 ## Extension Frames
 


### PR DESCRIPTION
This is the outcome we discussed in Kista.

One tweak here is to avoid allowing variant variable-length integer encodings.  The definition of variable-length integers would allow for four different encodings of the core set of frame types, which would require recipients to modify their code to look at more than one octet.  For instance, ping is 0x07, 0x4007, 0x80000007, and 0xc000000000000007.  I think that it's easier for all involved not to have to worry about long encodings until they want to experiment.

I'm flexible on that point, as I am with respect to registration policies.

Closes #58, #1072, #1068.