### PR TITLE
Use CONNECTION_CLOSE rather than CRYPTO_CLOSE

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -605,12 +605,12 @@ HelloRetryRequest is still used for incorrect key shares.
 If TLS experiences an error, it generates an appropriate alert as defined in
 Section 6 of {{TLS13}}.
 
-A TLS alert is turned into a QUIC connection error by converting the alert
-description into a QUIC error code.  The alert description is added to 0x200 to
-produce a QUIC error code from the range reserved for CRYPTO_ERROR.  The
-resulting value is sent in a QUIC CONNECTION_CLOSE frame.
+A TLS alert is turned into a QUIC connection error by converting the one-octet
+alert description into a QUIC error code.  The alert description is added to
+0x200 to produce a QUIC error code from the range reserved for CRYPTO_ERROR.
+The resulting value is sent in a QUIC CONNECTION_CLOSE frame.
 
-The alert level of all TLS alerts is "fatal", a TLS stack does not generate
+The alert level of all TLS alerts is "fatal", a TLS stack MUST NOT generate
 alerts at the "warning" level.
 
 

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -610,7 +610,7 @@ alert description into a QUIC error code.  The alert description is added to
 0x200 to produce a QUIC error code from the range reserved for CRYPTO_ERROR.
 The resulting value is sent in a QUIC CONNECTION_CLOSE frame.
 
-The alert level of all TLS alerts is "fatal", a TLS stack MUST NOT generate
+The alert level of all TLS alerts is "fatal"; a TLS stack MUST NOT generate
 alerts at the "warning" level.
 
 

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -329,8 +329,8 @@ encryption level, whereas those associated with transferring data can
 only appear in the 0-RTT and 1-RTT encryption levels
 
 - CRYPTO_HS frames MAY appear in packets of any encryption level.
-- CONNECTION_CLOSE and CRYPTO_CLOSE MAY appear in packets of any
-  encryption level other than 0-RTT.
+- CONNECTION_CLOSE MAY appear in packets of any encryption level other than
+  0-RTT.
 - PADDING and PING frames MAY appear in packets of any encryption level.
 - ACK frames MAY appear in packets of any encryption level other than
   0-RTT, but can only acknowledge packets which appeared in that
@@ -602,10 +602,16 @@ HelloRetryRequest is still used for incorrect key shares.
 
 ## TLS Errors
 
-If TLS experiences an error, it MUST generate an appropriate alert
-as defined in {{TLS13}}; Section 6) and then provide it to QUIC,
-which sends the alert in a CRYPTO_CLOSE frame. All such alerts are
-"fatal" (see {{TLS13}}, Section 6.2.
+If TLS experiences an error, it generates an appropriate alert as defined in
+Section 6 of {{TLS13}}.
+
+A TLS alert is turned into a QUIC connection error by converting the alert
+description into a QUIC error code.  The alert description is added to 0x200 to
+produce a QUIC error code from the range reserved for CRYPTO_ERROR.  The
+resulting value is sent in a QUIC CONNECTION_CLOSE frame.
+
+The alert level of all TLS alerts is "fatal", a TLS stack does not generate
+alerts at the "warning" level.
 
 
 # QUIC Packet Protection {#packet-protection}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -578,7 +578,7 @@ Token Length:
 Token:
 
 : An optional token blob previously received in either a Retry packet or
-NEW_TOKEN frame.
+  NEW_TOKEN frame.
 
 The client and server use the Initial packet type for any packet that
 contains an initial cryptographic handshake message. In addition to
@@ -649,7 +649,7 @@ Note:
 
 : The rationale for treating the client as unvalidated rather
 than discarding the packet is that the client might have received
-the token in a previous connection using the NEW_TOKEN message,
+the token in a previous connection using the NEW_TOKEN frame,
 and if the server has lost state, it might be unable to validate
 the token at all, leading to connection failure if the packet
 is discarded.
@@ -1032,7 +1032,7 @@ explained in more detail as they are referenced later in the document.
 | 0x0f        | PATH_RESPONSE     | {{frame-path-response}}     |
 | 0x10 - 0x17 | STREAM            | {{frame-stream}}            |
 | 0x18        | CRYPTO_HS         | {{frame-crypto}}            |
-| 0x20        | NEW_TOKEN         | {{frame-new-token}}         |
+| 0x19        | NEW_TOKEN         | {{frame-new-token}}         |
 {: #frame-types title="Frame Types"}
 
 All QUIC frames are idempotent.  That is, a valid frame does not cause
@@ -3090,7 +3090,7 @@ a connection error of type UNSOLICITED_PATH_RESPONSE.
 
 ## NEW_TOKEN frame {#frame-new-token}
 
-A server sends a NEW_TOKEN frame (type=0x21) to provide the client a token to
+A server sends a NEW_TOKEN frame (type=0x19) to provide the client a token to
 send in a the header of an Initial packet for a future connection.
 
 The NEW_TOKEN frame is as follows:
@@ -4153,7 +4153,7 @@ transport, including all those described in this document, are carried
 in a CONNECTION_CLOSE frame.  Other than the type of error code they
 carry, these frames are identical in format and semantics.
 
-A CONNECTION_CLOSE, or APPLICATION_CLOSE frame could be sent in a packet that is
+A CONNECTION_CLOSE or APPLICATION_CLOSE frame could be sent in a packet that is
 lost.  An endpoint SHOULD be prepared to retransmit a packet containing either
 frame type if it receives more packets on a terminated connection.  Limiting the
 number of retransmissions and the time over which this final packet is sent

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2199,7 +2199,7 @@ before the packet is received.
 
 ### Immediate Close
 
-An endpoint sends a closing frame, (CONNECTION_CLOSE or APPLICATION_CLOSE) to
+An endpoint sends a closing frame (CONNECTION_CLOSE or APPLICATION_CLOSE) to
 terminate the connection immediately.  Any closing frame causes all streams to
 immediately become closed; open streams can be assumed to be implicitly reset.
 


### PR DESCRIPTION
More frame types aren't really necessary here.

(This will conflict with the rename of CRYPTO_HS, but I can manage that.)