### PR TITLE
Prevent an unlikely deadlock

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -418,6 +418,12 @@ used to send a probe into the network prior to establishing any packet loss,
 prior unacknowledged packets SHOULD NOT be marked as lost when a TLP timer
 expires.
 
+If no new data or unacknowledged data is available to send, a retransmittable
+frame SHOULD be sent.  Sending a retransmittable frame ensures that any in
+flight packets are acknowledged or declared lost in a timely manner,
+potentially preventing a deadlock if all in flight packets contain no data
+that needs to be retransmission.  
+
 A sender may not know that a packet being sent is a tail packet.  Consequently,
 a sender may have to arm or adjust the TLP timer on every sent retransmittable
 packet.


### PR DESCRIPTION
QUIC, unlike TCP, allows the connection to get into a situation where there could be packets in flight, and a connection could even be CWND limited, but there may not be any outstanding data to retransmit.

The suggested solution is to send a retransmittable frame.