### PR TITLE
Only ack headers that have non-zero declared Largest Reference

### DIFF
--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -573,11 +573,11 @@ before using it.
 
 ### Header Acknowledgement
 
-After processing a header block on a request or push stream, the decoder emits a
-Header Acknowledgement instruction on the decoder stream.  The instruction
-begins with the '1' one-bit pattern and includes the request stream's stream ID,
-encoded as a 7-bit prefix integer.  It is used by the peer's QPACK encoder to
-know when it is safe to evict an entry.
+After processing a header block whose declared Largest Reference is not zero,
+the decoder emits a Header Acknowledgement instruction on the decoder stream.
+The instruction begins with the '1' one-bit pattern and includes the request
+stream's stream ID, encoded as a 7-bit prefix integer.  It is used by the
+peer's QPACK encoder to know when it is safe to evict an entry.
 
 The same Stream ID can be identified multiple times, as multiple header blocks
 can be sent on a single stream in the case of intermediate responses, trailers,


### PR DESCRIPTION
Acknowledging headers that do not reference the dynamic table convey no useful information to the encoder.

I took the liberty to remove the part that a header block is "on a request or push stream."  This qualification is not required in the context of the changed sentence.  This information is also included in several places elsewhere in the document.

Resolves issue #1603.