### PR TITLE
Spelling: "connection ID -> connection IDs"

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -546,7 +546,7 @@ shares, and long lists of supported ciphers, signature algorithms, versions,
 QUIC transport parameters, and other negotiable parameters and extensions could
 cause this message to grow.
 
-For servers, in addition to connection ID and tokens, the size of TLS session
+For servers, in addition to connection IDs and tokens, the size of TLS session
 tickets can have an effect on a client's ability to connect.  Minimizing the
 size of these values increases the probability that they can be successfully
 used by a client.


### PR DESCRIPTION
Since there are two connection ids in an Initial packet I think "connection IDs" should be used in this case.