### PR TITLE
Initial table size is the maximum permitted when table is first usable

### DIFF
--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -129,13 +129,13 @@ instructions on the encoder stream (see {{encoder-stream}}).
 
 The maximum size of the dynamic table can be modified by the encoder, subject to
 a decoder-controlled limit (see {{configuration}} and {{size-update}}).  The
-initial maximum size is the applicable value of this limit when HTTP requests or
-responses are first permitted to be sent. For clients using 0-RTT data in
-HTTP/QUIC, this means that the table size is the remembered value of
-`SETTINGS_HEADER_TABLE_SIZE`, even if the server later specifies a larger
-maximum in its SETTINGS frame.  For HTTP/QUIC servers and HTTP/QUIC clients not
-using 0-RTT data, this means that the initial maximum table size is the value of
-`SETTINGS_HEADER_TABLE_SIZE` in the peer's SETTINGS frame.
+initial maximum size is determined by the corresponding setting when HTTP
+requests or responses are first permitted to be sent. For clients using 0-RTT
+data in HTTP/QUIC, this means that the table size is the remembered value of the
+setting, even if the server later specifies a larger maximum in its SETTINGS
+frame.  For HTTP/QUIC servers and HTTP/QUIC clients when 0-RTT is not attempted
+or is rejected, this means that the initial maximum table size is the value of
+the setting in the peer's SETTINGS frame.
 
 Before a new entry is added to the dynamic table, entries are evicted from the
 end of the dynamic table until the size of the dynamic table is less than or

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -127,6 +127,16 @@ The dynamic table consists of a list of header fields maintained in first-in,
 first-out order.  The dynamic table is initially empty.  Entries are added by
 instructions on the encoder stream (see {{encoder-stream}}).
 
+The maximum size of the dynamic table can be modified by the encoder, subject to
+a decoder-controlled limit (see {{configuration}} and {{size-update}}).  The
+initial maximum size is the applicable value of this limit when HTTP requests or
+responses are first permitted to be sent. For clients using 0-RTT data in
+HTTP/QUIC, this means that the table size is the remembered value of
+`SETTINGS_HEADER_TABLE_SIZE`, even if the server later specifies a larger
+maximum in its SETTINGS frame.  For HTTP/QUIC servers and HTTP/QUIC clients not
+using 0-RTT data, this means that the initial maximum table size is the value of
+`SETTINGS_HEADER_TABLE_SIZE` in the peer's SETTINGS frame.
+
 Before a new entry is added to the dynamic table, entries are evicted from the
 end of the dynamic table until the size of the dynamic table is less than or
 equal to (maximum size - new entry size) or until the table is empty.

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -131,11 +131,11 @@ The maximum size of the dynamic table can be modified by the encoder, subject to
 a decoder-controlled limit (see {{configuration}} and {{size-update}}).  The
 initial maximum size is determined by the corresponding setting when HTTP
 requests or responses are first permitted to be sent. For clients using 0-RTT
-data in HTTP/QUIC, this means that the table size is the remembered value of the
-setting, even if the server later specifies a larger maximum in its SETTINGS
-frame.  For HTTP/QUIC servers and HTTP/QUIC clients when 0-RTT is not attempted
-or is rejected, this means that the initial maximum table size is the value of
-the setting in the peer's SETTINGS frame.
+data in HTTP/QUIC, the table size is the remembered value of the setting, even
+if the server later specifies a larger maximum in its SETTINGS frame.  For
+HTTP/QUIC servers and HTTP/QUIC clients when 0-RTT is not attempted or is
+rejected, the initial maximum table size is the value of the setting in the
+peer's SETTINGS frame.
 
 Before a new entry is added to the dynamic table, entries are evicted from the
 end of the dynamic table until the size of the dynamic table is less than or


### PR DESCRIPTION
Fixes #1530.

Makes the initial size the applicable limit when the encoder is first usable.  For 0-RTT on clients, that's the remembered value regardless of later SETTINGS frames (and per #1641, that value can't be reduced but might be increased later).  For 1-RTT clients and servers always, that's just the value in the SETTINGS frame.

Text feels rather ugly; wordsmithing suggestions gratefully accepted.

Note that this is one more reason the server can't do anything until it has seen the client's SETTINGS frame, but that's a prohibition we already have.