### PR TITLE
Stop reserving application error codes

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1526,7 +1526,7 @@ The entries in the following table are registered by this document.
 | ----------------------------------- | ---------- | ---------------------------------------- | ---------------------- |
 | Name                                | Code       | Description                              | Specification          |
 | ----------------------------------- | ---------- | ---------------------------------------- | ---------------------- |
-| HTTP_NO_ERROR                       | 0x0001     | No error                                 | {{http-error-codes}}   |
+| HTTP_NO_ERROR                       | 0x0000     | No error                                 | {{http-error-codes}}   |
 | HTTP_PUSH_REFUSED                   | 0x0002     | Client refused pushed content            | {{http-error-codes}}   |
 | HTTP_INTERNAL_ERROR                 | 0x0003     | Internal error                           | {{http-error-codes}}   |
 | HTTP_PUSH_ALREADY_IN_CACHE          | 0x0004     | Pushed content already cached            | {{http-error-codes}}   |

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1271,11 +1271,7 @@ express the cause of a connection or stream error.
 The following error codes are defined for use in QUIC RST_STREAM, STOP_SENDING,
 and APPLICATION_CLOSE frames when using HTTP/QUIC.
 
-HTTP_STOPPING (0x00):
-: This value can be used in QUIC RST_STREAM frames in response to QUIC
-  STOP_SENDING frames.
-
-HTTP_NO_ERROR (0x01):
+HTTP_NO_ERROR (0x00):
 : No error.  This is used when the connection or stream needs to be closed, but
   there is no error to signal.
 
@@ -1530,7 +1526,6 @@ The entries in the following table are registered by this document.
 | ----------------------------------- | ---------- | ---------------------------------------- | ---------------------- |
 | Name                                | Code       | Description                              | Specification          |
 | ----------------------------------- | ---------- | ---------------------------------------- | ---------------------- |
-| HTTP_STOPPING                       | 0x0000     | Solicited stream reset                   | {{http-error-codes}}   |
 | HTTP_NO_ERROR                       | 0x0001     | No error                                 | {{http-error-codes}}   |
 | HTTP_PUSH_REFUSED                   | 0x0002     | Client refused pushed content            | {{http-error-codes}}   |
 | HTTP_INTERNAL_ERROR                 | 0x0003     | Internal error                           | {{http-error-codes}}   |

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1271,8 +1271,8 @@ express the cause of a connection or stream error.
 The following error codes are defined for use in QUIC RST_STREAM, STOP_SENDING,
 and APPLICATION_CLOSE frames when using HTTP/QUIC.
 
-STOPPING (0x00):
-: This value is reserved by the transport to be used in response to QUIC
+HTTP_STOPPING (0x00):
+: This value can be used in QUIC RST_STREAM frames in response to QUIC
   STOP_SENDING frames.
 
 HTTP_NO_ERROR (0x01):
@@ -1530,7 +1530,7 @@ The entries in the following table are registered by this document.
 | ----------------------------------- | ---------- | ---------------------------------------- | ---------------------- |
 | Name                                | Code       | Description                              | Specification          |
 | ----------------------------------- | ---------- | ---------------------------------------- | ---------------------- |
-| STOPPING                            | 0x0000     | Reserved by QUIC                         | {{QUIC-TRANSPORT}}     |
+| HTTP_STOPPING                       | 0x0000     | Solicited stream reset                   | {{http-error-codes}}   |
 | HTTP_NO_ERROR                       | 0x0001     | No error                                 | {{http-error-codes}}   |
 | HTTP_PUSH_REFUSED                   | 0x0002     | Client refused pushed content            | {{http-error-codes}}   |
 | HTTP_INTERNAL_ERROR                 | 0x0003     | Internal error                           | {{http-error-codes}}   |

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -5015,11 +5015,6 @@ Application protocol error codes are used for the RST_STREAM
 ({{frame-rst-stream}}) and APPLICATION_CLOSE ({{frame-application-close}})
 frames.
 
-There is no restriction on the use of the 16-bit error code space for
-application protocols.  Endpoints are encouraged to send a RST_STREAM with an
-error code of 0 in response to receiving a STOP_SENDING frame, so reserving 0
-for that use, or to indicate "no error", is advised.
-
 
 # Security Considerations
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2495,7 +2495,8 @@ connection in a recoverable state, the endpoint can send a RST_STREAM frame
 ({{frame-rst-stream}}) with an appropriate error code to terminate just the
 affected stream.
 
-RST_STREAM MUST be instigated by the application.  RST_STREAM carries an
+RST_STREAM MUST be instigated by the protocol using QUIC, either directly or
+through the receipt of a STOP_SENDING frame from a peer.  RST_STREAM carries an
 application error code.  Resetting a stream without knowledge of the application
 protocol could cause the protocol to enter an unrecoverable state.  Application
 protocols might require certain streams to be reliably delivered in order to

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -706,11 +706,10 @@ frames count toward flow control.
 
 A STOP_SENDING frame requests that the receiving endpoint send a RST_STREAM
 frame.  An endpoint that receives a STOP_SENDING frame MUST send a RST_STREAM
-frame for that stream.  An endpoint can use any application error code, though
-they SHOULD send the error code with a value of 0.  The endpoint that sends a
-STOP_SENDING frame SHOULD ignore the error code carried in the RST_STREAM frame.
-An application protocol can reserve an error code for this purpose, but
-endpoints cannot depend on that code being used.
+frame for that stream.  An endpoint can use any application error code in the
+RST_STREAM frame, though they can copy the error code from the STOP_SENDING
+frame if no other option is available.  The endpoint that sends a STOP_SENDING
+frame can ignore the error code carried in any RST_STREAM frame they receive.
 
 If the STOP_SENDING frame is received on a send stream that is already in the
 "Data Sent" state, a RST_STREAM frame MAY still be sent in order to cancel

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -706,10 +706,10 @@ frames count toward flow control.
 
 A STOP_SENDING frame requests that the receiving endpoint send a RST_STREAM
 frame.  An endpoint that receives a STOP_SENDING frame MUST send a RST_STREAM
-frame for that stream.  An endpoint can use any application error code in the
-RST_STREAM frame, though they can copy the error code from the STOP_SENDING
-frame if no other option is available.  The endpoint that sends a STOP_SENDING
-frame can ignore the error code carried in any RST_STREAM frame they receive.
+frame for that stream.  An endpoint SHOULD copy the error code from the
+STOP_SENDING frame, but MAY use any other application error code.  The endpoint
+that sends a STOP_SENDING frame can ignore the error code carried in any
+RST_STREAM frame they receive.
 
 If the STOP_SENDING frame is received on a send stream that is already in the
 "Data Sent" state, a RST_STREAM frame MAY still be sent in order to cancel

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -706,9 +706,14 @@ frames count toward flow control.
 
 A STOP_SENDING frame requests that the receiving endpoint send a RST_STREAM
 frame.  An endpoint that receives a STOP_SENDING frame MUST send a RST_STREAM
-frame for that stream, and can use an error code of STOPPING.  If the
-STOP_SENDING frame is received on a send stream that is already in the "Data
-Sent" state, a RST_STREAM frame MAY still be sent in order to cancel
+frame for that stream.  An endpoint can use any application error code, though
+they SHOULD send the error code with a value of 0.  The endpoint that sends a
+STOP_SENDING frame SHOULD ignore the error code carried in the RST_STREAM frame.
+An application protocol can reserve an error code for this purpose, but
+endpoints cannot depend on that code being used.
+
+If the STOP_SENDING frame is received on a send stream that is already in the
+"Data Sent" state, a RST_STREAM frame MAY still be sent in order to cancel
 retransmission of previously-sent STREAM frames.
 
 STOP_SENDING SHOULD only be sent for a receive stream that has not been
@@ -2491,13 +2496,11 @@ connection in a recoverable state, the endpoint can send a RST_STREAM frame
 ({{frame-rst-stream}}) with an appropriate error code to terminate just the
 affected stream.
 
-Other than STOPPING ({{solicited-state-transitions}}), RST_STREAM MUST be
-instigated by the application and MUST carry an application error code.
-Resetting a stream without knowledge of the application protocol could cause the
-protocol to enter an unrecoverable state.  Application protocols might require
-certain streams to be reliably delivered in order to guarantee consistent state
-between endpoints.
-
+RST_STREAM MUST be instigated by the application.  RST_STREAM carries an
+application error code.  Resetting a stream without knowledge of the application
+protocol could cause the protocol to enter an unrecoverable state.  Application
+protocols might require certain streams to be reliably delivered in order to
+guarantee consistent state between endpoints.
 
 
 # Packets and Frames {#packets-frames}
@@ -5014,9 +5017,9 @@ Application protocol error codes are used for the RST_STREAM
 frames.
 
 There is no restriction on the use of the 16-bit error code space for
-application protocols.  However, QUIC reserves the error code with a value of 0
-to mean STOPPING.  The application error code of STOPPING (0) is used by the
-transport to cancel a stream in response to receipt of a STOP_SENDING frame.
+application protocols.  Endpoints are encouraged to send a RST_STREAM with an
+error code of 0 in response to receiving a STOP_SENDING frame, so reserving 0
+for that use, or to indicate "no error", is advised.
 
 
 # Security Considerations


### PR DESCRIPTION
We really don't need to do this.  As observed, the error code in
RST_STREAM really doesn't matter once you have requested that it stop.

I know that this wasn't a universally-held opinion, but we don't need to
stomp on values in the application protocol, so we shouldn't.  (Igor
suggested a new frame type, and that is maybe cleaner, but it's
wasteful when it won't be used, so I think that this is better.)

I've gone with the minimal change to HTTP.  The bigger change would be to recommend the use of NO_ERROR for this case and to renumber error code.  I'll let @MikeBishop decide what happens there.

Closes #1804.