### PR TITLE
Define idle timeout more precisely

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2377,18 +2377,18 @@ A connection that remains idle for longer than the advertised idle timeout (see
 {{transport-parameter-definitions}}) is closed.  A connection enters the
 draining state when the idle timeout expires.
 
-Endpoints use the value they advertise when determining an idle timeout.  The
-idle timeout starts from the last packet received, or the first packet sent
-after sending that packet.  The latter condition ensures that initiating new
-activity postpones a timeout.
+Each endpoint advertises their own idle timeout to their peer. The idle timeout
+starts from the last packet received, or the first packet sent after sending
+that packet.  The latter condition ensures that initiating new activity
+postpones a timeout.
 
-The value for an idle timeout can be asymmetric.  The value advertised by a peer
-is only used to determine whether the connection is live at a peer.  An endpoint
-that sends packets near the end of the idle timeout period of a peer risks
-having those packets discarded if its peer enters the draining state before the
-packets arrive.  If a peer could timeout within an RTO (see Section 4.3.3 of
-{{QUIC-RECOVERY}}), it is advisable to test for liveness before sending any data
-that cannot be retried safely.
+The value for an idle timeout can be asymmetric.  The value advertised by an
+endpoint is only used to determine whether the connection is live at that
+endpoint.  An endpoint that sends packets near the end of the idle timeout
+period of a peer risks having those packets discarded if its peer enters the
+draining state before the packets arrive.  If a peer could timeout within an RTO
+(see Section 4.3.3 of {{QUIC-RECOVERY}}), it is advisable to test for liveness
+before sending any data that cannot be retried safely.
 
 
 ### Immediate Close

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2378,8 +2378,8 @@ A connection that remains idle for longer than the advertised idle timeout (see
 draining state when the idle timeout expires.
 
 Each endpoint advertises their own idle timeout to their peer. The idle timeout
-starts from the last packet received, or the first packet sent after sending
-that packet.  The latter condition ensures that initiating new activity
+starts from the last packet received, or the first packet sent after the last
+received packet.  The latter condition ensures that initiating new activity
 postpones a timeout.
 
 The value for an idle timeout can be asymmetric.  The value advertised by an

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2386,9 +2386,9 @@ The value for an idle timeout can be asymmetric.  The value advertised by a peer
 is only used to determine whether the connection is live at a peer.  An endpoint
 that sends packets near the end of the idle timeout period of a peer risks
 having those packets discarded if its peer enters the draining state before the
-packets arrive.  If a peer could be in within an RTO (see Section 4.3.3 of
-{{QUIC-RECOVERY}}) of an idle timeout, it is advisable to test for liveness
-before sending any data that cannot be retried safely.
+packets arrive.  If a peer could timeout within an RTO (see Section 4.3.3 of
+{{QUIC-RECOVERY}}), it is advisable to test for liveness before sending any data
+that cannot be retried safely.
 
 
 ### Immediate Close

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2373,14 +2373,22 @@ source address.
 
 ### Idle Timeout
 
-A connection that remains idle for longer than the idle timeout (see
+A connection that remains idle for longer than the advertised idle timeout (see
 {{transport-parameter-definitions}}) is closed.  A connection enters the
 draining state when the idle timeout expires.
 
-The time at which an idle timeout takes effect won't be perfectly synchronized
-on both endpoints.  An endpoint that sends packets near the end of an idle
-period could have those packets discarded if its peer enters the draining state
-before the packet is received.
+Endpoints use the value they advertise when determining an idle timeout.  The
+idle timeout starts from the last packet received, or the first packet sent
+after sending that packet.  The latter condition ensures that initiating new
+activity postpones a timeout.
+
+The value for an idle timeout can be asymmetric.  The value advertised by a peer
+is only used to determine whether the connection is live at a peer.  An endpoint
+that sends packets near the end of the idle timeout period of a peer risks
+having those packets discarded if its peer enters the draining state before the
+packets arrive.  If a peer could be in within an RTO (see Section 4.3.3 of
+{{QUIC-RECOVERY}}) of an idle timeout, it is advisable to test for liveness
+before sending any data that cannot be retried safely.
 
 
 ### Immediate Close


### PR DESCRIPTION
This uses the definition that @ianswett provided, which is as good as any we have.  The primary measure here is receipt of new packets, though initiating new activity refreshes the timer as well (to avoid pathological timeout cases that are entirely under local control).

The point about asymmetry means that getting this time absolutely right isn't necessary.  The timeout is entirely under an endpoints own control.  We communicate this so that peers can be careful about sending near this boundary.

Closes #1429, #1049.