### PR TITLE
Grammar fix to invariants draft

### DIFF
--- a/draft-ietf-quic-invariants.md
+++ b/draft-ietf-quic-invariants.md
@@ -313,7 +313,7 @@ reliably extracting information from a flow based on version-specific traits
 requires that middleboxes retain state for every connection ID they see.
 
 The Version Negotiation packet described in this document is not
-integrity-protected, it only has modest protection against insertion by off-path
+integrity-protected; it only has modest protection against insertion by off-path
 attackers.  QUIC versions MUST define a mechanism that authenticates the values
 it contains.
 


### PR DESCRIPTION
Independent clauses of a compound sentence can be joined by a coordinating conjunction (for, and, nor, but, or, yet, so) or a semicolon.