### PR TITLE
Single Packet Number Space

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -91,10 +91,8 @@ when, and only when, they appear in all capitals, as shown here.
 
 All transmissions in QUIC are sent with a packet-level header, which indicates
 the encryption level and includes a packet sequence number (referred to below as
-a packet number).  The encryption level indicates the packet number space, as
-described in {{QUIC-TRANSPORT}}.  Packet numbers never repeat within a packet
-number space for the lifetime of a connection.  Packet numbers monotonically
-increase within a space, preventing ambiguity.
+a packet number).  Packet numbers never repeat for the lifetime of a connection.
+Packet numbers monotonically increase within a space, preventing ambiguity.
 
 This design obviates the need for disambiguating between transmissions and
 retransmissions and eliminates significant complexity from QUIC's interpretation
@@ -126,15 +124,6 @@ Readers familiar with TCP's loss detection and congestion control will find
 algorithms here that parallel well-known TCP ones. Protocol differences between
 QUIC and TCP however contribute to algorithmic differences. We briefly describe
 these protocol differences below.
-
-### Separate Packet Number Spaces
-
-QUIC uses separate packet number spaces for each encryption level, except 0-RTT
-and all generations of 1-RTT keys use the same packet number space.  Separate
-packet number spaces ensures acknowledgement of packets sent with one level of
-encryption will not cause spurious retransmission of packets sent with a
-different encryption level.  Congestion control and RTT measurement are unified
-across packet number spaces.
 
 ### Monotonically Increasing Packet Numbers
 
@@ -588,9 +577,7 @@ sent_packets:
   was sent, a boolean indicating whether the packet is ack only, a boolean
   indicating whether it counts towards bytes in flight, and a bytes
   field indicating the packet's size.  sent_packets is ordered by packet number,
-  and packets remain in sent_packets until acknowledged or lost.  A sent_packets
-  data structure is maintained per packet number space, and ACK processing only
-  applies to a single space.
+  and packets remain in sent_packets until acknowledged or lost.
 
 ### Initialization
 
@@ -849,11 +836,10 @@ Pseudocode for OnLossDetectionTimeout follows:
 
 ### Detecting Lost Packets
 
-Packets in QUIC are only considered lost once a larger packet number in
-the same packet number space is acknowledged.  DetectLostPackets is called
-every time an ack is received and operates on the sent_packets for that
-packet number space.  If the loss detection timer expires and the loss_time
-is set, the previous largest acked packet is supplied.
+Packets in QUIC are only considered lost once a larger packet number is
+acknowledged.  DetectLostPackets is called every time an ack is received.  If
+the loss detection timer expires and the loss_time is set, the previous largest
+acked packet is supplied.
 
 #### Pseudocode
 
@@ -1188,6 +1174,10 @@ This document has no IANA actions.  Yet.
 
 > **RFC Editor's Note:**  Please remove this section prior to
 > publication of a final version of this document.
+
+## Since draft-ietf-quic-recovery-13
+
+- Move back to a single packet number space (#1579)
 
 ## Since draft-ietf-quic-recovery-12
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -119,7 +119,7 @@ Retransmittable Packets:
 All transmissions in QUIC are sent with a packet-level header, which indicates
 the encryption level and includes a packet sequence number (referred to below as
 a packet number).  Packet numbers never repeat for the lifetime of a connection.
-Packet numbers monotonically increase within a space, preventing ambiguity.
+Packet numbers monotonically increase, preventing ambiguity.
 
 This design obviates the need for disambiguating between transmissions and
 retransmissions and eliminates significant complexity from QUIC's interpretation

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -342,13 +342,13 @@ indicate which level a given packet was encrypted under, as shown in
 need to be sent, endpoints SHOULD use coalesced packets to send them in the same
 UDP datagram.
 
-| Packet Type     | Encryption Level | PN Space  |
-|:----------------|:-----------------|:----------|
-| Initial         | Initial secrets  | Initial   |
-| 0-RTT Protected | 0-RTT            | 0/1-RTT   |
-| Handshake       | Handshake        | Handshake |
-| Retry           | N/A              | N/A       |
-| Short Header    | 1-RTT            | 0/1-RTT   |
+| Packet Type     | Encryption Level |
+|:----------------|:-----------------|
+| Initial         | Initial secrets  |
+| 0-RTT Protected | 0-RTT            |
+| Handshake       | Handshake        |
+| Retry           | N/A              |
+| Short Header    | 1-RTT            |
 {: #packet-types-levels title="Encryption Levels by Packet Type"}
 
 Section 6.3 of {{QUIC-TRANSPORT}} shows how packets at the various encryption
@@ -804,11 +804,11 @@ encrypted_pn = ChaCha20(pn_key, counter, nonce, packet_number)
 ## Receiving Protected Packets
 
 Once an endpoint successfully receives a packet with a given packet number, it
-MUST discard all packets in the same packet number space with higher packet
-numbers if they cannot be successfully unprotected with either the same key, or
-- if there is a key update - the next packet protection key (see
-{{key-update}}).  Similarly, a packet that appears to trigger a key update, but
-cannot be unprotected successfully MUST be discarded.
+MUST discard all packets with higher packet numbers if they cannot be
+successfully unprotected with either the same key, or - if there is a key update
+- the next packet protection key (see {{key-update}}).  Similarly, a packet that
+appears to trigger a key update, but cannot be unprotected successfully MUST be
+discarded.
 
 Failure to unprotect a packet does not necessarily indicate the existence of a
 protocol error in a peer or an attack.  The truncated packet number encoding
@@ -1121,6 +1121,10 @@ values in the following registries:
 > final version of this document.
 
 Issue and pull request numbers are listed with a leading octothorp.
+
+## Since draft-ietf-quic-tls-13
+
+- Move back to a single packet number space (#1579)
 
 ## Since draft-ietf-quic-tls-12
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3240,7 +3240,7 @@ ACK frames that acknowledge protected packets MUST be carried in a packet that
 has an equivalent or greater level of packet protection.  ACK frames MUST NOT be
 sent in Initial packets.  An Initial packet that carries acknowledgements must
 be discarded in its entirety.
-   
+
 Packets that are protected with 1-RTT keys MUST be acknowledged in packets that
 are also protected with 1-RTT keys.
 


### PR DESCRIPTION
Fixes #1579 (see for more details on the problem).

- Moves back to a single packet number space across all encryption levels.
- Allows for a packet to be acknowledged in a greater than or equal encryption level.
- Initial packets cannot carry ACK frames, and therefore must be acknowledged in Handshake (or greater) encryption level.
- Handshake packets can acknowledge 0-RTT packets.

With these design changes, implementations do not have to track 3 separate packet number spaces (and all the overhead that goes with it). The number of QUIC packets (not UDP datagrams) required to be sent during the handshake is reduced (see Example Handshake Flows section). There is no Initial packet ACK spoofing since they must be acknowledged in a higher encryption level. 0-RTT packets can be acknowledged a bit quicker in the handshake process by using the Handshake encryption level; generally the first server ACK block will be able to ACK all Initial and 0-RTT packets it has received in one atomic operation.

Also makes sure #1018 and #1413 don't regress and are still solved.