### PR TITLE
Move HTTP_*PACK_COMPRESSION_FAILED to QPACK

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1149,9 +1149,6 @@ HTTP_PUSH_ALREADY_IN_CACHE (0x04):
 HTTP_REQUEST_CANCELLED (0x05):
 : The client no longer needs the requested data.
 
-HTTP_QPACK_DECOMPRESSION_FAILED (0x06):
-: QPACK failed to decompress a frame and cannot continue.
-
 HTTP_CONNECT_ERROR (0x07):
 : The connection established in response to a CONNECT request was reset or
   abnormally closed.
@@ -1403,7 +1400,7 @@ CANCEL (0x8):
 : HTTP_REQUEST_CANCELLED in {{http-error-codes}}.
 
 COMPRESSION_ERROR (0x9):
-: HTTP_HPACK_DECOMPRESSION_FAILED in {{http-error-codes}}.
+: HTTP_QPACK_DECOMPRESSION_FAILED in [QPACK].
 
 CONNECT_ERROR (0xa):
 : HTTP_CONNECT_ERROR in {{http-error-codes}}.
@@ -1603,7 +1600,6 @@ The entries in the following table are registered by this document.
 | HTTP_INTERNAL_ERROR                 | 0x0003     | Internal error                           | {{http-error-codes}}   |
 | HTTP_PUSH_ALREADY_IN_CACHE          | 0x0004     | Pushed content already cached            | {{http-error-codes}}   |
 | HTTP_REQUEST_CANCELLED              | 0x0005     | Data no longer needed                    | {{http-error-codes}}   |
-| HTTP_HPACK_DECOMPRESSION_FAILED     | 0x0006     | HPACK cannot continue                    | {{http-error-codes}}   |
 | HTTP_CONNECT_ERROR                  | 0x0007     | TCP reset or error on CONNECT request    | {{http-error-codes}}   |
 | HTTP_EXCESSIVE_LOAD                 | 0x0008     | Peer generating excessive load           | {{http-error-codes}}   |
 | HTTP_VERSION_FALLBACK               | 0x0009     | Retry over HTTP/2                        | {{http-error-codes}}   |

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -817,6 +817,15 @@ represented as an 8-bit prefix string literal.
 {: title="Literal Header Field Without Name Reference"}
 
 
+# Error Handling
+
+The following error code is defined for HTTP/QUIC to indicate all failures of
+QPACK which prevent the stream or connection from continuing:
+
+HTTP_QPACK_DECOMPRESSION_FAILED (0x06):
+: QPACK failed to decompress a frame and cannot continue.
+
+
 # Encoding Strategies
 
 ## Single Pass Encoding
@@ -974,6 +983,21 @@ The entries in the following table are registered by this document.
 | QPACK Encoder Stream         | 0x48   | {{wire-format}}           | Both   |
 | QPACK Decoder Stream         | 0x68   | {{wire-format}}           | Both   |
 | ---------------------------- | ------ | ------------------------- | ------ |
+
+## Error Code Registration
+
+This document establishes one new error code in the "HTTP/QUIC Error Code"
+registry established in {{QUIC-HTTP}}.
+
+Name:
+: HTTP_QPACK_DECOMPRESSION_FAILED
+
+Code:
+: 0x06
+
+Description:
+: QPACK failed to decompress a frame and cannot continue.
+
 
 --- back
 

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -996,7 +996,7 @@ Code:
 : 0x06
 
 Description:
-: QPACK failed to decompress a frame and cannot continue.
+: QPACK failed to interpret an instruction and cannot continue.
 
 
 --- back


### PR DESCRIPTION
Closes #1529; finishes what #1358 started.