### PR TITLE
Improve description of max_ack_delay transport parameter

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1729,7 +1729,7 @@ disable_migration (0x0009):
 max_ack_delay (0x000c):
 
 : An 8 bit unsigned integer value indicating the maximum amount of time in
-  milliseconds by which the endpoint will delay sending of acknowledgments.
+  milliseconds by which the endpoint will delay sending acknowledgments.
   If this value is absent, a default of 25 milliseconds is assumed.
 
 Either peer MAY advertise an initial value for the flow control on each type of


### PR DESCRIPTION
The sentence it replaces is awkward:

> An 8 bit unsigned integer value indicating the maximum amount of time in milliseconds by which _it_ will delay sending of acknowledgments.

What is _it_ -- the integer value?  Can an integer value delay sending of acknowledgements?