### PR TITLE
Add another condition to idle timeout

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2491,9 +2491,14 @@ A connection that remains idle for longer than the advertised idle timeout (see
 draining state when the idle timeout expires.
 
 Each endpoint advertises their own idle timeout to their peer. The idle timeout
-starts from the last packet received, or the first packet sent after the last
-received packet.  The latter condition ensures that initiating new activity
-postpones a timeout.
+is started if any of the following events occur:
+
+- A new packet is received
+- The first packet is sent after the last packet received
+- The first packet is sent after there are no outstanding packets.
+
+The latter two conditions ensure that initiating new activity postpones a
+timeout.
 
 The value for an idle timeout can be asymmetric.  The value advertised by an
 endpoint is only used to determine whether the connection is live at that


### PR DESCRIPTION
When implementing the new idle timeout, I noticed that there might be one condition missing from this. 

Previously if you send the first packet in the connection or send the first packet after all your ACKs are received / packets lost, then your idle timeout will not be set.

This changes it so that when there are no outstanding packets and you send a packet, it resets the idle timeout.