### PR TITLE
Move and consolidate address validation

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1575,7 +1575,7 @@ NEW_TOKEN frame (see {{validate-future}}).
 QUIC uses token-based address validation during connection establishment.  Any
 time the server wishes to validate a client address, it provides the client with
 a token.  As long as it is not possible for an attacker to generate a valid
-token for its address (see {{token-integrity}}) and the client is able to return
+token for its own address (see {{token-integrity}}) and the client is able to return
 that token, it proves to the server that it received the token.
 
 Upon receiving the client's Initial packet, the server can request address

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1631,7 +1631,8 @@ dynamically calculate the expiration time.  It is also unlikely that the client
 port number is the same on two different connections; validating the port is
 therefore unlikely to be successful.
 
-A resumption token SHOULD be easily distinguishable from tokens that are sent in
+A resumption token SHOULD be constructed to be easily distinguishable from tokens
+that are sent in Retry packets as they are carried in the same field.
 Retry packets as they are carried in the same field.
 
 If the client has a token received in a NEW_TOKEN frame on a previous connection

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1640,7 +1640,6 @@ Token field of its Initial packet.
 
 A token allows a server to correlate activity between the connection where the
 token was issued and any connection where it is used.
-Specifically, the connection where the token was issued, and any connection
 where it is used.  Clients that want to break continuity of identity with a
 server MAY discard tokens provided using the NEW_TOKEN frame.  Tokens obtained
 in Retry packets MUST NOT be discarded.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1553,15 +1553,10 @@ Handshake keys, it SHOULD send an Initial packet in a UDP datagram of at least
 packet.
 
 A server might wish to validate the client address before starting the
-handshake.  To send additional data prior to completing the cryptographic
-handshake, the server then needs to validate that the client owns the address
-that it claims.  QUIC therefore provides mechanisms for source address
-validation during connection establishment.
-
-Source addresses can be verified through an address validation token.  This
-token is delivered during connection establishment with a Retry packet (see
-{{validate-retry}}) or in a previous connection using the NEW_TOKEN frame (see
-{{validate-future}}).
+cryptographic handshake.  Source addresses can be verified using an address
+validation token.  This token is delivered during connection establishment with
+a Retry packet (see {{validate-retry}}) or in a previous connection using the
+NEW_TOKEN frame (see {{validate-future}}).
 
 
 ### Address Validation using Retry Packets {#validate-retry}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1586,7 +1586,8 @@ either abort the connection or permit it to proceed.
 
 A server can also use a Retry packet to defer the state and processing costs
 of connection establishment.  By giving the client a different connection ID to
-use, the connection might be routed to a different server instance, which have
+use, a server can cause the connection to be routed to a server instance with
+more resources available for new connections.
 additional capacity for new connections.
 
 A flow showing the use of a Retry packet is shown in {{fig-retry}}.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1575,8 +1575,8 @@ NEW_TOKEN frame (see {{validate-future}}).
 QUIC uses token-based address validation during connection establishment.  Any
 time the server wishes to validate a client address, it provides the client with
 a token.  As long as it is not possible for an attacker to generate a valid
-token for its own address (see {{token-integrity}}) and the client is able to return
-that token, it proves to the server that it received the token.
+token for its own address (see {{token-integrity}}) and the client is able to
+return that token, it proves to the server that it received the token.
 
 Upon receiving the client's Initial packet, the server can request address
 validation by sending a Retry packet ({{packet-retry}}) containing a token. This

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1584,7 +1584,7 @@ token is repeated by the client in an Initial packet after it receives the Retry
 packet.  In response to receiving a token in an Initial packet, a server can
 either abort the connection or permit it to proceed.
 
-A server can also use the Retry packet to defer the state and processing costs
+A server can also use a Retry packet to defer the state and processing costs
 of connection establishment.  By giving the client a different connection ID to
 use, the connection might be routed to a different server instance, which have
 additional capacity for new connections.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1517,10 +1517,12 @@ use the server to send more data toward the victim than it would be able to send
 on its own.
 
 The primary defense against amplification attack is verifying that an endpoint
-is able to receive packets at the transport address that it claims.
+is able to receive packets at the transport address that it claims.  Address
+validation is performed both during connection establishment (see
+{{validate-new}}) and during connection migration (see {{migrate-validate}}).
 
 
-## Address Validation During Connection Establishment
+## Address Validation During Connection Establishment {#validate-new}
 
 During the initial handshake, QUIC requires that clients send UDP datagrams with
 at least 1200 octets of payload until the server has completed address
@@ -1552,9 +1554,6 @@ always send a packet upon a handshake timeout, as described in
 Handshake keys, it SHOULD send an Initial packet in a UDP datagram of at least
 1200 octets.  If the client has Handshake keys, it SHOULD send a Handshake
 packet.
-
-A different type of source address validation is performed after a connection
-migration, see {{migrate-validate}}.
 
 
 ### Client Address Validation

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1564,7 +1564,7 @@ Handshake keys, it SHOULD send an Initial packet in a UDP datagram of at least
 packet.
 
 
-### Token-Based Address Validation {#validate-retry}
+### Address Validation using Retry Packets {#validate-retry}
 
 QUIC uses token-based address validation during connection establishment.  Any
 time the server wishes to validate a client address, it provides the client with
@@ -1602,7 +1602,7 @@ Initial+Token[0]: CRYPTO[CH] ->
 {: #fig-retry title="Example Handshake with Retry"}
 
 
-### Address Validation for Future Connections {#validation-future}
+### Address Validation for Future Connections {#validate-future}
 
 A server MAY provide clients with an address validation token during one
 connection that can be used on a subsequent connection.  Address validation is
@@ -3749,7 +3749,7 @@ Connection ID also results in a change to the keys used to protect the Initial
 packet. It also sets the Token field to the token provided in the Retry. The
 client MUST NOT change the Source Connection ID because the server could include
 the connection ID as part of its token validation logic (see
-{{validation-future}}).
+{{validate-future}}).
 
 All subsequent Initial packets from the client MUST use the connection ID and
 token values from the Retry packet.  Aside from this, the Initial packet sent

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1669,12 +1669,6 @@ addresses.
 
 ### Address Validation Token Integrity {#token-integrity}
 
-There is no need for a single well-defined format for the token because the
-server that generates the token also consumes it.  A token could include
-information about the claimed client address (IP and port), a timestamp, and any
-other supplementary information the server will need to validate the token in
-the future.
-
 An address validation token MUST be difficult to guess.  Including a large
 enough random value in the token would be sufficient, but this depends on the
 server remembering the value it sends to clients.
@@ -1685,6 +1679,12 @@ integrity protection against modification or falsification by clients.  Without
 integrity protection, malicious clients could generate or guess values for
 tokens that would be accepted by the server.  Only the server requires access to
 the integrity protection key for tokens.
+
+There is no need for a single well-defined format for the token because the
+server that generates the token also consumes it.  A token could include
+information about the claimed client address (IP and port), a timestamp, and any
+other supplementary information the server will need to validate the token in
+the future.
 
 
 ## Path Validation {#migrate-validate}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1638,7 +1638,8 @@ If the client has a token received in a NEW_TOKEN frame on a previous connection
 to what it believes to be the same server, it can include that value in the
 Token field of its Initial packet.
 
-A token allows a server to correlate activity between connections.
+A token allows a server to correlate activity between the connection where the
+token was issued and any connection where it is used.
 Specifically, the connection where the token was issued, and any connection
 where it is used.  Clients that want to break continuity of identity with a
 server MAY discard tokens provided using the NEW_TOKEN frame.  Tokens obtained

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1633,7 +1633,6 @@ therefore unlikely to be successful.
 
 A resumption token SHOULD be constructed to be easily distinguishable from tokens
 that are sent in Retry packets as they are carried in the same field.
-Retry packets as they are carried in the same field.
 
 If the client has a token received in a NEW_TOKEN frame on a previous connection
 to what it believes to be the same server, it can include that value in the

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1079,7 +1079,18 @@ TBD.
 <!-- Goes into how the next few sections are connected. Specifically, one goal
 is to combine the address validation section that shows up below with path
 validation that shows up later, and explain why these two mechanisms are
-required here. -->
+required here.
+
+suggested structure:
+
+ - establishment
+   - VN
+   - Retry
+   - Crypto
+ - use (include migration)
+ - shutdown
+
+-->
 
 
 # Version Negotiation {#version-negotiation}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1640,7 +1640,7 @@ Token field of its Initial packet.
 
 A token allows a server to correlate activity between the connection where the
 token was issued and any connection where it is used.
-where it is used.  Clients that want to break continuity of identity with a
+Clients that want to break continuity of identity with a
 server MAY discard tokens provided using the NEW_TOKEN frame.  Tokens obtained
 in Retry packets MUST NOT be discarded.
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1588,7 +1588,6 @@ A server can also use a Retry packet to defer the state and processing costs
 of connection establishment.  By giving the client a different connection ID to
 use, a server can cause the connection to be routed to a server instance with
 more resources available for new connections.
-additional capacity for new connections.
 
 A flow showing the use of a Retry packet is shown in {{fig-retry}}.
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1564,7 +1564,7 @@ Handshake keys, it SHOULD send an Initial packet in a UDP datagram of at least
 packet.
 
 A server might wish to validate the client address before starting the
-cryptographic handshake.  Source addresses can be verified using an address
+cryptographic handshake.  Client addresses can be verified using an address
 validation token.  This token is delivered during connection establishment with
 a Retry packet (see {{validate-retry}}) or in a previous connection using the
 NEW_TOKEN frame (see {{validate-future}}).

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1530,19 +1530,11 @@ validation is performed both during connection establishment (see
 
 ## Address Validation During Connection Establishment {#validate-new}
 
-Successful receipt of the first packet protected with Handshake keys confirms
-that a client received the Initial packet from the server.
-
-However, a server might wish to validate the client address before starting the
-handshake.  To send additional data prior to completing the cryptographic
-handshake, the server then needs to validate that the client owns the address
-that it claims.  QUIC therefore provides mechanisms for source address
-validation during connection establishment.
-
-Source addresses can be verified through an address validation token.  This
-token is delivered during connection establishment with a Retry packet (see
-{{validate-retry}}) or in a previous connection using the NEW_TOKEN frame (see
-{{validate-future}}).
+Connection establishment implicitly provides address validation for both
+endpoints.  In particular, receipt of a packet protected with Handshake keys
+confirms that the client received the Initial packet from the server.  Once the
+server has successfully processed a Handshake packet from the client, it can
+consider the client address to have been validated.
 
 Prior to validating the client address, servers MUST NOT send more than three
 times as many bytes as the number of bytes they have received.  This limits the
@@ -1559,6 +1551,17 @@ to send, clients SHOULD send a packet upon a handshake timeout, as described in
 Handshake keys, it SHOULD send an Initial packet in a UDP datagram of at least
 1200 octets.  If the client has Handshake keys, it SHOULD send a Handshake
 packet.
+
+A server might wish to validate the client address before starting the
+handshake.  To send additional data prior to completing the cryptographic
+handshake, the server then needs to validate that the client owns the address
+that it claims.  QUIC therefore provides mechanisms for source address
+validation during connection establishment.
+
+Source addresses can be verified through an address validation token.  This
+token is delivered during connection establishment with a Retry packet (see
+{{validate-retry}}) or in a previous connection using the NEW_TOKEN frame (see
+{{validate-future}}).
 
 
 ### Address Validation using Retry Packets {#validate-retry}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1584,7 +1584,6 @@ token is repeated by the client in an Initial packet after it receives the Retry
 packet.  In response to receiving a token in an Initial packet, a server can
 either abort the connection or permit it to proceed.
 
-
 A server can also use the Retry packet to defer the state and processing costs
 of connection establishment.  By giving the client a different connection ID to
 use, the connection might be routed to a different server instance, which have

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1494,19 +1494,6 @@ One way that a new format could be introduced is to define a TLS extension with
 a different codepoint.
 
 
-## Stateless Retries {#stateless-retry}
-<!-- TODO: Move this section elsewhere. -->
-
-A server can process an Initial packet from a client without committing any
-state. This allows a server to perform address validation
-({{address-validation}}), or to defer connection establishment costs.
-
-A server that generates a response to an Initial packet without retaining
-connection state MUST use the Retry packet ({{packet-retry}}).  This packet
-causes a client to restart the connection attempt and includes the token in the
-new Initial packet ({{packet-initial}}) to prove source address ownership.
-
-
 # Proof of Source Address Ownership {#address-validation}
 
 Address validation is used by QUIC to avoid being used for a traffic
@@ -1649,7 +1636,7 @@ When a server receives an Initial packet with an address validation token, it
 SHOULD attempt to validate it.  If the token is invalid then the server SHOULD
 proceed as if the client did not have a validated address, including potentially
 sending a Retry. If the validation succeeds, the server SHOULD then allow the
-handshake to proceed (see {{stateless-retry}}).
+handshake to proceed.
 
 Note:
 
@@ -3663,7 +3650,7 @@ a connection error.
 
 A Retry packet uses a long packet header with a type value of 0x7E. It carries
 an address validation token created by the server. It is used by a server that
-wishes to perform a stateless retry (see {{stateless-retry}}).
+wishes to perform a stateless retry (see {{validate-new}}).
 
 ~~~
  0                   1                   2                   3


### PR DESCRIPTION
The two disparate sections on address validation are better together.  That means deferring the description of Retry to after the connection establishment section, but I think that makes sense.  I've added a forward reference.

Aside from moves there is a tiny bit of new glue text in the top of the respective sections.  I had to tweak some of it to reflect the reorganization, and I noticed some duplication that I eliminated from the first two paragraphs of the path migration section.

I added a picture showing how Retry is added to the handshake flow, addressing a TODO.

I merged the sections on dealing with NEW_TOKEN and address validation for future connections (or should that be returning connections...).  That was just removing the section heading.