### PR TITLE
The spin-bit should be some times disabled

### DIFF
--- a/draft-ietf-quic-spin-exp.md
+++ b/draft-ietf-quic-spin-exp.md
@@ -271,7 +271,7 @@ RTT, and will thus enable adversaries near the client to discover that
 the connection does not terminate at the visible destination address, and
 that the client is probably accessing a hidden server through a proxy.
 
-Clients that want to hide their use of a proxy or a relay will want to
+Endpoints that want to hide their use of a proxy or a relay will want to
 disable the spin bit. However, if only privacy sensitive clients ever
 disabled the spin bit, they would stick out. The probabilistic disabling
 behavior explained in {#disabling-the-spin-bit} ensures that other clients

--- a/draft-ietf-quic-spin-exp.md
+++ b/draft-ietf-quic-spin-exp.md
@@ -242,7 +242,7 @@ in the downstream direction, and vice versa.
 
 Implementations SHOULD allow users to disable the spin bit either globally,
 or on a per-connection basis. Even when the spin bit is not disabled by
-the user, implementations SHOULD disable the spin-bit on a randomly chosen
+the user, implementations SHOULD disable the spin bit on a randomly chosen
 fraction of connections. The random process SHOULD be designed so that
 on average the spin-bit is disabled for at least 1/8th of the connections.
 

--- a/draft-ietf-quic-spin-exp.md
+++ b/draft-ietf-quic-spin-exp.md
@@ -240,7 +240,7 @@ in the downstream direction, and vice versa.
 
 # Disabling the Spin Bit
 
-Implementation SHOULD allow users to disable the spin-bit either globally,
+Implementations SHOULD allow users to disable the spin bit either globally,
 or on a per-connection basis. Even when the spin-bit is not disabled by
 the user, implementations SHOULD disable the spin-bit on a randomly chosen
 fraction of connections. The random process SHOULD be designed so that

--- a/draft-ietf-quic-spin-exp.md
+++ b/draft-ietf-quic-spin-exp.md
@@ -267,7 +267,7 @@ on-path devices is in most cases negligible.
 There is however an exception, when parts of the path from client to server
 are hidden from observers. An example would be a server accessed through a
 proxy. The spin bit allows for measurement of the end-to-end
-RTT, and will thus enable adversaries near the client to discover that
+RTT, and will thus enable adversaries near the endpoint to discover that
 the connection does not terminate at the visible destination address, and
 that the client is probably accessing a hidden server through a proxy.
 

--- a/draft-ietf-quic-spin-exp.md
+++ b/draft-ietf-quic-spin-exp.md
@@ -238,7 +238,7 @@ and the observer and the client, respectively. It does this by measuring the
 delay between a spin edge observed in the upstream direction and that observed
 in the downstream direction, and vice versa.
 
-# Disabling the spin bit
+# Disabling the Spin Bit
 
 Implementation SHOULD allow users to disable the spin-bit either globally,
 or on a per-connection basis. Even when the spin-bit is not disabled by

--- a/draft-ietf-quic-spin-exp.md
+++ b/draft-ietf-quic-spin-exp.md
@@ -241,7 +241,7 @@ in the downstream direction, and vice versa.
 # Disabling the Spin Bit
 
 Implementations SHOULD allow users to disable the spin bit either globally,
-or on a per-connection basis. Even when the spin-bit is not disabled by
+or on a per-connection basis. Even when the spin bit is not disabled by
 the user, implementations SHOULD disable the spin-bit on a randomly chosen
 fraction of connections. The random process SHOULD be designed so that
 on average the spin-bit is disabled for at least 1/8th of the connections.

--- a/draft-ietf-quic-spin-exp.md
+++ b/draft-ietf-quic-spin-exp.md
@@ -241,7 +241,7 @@ in the downstream direction, and vice versa.
 # Disabling the Spin Bit
 
 Implementations SHOULD allow administrators of clients and servers to disable
-the spin bit either globally, or on a per-connection basis.
+the spin bit either globally or on a per-connection basis.
 Even when the spin bit is not disabled by the administrator implementations
 SHOULD disable the spin bit on a randomly chosen
 fraction of connections.  The selection process should be designed such that
@@ -274,7 +274,7 @@ the connection does not terminate at the visible destination address.
 Endpoints that want to hide their use of a proxy or a relay will want to
 disable the spin bit. However, if only privacy-sensitive clients or servers ever
 disabled the spin bit, they would stick out. The probabilistic disabling
-behavior explained in {#disabling-the-spin-bit} ensures that other endpoints
+behavior explained in {{disabling-the-spin-bit}} ensures that other endpoints
 will also disable the spin bit some of the time, thus hiding the
 privacy sensitive endpoints in a large anonymity set. It also provides
 for a minimal greasing of the spin bit, in order to mitigate risks of
@@ -288,7 +288,7 @@ ossification.
 
 ## Since draft-ietf-spin-exp-00
 
-Nothing yet.
+Adding section on disabling the spin bit and privacy considerations.
 
 # Acknowledgments
 {:numbered="false"}

--- a/draft-ietf-quic-spin-exp.md
+++ b/draft-ietf-quic-spin-exp.md
@@ -272,7 +272,7 @@ RTT, and will thus enable adversaries near the endpoint to discover that
 the connection does not terminate at the visible destination address.
 
 Endpoints that want to hide their use of a proxy or a relay will want to
-disable the spin bit. However, if only privacy sensitive clients or servers ever
+disable the spin bit. However, if only privacy-sensitive clients or servers ever
 disabled the spin bit, they would stick out. The probabilistic disabling
 behavior explained in {#disabling-the-spin-bit} ensures that other endpoints
 will also disable the spin bit some of the time, thus hiding the

--- a/draft-ietf-quic-spin-exp.md
+++ b/draft-ietf-quic-spin-exp.md
@@ -269,7 +269,7 @@ There is however an exception, when parts of the path from client to server
 are hidden from observers. An example would be a server accessed through a
 proxy. The spin bit allows for measurement of the end-to-end
 RTT, and will thus enable adversaries near the endpoint to discover that
-the connection does not terminate at the visible destination address, and
+the connection does not terminate at the visible destination address.
 that the client is probably accessing a hidden server through a proxy.
 
 Endpoints that want to hide their use of a proxy or a relay will want to

--- a/draft-ietf-quic-spin-exp.md
+++ b/draft-ietf-quic-spin-exp.md
@@ -270,7 +270,6 @@ are hidden from observers. An example would be a server accessed through a
 proxy. The spin bit allows for measurement of the end-to-end
 RTT, and will thus enable adversaries near the endpoint to discover that
 the connection does not terminate at the visible destination address.
-that the client is probably accessing a hidden server through a proxy.
 
 Endpoints that want to hide their use of a proxy or a relay will want to
 disable the spin bit. However, if only privacy sensitive clients or servers ever

--- a/draft-ietf-quic-spin-exp.md
+++ b/draft-ietf-quic-spin-exp.md
@@ -244,7 +244,7 @@ Implementations SHOULD allow administrators of clients and servers to disable
 the spin bit either globally, or on a per-connection basis.
 Even when the spin bit is not disabled by the administrator implementations
 SHOULD disable the spin bit on a randomly chosen
-fraction of connections. The random process SHOULD be designed so that
+fraction of connections.  The selection process should be designed such that
 on average the spin bit is disabled for at least 1/8th of the connections.
 
 When the spin bit is disabled, endpoints SHOULD set the spin bit value to zero,

--- a/draft-ietf-quic-spin-exp.md
+++ b/draft-ietf-quic-spin-exp.md
@@ -238,6 +238,17 @@ and the observer and the client, respectively. It does this by measuring the
 delay between a spin edge observed in the upstream direction and that observed
 in the downstream direction, and vice versa.
 
+# Disabling the spin bit
+
+Implementation SHOULD allow users to disable the spin-bit either globally,
+or on a per-connection basis. Even when the spin-bit is not disabled by
+the user, implementations SHOULD disable the spin-bit on a randomly chosen
+fraction of connections. The random process SHOULD be designed so that
+on average the spin-bit is disabled for at least 1/8th of the connections.
+
+When the spin-bit is disabled, peers MUST set the spin bit value to zero,
+regardless of the values received from their peer.
+
 
 # IANA Considerations
 
@@ -251,7 +262,23 @@ same as those for passive RTT measurement in general. It has been shown
 {{PAM-RTT}} that RTT measurements do not provide more information for
 geolocation than is available in the most basic, freely-available IP address
 based location databases. The risk of exposure of per-flow network RTT to
-on-path devices is therefore negligible.
+on-path devices is in most cases negligible.
+
+There is however an exception, when parts of the path from client to server
+are hidden from observers. An example would be a server accessed through a
+proxy. The spin bit allows for measurement of the end-to-end
+RTT, and will thus enable adversaries near the client to discover that
+the connection does not terminate at the visible destination address, and
+that the client is probably accessing a hidden server through a proxy.
+
+Clients that want to hide their use of a proxy or a relay will want to
+disable the spin bit. However, if only privacy sensitive clients ever
+disabled the spin bit, they would stick out. The probabilistic disabling
+behavior explained in {#disabling-the-spin-bit} ensures that other clients
+will also disabling the spin bit some of the time, thus hiding the
+privacy sensitive clients in a large anonymity set. It also provides
+for a minimal greasing of the spin bit, in order to mitigate risks of
+ossification.
 
 
 # Change Log

--- a/draft-ietf-quic-spin-exp.md
+++ b/draft-ietf-quic-spin-exp.md
@@ -240,15 +240,16 @@ in the downstream direction, and vice versa.
 
 # Disabling the Spin Bit
 
-Implementations SHOULD allow users to disable the spin bit either globally,
-or on a per-connection basis. Even when the spin bit is not disabled by
-the user, implementations SHOULD disable the spin bit on a randomly chosen
+Implementations SHOULD allow administrators of clients and servers to disable
+the spin bit either globally, or on a per-connection basis.
+Even when the spin bit is not disabled by the administrator implementations
+SHOULD disable the spin bit on a randomly chosen
 fraction of connections. The random process SHOULD be designed so that
-on average the spin-bit is disabled for at least 1/8th of the connections.
+on average the spin bit is disabled for at least 1/8th of the connections.
 
-When the spin-bit is disabled, peers MUST set the spin bit value to zero,
-regardless of the values received from their peer.
-
+When the spin bit is disabled, endpoints SHOULD set the spin bit value to zero,
+regardless of the values received from their peer. Addendums or revisions to
+this document MAY define alternative behaviors in the future.
 
 # IANA Considerations
 
@@ -272,11 +273,11 @@ the connection does not terminate at the visible destination address, and
 that the client is probably accessing a hidden server through a proxy.
 
 Endpoints that want to hide their use of a proxy or a relay will want to
-disable the spin bit. However, if only privacy sensitive clients ever
+disable the spin bit. However, if only privacy sensitive clients or servers ever
 disabled the spin bit, they would stick out. The probabilistic disabling
-behavior explained in {#disabling-the-spin-bit} ensures that other clients
-will also disabling the spin bit some of the time, thus hiding the
-privacy sensitive clients in a large anonymity set. It also provides
+behavior explained in {#disabling-the-spin-bit} ensures that other endpoints
+will also disable the spin bit some of the time, thus hiding the
+privacy sensitive endpoints in a large anonymity set. It also provides
 for a minimal greasing of the spin bit, in order to mitigate risks of
 ossification.
 


### PR DESCRIPTION
For privacy reasons, and in a probabilistic way to grease the spin-bit, and to provide a sufficient anonymity set to the privacy conscious folks.