### PR TITLE
Pad to 38 if you want a stateless reset

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2733,8 +2733,8 @@ a small packet might result in Stateless Reset not being useful in detecting
 cases of broken connections where only very small packets are sent; such
 failures might only be detected by other means, such as timers.
 
-An endpoint that wants to improve the chances that it triggers a Stateless Reset
-when its peer loses state can pad all packets it sends to 38 octets.
+An endpoint can increase the odds that a packet will trigger a Stateless Reset
+if it cannot be processed by padding it to at least 38 octets.
 
 
 # Frame Types and Formats

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2734,8 +2734,7 @@ cases of broken connections where only very small packets are sent; such
 failures might only be detected by other means, such as timers.
 
 An endpoint that wants to improve the chances that it triggers a Stateless Reset
-when its peer loses state can pad all packets it sends - aside from those
-containing only ACK and PADDING frames - to 38 octets.
+when its peer loses state can pad all packets it sends to 38 octets.
 
 
 # Frame Types and Formats

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2733,6 +2733,10 @@ a small packet might result in Stateless Reset not being useful in detecting
 cases of broken connections where only very small packets are sent; such
 failures might only be detected by other means, such as timers.
 
+An endpoint that wants to improve the chances that it triggers a Stateless Reset
+when its peer loses state can pad all packets it sends - aside from those
+containing only ACK and PADDING frames - to 38 octets.
+
 
 # Frame Types and Formats
 


### PR DESCRIPTION
But there isn't much point in doing that if you aren't expecting a response, so ACK-only packets don't need the same treatment (unless, like @huitema, you are doing that for a measure of traffic analysis protection).

Closes #1681.