### PR TITLE
Fix: a connection is not identified by a *collection*

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1183,10 +1183,10 @@ endpoint, as described in {{termination}}.
 
 ## Connection ID
 
-Each connection is identified by a collection of identifiers assigned to it. A
-connection ID can be 0 octets in length (and thus unlikely to be unique), or
-between 4 and 18 octets (inclusive).  Connection IDs are selected independently
-in each direction.
+Each connection possesses a set of identifiers, any of which could be used to
+distinguish it from other connections.  A connection ID can be either 0 octets
+in length, or between 4 and 18 octets (inclusive).  Connection IDs are selected
+independently in each direction.
 
 The primary function of a connection ID is to ensure that changes in addressing
 at lower protocol layers (UDP, IP, and below) don't cause packets for a QUIC


### PR DESCRIPTION
This small change contains several other improvements, each with a clear
purpose behind it.

    1. Replace the word "collection" with the word "set," as the former
       looks a lot like "connection."

    2. Remove the "unlikely to be unique" parenthetical clause: it is
       obvious that there can only be one unique zero-length connection ID.

    3. Drop the "assigned to it" part of the sentence, as it is unnecessary
       in this introductory paragraph.