### PR TITLE
Tokens are a mess

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -786,6 +786,14 @@ Note:
   the packet is discarded.  A server MAY encode tokens provided with NEW_TOKEN
   frames and Retry packets differently, and validate the latter more strictly.
 
+In a stateless design, a server can use encrypted and authenticated tokens to
+pass information to clients that the server can later recover and use to
+validate a client address.  Tokens are not integrated into the crypto graphic
+handshake and so they cannot be authenticated.  For instance, a client might be
+able to reuse a token.  To avoid attacks that exploit this property, a server
+can limit its use of tokens to only the information needed validate client
+addresses.
+
 
 ### Starting Packet Numbers
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -788,8 +788,8 @@ Note:
 
 In a stateless design, a server can use encrypted and authenticated tokens to
 pass information to clients that the server can later recover and use to
-validate a client address.  Tokens are not integrated into the crypto graphic
-handshake and so they cannot be authenticated.  For instance, a client might be
+validate a client address.  Tokens are not integrated into the cryptographic
+handshake and so they are not authenticated.  For instance, a client might be
 able to reuse a token.  To avoid attacks that exploit this property, a server
 can limit its use of tokens to only the information needed validate client
 addresses.


### PR DESCRIPTION
We can't realistically authenticate all tokens with up to three Retry
packets and the NEW_TOKEN message.  So they aren't really safe for much.
Describe the limitations and advise a very narrow usage.

I really hope that this choice doesn't bite us later.  It doesn't feel
that good, but I don't know how to fix this without going back to just
one Retry (and even then a solution would be ugly).

Closes #1647.