### PR TITLE
Replace handshake with crypto

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -311,23 +311,23 @@ RTT.
 
 At the beginning, there are no prior RTT samples within a connection.  Resumed
 connections over the same network SHOULD use the previous connection's final
-smoothed RTT value as the resumed connection's initial RTT.
+smoothed RTT value as the resumed connection's initial RTT.  When an
+acknowledgement is received, a new RTT is computed and the timer
+SHOULD be set for twice the newly computed smoothed RTT.
 
 If no previous RTT is available, or if the network changes, the initial RTT
 SHOULD be set to 100ms.
 
-When CRYPTO frames are sent, the sender SHOULD set a timer for the crypto
-timeout period.  Upon timeout, the sender MUST retransmit all unacknowledged
-CRYPTO data by calling RetransmitAllUnackedCryptoData(). On each consecutive
-expiration of the crypto timer without receiving an acknowledgement for a new
-packet, the sender SHOULD double the crypto handshake timeout and set a timer
-for this period.
+When CRYPTO frames are sent in Initial or Handshake packets, the sender SHOULD
+set a timer for the crypto timeout period.  Upon timeout, the sender MUST
+retransmit all unacknowledged CRYPTO data by calling
+RetransmitAllUnackedCryptoData(). On each consecutive expiration of the
+crypto timer without receiving an acknowledgement for a new packet, the
+sender SHOULD double the crypto handshake timeout and set a timer for this
+period.
 
 When CRYPTO frames are outstanding, the TLP and RTO timers are not active unless
 the CRYPTO frames were sent at 1-RTT encryption.
-
-When an acknowledgement is received for a crypto packet, the new RTT is
-computed and the timer SHOULD be set for twice the newly computed smoothed RTT.
 
 #### Retry and Version Negotiation
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -303,9 +303,10 @@ Retransmission Timeout mechanisms.
 
 Data in CRYPTO frames is critical to QUIC transport and crypto negotiation, so a
 more aggressive timeout is used to retransmit it.  Below, the term "crypto
-packet" is used to refer to packets containing CRYPTO frames.
+packet" is used to refer to packets containing CRYPTO frames before the
+handshake is complete.
 
-The initial crypto timeout SHOULD be set to twice the initial RTT.
+The initial crypto handshake timeout SHOULD be set to twice the initial RTT.
 
 At the beginning, there are no prior RTT samples within a connection.  Resumed
 connections over the same network SHOULD use the previous connection's final
@@ -318,8 +319,8 @@ When CRYPTO frames are sent, the sender SHOULD set a timer for the crypto
 timeout period.  Upon timeout, the sender MUST retransmit all unacknowledged
 CRYPTO data by calling RetransmitAllUnackedCryptoData(). On each consecutive
 expiration of the crypto timer without receiving an acknowledgement for a new
-packet, the sender SHOULD double the crypto timeout and set a timer for this
-period.
+packet, the sender SHOULD double the crypto handshake timeout and set a timer
+for this period.
 
 When CRYPTO frames are outstanding, the TLP and RTO timers are not active unless
 the CRYPTO frames were sent at 1-RTT encryption.
@@ -766,7 +767,7 @@ below shows how the single timer is set.
 #### Crypto Handshake Timer
 
 When a connection has unacknowledged handshake data, the handshake timer is
-set and when it expires, all unacknowledgedd CRYPTO data is retransmitted.
+set and when it expires, all unacknowledged CRYPTO data is retransmitted.
 
 When stateless rejects are in use, the connection is considered immediately
 closed once a reject is sent, so no timer is set to retransmit the reject.
@@ -814,8 +815,8 @@ Pseudocode for SetLossDetectionTimer follows:
       timeout = timeout * (2 ^ crypto_count)
       loss_detection_timer.set(
         time_of_last_sent_crypto_packet + timeout)
-      return;
-    else if (loss_time != 0):
+      return
+    if (loss_time != 0):
       // Early retransmit timer or time loss detection.
       timeout = loss_time -
         time_of_last_sent_retransmittable_packet
@@ -846,7 +847,7 @@ Pseudocode for OnLossDetectionTimeout follows:
 ~~~
    OnLossDetectionTimeout():
      if (crypto packets are outstanding):
-       // Crypto timeout.
+       // Crypto handshake timeout.
        RetransmitAllUnackedCryptoData()
        crypto_count++
      else if (loss_time != 0):

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1,6 +1,6 @@
 ---
 title: QUIC Loss Detection and Congestion Control
-abbrev: QUIC Loss Detection
+abbrev: QUIC Loss Dfetection
 docname: draft-ietf-quic-recovery-latest
 date: {DATE}
 category: std
@@ -303,10 +303,11 @@ Retransmission Timeout mechanisms.
 
 Data in CRYPTO frames is critical to QUIC transport and crypto negotiation, so a
 more aggressive timeout is used to retransmit it.  Below, the term "crypto
-packet" is used to refer to packets containing CRYPTO frames that are part of
-the handshake.
+packet" is used to refer to packets containing CRYPTO data sent in Initial or
+Handshake packets.
 
-The initial crypto handshake timeout SHOULD be set to twice the initial RTT.
+The initial crypto retransmission timeout SHOULD be set to twice the initial
+RTT.
 
 At the beginning, there are no prior RTT samples within a connection.  Resumed
 connections over the same network SHOULD use the previous connection's final

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -300,7 +300,7 @@ timer for TCP as well, and this document incorporates this advancement.
 
 Timer-based loss detection recovers from losses that cannot be handled by
 ack-based loss detection.  It uses a single timer which switches between
-a handshake retransmission timer, a Tail Loss Probe timer and
+a crypto handshake retransmission timer, a Tail Loss Probe timer and
 Retransmission Timeout mechanisms.
 
 ### Crypto Handshake Timeout
@@ -460,7 +460,7 @@ delayed acknowledgement should be generated after processing incoming packets.
 ### Crypto Handshake Data
 
 In order to quickly complete the handshake and avoid spurious retransmissions
-due to handshake timeouts, handshake packets SHOULD use a very short ack
+due to crypto handshake timeouts, crypto packets SHOULD use a very short ack
 delay, such as 1ms.  ACK frames MAY be sent immediately when the crypto stack
 indicates all data for that encryption level has been received.
 
@@ -765,8 +765,8 @@ below shows how the single timer is set.
 
 #### Crypto Handshake Timer
 
-When a connection has unacknowledged handshake data, the handshake timer is
-set and when it expires, all unacknowledged CRYPTO data is retransmitted.
+When a connection has unacknowledged handshake data, the crypto handshake timer
+is set and when it expires, all unacknowledged CRYPTO data is retransmitted.
 
 When stateless rejects are in use, the connection is considered immediately
 closed once a reject is sent, so no timer is set to retransmit the reject.
@@ -782,8 +782,8 @@ are timer based mechanisms to recover from cases when there are
 outstanding retransmittable packets, but an acknowledgement has
 not been received in a timely manner.
 
-The TLP and RTO timers are armed when there is no unacknowledged handshake
-data.  The TLP timer is set until the max number of TLP packets have been
+The TLP and RTO timers are armed when there are no unacknowledged crypto
+packets.  The TLP timer is set until the max number of TLP packets have been
 sent, and then the RTO timer is set.
 
 #### Early Retransmit Timer

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -108,6 +108,10 @@ Retransmittable Packets:
 : Packets that contain retransmittable frames elicit an ACK from
   the receiver and are called retransmittable packets.
 
+Crypto Packets:
+
+: Packets containing CRYPTO data sent in Initial or Handshake
+  packets.
 
 # Design of the QUIC Transmission Machinery
 
@@ -302,9 +306,7 @@ Retransmission Timeout mechanisms.
 ### Crypto Handshake Timeout
 
 Data in CRYPTO frames is critical to QUIC transport and crypto negotiation, so a
-more aggressive timeout is used to retransmit it.  Below, the term "crypto
-packet" is used to refer to packets containing CRYPTO data sent in Initial or
-Handshake packets.
+more aggressive timeout is used to retransmit it.
 
 The initial crypto retransmission timeout SHOULD be set to twice the initial
 RTT.
@@ -316,16 +318,14 @@ is available, or if the network changes, the initial RTT SHOULD be set to 100ms.
 When an acknowledgement is received, a new RTT is computed and the timer
 SHOULD be set for twice the newly computed smoothed RTT.
 
-When CRYPTO frames are sent in Initial or Handshake packets, the sender SHOULD
-set a timer for the crypto timeout period.  Upon timeout, the sender MUST
-retransmit all unacknowledged CRYPTO data by calling
-RetransmitAllUnackedCryptoData(). On each consecutive expiration of the
-crypto timer without receiving an acknowledgement for a new packet, the
-sender SHOULD double the crypto handshake timeout and set a timer for this
-period.
+When crypto packets are sent, the sender SHOULD set a timer for the crypto
+timeout period.  Upon timeout, the sender MUST retransmit all unacknowledged
+CRYPTO data by calling RetransmitAllUnackedCryptoData(). On each consecutive
+expiration of the crypto timer without receiving an acknowledgement for a new
+packet, the sender SHOULD double the crypto handshake timeout and set a timer
+for this period.
 
-When CRYPTO frames are outstanding, the TLP and RTO timers are not active unless
-the CRYPTO frames were sent at 1-RTT encryption.
+When crypto packets are outstanding, the TLP and RTO timers are not active.
 
 #### Retry and Version Negotiation
 
@@ -558,7 +558,7 @@ time_of_last_sent_retransmittable_packet:
 : The time the most recent retransmittable packet was sent.
 
 time_of_last_sent_crypto_packet:
-: The time the most recent packet containing a CRYPTO frame was sent.
+: The time the most recent crypto packet was sent.
 
 largest_sent_packet:
 : The packet number of the most recently sent packet.

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1,6 +1,6 @@
 ---
 title: QUIC Loss Detection and Congestion Control
-abbrev: QUIC Loss Dfetection
+abbrev: QUIC Loss Detection
 docname: draft-ietf-quic-recovery-latest
 date: {DATE}
 category: std

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -311,12 +311,10 @@ RTT.
 
 At the beginning, there are no prior RTT samples within a connection.  Resumed
 connections over the same network SHOULD use the previous connection's final
-smoothed RTT value as the resumed connection's initial RTT.  When an
-acknowledgement is received, a new RTT is computed and the timer
+smoothed RTT value as the resumed connection's initial RTT.  If no previous RTT
+is available, or if the network changes, the initial RTT SHOULD be set to 100ms.
+When an acknowledgement is received, a new RTT is computed and the timer
 SHOULD be set for twice the newly computed smoothed RTT.
-
-If no previous RTT is available, or if the network changes, the initial RTT
-SHOULD be set to 100ms.
 
 When CRYPTO frames are sent in Initial or Handshake packets, the sender SHOULD
 set a timer for the crypto timeout period.  Upon timeout, the sender MUST

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -303,8 +303,8 @@ Retransmission Timeout mechanisms.
 
 Data in CRYPTO frames is critical to QUIC transport and crypto negotiation, so a
 more aggressive timeout is used to retransmit it.  Below, the term "crypto
-packet" is used to refer to packets containing CRYPTO frames before the
-handshake is complete.
+packet" is used to refer to packets containing CRYPTO frames that are part of
+the handshake.
 
 The initial crypto handshake timeout SHOULD be set to twice the initial RTT.
 


### PR DESCRIPTION
This replaces #1842 and tries to fix everything to consistently use crypto packets instead of handshake packets.

Fixes #1836.