### PR TITLE
Clarify OOO CRYPTO data handling

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3710,6 +3710,10 @@ functionally identical to STREAM frames, except that they do not bear a stream
 identifier; they are not flow controlled; and they do not carry markers for
 optional offset, optional length, and the end of the stream.
 
+If a QUIC endpoint receives a CRYPTO frame for a cryptographic context, having
+already received a CRYPTO frame in a more secure context, it MUST drop the data
+in the frame without delivering it to TLS for processing.
+
 A CRYPTO frame is shown below.
 
 ~~~

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3710,8 +3710,8 @@ functionally identical to STREAM frames, except that they do not bear a stream
 identifier; they are not flow controlled; and they do not carry markers for
 optional offset, optional length, and the end of the stream.
 
-If a QUIC endpoint receives a CRYPTO frame for a cryptographic context, having
-already received a CRYPTO frame in a more secure context, it MUST drop the data
+If a QUIC endpoint processses a CRYPTO frame for a cryptographic context, having
+already processed a CRYPTO frame in a more secure context, it MUST drop the data
 in the frame without delivering it to TLS for processing.
 
 A CRYPTO frame is shown below.


### PR DESCRIPTION
We should never pass up Initial CRYPTO payloads once we've passed up Handshake, etc. This would break the ordered delivery of data to TLS.