### PR TITLE
Specify behavior on incomplete requests

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -320,11 +320,11 @@ and cleanly closing its streams. Clients MUST NOT discard complete responses as
 a result of having their request terminated abruptly, though clients can always
 discard responses at their discretion for other reasons.
 
-Changes to the state of a request stream, including receiving a RST_STREAM
-(regardless of error code), do not affect the state of the server's response.
-Servers do not abort a response in progress solely due to a state change on the
-request stream. However, if the request stream terminates without containing a
-usable HTTP request, the server SHOULD abort its response with the error code
+Changes to the state of a request stream, including receiving a RST_STREAM with
+any error code, do not affect the state of the server's response. Servers do not
+abort a response in progress solely due to a state change on the request stream.
+However, if the request stream terminates without containing a usable HTTP
+request, the server SHOULD abort its response with the error code
 HTTP_INCOMPLETE_REQUEST.
 
 ### Header Formatting and Compression

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -322,10 +322,10 @@ discard responses at their discretion for other reasons.
 
 Changes to the state of a request stream, including receiving a RST_STREAM
 (regardless of error code), do not affect the state of the server's response.
-Servers MUST NOT abort a response in progress solely due to a state change on
-the request stream. However, if the request stream terminates without containing
-a fully-formed HTTP request, the server SHOULD abort its response with the error
-code HTTP_INCOMPLETE_REQUEST.
+Servers do not abort a response in progress solely due to a state change on the
+request stream. However, if the request stream terminates without containing a
+usable HTTP request, the server SHOULD abort its response with the error code
+HTTP_INCOMPLETE_REQUEST.
 
 ### Header Formatting and Compression
 

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1220,6 +1220,7 @@ HTTP_WRONG_STREAM_DIRECTION (0x0010):
 : A unidirectional stream type was used by a peer which is not permitted to do
   so.
 
+  For use in STOP_SENDING only.
 HTTP_GENERAL_PROTOCOL_ERROR (0x00FF):
 : Peer violated protocol requirements in a way which doesn't match a more
   specific error code, or endpoint declines to use the more specific error code.
@@ -1687,6 +1688,7 @@ The entries in the following table are registered by this document.
 | HTTP_WRONG_STREAM_COUNT             | 0x000E     | Too many unidirectional streams          | {{http-error-codes}}   |
 | HTTP_CLOSED_CRITICAL_STREAM         | 0x000F     | Critical stream was closed               | {{http-error-codes}}   |
 | HTTP_WRONG_STREAM_DIRECTION         | 0x0010     | Unidirectional stream in wrong direction | {{http-error-codes}}   |
+| HTTP_EARLY_RESPONSE                 | 0x0011     | Remainder of request not needed          | {{http-error-codes}}   |
 | HTTP_MALFORMED_FRAME                | 0x01XX     | Error in frame formatting or use         | {{http-error-codes}}   |
 | ----------------------------------- | ---------- | ---------------------------------------- | ---------------------- |
 

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -306,9 +306,10 @@ Trailing header fields are carried in an additional header block following the
 body. Senders MUST send only one header block in the trailers section;
 receivers MUST discard any subsequent header blocks.
 
-An HTTP request/response exchange fully consumes a QUIC stream. After sending a
-request, a client closes the stream for sending; after sending a response, the
-server closes the stream for sending and the QUIC stream is fully closed.
+An HTTP request/response exchange fully consumes a bidirectional QUIC stream.
+After sending a request, a client closes the stream for sending; after sending a
+response, the server closes the stream for sending and the QUIC stream is fully
+closed.
 
 A server can send a complete response prior to the client sending an entire
 request if the response does not depend on any portion of the request that has
@@ -317,8 +318,13 @@ client abort transmission of a request without error by triggering a QUIC
 STOP_SENDING with error code HTTP_EARLY_RESPONSE, sending a complete response,
 and cleanly closing its streams. Clients MUST NOT discard complete responses as
 a result of having their request terminated abruptly, though clients can always
-discard responses at their discretion for other reasons.  Servers MUST NOT
-abort a response in progress as a result of receiving a solicited RST_STREAM.
+discard responses at their discretion for other reasons.
+
+Servers MUST NOT abort a response in progress as a result of receiving a
+solicited RST_STREAM (i.e. with error code STOPPING).  If the request stream
+terminates for any other reason without containing a fully-formed HTTP request,
+the server SHOULD abort its response with the error code
+HTTP_INCOMPLETE_REQUEST.
 
 ### Header Formatting and Compression
 
@@ -1185,6 +1191,9 @@ HTTP_PUSH_ALREADY_IN_CACHE (0x04):
 HTTP_REQUEST_CANCELLED (0x05):
 : The client no longer needs the requested data.
 
+HTTP_INCOMPLETE_REQUEST (0x06):
+: The client's stream terminated without containing a fully-formed request.
+
 HTTP_CONNECT_ERROR (0x07):
 : The connection established in response to a CONNECT request was reset or
   abnormally closed.
@@ -1220,7 +1229,10 @@ HTTP_WRONG_STREAM_DIRECTION (0x0010):
 : A unidirectional stream type was used by a peer which is not permitted to do
   so.
 
+HTTP_EARLY_RESPONSE (0x0011):
+: The remainder of the client's request is not needed to produce a response.
   For use in STOP_SENDING only.
+
 HTTP_GENERAL_PROTOCOL_ERROR (0x00FF):
 : Peer violated protocol requirements in a way which doesn't match a more
   specific error code, or endpoint declines to use the more specific error code.
@@ -1678,6 +1690,7 @@ The entries in the following table are registered by this document.
 | HTTP_INTERNAL_ERROR                 | 0x0003     | Internal error                           | {{http-error-codes}}   |
 | HTTP_PUSH_ALREADY_IN_CACHE          | 0x0004     | Pushed content already cached            | {{http-error-codes}}   |
 | HTTP_REQUEST_CANCELLED              | 0x0005     | Data no longer needed                    | {{http-error-codes}}   |
+| HTTP_INCOMPLETE_REQUEST             | 0x0006     | Stream terminated early                  | {{http-error-codes}}   |
 | HTTP_CONNECT_ERROR                  | 0x0007     | TCP reset or error on CONNECT request    | {{http-error-codes}}   |
 | HTTP_EXCESSIVE_LOAD                 | 0x0008     | Peer generating excessive load           | {{http-error-codes}}   |
 | HTTP_VERSION_FALLBACK               | 0x0009     | Retry over HTTP/2                        | {{http-error-codes}}   |

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -320,11 +320,12 @@ and cleanly closing its streams. Clients MUST NOT discard complete responses as
 a result of having their request terminated abruptly, though clients can always
 discard responses at their discretion for other reasons.
 
-Servers MUST NOT abort a response in progress as a result of receiving a
-solicited RST_STREAM (i.e. with error code STOPPING).  If the request stream
-terminates for any other reason without containing a fully-formed HTTP request,
-the server SHOULD abort its response with the error code
-HTTP_INCOMPLETE_REQUEST.
+Changes to the state of a request stream, including receiving a RST_STREAM
+(regardless of error code), do not affect the state of the server's response.
+Servers MUST NOT abort a response in progress solely due to a state change on
+the request stream. However, if the request stream terminates without containing
+a fully-formed HTTP request, the server SHOULD abort its response with the error
+code HTTP_INCOMPLETE_REQUEST.
 
 ### Header Formatting and Compression
 
@@ -397,15 +398,15 @@ detects an error with the stream or the QUIC connection.
 Either client or server can cancel requests by aborting the stream (QUIC
 RST_STREAM or STOP_SENDING frames, as appropriate) with an error code of
 HTTP_REQUEST_CANCELLED ({{http-error-codes}}).  When the client cancels a
-request or response, it indicates that the response is no longer of interest.
-Clients SHOULD cancel requests by aborting both directions of a stream.
+response, it indicates that this response is no longer of interest. Clients
+SHOULD cancel requests by aborting both directions of a stream.
 
-When the server cancels either direction of the request stream using
-HTTP_REQUEST_CANCELLED, it indicates that no application processing was
-performed.  The client can treat requests cancelled by the server as though they
-had never been sent at all, thereby allowing them to be retried later on a new
-connection.  Servers MUST NOT use the HTTP_REQUEST_CANCELLED status for requests
-which were partially or fully processed.
+When the server cancels its response stream using HTTP_REQUEST_CANCELLED, it
+indicates that no application processing was performed.  The client can treat
+requests cancelled by the server as though they had never been sent at all,
+thereby allowing them to be retried later on a new connection.  Servers MUST NOT
+use the HTTP_REQUEST_CANCELLED status for requests which were partially or fully
+processed.
 
   Note:
   : In this context, "processed" means that some data from the stream was

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -394,10 +394,11 @@ detects an error with the stream or the QUIC connection.
 
 ### Request Cancellation
 
-Either client or server can cancel requests by closing the stream (QUIC
-RST_STREAM or STOP_SENDING frames, as appropriate) with an error type of
+Either client or server can cancel requests by aborting the stream (QUIC
+RST_STREAM or STOP_SENDING frames, as appropriate) with an error code of
 HTTP_REQUEST_CANCELLED ({{http-error-codes}}).  When the client cancels a
 request or response, it indicates that the response is no longer of interest.
+Clients SHOULD cancel requests by aborting both directions of a stream.
 
 When the server cancels either direction of the request stream using
 HTTP_REQUEST_CANCELLED, it indicates that no application processing was


### PR DESCRIPTION
Fixes #1596 (and an oversight I caught in passing) by specifying server behavior if it reaches the end of readable data on a stream and hasn't parsed a full HTTP request yet.  There are a couple cases here, and I think this generically covers all the interesting ones.

- **Client sends FIN early.**  Server sees truncated request, but non-error end of stream.
- **Client sends RST_STREAM part-way through request.**  Server sees truncated request with read error.
- **Client sends a RST_STREAM (but not a STOP_SENDING) after sending a fully-formed request.**
    - **...and packet loss occurred.**  No retransmissions, so same as sending it part-way through request.
    - **...after the server has read the request and generated / begun generating a response.**  The server probably never realizes and responds merrily.  If you didn't want it, you should have sent a STOP_SENDING.
    - **...but before the server has read all the data out of the buffer.**  Depends on implementation; transport might discard unread data or deliver all the data anyway.  Either way, this is identical to one of the two previous cases.

We already discuss cancelling requests, so I added a suggestion that clients go ahead and include a STOP_SENDING if they reset their request stream.