### PR TITLE
Duplicates are dropped

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1066,12 +1066,12 @@ sending a packet with a number of 0x6b2d79 requires a packet number encoding
 with 14 bits or more; whereas the 30-bit packet number encoding is needed to
 send a packet with a number of 0x6bc107.
 
-An endpoint MUST discard packets with duplicate packet numbers.  After
-unprotecting a packet, the receiver MUST check that it has not already processed
-a packet with this PN and if so discard it. Duplicate suppression MUST happen
-after the packet has been unprotected for the reasons described in Section 9.3
-of {{QUIC-TLS}}. An efficient algorithm for duplicate suppression can be found
-in Section 3.4.3 of {{?RFC2406}}.
+A receiver MUST discard a newly unprotected packet unless it is certain that it
+has not processed another packet with the same packet number from the same
+packet number space. Duplicate suppression MUST happen after removing packet
+protection for the reasons described in Section 9.3 of {{QUIC-TLS}}. An
+efficient algorithm for duplicate suppression can be found in Section 3.4.3 of
+{{?RFC2406}}.
 
 A Version Negotiation packet ({{packet-version}}) does not include a packet
 number.  The Retry packet ({{packet-retry}}) has special rules for populating

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1066,11 +1066,12 @@ sending a packet with a number of 0x6b2d79 requires a packet number encoding
 with 14 bits or more; whereas the 30-bit packet number encoding is needed to
 send a packet with a number of 0x6bc107.
 
-An endpoint MUST discard packets with duplicate packet numbers.  That is, a
-packet is discarded if the reconstructed packet number is equal to the
-reconstructed packet number of a previously received and processed packet.  Note
-however that endpoints MUST attempt to remove packet protection before
-discarding packets (see Section 9.3 of {{QUIC-TLS}}).
+An endpoint MUST discard packets with duplicate packet numbers.  After
+unprotecting a packet, the receiver MUST check that it has not already processed
+a packet with this PN and if so discard it. Duplicate suppression MUST happen
+after the packet has been unprotected for the reasons described in Section 9.3
+of {{QUIC-TLS}}. An efficient algorithm for duplicate suppression can be found
+in Section 3.4.3 of {{?RFC2406}}.
 
 A Version Negotiation packet ({{packet-version}}) does not include a packet
 number.  The Retry packet ({{packet-retry}}) has special rules for populating

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -979,6 +979,7 @@ The connection ID can change over the lifetime of a connection, especially in
 response to connection migration ({{migration}}). NEW_CONNECTION_ID frames
 ({{frame-new-connection-id}}) are used to provide new connection ID values.
 
+
 ## Packet Numbers {#packet-numbers}
 
 The packet number is an integer in the range 0 to 2^62-1. The value is used in
@@ -1064,6 +1065,10 @@ For example, if an endpoint has received an acknowledgment for packet 0x6afa2f,
 sending a packet with a number of 0x6b2d79 requires a packet number encoding
 with 14 bits or more; whereas the 30-bit packet number encoding is needed to
 send a packet with a number of 0x6bc107.
+
+An endpoint MUST discard packets with duplicate packet numbers.  That is, a
+packet is discarded if the reconstructed packet number is equal to the
+reconstructed packet number of a previously received and processed packet.
 
 A Version Negotiation packet ({{packet-version}}) does not include a packet
 number.  The Retry packet ({{packet-retry}}) has special rules for populating

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1068,7 +1068,9 @@ send a packet with a number of 0x6bc107.
 
 An endpoint MUST discard packets with duplicate packet numbers.  That is, a
 packet is discarded if the reconstructed packet number is equal to the
-reconstructed packet number of a previously received and processed packet.
+reconstructed packet number of a previously received and processed packet.  Note
+however that endpoints MUST attempt to remove packet protection before
+discarding packets (see Section 9.3 of {{QUIC-TLS}}).
 
 A Version Negotiation packet ({{packet-version}}) does not include a packet
 number.  The Retry packet ({{packet-retry}}) has special rules for populating


### PR DESCRIPTION
It's a little surprising that we didn't say this already.

I thought about a mention of the security considerations in the TLS
draft with this change, but I think that's unnecessary at this point.

Closes #1405.