### PR TITLE
Cite RFC 8446 for TLS 1.3

### DIFF
--- a/draft-ietf-quic-spin-exp.md
+++ b/draft-ietf-quic-spin-exp.md
@@ -104,7 +104,7 @@ code and issues list for this draft can be found at
 # Introduction
 
 The QUIC transport protocol {{QUIC-TRANSPORT}} uses
-Transport Layer Security (TLS) {{?TLS=I-D.ietf-tls-tls13}} to encrypt most of
+Transport Layer Security (TLS) {{?TLS=RFC8446}} to encrypt most of
 its protocol internals. In contrast to TCP where the sequence and
 acknowledgement numbers and timestamps (if the respective option is in use)
 can be seen by on-path observers and used to estimate end-to-end latency,
@@ -285,5 +285,3 @@ grant agreement no. 688421 Measurement and Architecture for a Middleboxed
 Internet (MAMI), and by the Swiss State Secretariat for Education, Research,
 and Innovation under contract no. 15.0268. This support does not imply
 endorsement.
-
-

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -113,12 +113,12 @@ code and issues list for this draft can be found at
 # Introduction
 
 This document describes how QUIC {{QUIC-TRANSPORT}} is secured using Transport
-Layer Security (TLS) version 1.3 {{!TLS13=I-D.ietf-tls-tls13}}.  TLS 1.3
-provides critical latency improvements for connection establishment over
-previous versions.  Absent packet loss, most new connections can be established
-and secured within a single round trip; on subsequent connections between the
-same client and server, the client can often send application data immediately,
-that is, using a zero round trip setup.
+Layer Security (TLS) version 1.3 {{!TLS13=RFC8446}}.  TLS 1.3 provides critical
+latency improvements for connection establishment over previous versions.
+Absent packet loss, most new connections can be established and secured within a
+single round trip; on subsequent connections between the same client and server,
+the client can often send application data immediately, that is, using a zero
+round trip setup.
 
 This document describes how the standardized TLS 1.3 acts as a security
 component of QUIC.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1528,7 +1528,7 @@ handling.
 
 The format of the transport parameters is the TransportParameters struct from
 {{figure-transport-parameters}}.  This is described using the presentation
-language from Section 3 of {{!TLS13=I-D.ietf-tls-tls13}}.
+language from Section 3 of {{!TLS13=RFC8446}}.
 
 ~~~
    uint32 QuicVersion;


### PR DESCRIPTION
This also hits the -transport and -spin-exp drafts, but I'm assuming that this is OK.