### PR TITLE
Tighten error processing of NEW CONNECTION ID

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3218,6 +3218,19 @@ value of the connection ID changed.  An endpoint that is sending packets with a
 zero-length Destination Connection ID MUST treat receipt of a NEW_CONNECTION_ID
 frame as a connection error of type PROTOCOL_VIOLATION.
 
+Transmission errors, time-outs and retransmission may cause the same
+NEW_CONNECTION_ID frame to be received multiple time. Additional
+transmissions SHOULD be ignored and MUST NOT cause a connection
+error.
+
+If an endpoint receives a NEW_CONNECTION_ID frame that repeats the same
+connection ID as a previous NEW_CONNECTION_ID framebut with a different
+Stateless Reset Token or a different Sequence, the endpoint MUST
+treat that receipt as a connection error of type PROTOCOL_VIOLATION.
+Similarly, if an endpoint receives a NEW_CONNECTION_ID frame that repeats
+the Source Connection ID used by the peer during the initial
+handshake, it MUST treat that receipt as a connection error of type
+PROTOCOL_VIOLATION.
 
 ## STOP_SENDING Frame {#frame-stop-sending}
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3224,7 +3224,7 @@ transmissions SHOULD be ignored and MUST NOT cause a connection
 error.
 
 If an endpoint receives a NEW_CONNECTION_ID frame that repeats the same
-connection ID as a previous NEW_CONNECTION_ID framebut with a different
+connection ID as a previous NEW_CONNECTION_ID frame but with a different
 Stateless Reset Token or a different Sequence, the endpoint MUST
 treat that receipt as a connection error of type PROTOCOL_VIOLATION.
 Similarly, if an endpoint receives a NEW_CONNECTION_ID frame that repeats


### PR DESCRIPTION
Generate an error if the same connection ID is announced twice, with different reset secret or different sequence number. Also prohibits repeating the connection ID used in handshake in a new connection ID frame.