### PR TITLE
Fix type value for RETIRE_CONNECTION_ID frame

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4439,7 +4439,7 @@ type PROTOCOL_VIOLATION.
 
 ## RETIRE_CONNECTION_ID Frame {#frame-retire-connection-id}
 
-An endpoint sends a RETIRE_CONNECTION_ID frame (type=0x1b) to indicate that it
+An endpoint sends a RETIRE_CONNECTION_ID frame (type=0x0d) to indicate that it
 will no longer use a connection ID that was issued by its peer. This may include
 the connection ID provided during the handshake.  Sending a RETIRE_CONNECTION_ID
 frame also serves as a request to the peer to send additional connection IDs for


### PR DESCRIPTION
The correct frame type value for RETIRE_CONNECTION_ID, as listed in page 63 (https://tools.ietf.org/html/draft-ietf-quic-transport-16#page-63) is 0x0d. However, in the section that describes the structure of RETIRE_CONNECTION_ID, it says 0x1b, which is conflicts with the type values for Ack Frame.