### PR TITLE
Optimize definition IP addr in TP PreferredAddress

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1445,18 +1445,10 @@ language from Section 3 of {{!I-D.ietf-tls-tls13}}.
    } TransportParameters;
 
    struct {
-     uint8[4] addr;
-   } IPv4addr;
-
-   struct {
-     uint8[16] addr;
-   } IPv6addr;
-
-   struct {
      enum { IPv4(4), IPv6(6), (15) } ipVersion;
      select (PreferredAddress.ipVersion) {
-       case IPv4: IPv4addr;
-       case IPv6: IPv6addr;
+       case IPv4: uint8 IPv4addr[4];
+       case IPv6: uint8 IPv6addr[16];
      };
      uint16 port;
      opaque connectionId<0..18>;

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1445,8 +1445,19 @@ language from Section 3 of {{!I-D.ietf-tls-tls13}}.
    } TransportParameters;
 
    struct {
+     uint8[4] addr;
+   } IPv4addr;
+
+   struct {
+     uint8[16] addr;
+   } IPv6addr;
+
+   struct {
      enum { IPv4(4), IPv6(6), (15) } ipVersion;
-     opaque ipAddress<4..2^8-1>;
+     select (PreferredAddress.ipVersion) {
+       case IPv4: IPv4addr;
+       case IPv6: IPv6addr;
+     };
      uint16 port;
      opaque connectionId<0..18>;
      opaque statelessResetToken[16];


### PR DESCRIPTION
There are two reasons for this change.

First, having the IP address stored as an opaque string 4 to 255 octets
in length does not make it clear in what format the IP address is stored.
The choice of 4 and 16 bytes makes the format obvious.

Second, the longer of the two possibilities is 16 bytes.  There is no
reason to allow for longer values.  Only allowing 4 and 16 bytes make
the checks both stricter and simpler and implementations more efficient.