### PR TITLE
Unified ACK frame

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3347,8 +3347,9 @@ ACK Block includes at least one value; a encoded value of 0 indicates that the
 range contains one packet number.  Each range is described starts at one lower
 than the minimum value from the previous range.  The first ACK Block starts with
 the Largest Acknowledged packet number and describes a range up and including
-that packet number.  Thus, ranges of packet numbers covered by each ACK Block
-can found with:
+that packet number.
+
+Thus, ranges of packet numbers covered by each ACK Block can found with:
 
 ```
 ack_range_i = { low: largest_i - ack_size_i,
@@ -3358,8 +3359,8 @@ ack_largest_i+1 = ack_range_i[low] - 1
 
 For example, the hex sequence 0x00 indicates a gap of one packet, the sequence
 0x05 indicates two unmarked packets, the sequence 0x4037 indicates that there
-are 53 packets with ECN-CE markings, and the sequence 0x80b1d34a indicates that
-there are 5826980 packets that are ECT(1) marked.
+are 14 packets with ECN-CE markings, and the sequence 0x80b1d34a indicates that
+there are 2913491 packets that are ECT(1) marked.
 
 
 ### Sending ACK Frames

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3325,9 +3325,9 @@ Unmarked (1):
 : Unmarked packets are those packets that are acknowledged, but for which the
   ECN marking is either not present, ECT(1), or unknown.
 
-ECT(0) Marked (2):
+ECT Marked (2):
 
-: Packets that are ECT(0) marked are acknowledged using a type of 3.
+: Packets that are ECT(0) marked are acknowledged using a type of 2.
 
 ECN-CE Marked (3):
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3302,14 +3302,16 @@ ACK Blocks:
 
 ### ACK Blocks {#ack-blocks}
 
-Each ACK Block in an ACK frame describes a contiguous range of packets, as well
-as the observed type of the packets in that range.  Each range of packets is
-attributed a type, which is encoded into the two least significant bits of the
-decoded variable-length integer value.  The size of the range is encoded into
-the remainder of the value.
+Each ACK Block in an ACK frame describes a contiguous range of packets.  Each
+ACK Block includes the size of the block and whether the range represents
+unacknowledged packets (a gap), or the type of ECN marking the recipient
+observed for packets that are acknowledged.
 
-The two least significant bits of the decoded value of the ACK Block describe
-the type.  That is, the type of an ACK block is found by:
+The acknowledgment type and size of the range are packed into a single
+variable-length integer.  The two least significant bits of the decoded value
+encode the acknowledgment type.  The size of the range is found by
+right-shifting the value by two bits.  That is, an ACK block is decoded by
+decoding the integer and splitting it into a type and size:
 
 ```
 ack_block_i = decode_varint()


### PR DESCRIPTION
This takes the design discussed on the list and enacts it.  This turns
out to be quite simple.  Lots of red in this change.

This treats ECT(1) as equivalent to unmarked, meaning that QUIC won't be
able to use ECT(1) without an extension or revision.  That keeps the
encoding simpler.

Closes #1439.