### PR TITLE
Stateless reset is near-pointless for long headers

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2470,6 +2470,13 @@ the packet it receives.  Endpoints MUST discard packets that are too small to be
 valid QUIC packets.  With the set of AEAD functions defined in {{QUIC-TLS}},
 packets less than 19 octets long are never valid.
 
+An endpoint MAY send a stateless reset in response to a packet with a long
+header.  This would not be effective if the stateless reset token was not yet
+available to a peer.  In this QUIC version, packets with a long header are only
+used during connection establishment.   Because the stateless reset token is not
+available until connection establishment is complete or near completion,
+ignoring an unknown packet with a long header might be more effective.
+
 An endpoint cannot determine the Source Connection ID from a packet with a short
 header, therefore it cannot set the Destination Connection ID in the stateless
 reset packet.  The destination connection ID will therefore differ from the


### PR DESCRIPTION
...but prohibiting it might make it harder for us to define new uses for
packets with long headers.

Closes #1348.