### PR TITLE
Late alarms and max_ack_delay

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3929,7 +3929,7 @@ max_ack_delay (0x000b):
 
 : The maximum ACK delay is an integer value indicating the
   maximum amount of time in milliseconds by which the endpoint will delay
-  sending acknowledgments.  This value should include the receiver's expected
+  sending acknowledgments.  This value SHOULD include the receiver's expected
   delays in alarms firing.  For example, if a receiver sets a timer for 5ms
   and alarms commonly fire up to 1ms late, then it should send a max_ack_delay
   of 6ms.  If this value is absent, a default of 25 milliseconds is assumed.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3930,10 +3930,9 @@ max_ack_delay (0x000b):
 : The maximum ACK delay is an integer value indicating the
   maximum amount of time in milliseconds by which the endpoint will delay
   sending acknowledgments.  This value should include the receiver's expected
-  delays in alarms firing.  For example, if a receiver specifies a 5ms
-  max_ack_delay and alarms commonly fire up to 1ms late, then it should set
-  a timer for 4ms.  If this value is absent, a default of 25 milliseconds is
-  assumed.
+  delays in alarms firing.  For example, if a receiver sets a timer for 5ms
+  and alarms commonly fire up to 1ms late, then it should send a max_ack_delay
+  of 6ms.  If this value is absent, a default of 25 milliseconds is assumed.
 
 disable_migration (0x000c):
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3929,8 +3929,11 @@ max_ack_delay (0x000b):
 
 : The maximum ACK delay is an integer value indicating the
   maximum amount of time in milliseconds by which the endpoint will delay
-  sending acknowledgments.  If this value is absent, a default of 25
-  milliseconds is assumed.
+  sending acknowledgments.  This value should include the receiver's expected
+  delays in alarms firing.  For example, if a receiver specifies a 5ms
+  max_ack_delay and alarms commonly fire up to 1ms late, then it should set
+  a timer for 4ms.  If this value is absent, a default of 25 milliseconds is
+  assumed.
 
 disable_migration (0x000c):
 


### PR DESCRIPTION
Add some text on how to correctly specify max_ack_delay on systems where the alarm may fire late.