### PR TITLE
Relax 1200B requirement for Initial ACKs/Retx

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1556,9 +1556,10 @@ times as many bytes as the number of bytes they have received.  This limits the
 magnitude of any amplification attack that can be mounted using spoofed source
 addresses.
 
-To ensure that the server is not overly constrained by this restriction, clients
-MUST send UDP datagrams with at least 1200 octets of payload until the server
-has completed address validation, see {{packet-size}}.
+If sending a UDP datagram consisting entirely of an Initial Packet, clients
+MUST pad that packet to at least 1200 bytes unless the client has received a
+Handshake Packet ack from the server. This ensures that the server is not
+overly constrained by the amplification restriction.
 
 In order to prevent a handshake deadlock as a result of the server being unable
 to send, clients SHOULD send a packet upon a handshake timeout, as described in

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1250,9 +1250,9 @@ that meets the requirements of the cryptographic handshake protocol:
   {{?RFC7301}} for this purpose)
 
 The first CRYPTO frame from a client MUST be sent in a single packet.  Any
-second attempt that is triggered by address validation (see {{validate-new}})
-MUST also be sent within a single packet. This avoids having to reassemble a
-message from multiple packets.
+second attempt that is triggered by address validation (see
+{{validate-handshake}}) MUST also be sent within a single packet. This avoids
+having to reassemble a message from multiple packets.
 
 The first client packet of the cryptographic handshake protocol MUST fit within
 a 1232 octet QUIC packet payload.  This includes overheads that reduce the space
@@ -1539,10 +1539,11 @@ on its own.
 The primary defense against amplification attack is verifying that an endpoint
 is able to receive packets at the transport address that it claims.  Address
 validation is performed both during connection establishment (see
-{{validate-new}}) and during connection migration (see {{migrate-validate}}).
+{{validate-handshake}}) and during connection migration (see
+{{migrate-validate}}).
 
 
-## Address Validation During Connection Establishment {#validate-new}
+## Address Validation During Connection Establishment {#validate-handshake}
 
 Connection establishment implicitly provides address validation for both
 endpoints.  In particular, receipt of a packet protected with Handshake keys
@@ -3680,7 +3681,7 @@ a connection error.
 
 A Retry packet uses a long packet header with a type value of 0x7E. It carries
 an address validation token created by the server. It is used by a server that
-wishes to perform a stateless retry (see {{validate-new}}).
+wishes to perform a stateless retry (see {{validate-handshake}}).
 
 ~~~
  0                   1                   2                   3

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4440,7 +4440,7 @@ type PROTOCOL_VIOLATION.
 
 ## RETIRE_CONNECTION_ID Frame {#frame-retire-connection-id}
 
-An endpoint sends a RETIRE_CONNECTION_ID frame (type=0x1b) to indicate that it
+An endpoint sends a RETIRE_CONNECTION_ID frame (type=0x0d) to indicate that it
 will no longer use a connection ID that was issued by its peer. This may include
 the connection ID provided during the handshake.  Sending a RETIRE_CONNECTION_ID
 frame also serves as a request to the peer to send additional connection IDs for


### PR DESCRIPTION
IMO it's silly to pad out a packet that contains the client's initial and handshake acks, because if delivered it verifies the address.