### PR TITLE
Ack Delay and TLP

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -828,12 +828,11 @@ Pseudocode for SetLossDetectionTimer follows:
       if (tlp_count < kMaxTLPs):
         // Tail Loss Probe
         if (bytes_in_flight < 2400):
-          // Less than one full-sized packet in flight.
+          // Less than two full-sized packets in flight.
           tlp_timeout = max(1.5 * smoothed_rtt
                               + max_ack_delay, kMinTLPTimeout)
         else:
-          tlp_timeout = max(1.5 * smoothed_rtt,
-                              kMinTLPTimeout)
+          tlp_timeout = max(2 * smoothed_rtt, kMinTLPTimeout)
         timeout = min(tlp_timeout, timeout)
 
     loss_detection_timer.set(

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -439,10 +439,10 @@ ack delay to avoid causing the peer spurious timeouts.  The maximum ack delay
 is communicated in the `max_ack_delay` transport parameter and the default
 value is 25ms.
 
-An acknowledgement SHOULD be sent for every second full-sized packet, as TCP
-does {{?RFC5681}}, or may be sent less frequently, as long as the delay does
-not exceed the maximum ack delay. QUIC recovery algorithms do not assume the
-peer generates an acknowledgement immediately when receiving a second full-sized
+An acknowledgement SHOULD be sent for every second full-sized packet, as TCP does
+{{?RFC5681}}, or may be sent less frequently, as long as the delay does not
+exceed the maximum ack delay. QUIC recovery algorithms do not assume the peer
+generates an acknowledgement immediately when receiving a second full-sized
 packet.
 
 Out-of-order packets SHOULD be acknowledged more quickly, in order to accelerate

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -352,11 +352,11 @@ receiver.
 The timer duration, or Probe Timeout (PTO), is set based on the following
 conditions:
 
-* If less than 2400 bytes are in flight, PTO SHOULD be scheduled for
-  max(1.5*SRTT+MaxAckDelay, kMinTLPTimeout).
+* If less than 2*kMaxDatagramSize bytes are in flight, PTO SHOULD be
+  scheduled for max(1.5*SRTT+MaxAckDelay, kMinTLPTimeout).
 
-* If at least 2400 bytes are in flight, PTO SHOULD be scheduled for
-  max(2*SRTT, kMinTLPTimeout).
+* If at least 2*kMaxDatagramSize bytes are in flight, PTO SHOULD be
+  scheduled for max(2*SRTT, kMinTLPTimeout).
 
 * If RTO ({{rto}}) is earlier, schedule a TLP in its place. That is,
   PTO SHOULD be scheduled for min(RTO, PTO).
@@ -535,6 +535,11 @@ kDelayedAckTimeout:
 
 kInitialRtt:
 : The RTT used before an RTT sample is taken. The RECOMMENDED value is 100ms.
+
+kMaxDatagramSize:
+: The sender's maximum payload size. Does not include UDP or IP overhead.
+  The max packet size is used for calculating initial and minimum congestion
+  windows, as well as the TLP timeout. The RECOMMENDED value is 1200 bytes.
 
 ### Variables of interest
 
@@ -827,7 +832,7 @@ Pseudocode for SetLossDetectionTimer follows:
       timeout = timeout * (2 ^ rto_count)
       if (tlp_count < kMaxTLPs):
         // Tail Loss Probe
-        if (bytes_in_flight < 2400):
+        if (bytes_in_flight < 2 * kMaxDatagramSize):
           // Less than two full-sized packets in flight.
           tlp_timeout = max(1.5 * smoothed_rtt
                               + max_ack_delay, kMinTLPTimeout)
@@ -1027,11 +1032,6 @@ in Linux (3.11 onwards).
 Constants used in congestion control are based on a combination of RFCs,
 papers, and common practice.  Some may need to be changed or negotiated
 in order to better suit a variety of environments.
-
-kMaxDatagramSize:
-: The sender's maximum payload size. Does not include UDP or IP
-  overhead. The max packet size is used for calculating initial and
-  minimum congestion windows. The RECOMMENDED value is 1200 bytes.
 
 kInitialWindow:
 : Default limit on the initial amount of outstanding data in bytes.

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -362,7 +362,7 @@ delay may come into play, regardless of the number of packets outstanding.
 TCP's TLP assumes if at least 2 packets are outstanding, acks will not be
 delayed.
 
-A PTO value of at least 1.5*SRTT ensures that the ACK is overdue. The 1.5 is
+A PTO value of at least 1.5*SRTT ensures that the ACK is overdue.  The 1.5 is
 based on {{?TLP}}, but implementations MAY experiment with other constants.
 
 To reduce latency, it is RECOMMENDED that the sender set and allow the TLP timer

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -531,11 +531,6 @@ kDelayedAckTimeout:
 kInitialRtt:
 : The RTT used before an RTT sample is taken. The RECOMMENDED value is 100ms.
 
-kMaxDatagramSize:
-: The sender's maximum payload size. Does not include UDP or IP overhead.
-  The max packet size is used for calculating initial and minimum congestion
-  windows, as well as the TLP timeout. The RECOMMENDED value is 1200 bytes.
-
 ### Variables of interest
 
 Variables required to implement the congestion control mechanisms
@@ -1023,6 +1018,11 @@ in Linux (3.11 onwards).
 Constants used in congestion control are based on a combination of RFCs,
 papers, and common practice.  Some may need to be changed or negotiated
 in order to better suit a variety of environments.
+
+kMaxDatagramSize:
+: The sender's maximum payload size. Does not include UDP or IP overhead.
+  The max packet size is used for calculating initial and minimum congestion
+  windows, as well as the TLP timeout. The RECOMMENDED value is 1200 bytes.
 
 kInitialWindow:
 : Default limit on the initial amount of outstanding data in bytes.

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -439,11 +439,10 @@ ack delay to avoid causing the peer spurious timeouts.  The maximum ack delay
 is communicated in the `max_ack_delay` transport parameter and the default
 value is 25ms.
 
-An acknowledgement SHOULD be sent for every second full-sized packet, as TCP
-does {{?RFC5681}}, or may be sent less frequently, as long as the delay does
-not exceed the maximum ack delay. QUIC recovery algorithms do not assume the
-peer generates an acknowledgement immediately when receiving a second full-sized
-packet.
+An acknowledgement SHOULD be sent immediately upon receipt of a second
+full-sized packet, as TCP does {{?RFC5681}}, but the delay should not exceed
+the maximum ack delay. QUIC recovery algorithms do not assume the peer generates
+an acknowledgement immediately when receiving a second full-sized packet.
 
 Out-of-order packets SHOULD be acknowledged more quickly, in order to accelerate
 loss recovery.  The receiver SHOULD send an immediate ACK when it receives a new

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -439,10 +439,10 @@ ack delay to avoid causing the peer spurious timeouts.  The maximum ack delay
 is communicated in the `max_ack_delay` transport parameter and the default
 value is 25ms.
 
-An acknowledgement SHOULD be sent immediately upon receiving two or more
-retransmitable full-sized packets, as TCP does {{?RFC5681}}.  QUIC recovery
-algorithms, including tail loss probe{{tail-loss-probe}}, assume the peer
-generates an acknowledgement immediately when receiving a second full-sized
+An acknowledgement SHOULD be sent for every second full-sized packet, as TCP
+does {{?RFC5681}}, or may be sent less frequently, as long as the delay does
+not exceed the maximum ack delay. QUIC recovery algorithms do not assume the
+peer generates an acknowledgement immediately when receiving a second full-sized
 packet.
 
 Out-of-order packets SHOULD be acknowledged more quickly, in order to accelerate

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -439,10 +439,10 @@ ack delay to avoid causing the peer spurious timeouts.  The maximum ack delay
 is communicated in the `max_ack_delay` transport parameter and the default
 value is 25ms.
 
-An acknowledgement SHOULD be sent for every second full-sized packet, as TCP does
-{{?RFC5681}}, or may be sent less frequently, as long as the delay does not
-exceed the maximum ack delay. QUIC recovery algorithms do not assume the peer
-generates an acknowledgement immediately when receiving a second full-sized
+An acknowledgement SHOULD be sent for every second full-sized packet, as TCP
+does {{?RFC5681}}, or may be sent less frequently, as long as the delay does
+not exceed the maximum ack delay. QUIC recovery algorithms do not assume the
+peer generates an acknowledgement immediately when receiving a second full-sized
 packet.
 
 Out-of-order packets SHOULD be acknowledged more quickly, in order to accelerate

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -362,8 +362,8 @@ delay may come into play, regardless of the number of packets outstanding.
 TCP's TLP assumes if at least 2 packets are outstanding, acks will not be
 delayed.
 
-A PTO value of at least 1.5*SRTT ensures that the ACK is overdue. The 1.5
-is based on {{?TLP}}, but implementations MAY experiment with other constants.
+A PTO value of at least 1.5*SRTT ensures that the ACK is overdue. The 1.5 is
+based on {{?TLP}}, but implementations MAY experiment with other constants.
 
 To reduce latency, it is RECOMMENDED that the sender set and allow the TLP timer
 to fire twice before setting an RTO timer. In other words, when the TLP timer

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -440,9 +440,9 @@ is communicated in the `max_ack_delay` transport parameter and the default
 value is 25ms.
 
 An acknowledgement SHOULD be sent immediately upon receipt of a second
-full-sized packet, as TCP does {{?RFC5681}}, but the delay should not exceed
-the maximum ack delay. QUIC recovery algorithms do not assume the peer generates
-an acknowledgement immediately when receiving a second full-sized packet.
+packet but the delay SHOULD NOT exceed the maximum ack delay. QUIC recovery
+algorithms do not assume the peer generates an acknowledgement immediately when
+receiving a second full-packet.
 
 Out-of-order packets SHOULD be acknowledged more quickly, in order to accelerate
 loss recovery.  The receiver SHOULD send an immediate ACK when it receives a new
@@ -1021,7 +1021,7 @@ in order to better suit a variety of environments.
 kMaxDatagramSize:
 : The sender's maximum payload size. Does not include UDP or IP overhead.
   The max packet size is used for calculating initial and minimum congestion
-  windows, as well as the TLP timeout. The RECOMMENDED value is 1200 bytes.
+  windows. The RECOMMENDED value is 1200 bytes.
 
 kInitialWindow:
 : Default limit on the initial amount of outstanding data in bytes.

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -362,7 +362,7 @@ delay may come into play, regardless of the number of packets outstanding.
 TCP's TLP assumes if at least 2 packets are outstanding, acks will not be
 delayed.
 
-A PTO values of at least 1.5*SRTT and 2*SRTT ensures that the ACK is overdue.
+A PTO values of at least 1.5*SRTT ensures that the ACK is overdue.
 Both constants are based on {{?TLP}}, but implementations MAY experiment with
 other constants.
 
@@ -828,12 +828,8 @@ Pseudocode for SetLossDetectionTimer follows:
       timeout = timeout * (2 ^ rto_count)
       if (tlp_count < kMaxTLPs):
         // Tail Loss Probe
-        if (bytes_in_flight < 2 * kMaxDatagramSize):
-          // Less than two full-sized packets in flight.
-          tlp_timeout = max(1.5 * smoothed_rtt
-                              + max_ack_delay, kMinTLPTimeout)
-        else:
-          tlp_timeout = max(2 * smoothed_rtt, kMinTLPTimeout)
+        tlp_timeout = max(1.5 * smoothed_rtt
+                           + max_ack_delay, kMinTLPTimeout)
         timeout = min(tlp_timeout, timeout)
 
     loss_detection_timer.set(

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -362,9 +362,8 @@ delay may come into play, regardless of the number of packets outstanding.
 TCP's TLP assumes if at least 2 packets are outstanding, acks will not be
 delayed.
 
-A PTO values of at least 1.5*SRTT ensures that the ACK is overdue.
-Both constants are based on {{?TLP}}, but implementations MAY experiment with
-other constants.
+A PTO value of at least 1.5*SRTT ensures that the ACK is overdue. The 1.5
+is based on {{?TLP}}, but implementations MAY experiment with other constants.
 
 To reduce latency, it is RECOMMENDED that the sender set and allow the TLP timer
 to fire twice before setting an RTO timer. In other words, when the TLP timer

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -352,11 +352,7 @@ receiver.
 The timer duration, or Probe Timeout (PTO), is set based on the following
 conditions:
 
-* If less than 2*kMaxDatagramSize bytes are in flight, PTO SHOULD be
-  scheduled for max(1.5*SRTT+MaxAckDelay, kMinTLPTimeout).
-
-* If at least 2*kMaxDatagramSize bytes are in flight, PTO SHOULD be
-  scheduled for max(2*SRTT, kMinTLPTimeout).
+* PTO SHOULD be scheduled for max(1.5*SRTT+MaxAckDelay, kMinTLPTimeout)
 
 * If RTO ({{rto}}) is earlier, schedule a TLP in its place. That is,
   PTO SHOULD be scheduled for min(RTO, PTO).


### PR DESCRIPTION
Fixes some remaining issues now that QUIC recommends sending an ACK every two packets, mostly involving reverting to the TCP style TLP calculation.

I wrote this based on 'two full-sized packets' equalling a fixed 2400 bytes.  QUIC could send immediate acks for non-full-sized packets, but that's not what TCP does.  I could base it on the connection's packet size, but that requires the receiver to monitor the sender's max packet size, which made me a bit concerned?

Advice on how to ensure sender and receiver agree on packet size would be appreciated.