### PR TITLE
Fix spelling error

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4461,7 +4461,7 @@ authentication messages.
 STREAM data in frames determined to be lost SHOULD be retransmitted before
 sending new data, unless application priorities indicate otherwise.
 Retransmitting lost stream data can fill in gaps, which allows the peer to
-consume already received data and free up flow control window.
+consume already received data and free up the flow control window.
 
 
 # Flow Control {#flow-control}


### PR DESCRIPTION
Not entirely sure about this one but I think it should be "the flow control window"