### PR TITLE
Send Stream State starts with "Send" for peer-initiated bidi streams

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4179,38 +4179,36 @@ Note:
 data to a peer.
 
 ~~~
-   o
-   | Create Bidirectional Stream (Receiving)
-   |
-   |       o
-   |       | Create Stream (Sending)
-   |       v
-   |   +-------+
-   |   | Ready | Send RST_STREAM
-   |   |       |-----------------------.
-   |   +-------+                       |
-   |       |                           |
-   |       | Send STREAM /             |
-   |       |      STREAM_BLOCKED       |
-   |       v                           |
-   |   +-------+                       |
-   |   | Send  | Send RST_STREAM       |
-   `-->|       |---------------------->|
-       +-------+                       |
-           |                           |
-           | Send STREAM + FIN         |
-           v                           v
-       +-------+                   +-------+
-       | Data  | Send RST_STREAM   | Reset |
-       | Sent  |------------------>| Sent  |
-       +-------+                   +-------+
-           |                           |
-           | Recv All ACKs             | Recv ACK
-           v                           v
-       +-------+                   +-------+
-       | Data  |                   | Reset |
-       | Recvd |                   | Recvd |
-       +-------+                   +-------+
+       o
+       | Create Stream (Sending)
+       | Create Bidirectional Stream (Receiving)
+       v
+   +-------+
+   | Ready | Send RST_STREAM
+   |       |-----------------------.
+   +-------+                       |
+       |                           |
+       | Send STREAM /             |
+       |      STREAM_BLOCKED       |
+       v                           |
+   +-------+                       |
+   | Send  | Send RST_STREAM       |
+   |       |---------------------->|
+   +-------+                       |
+       |                           |
+       | Send STREAM + FIN         |
+       v                           v
+   +-------+                   +-------+
+   | Data  | Send RST_STREAM   | Reset |
+   | Sent  |------------------>| Sent  |
+   +-------+                   +-------+
+       |                           |
+       | Recv All ACKs             | Recv ACK
+       v                           v
+   +-------+                   +-------+
+   | Data  |                   | Reset |
+   | Recvd |                   | Recvd |
+   +-------+                   +-------+
 ~~~
 {: #fig-stream-send-states title="States for Send Streams"}
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4218,14 +4218,14 @@ protocol.  The "Ready" state represents a newly created stream that is able to
 accept data from the application.  Stream data might be buffered in this state
 in preparation for sending.
 
-The sending part of a bidirectional stream initiated by a peer (type 0 for a
-server, type 1 for a client) enters the "Ready" state if the receiving part
-enters the "Recv" state.
-
 Sending the first STREAM or STREAM_BLOCKED frame causes a send stream to enter
 the "Send" state.  An implementation might choose to defer allocating a Stream
 ID to a send stream until it sends the first frame and enters this state, which
 can allow for better stream prioritization.
+
+The sending part of a bidirectional stream initiated by a peer (type 0 for a
+server, type 1 for a client) enters the "Send" state if the receiving part
+enters the "Recv" state.
 
 In the "Send" state, an endpoint transmits - and retransmits as necessary - data
 in STREAM frames.  The endpoint respects the flow control limits of its peer,

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4224,8 +4224,8 @@ ID to a send stream until it sends the first frame and enters this state, which
 can allow for better stream prioritization.
 
 The sending part of a bidirectional stream initiated by a peer (type 0 for a
-server, type 1 for a client) enters the "Ready" state then immediately transits
-to the "Send" state if the receiving part enters the "Recv" state.
+server, type 1 for a client) enters the "Ready" state then immediately
+transitions to the "Send" state if the receiving part enters the "Recv" state.
 
 In the "Send" state, an endpoint transmits - and retransmits as necessary - data
 in STREAM frames.  The endpoint respects the flow control limits of its peer,

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4179,36 +4179,38 @@ Note:
 data to a peer.
 
 ~~~
-       o
-       | Create Stream (Sending)
-       | Create Bidirectional Stream (Receiving)
-       v
-   +-------+
-   | Ready | Send RST_STREAM
-   |       |-----------------------.
-   +-------+                       |
-       |                           |
-       | Send STREAM /             |
-       |      STREAM_BLOCKED       |
-       v                           |
-   +-------+                       |
-   | Send  | Send RST_STREAM       |
-   |       |---------------------->|
-   +-------+                       |
-       |                           |
-       | Send STREAM + FIN         |
-       v                           v
-   +-------+                   +-------+
-   | Data  | Send RST_STREAM   | Reset |
-   | Sent  |------------------>| Sent  |
-   +-------+                   +-------+
-       |                           |
-       | Recv All ACKs             | Recv ACK
-       v                           v
-   +-------+                   +-------+
-   | Data  |                   | Reset |
-   | Recvd |                   | Recvd |
-   +-------+                   +-------+
+   o
+   | Create Bidirectional Stream (Receiving)
+   |
+   |       o
+   |       | Create Stream (Sending)
+   |       v
+   |   +-------+
+   |   | Ready | Send RST_STREAM
+   |   |       |-----------------------.
+   |   +-------+                       |
+   |       |                           |
+   |       | Send STREAM /             |
+   |       |      STREAM_BLOCKED       |
+   |       v                           |
+   |   +-------+                       |
+   |   | Send  | Send RST_STREAM       |
+   `-->|       |---------------------->|
+       +-------+                       |
+           |                           |
+           | Send STREAM + FIN         |
+           v                           v
+       +-------+                   +-------+
+       | Data  | Send RST_STREAM   | Reset |
+       | Sent  |------------------>| Sent  |
+       +-------+                   +-------+
+           |                           |
+           | Recv All ACKs             | Recv ACK
+           v                           v
+       +-------+                   +-------+
+       | Data  |                   | Reset |
+       | Recvd |                   | Recvd |
+       +-------+                   +-------+
 ~~~
 {: #fig-stream-send-states title="States for Send Streams"}
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4224,8 +4224,8 @@ ID to a send stream until it sends the first frame and enters this state, which
 can allow for better stream prioritization.
 
 The sending part of a bidirectional stream initiated by a peer (type 0 for a
-server, type 1 for a client) enters the "Send" state if the receiving part
-enters the "Recv" state.
+server, type 1 for a client) enters the "Ready" state then immediately transits
+to the "Send" state if the receiving part enters the "Recv" state.
 
 In the "Send" state, an endpoint transmits - and retransmits as necessary - data
 in STREAM frames.  The endpoint respects the flow control limits of its peer,

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4180,7 +4180,7 @@ data to a peer.
 
 ~~~
    o
-   | Create Bidirectional Stream (Peer-initiated)
+   | Create Bidirectional Stream (Receiving)
    |
    |       o
    |       | Create Stream (Sending)

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4180,7 +4180,7 @@ data to a peer.
 
 ~~~
    o
-   | Create Bidirectional Stream (Receiving)
+   | Create Bidirectional Stream (Peer-initiated)
    |
    |       o
    |       | Create Stream (Sending)


### PR DESCRIPTION
The change fixes #1797, and also clarifies that deferring the allocation of stream ID while in "Ready" state does not apply to pere-initated bidi streams.