### PR TITLE
Crisp definition of BLOCKING and friends

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4281,8 +4281,8 @@ The BLOCKED frame contains a single field.
 
 Offset:
 
-: A variable-length integer indicating the connection-level offset at which
-  the blocking occurred.
+: A variable-length integer indicating the connection flow control limit at the
+  time the frame is sent.
 
 
 ## STREAM_BLOCKED Frame {#frame-stream-blocked}
@@ -4314,8 +4314,8 @@ Stream ID:
 
 Offset:
 
-: A variable-length integer indicating the offset of the stream at which the
-  blocking occurred.
+: A variable-length integer indicating the stream flow control limit at the time
+  the frame is sent.
 
 
 ## STREAM_ID_BLOCKED Frame {#frame-stream-id-blocked}
@@ -4340,8 +4340,9 @@ The STREAM_ID_BLOCKED frame contains a single field.
 
 Stream ID:
 
-: A variable-length integer indicating the highest stream ID that the sender
-  was permitted to open.
+: A variable-length integer indicating the stream ID limit at the time the
+  sender was unable to open new streams.
+
 
 ## NEW_CONNECTION_ID Frame {#frame-new-connection-id}
 


### PR DESCRIPTION
Recent discussion around the use of BLOCKING frames highlighted some
inconsistency - and even disagreement - about what the purpose of the
frames are.  If you read through all the text for the flow
control-related frames, it is clear that the frame carries the *limit*
at the time the frame is sent.

> These frames always include the limit that is causing blocking at the
> time that they are transmitted.

This enacts that change more consistently, especially for
STREAM_ID_BLOCKED, which was the most unclear.

The discussion on #1851 suggested that there was value in knowing what
the sender (or stream opener) wanted to get to.  That is, the frames
would carry a higher value.  If the limit was X and the sender wanted to
send octet X+Y (or open stream X+Y), they would convey that information
instead.  The theory here is that the larger value (X+Y) would be sent,
allowing the receiver to make those resources available.

The problem with this alternative approach is that the value advertised
changes over time and it is difficult to connect the signal (a BLOCKED
frame), with the limit that was in force at the time.

I suspect that there is value in signaling the desired limits as well,
but that would require greater justification.  It also entails a change
and I'm leery of feature creep at this stage.

Closes #1851, #1850.