### PR TITLE
Correct transitions described by diagram

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4161,10 +4161,10 @@ application protocol some of which cannot be observed by the sender.
        |                           |
        | Recv All Data             |
        v                           v
-   +-------+                   +-------+
-   | Data  | Recv RST_STREAM   | Reset |
-   | Recvd |<-- (optional) --->| Recvd |
-   +-------+                   +-------+
+   +-------+  Recv RST_STREAM  +-------+
+   | Data  |--- (optional) --->| Reset |
+   | Recvd |  Recv All Data    | Recvd |
+   +-------+<-- (optional) ----+-------+
        |                           |
        | App Read All Data         | App Read RST
        v                           v


### PR DESCRIPTION
Receiving the RST_STREAM frame may cause a transition from "Data Recvd"
to "Reset Recvd," but it cannot cause a transition in the other
direction. Update the diagram to accurately describe the condition which
may cause a transition in that direction.