### PR TITLE
Require that QPACK preserves header field order.

### DIFF
--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -101,6 +101,11 @@ balance between resilience against head-of-line blocking and optimal compression
 ratio.  The design goals are to closely approach the compression ratio of HPACK
 with substantially less head-of-line blocking under the same loss conditions.
 
+QPACK preserves the ordering of header fields within each header list.  An
+encoder MUST emit header field representations in the order they appear in the
+input header list.  A decoder MUST must emit header fields in the order their
+representations appear in the input header block.
+
 # Header Tables
 
 Like HPACK, QPACK uses two tables for associating header fields to indices.  The
@@ -330,25 +335,27 @@ when, and only when, they appear in all capitals, as shown here.
 
 Definitions of terms that are used in this document:
 
-Header:
+Header field:
 
 : A name-value pair sent as part of an HTTP message.
 
-Header set:
+Header list:
 
-: The full collection of headers associated with an HTTP message.
+: The ordered collection of header fields associated with an HTTP message.  A
+  header list can contain multiple header fields with identical name, or
+  duplicate header fields.
 
 Header block:
 
-: The compressed representation of a header set.
+: The compressed representation of a header list.
 
 Encoder:
 
-: An implementation which transforms a header set into a header block.
+: An implementation which transforms a header list into a header block.
 
 Decoder:
 
-: An implementation which transforms a header block into a header set.
+: An implementation which transforms a header block into a header list.
 
 QPACK is a name, not an acronym.
 

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -342,8 +342,8 @@ Header field:
 Header list:
 
 : The ordered collection of header fields associated with an HTTP message.  A
-  header list can contain multiple header fields with identical name, or
-  duplicate header fields.
+  header list can contain multiple header fields with the same name.  It can
+  also contain duplicate header fields.
 
 Header block:
 


### PR DESCRIPTION
Fixes #1684.

1. Rename "header" to "header field" in the definition section, just
like in HPACK, RFC7541 Section 1.3.  Note that already before this
change the term "header field" appears 44 times in the text.

2. Rename "header set" to "header list" and define it to be ordered and
explicitly allow duplicate header fields, not unlike in HPACK, RFC7541
Section 1.3.  Also explicitly allow header fields with identical name.

3. Add a paragraph to require that ordering is preserved, much like
HPACK, RFC7541 Section 2.1.