### PR TITLE
Optional Idle Timeout

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1629,13 +1629,23 @@ initial_max_bidi_streams (0x0002):
   MAX_STREAM_ID containing 16 when received by a client or 17 when received by a
   server.
 
+initial_max_uni_streams (0x0008):
+
+: The initial maximum unidirectional streams parameter contains the initial
+  maximum number of unidirectional streams the peer may initiate, encoded as an
+  unsigned 16-bit integer.  If this parameter is absent or zero, unidirectional
+  streams cannot be created until a MAX_STREAM_ID frame is sent.  Setting this
+  parameter is equivalent to sending a MAX_STREAM_ID ({{frame-max-stream-id}})
+  immediately after completing the handshake containing the corresponding Stream
+  ID. For example, a value of 0x05 would be equivalent to receiving a
+  MAX_STREAM_ID containing 18 when received by a client or 19 when received by a
+  server.
+
 idle_timeout (0x0003):
 
 : The idle timeout is a value in seconds that is encoded as an unsigned 16-bit
-  integer.  There is no maximum value besides the maximum encodable value of
-  0xFFFF (about 18 hours).  If this parameter is absent or zero then the idle
-  timeout is disabled.  In this case, the transport never closes the connection
-  in response to being idle.
+  integer.  If this parameter is absent or zero then the idle timeout is
+  disabled.
 
 max_packet_size (0x0005):
 
@@ -1653,18 +1663,6 @@ ack_delay_exponent (0x0007):
   default value of 3 is assumed (indicating a multiplier of 8).  The default
   value is also used for ACK frames that are sent in Initial and Handshake
   packets.  Values above 20 are invalid.
-
-initial_max_uni_streams (0x0008):
-
-: The initial maximum unidirectional streams parameter contains the initial
-  maximum number of unidirectional streams the peer may initiate, encoded as an
-  unsigned 16-bit integer.  If this parameter is absent or zero, unidirectional
-  streams cannot be created until a MAX_STREAM_ID frame is sent.  Setting this
-  parameter is equivalent to sending a MAX_STREAM_ID ({{frame-max-stream-id}})
-  immediately after completing the handshake containing the corresponding Stream
-  ID. For example, a value of 0x05 would be equivalent to receiving a
-  MAX_STREAM_ID containing 18 when received by a client or 19 when received by a
-  server.
 
 disable_migration (0x0009):
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1606,14 +1606,6 @@ type TRANSPORT_PARAMETER_ERROR.
 
 ### Transport Parameter Definitions
 
-An endpoint MUST include the following parameters in its encoded
-TransportParameters:
-
-idle_timeout (0x0003):
-
-: The idle timeout is a value in seconds that is encoded as an unsigned 16-bit
-  integer.  The maximum value is 600 seconds (10 minutes).
-
 An endpoint MAY use the following transport parameters:
 
 initial_max_data (0x0001):
@@ -1636,6 +1628,14 @@ initial_max_bidi_streams (0x0002):
   ID. For example, a value of 0x05 would be equivalent to receiving a
   MAX_STREAM_ID containing 16 when received by a client or 17 when received by a
   server.
+
+idle_timeout (0x0003):
+
+: The idle timeout is a value in seconds that is encoded as an unsigned 16-bit
+  integer.  There is no maximum value besides the maximum encodable value of
+  0xFFFF (about 18 hours).  If this parameter is abset or zero then the idle
+  timeout is disabled.  In this case, the transport never closes the connection
+  in response to being idle.
 
 initial_max_uni_streams (0x0008):
 
@@ -2531,9 +2531,9 @@ source address.
 
 ### Idle Timeout
 
-A connection that remains idle for longer than the advertised idle timeout (see
-{{transport-parameter-definitions}}) is closed.  A connection enters the
-draining state when the idle timeout expires.
+If the idle timeout is enabled, a connection that remains idle for longer than
+the advertised idle timeout (see {{transport-parameter-definitions}}) is closed.
+A connection enters the draining state when the idle timeout expires.
 
 Each endpoint advertises their own idle timeout to their peer. The idle timeout
 starts from the last packet received.  In order to ensure that initiating new

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1633,21 +1633,9 @@ idle_timeout (0x0003):
 
 : The idle timeout is a value in seconds that is encoded as an unsigned 16-bit
   integer.  There is no maximum value besides the maximum encodable value of
-  0xFFFF (about 18 hours).  If this parameter is abset or zero then the idle
+  0xFFFF (about 18 hours).  If this parameter is absent or zero then the idle
   timeout is disabled.  In this case, the transport never closes the connection
   in response to being idle.
-
-initial_max_uni_streams (0x0008):
-
-: The initial maximum unidirectional streams parameter contains the initial
-  maximum number of unidirectional streams the peer may initiate, encoded as an
-  unsigned 16-bit integer.  If this parameter is absent or zero, unidirectional
-  streams cannot be created until a MAX_STREAM_ID frame is sent.  Setting this
-  parameter is equivalent to sending a MAX_STREAM_ID ({{frame-max-stream-id}})
-  immediately after completing the handshake containing the corresponding Stream
-  ID. For example, a value of 0x05 would be equivalent to receiving a
-  MAX_STREAM_ID containing 18 when received by a client or 19 when received by a
-  server.
 
 max_packet_size (0x0005):
 
@@ -1665,6 +1653,18 @@ ack_delay_exponent (0x0007):
   default value of 3 is assumed (indicating a multiplier of 8).  The default
   value is also used for ACK frames that are sent in Initial and Handshake
   packets.  Values above 20 are invalid.
+
+initial_max_uni_streams (0x0008):
+
+: The initial maximum unidirectional streams parameter contains the initial
+  maximum number of unidirectional streams the peer may initiate, encoded as an
+  unsigned 16-bit integer.  If this parameter is absent or zero, unidirectional
+  streams cannot be created until a MAX_STREAM_ID frame is sent.  Setting this
+  parameter is equivalent to sending a MAX_STREAM_ID ({{frame-max-stream-id}})
+  immediately after completing the handshake containing the corresponding Stream
+  ID. For example, a value of 0x05 would be equivalent to receiving a
+  MAX_STREAM_ID containing 18 when received by a client or 19 when received by a
+  server.
 
 disable_migration (0x0009):
 


### PR DESCRIPTION
Idle timeout is currently the last required transport parameter. This makes the parameter optional, defaulting to 0 or disabled if not present. It also removes the 10 minute maximum value. For other non-http protocols over QUIC, a 10 minute max doesn't really make sense.