### PR TITLE
Specify the packets that carry closing frames

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2245,10 +2245,10 @@ signal closure.
 If the connection has been successfully established, endpoints MUST send any
 closing frames in a 1-RTT packet.  Prior to connection establishment a peer
 might not have 1-RTT keys, so endpoints SHOULD send closing frames in a
-Handshake packet.  If they are not certain that the peer has Handshake keys, an
-endpoint MAY send closing frames in an Initial packet.  If multiple packets are
-sent, they can be coalesced (see {{packet-coalesce}}) to facilitate
-retransmission.
+Handshake packet.  If the endpoint does not have Handshake keys, or it is not
+certain that the peer has Handshake keys, it MAY send closing frames in an
+Initial packet.  If multiple packets are sent, they can be coalesced (see
+{{packet-coalesce}}) to facilitate retransmission.
 
 
 ## Stateless Reset {#stateless-reset}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2243,11 +2243,12 @@ protocol can use an APPLICATION_CLOSE message with an appropriate error code to
 signal closure.
 
 If the connection has been successfully established, endpoints MUST send any
-closing frames in a 1-RTT packet.  Prior to connection establishment, endpoints
-SHOULD send closing frames in a Handshake packet if possible.  An endpoint MAY
-send closing frames in an Initial packet.  Closing frames might be replicated
-into packets at different encryption levels, which can then be coalesced (see
-{{packet-coalesce}} to facilitate retransmission.
+closing frames in a 1-RTT packet.  Prior to connection establishment a peer
+might not have 1-RTT keys, so endpoints SHOULD send closing frames in a
+Handshake packet.  If they are not certain that the peer has Handshake keys, an
+endpoint MAY send closing frames in an Initial packet.  If multiple packets are
+sent, they can be coalesced (see {{packet-coalesce}}) to facilitate
+retransmission.
 
 
 ## Stateless Reset {#stateless-reset}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2313,6 +2313,12 @@ the application requests that the connection be closed.  The application
 protocol can use an APPLICATION_CLOSE message with an appropriate error code to
 signal closure.
 
+If the endpoint believes that a connection has been successfully established, it
+MUST send any closing frames in a 1-RTT packet.  Prior to connection
+establishment, endpoints SHOULD send closing frames in a Handshake packet.  An
+endpoint MAY send closing frames in an Initial packet.  Closing frames might be
+replicated into packets at different encryption levels, which can then be
+coalesced (see {{packet-coalesce}} to facilitate retransmission.
 
 ### Stateless Reset {#stateless-reset}
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2306,9 +2306,9 @@ signal closure.
 
 If the connection has been successfully established, endpoints MUST send any
 closing frames in a 1-RTT packet.  Prior to connection establishment, endpoints
-SHOULD send closing frames in a Handshake packet.  An endpoint MAY send closing
-frames in an Initial packet.  Closing frames might be replicated into packets at
-different encryption levels, which can then be coalesced (see
+SHOULD send closing frames in a Handshake packet if possible.  An endpoint MAY
+send closing frames in an Initial packet.  Closing frames might be replicated
+into packets at different encryption levels, which can then be coalesced (see
 {{packet-coalesce}} to facilitate retransmission.
 
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2272,15 +2272,6 @@ An endpoint sends a closing frame (CONNECTION_CLOSE or APPLICATION_CLOSE) to
 terminate the connection immediately.  Any closing frame causes all streams to
 immediately become closed; open streams can be assumed to be implicitly reset.
 
-If the endpoint has received an ACK for a 1-RTT packet, it SHOULD send
-CONNECTION_CLOSE in a 1-RTT packet. If not, and it has received a Handshake
-packet from the peer, it SHOULD send CONNECTION_CLOSE in a Handshake packet.
-
-If the endpoint has received only Initial packets from the peer, it SHOULD
-send CONNECTION_CLOSE in an Initial packet. If it has Handshake keys available,
-it SHOULD also send the frame in a Handshake packet coalesced with the Initial
-packet.
-
 After sending a closing frame, endpoints immediately enter the closing state.
 During the closing period, an endpoint that sends a closing frame SHOULD respond
 to any packet that it receives with another packet containing a closing frame.
@@ -2319,6 +2310,7 @@ SHOULD send closing frames in a Handshake packet.  An endpoint MAY send closing
 frames in an Initial packet.  Closing frames might be replicated into packets at
 different encryption levels, which can then be coalesced (see
 {{packet-coalesce}} to facilitate retransmission.
+
 
 ### Stateless Reset {#stateless-reset}
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2313,12 +2313,12 @@ the application requests that the connection be closed.  The application
 protocol can use an APPLICATION_CLOSE message with an appropriate error code to
 signal closure.
 
-If the endpoint believes that a connection has been successfully established, it
-MUST send any closing frames in a 1-RTT packet.  Prior to connection
-establishment, endpoints SHOULD send closing frames in a Handshake packet.  An
-endpoint MAY send closing frames in an Initial packet.  Closing frames might be
-replicated into packets at different encryption levels, which can then be
-coalesced (see {{packet-coalesce}} to facilitate retransmission.
+If the connection has been successfully established, endpoints MUST send any
+closing frames in a 1-RTT packet.  Prior to connection establishment, endpoints
+SHOULD send closing frames in a Handshake packet.  An endpoint MAY send closing
+frames in an Initial packet.  Closing frames might be replicated into packets at
+different encryption levels, which can then be coalesced (see
+{{packet-coalesce}} to facilitate retransmission.
 
 ### Stateless Reset {#stateless-reset}
 


### PR DESCRIPTION
I decided to reword #1818 after reading it.

I think that the second piece to #1786 , which was to make allowances for
fatal errors arising from Initial packets won't be necessary.  See my
comments on #1819 for that.

Closes #1818, #1786.