### PR TITLE
Exception in ECN detection when ACK loss happens

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1743,9 +1743,9 @@ network, an endpoint verifies the following when an ACK_ECN frame is received:
   the number of newly acknowledged packets, and the received ACK's
   smallest acknowledged is larger than the previous largest acknowledged,
   then it's likely acknowledgements were missed, and the above comparison
-  MUST NOT be performed. Instead a new comparision point is stored by the
+  MUST NOT be performed. Instead a new comparison point is stored by the
   sender so that only changes after this point will be used in the future
-  comaparisions.
+  comparisons.
 
 
 Upon successful verification, an endpoint continues to set ECT codepoints in

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1739,12 +1739,14 @@ network, an endpoint verifies the following when an ACK_ECN frame is received:
 * The increase in ECT(0) and ECT(1) counters MUST be no greater than the number
   of packets newly acknowledged that were sent with the corresponding codepoint.
 
-* If the increase in the ECT(0), ECT(1) and CE counters are greater than the
-  number of newly ACKed packets, and received ACK's smallest acknowledged is
-  larger than the previous largest acknowledged, then it's likely
-  acknowledgements were missed, and the above comparison MUST NOT be
-  performed. Instead a new comparision point is stored by the sender so that
-  only changes after this point will be used in the future comaparisions.
+* If the increase in the ECT(0), ECT(1) and CE counters are greater than
+  the number of newly acknowledged packets, and the received ACK's
+  smallest acknowledged is larger than the previous largest acknowledged,
+  then it's likely acknowledgements were missed, and the above comparison
+  MUST NOT be performed. Instead a new comparision point is stored by the
+  sender so that only changes after this point will be used in the future
+  comaparisions.
+
 
 Upon successful verification, an endpoint continues to set ECT codepoints in
 subsequent packets with the expectation that the path is ECN-capable.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1738,6 +1738,14 @@ network, an endpoint verifies the following when an ACK_ECN frame is received:
 
 * The increase in ECT(0) and ECT(1) counters MUST be no greater than the number
   of packets newly acknowledged that were sent with the corresponding codepoint.
+  
+* If the increase in the ECT(0), ECT(1) and CE counters are greater than the 
+  number of newly ACKed packets, and received ACK's smallest acknowledged or 
+  gap indicated packet number is larger than previously largest acknowledged 
+  packet known by the sender, i.e. there exist a lack of information, then the 
+  above comparisions MUST NOT be performed. Instead a new comparision point
+  is stored by the sender so that only changes after this point will be used
+  in the future comaparisions.   
 
 Upon successful verification, an endpoint continues to set ECT codepoints in
 subsequent packets with the expectation that the path is ECN-capable.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1747,7 +1747,6 @@ network, an endpoint verifies the following when an ACK_ECN frame is received:
   sender so that only changes after this point will be used in the future
   comparisons.
 
-
 Upon successful verification, an endpoint continues to set ECT codepoints in
 subsequent packets with the expectation that the path is ECN-capable.
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1738,14 +1738,14 @@ network, an endpoint verifies the following when an ACK_ECN frame is received:
 
 * The increase in ECT(0) and ECT(1) counters MUST be no greater than the number
   of packets newly acknowledged that were sent with the corresponding codepoint.
-  
-* If the increase in the ECT(0), ECT(1) and CE counters are greater than the 
-  number of newly ACKed packets, and received ACK's smallest acknowledged or 
-  gap indicated packet number is larger than previously largest acknowledged 
-  packet known by the sender, i.e. there exist a lack of information, then the 
+
+* If the increase in the ECT(0), ECT(1) and CE counters are greater than the
+  number of newly ACKed packets, and received ACK's smallest acknowledged or
+  gap indicated packet number is larger than previously largest acknowledged
+  packet known by the sender, i.e. there exist a lack of information, then the
   above comparisions MUST NOT be performed. Instead a new comparision point
   is stored by the sender so that only changes after this point will be used
-  in the future comaparisions.   
+  in the future comaparisions.
 
 Upon successful verification, an endpoint continues to set ECT codepoints in
 subsequent packets with the expectation that the path is ECN-capable.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1740,12 +1740,11 @@ network, an endpoint verifies the following when an ACK_ECN frame is received:
   of packets newly acknowledged that were sent with the corresponding codepoint.
 
 * If the increase in the ECT(0), ECT(1) and CE counters are greater than the
-  number of newly ACKed packets, and received ACK's smallest acknowledged or
-  gap indicated packet number is larger than previously largest acknowledged
-  packet known by the sender, i.e. there exist a lack of information, then the
-  above comparisions MUST NOT be performed. Instead a new comparision point
-  is stored by the sender so that only changes after this point will be used
-  in the future comaparisions.
+  number of newly ACKed packets, and received ACK's smallest acknowledged is
+  larger than the previous largest acknowledged, then it's likely
+  acknowledgements were missed, and the above comparison MUST NOT be
+  performed. Instead a new comparision point is stored by the sender so that
+  only changes after this point will be used in the future comaparisions.
 
 Upon successful verification, an endpoint continues to set ECT codepoints in
 subsequent packets with the expectation that the path is ECN-capable.


### PR DESCRIPTION
Adding an exception to the ECN detection to handle ACK loss if that occurs. 

Fixes Issue #1481 