### PR TITLE
Allow rate limiting of Version Negotiation

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1105,6 +1105,11 @@ retaining state.  Though either the Initial packet or the Version Negotiation
 packet that is sent in response could be lost, the client will send new packets
 until it successfully receives a response or it abandons the connection attempt.
 
+A server MAY limit the number of Version Negotiation packets it sends.  For
+instance, a server might choose not to send Version Negotiation packets in
+response to 0-RTT packets with the expectation that it will eventually receive
+an Initial packet.
+
 
 ## Handling Version Negotiation Packets {#handle-vn}
 


### PR DESCRIPTION
As discussed in #1758, we only need to allow rate limiting.

However, the particular example I draw on will become critical if we
adopt the proposed changes to version negotiation in #1755 (or something
like it), because the only packet a server can confidently respond to
with Version Negotiation in that case is the Initial.  If we adopt an
iteration of #1755, then this text would need to be expanded to explain
that also.

Closes #1758.

(I marked this editorial so that we can include it in -16.  I do that on the basis that a server can always feign packet loss, so this isn't really a testable requirement.  That's only slightly dishonest, I think.)