### PR TITLE
Time based to Time threshold in Recovery

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -269,9 +269,9 @@ degrees of reordering, causing a sender to detect spurious losses.
 Implementers MAY use algorithms developed for TCP, such as
 TCP-NCR {{?RFC4653}}, to improve QUIC's reordering resilience.
 
-#### Time-based
+#### Time Threshold
 
-Time-based loss detection uses a time threshold to determine how much
+Time threshold loss detection uses a time threshold to determine how much
 reordering to tolerate.  In this document, the threshold is expressed as a
 fraction of an RTT, but implemenantations MAY experiment with absolute
 thresholds.  This may be used either as a replacement for a packet reordering
@@ -594,12 +594,13 @@ kReorderingThreshold:
   considers a packet lost. The RECOMMENDED value is 3.
 
 kTimeReorderingFraction:
-: Maximum reordering in time space before time based loss detection considers
-  a packet lost.  In fraction of an RTT. The RECOMMENDED value is 1/8.
+: Maximum reordering in time space before time threshold loss detection
+  considers a packet lost.  In fraction of an RTT. The RECOMMENDED value
+  is 1/8.
 
 kUsingTimeLossDetection:
-: Whether time based loss detection is in use.  If false, uses FACK style
-  loss detection. The RECOMMENDED value is false.
+: Whether time threshold loss detection is in use.  If false, uses only packet
+  threshold loss detection. The RECOMMENDED value is false.
 
 kMinTLPTimeout:
 : Minimum time in the future a tail loss probe timer may be set for.
@@ -813,7 +814,7 @@ Pseudocode for OnPacketAcked follows:
 
 ### Setting the Loss Detection Timer
 
-QUIC loss detection uses a single timer for all timer-based loss detection.  The
+QUIC loss detection uses a single timer for all timeout based loss detection.  The
 duration of the timer is based on the timer's mode, which is set in the packet
 and timer events further below.  The function SetLossDetectionTimer defined
 below shows how the single timer is set.

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -814,7 +814,7 @@ Pseudocode for OnPacketAcked follows:
 
 ### Setting the Loss Detection Timer
 
-QUIC loss detection uses a single timer for all timeout based loss detection.  The
+QUIC loss detection uses a single timer for all timeout loss detection.  The
 duration of the timer is based on the timer's mode, which is set in the packet
 and timer events further below.  The function SetLossDetectionTimer defined
 below shows how the single timer is set.


### PR DESCRIPTION
Jana's tcpm slides use time threshold and packet threshold, which I like a lot better than time-based.