### PR TITLE
Remove error handling from the early stream description

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -306,13 +306,6 @@ The two type bits from a Stream ID therefore identify streams as summarized in
 
 The first bidirectional stream opened by the client is stream 0.
 
-If an endpoint receives a frame for a stream that it expects to initiate (i.e.,
-an even-numbered for the client or an odd-numbered for the server), but which it
-has not yet opened, it MUST close the connection with error code
-STREAM_STATE_ERROR.  Similarly, receiving a STREAM or RST_STREAM frame for a
-unidirectional stream that an endpoint expects to initiate MUST be treated as a
-connection error of type STREAM_STATE_ERROR.
-
 A QUIC endpoint MUST NOT reuse a Stream ID.  Streams of each type are created in
 numeric order.  Streams that are used out of order result in opening all
 lower-numbered streams of the same type in the same direction.


### PR DESCRIPTION
This was clearly not complete, and as a result it ends up being
confusing.  Better not to say anything and rely on later sections.