### PR TITLE
Connection IDs can change twice

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3788,11 +3788,11 @@ client MUST NOT change the Source Connection ID because the server could include
 the connection ID as part of its token validation logic (see
 {{validate-future}}).
 
-All subsequent Initial packets from the client MUST use the connection ID and
-token values from the Retry packet.  Aside from this, the Initial packet sent
-by the client is subject to the same restrictions as the first Initial packet.
-A client can either reuse the cryptographic handshake message or construct a
-new one at its discretion.
+The next Initial packet from the client uses the connection ID and token values
+from the Retry packet (see {{negotiating-connection-ids}}).  Aside from this,
+the Initial packet sent by the client is subject to the same restrictions as the
+first Initial packet.  A client can either reuse the cryptographic handshake
+message or construct a new one at its discretion.
 
 A client MAY attempt 0-RTT after receiving a Retry packet by sending 0-RTT
 packets to the connection ID provided by the server.  A client that sends


### PR DESCRIPTION
The text in Retry contradicted the text on negotiating connection IDs in
a subtle way.  No point in replicating text that exists elsewhere.

Closes #1830.