### PR TITLE
Parenthesize 2 * MaxEntries to prevent naive errors

### DIFF
--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -718,7 +718,7 @@ safe to process the rest of the block.  If Largest Reference is greater than
 zero, the encoder transforms it as follows before encoding:
 
 ~~~
-   LargestReference = LargestReference mod (2*MaxEntries) + 1
+   LargestReference = (LargestReference mod (2 * MaxEntries)) + 1
 ~~~
 
 The decoder reconstructs the Largest Reference using the following algorithm:
@@ -726,16 +726,16 @@ The decoder reconstructs the Largest Reference using the following algorithm:
 ~~~
    if LargestReference > 0:
       LargestReference -= 1
-      CurrentWrapped = TotalNumberOfInserts mod (2*MaxEntries)
+      CurrentWrapped = TotalNumberOfInserts mod (2 * MaxEntries)
 
       if CurrentWrapped >= LargestReference + MaxEntries:
          # Largest Reference wrapped around 1 extra time
-         LargestReference += 2*MaxEntries
+         LargestReference += 2 * MaxEntries
       else if CurrentWrapped + MaxEntries < LargestReference
          # Decoder wrapped around 1 extra time
-         CurrentWrapped += 2*MaxEntries
+         CurrentWrapped += 2 * MaxEntries
 
-      LargestReference += (TotalNumberOfInserts - CurrentWrapped)
+      LargestReference += TotalNumberOfInserts - CurrentWrapped
 ~~~
 
 TotalNumberOfInserts is the total number of inserts into the decoder's

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -726,7 +726,7 @@ The decoder reconstructs the Largest Reference using the following algorithm:
 ~~~
    if LargestReference > 0:
       LargestReference -= 1
-      CurrentWrapped = TableLargestAbsoluteIndex mod (2*MaxEntries)
+      CurrentWrapped = TotalNumberOfInserts mod (2*MaxEntries)
 
       if CurrentWrapped >= LargestReference + MaxEntries:
          # Largest Reference wrapped around 1 extra time
@@ -735,13 +735,12 @@ The decoder reconstructs the Largest Reference using the following algorithm:
          # Decoder wrapped around 1 extra time
          CurrentWrapped += 2*MaxEntries
 
-      LargestReference +=
-         (TableLargestAbsoluteIndex - CurrentWrapped)
+      LargestReference += (TotalNumberOfInserts - CurrentWrapped)
 ~~~
 
-TableLargestAbsoluteIndex is the Absolute Index of the most recently inserted
-item in the decoder's dynamic table.  This encoding limits the length of the
-prefix on long-lived connections.
+TotalNumberOfInserts is the total number of inserts into the decoder's
+dynamic table.  This encoding limits the length of the prefix on
+long-lived connections.
 
 `Base Index` is used to resolve references in the dynamic table as described in
 {{relative-indexing}}.

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -718,7 +718,7 @@ safe to process the rest of the block.  If Largest Reference is greater than
 zero, the encoder transforms it as follows before encoding:
 
 ~~~
-   LargestReference = LargestReference mod 2*MaxEntries + 1
+   LargestReference = LargestReference mod (2*MaxEntries) + 1
 ~~~
 
 The decoder reconstructs the Largest Reference using the following algorithm:
@@ -726,7 +726,7 @@ The decoder reconstructs the Largest Reference using the following algorithm:
 ~~~
    if LargestReference > 0:
       LargestReference -= 1
-      CurrentWrapped = TableLargestAbsoluteIndex mod 2*MaxEntries
+      CurrentWrapped = TableLargestAbsoluteIndex mod (2*MaxEntries)
 
       if CurrentWrapped >= LargestReference + MaxEntries:
          # Largest Reference wrapped around 1 extra time


### PR DESCRIPTION
Transcribing

```
  LargestReference mod 2*MaxEntries + 1
```

to C one of its offspring without parentheses around 2 * MaxEntries
will produce an incorrect result.