### PR TITLE
Remove the discussion about when to use long header

### DIFF
--- a/draft-ietf-quic-invariants.md
+++ b/draft-ietf-quic-invariants.md
@@ -344,6 +344,8 @@ The following statements are NOT guaranteed to be true for every QUIC version:
 
 * Every flow on a given 5-tuple will include a connection establishment phase
 
+* The first packets exchanged on a flow use the long header
+
 * QUIC forbids acknowledgments of packets that only contain ACK frames,
   therefore the last packet before a long period of quiescence might be assumed
   to contain an acknowledgment

--- a/draft-ietf-quic-invariants.md
+++ b/draft-ietf-quic-invariants.md
@@ -238,10 +238,7 @@ a specific QUIC version, or to a range of QUIC versions.
 A QUIC endpoint that receives a packet with a long header and a version it
 either does not understand or does not support might send a Version Negotiation
 packet in response.  Packets with a short header do not trigger version
-negotiation and are always associated with an existing connection.
-
-Consequently, until an endpoint has confirmed that its peer supports the QUIC
-version it has chosen, it can only send packets that use the long header.
+negotiation.
 
 A Version Negotiation packet sets the high bit of the first octet, and thus it
 conforms with the format of a packet with a long header as defined in


### PR DESCRIPTION
I think current text is a bit too restrictive (without necessity), and that it might cause misunderstanding.

* V2 and later versions should have the freedom to decide when to trigger version negotiation (note: version negotiation requires the use of long header packets).
* Removes the false impression that the use of a path always start with a long header. That is not the case for v1 due to involuntary NAT rebinding.