### PR TITLE
Allow Retry in response to 0-RTT packets

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -595,8 +595,9 @@ A Retry packet does not include a packet number and cannot be explictly
 acknowledged by a client.
 
 A server MUST NOT send a Retry in response to packets other than Initial
-or 0-RTT packets.  A server MAY discard 0-RTT packets and only send Retry in
-response to Initial packets.
+or 0-RTT packets.  A server MAY choose to only send Retry in response to Initial
+packets and discard or buffer 0-RTT packets corresponding to unvalidated client
+addresses.
 
 If the Original Destination Connection ID field does not match the Destination
 Connection ID from the most recent Initial packet it sent, clients MUST discard

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -594,7 +594,9 @@ of subsequent packets that it sends.
 A Retry packet does not include a packet number and cannot be explictly
 acknowledged by a client.
 
-A server MUST only send a Retry in response to a client Initial packet.
+A server MUST NOT send a Retry in response to packets other than Initial
+or 0-RTT packets.  A server MAY discard 0-RTT packets and only send Retry in
+response to Initial packets.
 
 If the Original Destination Connection ID field does not match the Destination
 Connection ID from the most recent Initial packet it sent, clients MUST discard


### PR DESCRIPTION
Closes #1547.

(Note the target of this PR.  This is blocked on #1498.)