### PR TITLE
Define stream limits as counts

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4247,11 +4247,11 @@ Loss or reordering can mean that a MAX_STREAMS frame can be received which
 states a lower stream limit than the client has previously received.
 MAX_STREAMS frames which do not increase the stream limit MUST be ignored.
 
-A peer MUST NOT initiate a stream with a higher stream ID than the largest limit
-it has received permits.  For instance, a server that receives a unidirectional
-stream limit of 3 is permitted to open stream 3, 7, and 11, but not stream 15.
-An endpoint MUST terminate a connection with a STREAM_LIMIT_ERROR error if a
-peer opens more streams than was permitted.
+A peer MUST NOT open more streams than the limit it received permits.  For
+instance, a server that receives a unidirectional stream limit of 3 is permitted
+to open stream 3, 7, and 11, but not stream 15.  An endpoint MUST terminate a
+connection with a STREAM_LIMIT_ERROR error if a peer opens more streams than was
+permitted.
 
 
 ## PING Frame {#frame-ping}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3944,19 +3944,19 @@ initial_max_streams_bidi (0x0002):
 
 : The initial maximum bidirectional streams parameter contains the initial
   maximum number of bidirectional streams the peer may initiate, encoded as an
-  unsigned 16-bit integer.  If this parameter is absent or zero, bidirectional
-  streams cannot be created until a MAX_STREAMS frame is sent.  Setting this
+  unsigned 16-bit integer.  If this parameter is absent or zero, the peer cannot
+  open bidirectional streams until a MAX_STREAMS frame is sent.  Setting this
   parameter is equivalent to sending a MAX_STREAMS ({{frame-max-streams}}) of
-  the corresponding type immediately after completing the handshake.
+  the corresponding type with the same value.
 
 initial_max_streams_uni (0x0008):
 
 : The initial maximum unidirectional streams parameter contains the initial
   maximum number of unidirectional streams the peer may initiate, encoded as an
-  unsigned 16-bit integer.  If this parameter is absent or zero, unidirectional
-  streams cannot be created until a MAX_STREAMS frame is sent.  Setting this
+  unsigned 16-bit integer.  If this parameter is absent or zero, the peer cannot
+  open unidirectional streams until a MAX_STREAMS frame is sent.  Setting this
   parameter is equivalent to sending a MAX_STREAMS ({{frame-max-streams}}) of
-  the corresponding type immediately after completing the handshake.
+  the corresponding type with the same value.
 
 A server MUST include the following transport parameter if it sent a Retry
 packet:
@@ -4224,7 +4224,7 @@ a change in the initial limits (see {{zerortt-parameters}}).
 ## MAX_STREAMS Frame {#frame-max-streams}
 
 The MAX_STREAMS frame (type=0x1c and 0x1d) informs the peer of the number of
-streams they are permitted to open.  A MAX_STREAMS frame with a type of 0x1c
+streams it is permitted to open.  A MAX_STREAMS frame with a type of 0x1c
 applies to bidirectional streams; a MAX_STREAMS frame with a type of 0x1d
 applies to unidirectional streams.
 
@@ -4249,9 +4249,9 @@ MAX_STREAMS frames which do not increase the stream limit MUST be ignored.
 
 A peer MUST NOT initiate a stream with a higher stream ID than the largest limit
 it has received permits.  For instance, a server that receives a unidirectional
-stream limit of 4 is permitted to open stream 15, but not stream 19.  An
-endpoint MUST terminate a connection with a STREAM_LIMIT_ERROR error if a peer
-opens more streams than was permitted.
+stream limit of 3 is permitted to open stream 3, 7, and 11, but not stream 15.
+An endpoint MUST terminate a connection with a STREAM_LIMIT_ERROR error if a
+peer opens more streams than was permitted.
 
 
 ## PING Frame {#frame-ping}
@@ -4341,9 +4341,9 @@ Data Limit:
 
 A sender SHOULD send a STREAMS_BLOCKED frame (type=0x1e or 0x1f) when it wishes
 to open a stream, but is unable to due to the maximum stream ID limit set by its
-peer (see {{frame-max-streams}}).  A STREAMS_BLOCKED frame of type 0x1e
-indicates a problem with the limit on bidirectional streams; a STREAMS_BLOCKED
-frame of type 0x1f indicates a problem with the limit on unidirectional streams.
+peer (see {{frame-max-streams}}).  A STREAMS_BLOCKED frame of type 0x1e is used
+to indicate reaching the bidirectional stream limit; a STREAMS_BLOCKED frame of
+type 0x1f indicates reaching the unidirectional stream limit.
 
 A STREAMS_BLOCKED frame does not open the stream, but informs the peer that a
 new stream was needed and the stream limit prevented the creation of the stream.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -894,6 +894,8 @@ bidirectional and unidirectional streams.
 
 As with stream and connection flow control, this document leaves when and how
 many streams to make available to a peer via MAX_STREAMS to implementations.
+Implementations might choose to increase limits as streams close to keep the
+number of streams available to peers roughly consistent.
 
 The STREAMS_BLOCKED frame ({{frame-streams-blocked}}) signals that a new stream
 could not be created. Implementations can use this as a signal to the peer to

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -320,10 +320,10 @@ endpoint limits the number of concurrently active incoming streams by limiting
 the number of streams (see {{stream-limit-increment}}).
 
 The stream limit is specific to each endpoint and applies only to the peer that
-receives the setting. That is, clients limit the number of streams the server
-can initiate, and servers limit the number of streams the client can initiate.
-Each endpoint may respond on streams initiated by the other peer, regardless of
-whether it is permitted to initiate new streams.
+receives the setting. That is, the client limits the number of streams the
+server can initiate, and the server limits the number of streams the client can
+initiate.  Each endpoint may respond on streams initiated by the other peer,
+regardless of whether it is permitted to initiate new streams.
 
 Endpoints MUST NOT exceed the limit set by their peer.  An endpoint that
 receives a STREAM frame with an ID greater than the limit it has sent MUST treat

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4271,7 +4271,9 @@ The frame is as follows:
 The fields in the MAX_STREAMS frame are as follows:
 
 Maximum Streams:
-: A count of the number of streams that can be opened.
+
+: A count of the total number of streams of the corresponding type that can be
+  opened.
 
 Loss or reordering can cause a MAX_STREAMS frame to be received which states a
 lower stream limit than an endpoint has previously received.  MAX_STREAMS frames
@@ -4282,6 +4284,10 @@ limit set by its peer.  For instance, a server that receives a unidirectional
 stream limit of 3 is permitted to open stream 3, 7, and 11, but not stream 15.
 An endpoint MUST terminate a connection with a STREAM_LIMIT_ERROR error if a
 peer opens more streams than was permitted.
+
+Note that these frames (and the corresponding transport parameters) do not
+describe the number of streams that can be opened concurrently.  The limit
+includes streams that have been closed as well as those that are open.
 
 
 ## PING Frame {#frame-ping}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -778,6 +778,7 @@ and monitoring purposes.
 A similar method is used to control the number of open streams (see
 {{stream-limit-increment}} for details).
 
+
 ## Handling of Stream Cancellation
 
 There are some edge cases which must be considered when dealing with stream and
@@ -813,6 +814,7 @@ opposite direction. The RST_STREAM sender can send a STOP_SENDING frame to
 encourage prompt termination. Both endpoints MUST maintain state for the stream
 in the unterminated direction until that direction enters a terminal state, or
 either side sends CONNECTION_CLOSE or APPLICATION_CLOSE.
+
 
 ## Data Limit Increments {#fc-credit}
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -317,13 +317,13 @@ lower-numbered streams of the same type in the same direction.
 
 QUIC allows for an arbitrary number of streams to operate concurrently.  An
 endpoint limits the number of concurrently active incoming streams by limiting
-the number of streams (see {{stream-limit-increment}}).
+the number of streams of each type (see {{stream-limit-increment}}).
 
 The stream limit is specific to each endpoint and applies only to the peer that
-receives the setting. That is, the client limits the number of streams the
-server can initiate, and the server limits the number of streams the client can
-initiate.  Each endpoint may respond on streams initiated by the other peer,
-regardless of whether it is permitted to initiate new streams.
+receives the setting.  That is, the client limits the number of streams of each
+type the server can initiate, and the server limits the number of streams the
+client can initiate.  Each endpoint can respond on streams initiated by the
+other peer, regardless of whether it is permitted to initiate new streams.
 
 Endpoints MUST NOT exceed the limit set by their peer.  An endpoint that
 receives a STREAM frame with an ID greater than the limit it has sent MUST treat

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4246,9 +4246,9 @@ The fields in the MAX_STREAMS frame are as follows:
 Maximum Streams:
 : A count of the number of streams that can be opened.
 
-Loss or reordering can mean that a MAX_STREAMS frame can be received which
-states a lower stream limit than the client has previously received.
-MAX_STREAMS frames which do not increase the stream limit MUST be ignored.
+Loss or reordering can cause a MAX_STREAMS frame to be received which states a
+lower stream limit than an endpoint has previously received.  MAX_STREAMS frames
+which do not increase the stream limit MUST be ignored.
 
 A peer MUST NOT open more streams than the limit it received permits.  For
 instance, a server that receives a unidirectional stream limit of 3 is permitted

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4249,11 +4249,11 @@ Loss or reordering can cause a MAX_STREAMS frame to be received which states a
 lower stream limit than an endpoint has previously received.  MAX_STREAMS frames
 which do not increase the stream limit MUST be ignored.
 
-A peer MUST NOT open more streams than the limit it received permits.  For
-instance, a server that receives a unidirectional stream limit of 3 is permitted
-to open stream 3, 7, and 11, but not stream 15.  An endpoint MUST terminate a
-connection with a STREAM_LIMIT_ERROR error if a peer opens more streams than was
-permitted.
+An endpoint MUST NOT open more streams than permitted by the current stream
+limit set by its peer.  For instance, a server that receives a unidirectional
+stream limit of 3 is permitted to open stream 3, 7, and 11, but not stream 15.
+An endpoint MUST terminate a connection with a STREAM_LIMIT_ERROR error if a
+peer opens more streams than was permitted.
 
 
 ## PING Frame {#frame-ping}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -893,9 +893,9 @@ bidirectional and unidirectional streams.
 As with stream and connection flow control, this document leaves when and how
 many streams to make available to a peer via MAX_STREAMS to implementations.
 
-The STREAMS_BLOCKED frame ({{frame-streams-blocked}}) can be used to signal a
-shortage of available streams. Implementations could use this as a signal to
-send a MAX_STREAMS frame with an updated limit.
+The STREAMS_BLOCKED frame ({{frame-streams-blocked}}) signals that a new stream
+could not be created. Implementations can use this as a signal to the peer to
+send a MAX_STREAMS frame with a larger limit.
 
 
 # Connections {#connections}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -327,8 +327,7 @@ other peer, regardless of whether it is permitted to initiate new streams.
 
 Endpoints MUST NOT exceed the limit set by their peer.  An endpoint that
 receives a STREAM frame with an ID greater than the limit it has sent MUST treat
-this as a stream error of type STREAM_LIMIT_ERROR ({{error-handling}}), unless
-this is a result of a change in the initial limits (see {{zerortt-parameters}}).
+this as a stream error of type STREAM_LIMIT_ERROR ({{error-handling}}).
 
 A receiver cannot renege on an advertisement; that is, once a receiver
 advertises a stream limit using the MAX_STREAMS frame, advertising a smaller

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4326,7 +4326,7 @@ The STREAM_DATA_BLOCKED frame is as follows:
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                        Stream ID (i)                        ...
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                        Data Limit (i)                       ...
+|                    Stream Data Limit (i)                    ...
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 ~~~
 
@@ -4336,7 +4336,7 @@ Stream ID:
 
 : A variable-length integer indicating the stream which is flow control blocked.
 
-Data Limit:
+Stream Data Limit:
 
 : A variable-length integer indicating the offset of the stream at which the
   blocking occurred.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4342,7 +4342,7 @@ Data Limit:
 ## STREAMS_BLOCKED Frame {#frame-streams-blocked}
 
 A sender SHOULD send a STREAMS_BLOCKED frame (type=0x1e or 0x1f) when it wishes
-to open a stream, but is unable to due to the maximum stream ID limit set by its
+to open a stream, but is unable to due to the maximum stream limit set by its
 peer (see {{frame-max-streams}}).  A STREAMS_BLOCKED frame of type 0x1e is used
 to indicate reaching the bidirectional stream limit; a STREAMS_BLOCKED frame of
 type 0x1f indicates reaching the unidirectional stream limit.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2880,11 +2880,10 @@ containing that information is acknowledged.
   endpoint SHOULD stop sending MAX_STREAM_DATA frames when the receive stream
   enters a "Size Known" state.
 
-* The limit on streams for a stream of a given type is sent in MAX_STREAMS
-  frames.  Like MAX_DATA, an updated value is sent when a packet containing the
-  most recent MAX_STREAMS for a stream type frame is declared lost or when the
-  limit is updated, with care taken to prevent the frame from being sent too
-  often.
+* The limit on streams of a given type is sent in MAX_STREAMS frames.  Like
+  MAX_DATA, an updated value is sent when a packet containing the most recent
+  MAX_STREAMS for a stream type frame is declared lost or when the limit is
+  updated, with care taken to prevent the frame from being sent too often.
 
 * Blocked signals are carried in BLOCKED, STREAM_BLOCKED, and STREAMS_BLOCKED
   frames. BLOCKED streams have connection scope, STREAM_BLOCKED frames have

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4346,8 +4346,7 @@ indicates a problem with the limit on bidirectional streams; a STREAMS_BLOCKED
 frame of type 0x1f indicates a problem with the limit on unidirectional streams.
 
 A STREAMS_BLOCKED frame does not open the stream, but informs the peer that a
-new stream was needed, but the stream limit prevented the creation of the
-stream.
+new stream was needed and the stream limit prevented the creation of the stream.
 
 The STREAMS_BLOCKED frame is as follows:
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1425,16 +1425,16 @@ by the server, the server MUST NOT reduce any limits or alter any values that
 might be violated by the client with its 0-RTT data.  In particular, a server
 that accepts 0-RTT data MUST NOT set values for initial_max_data,
 initial_max_stream_data_bidi_local, initial_max_stream_data_bidi_remote,
-initial_max_stream_data_uni, initial_max_bidi_streams, or
-initial_max_uni_streams ({{transport-parameter-definitions}}) that are smaller
+initial_max_stream_data_uni, initial_max_streams_bidi, or
+initial_max_streams_uni ({{transport-parameter-definitions}}) that are smaller
 than the remembered value of those parameters.
 
 Omitting or setting a zero value for certain transport parameters can result in
 0-RTT data being enabled, but not usable.  The applicable subset of transport
 parameters that permit sending of application data SHOULD be set to non-zero
 values for 0-RTT.  This includes initial_max_data and either
-initial_max_bidi_streams and initial_max_stream_data_bidi_remote, or
-initial_max_uni_streams and initial_max_stream_data_uni.
+initial_max_streams_bidi and initial_max_stream_data_bidi_remote, or
+initial_max_streams_uni and initial_max_stream_data_uni.
 
 The value of the server's previous preferred_address MUST NOT be used when
 establishing a new connection; rather, the client should wait to observe the
@@ -3802,13 +3802,13 @@ language from Section 3 of {{!TLS13=RFC8446}}.
    enum {
       initial_max_stream_data_bidi_local(0),
       initial_max_data(1),
-      initial_max_bidi_streams(2),
+      initial_max_streams_bidi(2),
       idle_timeout(3),
       preferred_address(4),
       max_packet_size(5),
       stateless_reset_token(6),
       ack_delay_exponent(7),
-      initial_max_uni_streams(8),
+      initial_max_streams_uni(8),
       disable_migration(9),
       initial_max_stream_data_bidi_remote(10),
       initial_max_stream_data_uni(11),
@@ -3940,7 +3940,7 @@ initial_max_data (0x0001):
   completing the handshake. If the transport parameter is absent, the connection
   starts with a flow control limit of 0.
 
-initial_max_bidi_streams (0x0002):
+initial_max_streams_bidi (0x0002):
 
 : The initial maximum bidirectional streams parameter contains the initial
   maximum number of bidirectional streams the peer may initiate, encoded as an
@@ -3949,7 +3949,7 @@ initial_max_bidi_streams (0x0002):
   parameter is equivalent to sending a MAX_STREAMS ({{frame-max-streams}}) of
   the corresponding type immediately after completing the handshake.
 
-initial_max_uni_streams (0x0008):
+initial_max_streams_uni (0x0008):
 
 : The initial maximum unidirectional streams parameter contains the initial
   maximum number of unidirectional streams the peer may initiate, encoded as an
@@ -5236,13 +5236,13 @@ The initial contents of this registry are shown in {{iana-tp-table}}.
 |:-------|:----------------------------|:------------------------------------|
 | 0x0000 | initial_max_stream_data_bidi_local | {{transport-parameter-definitions}} |
 | 0x0001 | initial_max_data            | {{transport-parameter-definitions}} |
-| 0x0002 | initial_max_bidi_streams    | {{transport-parameter-definitions}} |
+| 0x0002 | initial_max_streams_bidi    | {{transport-parameter-definitions}} |
 | 0x0003 | idle_timeout                | {{transport-parameter-definitions}} |
 | 0x0004 | preferred_address           | {{transport-parameter-definitions}} |
 | 0x0005 | max_packet_size             | {{transport-parameter-definitions}} |
 | 0x0006 | stateless_reset_token       | {{transport-parameter-definitions}} |
 | 0x0007 | ack_delay_exponent          | {{transport-parameter-definitions}} |
-| 0x0008 | initial_max_uni_streams     | {{transport-parameter-definitions}} |
+| 0x0008 | initial_max_streams_uni     | {{transport-parameter-definitions}} |
 | 0x0009 | disable_migration           | {{transport-parameter-definitions}} |
 | 0x000a | initial_max_stream_data_bidi_remote | {{transport-parameter-definitions}} |
 | 0x000b | initial_max_stream_data_uni | {{transport-parameter-definitions}} |


### PR DESCRIPTION
The problems we've been having with stream limits turned out to be
intractable without a larger shift.  This aligns stream limits with flow
control limits.  To do that, it takes two frame types, both for
increasing the limit and for signaling blocking.

Note that these frame types will be renumbered afterwards.  I realize
that this is a terrible arrangement, but it's temporary.  Ideally all
this limiting stuff is in a contiguous block.

Closes #1850.