### PR TITLE
Clarify use of the term "supports ECN"

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1834,26 +1834,31 @@ congestion in the network by setting a codepoint in the IP header of a packet
 instead of dropping it.  Endpoints react to congestion by reducing their sending
 rate in response, as described in {{QUIC-RECOVERY}}.
 
-To use ECN, QUIC endpoints first determine whether a path and peer support ECN
-marking. Verifying the path occurs at the beginning of a connection and when the
+To use ECN, QUIC endpoints first determine whether a path supports ECN
+marking and the peer is able to access the ECN codepoint in the IP header. 
+A network path regarded as not supporting ECN, if ECN marked packets get dropped
+or ECN marking are rewritten on the path.
+Verifying the path occurs at the beginning of a connection and when the
 connection migrates to a new path (see {{migration}}).
 
-Each endpoint independently verifies and enables ECN for the path from it to the
-peer.
+Each endpoint independently verifies and enables use of ECN by setting the IP
+header ECN codepoint to ECN Capable Transport (ECT) for the path from it to the
+peer. Even if ECN is not used on the path to the peer, the endpoint MUST provide
+ECN feedback information if the receive of a non-zero ECN IP codepoint is observed.
 
-To verify that both a path and the peer support ECN, an endpoint MUST set one of
-the ECN Capable Transport (ECT) codepoints -- ECT(0) or ECT(1) -- in the IP
-header {{!RFC8311}} of all outgoing packets.
+To verify both that a path supports ECN and the peer can provide ECN feedback, 
+an endpoint MUST set the ECT(0) codepoint in the IP header of all outgoing packets
+{{!RFC8311}}. 
 
 If an ECT codepoint set in the IP header is not corrupted by a network device,
 then a received packet contains either the codepoint sent by the peer or the
 Congestion Experienced (CE) codepoint set by a network device that is
 experiencing congestion.
 
-On receiving a packet with an ECT or CE codepoint, an endpoint that supports ECN
-increases the corresponding ECT(0), ECT(1), or CE count, and includes these
-counters in subsequent (see {{processing-and-ack}}) ACK_ECN frames (see
-{{frame-ack-ecn}}).
+On receiving a packet with an ECT or CE codepoint, an endpoint that can access the
+IP ECN codepoints increases the corresponding ECT(0), ECT(1), or CE count, and 
+includes these counters in subsequent (see {{processing-and-ack}}) ACK_ECN frames 
+(see {{frame-ack-ecn}}).
 
 A packet detected by a receiver as a duplicate does not affect the receiver's
 local ECN codepoint counts; see ({{security-ecn}}) for relevant security
@@ -1862,7 +1867,7 @@ concerns.
 If an endpoint receives a packet without an ECT or CE codepoint, it responds per
 {{processing-and-ack}} with an ACK frame.
 
-If an endpoint does not support ECN or does not have access to received ECN
+If an endpoint does not have access to received ECN
 codepoints, it acknowledges received packets per {{processing-and-ack}} with an
 ACK frame.
 


### PR DESCRIPTION
See issue #158: "support" should only be used for the path. I have left two occasions where it is used for both the path and the peer but I think that is okay because it only addresses the case where there is no support.