### PR TITLE
Recovery uses both time and packet thresholds

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -271,8 +271,12 @@ they do not use a timer to send probes, but rather to declare packets lost.
 ### Fast Retransmit
 
 An unacknowledged packet is marked as lost when an acknowledgment is received
-for a packet that was sent kPacketThreshold number of packets or
-kTimeThreshold amount of time after the unacknowledged packet.
+for a packet sent sufficiently after the unacknowledged packet.
+* The largest acknowledged packet is more than kPacketThreshold packets larger
+  than the unacknowleged packet.
+* The unacknowledged packet was sent more than
+  (1 + kTimeThreshold) * max(SRTT, latest_RTT) ago.
+
 Receipt of the acknowledgement indicates that a later packet was received,
 while the reordering threshold provides some tolerance for reordering of
 packets in the network.

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -240,11 +240,10 @@ underestimation of min RTT, which in turn prevents underestimating smoothed RTT.
 
 Ack-based loss detection implements the spirit of TCP's Fast Retransmit
 {{?RFC5681}}, Early Retransmit {{?RFC5827}}, FACK, SACK loss recovery
-{{?RFC6675}}, and RACK {{draft-ietf-tcpm-rack-04}}. This section provides an
-overview of how these algorithms are implemented in QUIC.  Though both
-time-based loss detection and early retransmit use a timer, they are part
-of ack-based detection because they do not use a timer to send probes,
-but rather to declare packets lost.
+{{?RFC6675}}, and RACK. This section provides an overview of how these
+algorithms are implemented in QUIC.  Though both time-based loss detection
+and early retransmit use a timer, they are part of ack-based detection because
+they do not use a timer to send probes, but rather to declare packets lost.
 
 ### Fast Retransmit
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -263,7 +263,7 @@ underestimation of min RTT, which in turn prevents underestimating smoothed RTT.
 
 Ack-based loss detection implements the spirit of TCP's Fast Retransmit
 {{?RFC5681}}, Early Retransmit {{?RFC5827}}, FACK, SACK loss recovery
-{{?RFC6675}}, and RACK. This section provides an overview of how these
+{{?RFC6675}}, and RACK {{RACK}}. This section provides an overview of how these
 algorithms are implemented in QUIC.  Though both time threshold loss detection
 and early retransmit use a timer, they are part of ack-based detection because
 they do not use a timer to send probes, but rather to declare packets lost.

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -249,7 +249,7 @@ timer to send probes, but rather to declare packets lost.
 
 An unacknowledged packet is marked as lost when an acknowledgment is received
 for a packet that was sent a threshold number of packets (kReorderingThreshold)
-and/or a threshold amount of time after the unacknowledged packet. Receipt of
+or a threshold amount of time after the unacknowledged packet. Receipt of
 the acknowledgement indicates that a later packet was received, while the
 reordering threshold provides some tolerance for reordering of packets in the
 network.

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -239,20 +239,21 @@ underestimation of min RTT, which in turn prevents underestimating smoothed RTT.
 ## Ack-based Detection
 
 Ack-based loss detection implements the spirit of TCP's Fast Retransmit
-{{?RFC5681}}, Early Retransmit {{?RFC5827}}, FACK, and SACK loss recovery
-{{?RFC6675}}. This section provides an overview of how these algorithms are
-implemented in QUIC.  Though both time-based loss detection and early retransmit
-use a timer, they are part of ack-based detection because they do not use a
-timer to send probes, but rather to declare packets lost.
+{{?RFC5681}}, Early Retransmit {{?RFC5827}}, FACK, SACK loss recovery
+{{?RFC6675}}, and RACK {{draft-ietf-tcpm-rack-04}}. This section provides an
+overview of how these algorithms are implemented in QUIC.  Though both
+time-based loss detection and early retransmit use a timer, they are part
+of ack-based detection because they do not use a timer to send probes,
+but rather to declare packets lost.
 
 ### Fast Retransmit
 
 An unacknowledged packet is marked as lost when an acknowledgment is received
 for a packet that was sent a threshold number of packets (kReorderingThreshold)
-or a threshold amount of time after the unacknowledged packet. Receipt of
-the acknowledgement indicates that a later packet was received, while the
-reordering threshold provides some tolerance for reordering of packets in the
-network.
+or a threshold amount of time (kTimeReorderingFraction) after the
+unacknowledged packet. Receipt of the acknowledgement indicates that a later
+packet was received, while the reordering threshold provides some tolerance
+for reordering of packets in the network.
 
 Spuriously declaring packets lost leads to unnecessary retransmissions and
 may result in degraded performance due to the actions of the congestion

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -274,19 +274,14 @@ TCP-NCR {{?RFC4653}}, to improve QUIC's reordering resilience.
 Time threshold loss detection uses a time threshold to determine how much
 reordering to tolerate.  In this document, the threshold is expressed as a
 fraction of an RTT, but implemenantations MAY experiment with absolute
-thresholds.  This may be used either as a replacement for a packet reordering
-threshold or in addition to it.
-
-When a larger packet is acknowledged, if it was sent more than the threshold
-after any in flight packets, those packets are immediately declared lost.
-Otherwise, a timer is set for the the reordering threshold minus the time
-difference between the earliest in flight packet and the largest newly
-acknowledged packet.  Note that in some cases the timer could become longer when
-packets are acknowleged out of order. The RECOMMENDED time threshold, expressed
+thresholds.  It is recommended this is is used in conjunction with packet
+threshold fast retransmit. The RECOMMENDED time threshold, expressed
 as a fraction of the round-trip time (kTimeReorderingFraction), is 1/8.
 
-An endpoint SHOULD set the timer such that a packet is marked as lost no earlier
-than 1.125 * max(SRTT, latest_RTT) since when it was sent.
+An endpoint SHOULD declare packets lost no earlier than
+1.125 * max(SRTT, latest_RTT) after when they were sent.  If packets sent prior
+to the largest acknowledged packet cannot yet be declared lost, then a timer
+SHOULD be set for the remainint time.
 
 Using max(SRTT, latest_RTT) protects from the two following cases:
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -248,11 +248,11 @@ they do not use a timer to send probes, but rather to declare packets lost.
 ### Fast Retransmit
 
 An unacknowledged packet is marked as lost when an acknowledgment is received
-for a packet that was sent a threshold number of packets (kReorderingThreshold)
-or a threshold amount of time (kTimeReorderingFraction) after the
-unacknowledged packet. Receipt of the acknowledgement indicates that a later
-packet was received, while the reordering threshold provides some tolerance
-for reordering of packets in the network.
+for a packet that was sent kReorderingThreshold number of packets or
+kTimeReorderingFraction amount of time after the unacknowledged packet.
+Receipt of the acknowledgement indicates that a later packet was received,
+while the reordering threshold provides some tolerance for reordering of
+packets in the network.
 
 Spuriously declaring packets lost leads to unnecessary retransmissions and
 may result in degraded performance due to the actions of the congestion
@@ -274,9 +274,8 @@ TCP-NCR {{?RFC4653}}, to improve QUIC's reordering resilience.
 Time threshold loss detection uses a time threshold to determine how much
 reordering to tolerate.  In this document, the threshold is expressed as a
 fraction of an RTT, but implemenantations MAY experiment with absolute
-thresholds.  It is recommended this is is used in conjunction with packet
-threshold fast retransmit. The RECOMMENDED time threshold, expressed
-as a fraction of the round-trip time (kTimeReorderingFraction), is 1/8.
+thresholds. The RECOMMENDED time threshold, expressed as a fraction
+of the round-trip time (kTimeReorderingFraction), is 1/8.
 
 An endpoint SHOULD declare packets lost no earlier than
 (1 + kTimeReorderingFraction) * max(SRTT, latest_RTT) after when they were

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -649,7 +649,7 @@ packet_threshold:
   retransmittable packet and an unacknowledged
   retransmittable packet before it is declared lost.
 
-time_reordering_threshold:
+time_threshold:
 : The reordering window as a fraction of max(smoothed_rtt, latest_rtt).
 
 loss_time:

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -281,7 +281,7 @@ as a fraction of the round-trip time (kTimeReorderingFraction), is 1/8.
 An endpoint SHOULD declare packets lost no earlier than
 (1 + kTimeReorderingFraction) * max(SRTT, latest_RTT) after when they were
 sent.  If packets sent prior to the largest acknowledged packet cannot yet
-be declared lost, then a timer SHOULD be set for the remainint time.
+be declared lost, then a timer SHOULD be set for the remaining time.
 
 Using max(SRTT, latest_RTT) protects from the two following cases:
 
@@ -292,7 +292,7 @@ Using max(SRTT, latest_RTT) protects from the two following cases:
 * the latest RTT sample is higher than the SRTT, perhaps due to a sustained
   increase in the actual RTT, but the smoothed SRTT has not yet caught up.
 
-Implementers MAY experiment with using other reordering fractoins, bearing
+Implementers MAY experiment with using other reordering fractions, bearing
 in mind that a lower multiplier reduces reordering resilience and increases
 spurious retransmissions, and a higher multiplier increases loss recovery
 delay.

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -47,6 +47,33 @@ normative:
 
 informative:
 
+  RACK:
+    title: "RACK: a time-based fast loss detection algorithm for TCP"
+    date: {DATE}
+    seriesinfo:
+      Internet-Draft: draft-ietf-tcpm-rack-latest
+    author:
+      -
+        ins: Y. Cheng
+        name: Yuchung Cheng
+        org: Google
+        role: author
+      -
+        ins: N. Cardwell
+        name: Neal Cardwell
+        org: Google
+        role: author
+      -
+        ins: N. Dukkipati
+        name: Nandita Dukkipati
+        org: Google
+        role: author
+      -
+        ins: P. Jha
+        name: Priyaranjan Jha
+        org: Google
+        role: author
+
 
 --- abstract
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -509,57 +509,6 @@ frames containing them could be lost. In this case, the loss recovery algorithm
 may cause spurious retransmits, but the sender will continue making forward
 progress.
 
-## Tracking Sent Packets {#tracking-sent-packets}
-
-QUIC stores information about every packet sent. It's expected implementations
-will index this information by packet number and crypto context and store the
-per-packet fields detailed below for loss recovery and congestion control.
-Additionally, implementations MUST ensure that any retransmittable frames
-being transmitted are tracked in case of loss.
-
-If a packet containing retransmittable frames is lost, the QUIC transport
-needs to recover from that loss, such as by retransmitting the data,
-sending an updated frame, or abandoning the frame.  For more information,
-see Section 13.2 of {{QUIC-TRANSPORT}}.
-
-Packets MUST be tracked until acknowledged or lost.  After a packet is lost,
-it SHOULD be tracked for an amount of time comparable to the maximum
-expected packet reordering, such as 1 RTT.  This allows detection of
-spurious retransmissions and MAY avoid extra retransmissions if the frames
-contained within the packet were retransmitted and lost again.
-
-Sent packets are tracked for each packet number space, and ACK
-processing only applies to a single space.
-
-### Sent Packet Fields {#sent-packets-fields}
-
-packet_number:
-: The packet number of the sent packet.
-
-retransmittable:
-: A boolean that indicates whether a packet is retransmittable.
-  If true, it is expected that an acknowledgement will be received,
-  though the peer could delay sending the ACK frame containing it
-  by up to the MaxAckDelay.
-
-in_flight:
-: A boolean that indicates whether the packet counts towards bytes in
-  flight.
-
-is_crypto_packet:
-: A boolean that indicates whether the packet contains
-  cryptographic handshake messages critical to the completion of the QUIC
-  handshake. In this version of QUIC, this includes any packet with the long
-  header that includes a CRYPTO frame.
-
-sent_bytes:
-: The number of bytes sent in the packet, not including UDP or IP
-  overhead, but including QUIC framing overhead.
-
-time:
-: The time the packet was sent.
-
-
 ## Pseudocode
 
 ### Constants of interest
@@ -666,8 +615,15 @@ loss_time:
 transmit or exceeding the reordering window in time.
 
 sent_packets:
-: An association of packet numbers to information about them.  Described
-  in detail above in {{tracking-sent-packets}}.
+
+: An association of packet numbers to information about them, including a number
+  field indicating the packet number, a time field indicating the time a packet
+  was sent, a boolean indicating whether the packet is retransmittable,
+  a boolean indicating whether it counts towards bytes in flight, and a size
+  field indicating the packet's size in bytes.  sent_packets is ordered and
+  indexed by packet number. Packets remain in sent_packets until acknowledged
+  or lost.  A sent_packets data structure is maintained per packet number space,
+  and processing of an ACK frame only applies to a single space.
 
 ### Initialization
 
@@ -697,8 +653,27 @@ follows:
 
 ### On Sending a Packet
 
-After any packet is sent.  The parameters to OnPacketSent are described in
-detail above in {{sent-packets-fields}}.
+After any packet is sent, be it a new transmission or a rebundled transmission,
+the following OnPacketSent function is called.  The parameters to OnPacketSent
+are as follows:
+
+* packet_number: The packet number of the sent packet.
+
+* retransmittable: A boolean that indicates whether a packet is
+  retransmittable. If true, it is expected that an acknowledgement will
+  be received, though the peer could delay sending the ACK frame containing
+  it by up to the MaxAckDelay.
+
+* in_flight: A boolean that indicates whether the packet counts towards bytes in
+  flight.
+
+* is_crypto_packet: A boolean that indicates whether the packet contains
+  cryptographic handshake messages critical to the completion of the QUIC
+  handshake. In this version of QUIC, this includes any packet with the long
+  header that includes a CRYPTO frame.
+
+* sent_bytes: The number of bytes sent in the packet, not including UDP or IP
+  overhead, but including QUIC framing overhead.
 
 Pseudocode for OnPacketSent follows:
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -241,7 +241,7 @@ underestimation of min RTT, which in turn prevents underestimating smoothed RTT.
 Ack-based loss detection implements the spirit of TCP's Fast Retransmit
 {{?RFC5681}}, Early Retransmit {{?RFC5827}}, FACK, SACK loss recovery
 {{?RFC6675}}, and RACK. This section provides an overview of how these
-algorithms are implemented in QUIC.  Though both time-based loss detection
+algorithms are implemented in QUIC.  Though both time threshold loss detection
 and early retransmit use a timer, they are part of ack-based detection because
 they do not use a timer to send probes, but rather to declare packets lost.
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -248,8 +248,8 @@ they do not use a timer to send probes, but rather to declare packets lost.
 ### Fast Retransmit
 
 An unacknowledged packet is marked as lost when an acknowledgment is received
-for a packet that was sent kReorderingThreshold number of packets or
-kTimeReorderingFraction amount of time after the unacknowledged packet.
+for a packet that was sent kPacketThreshold number of packets or
+kTimeThreshold amount of time after the unacknowledged packet.
 Receipt of the acknowledgement indicates that a later packet was received,
 while the reordering threshold provides some tolerance for reordering of
 packets in the network.
@@ -263,7 +263,7 @@ recovery latency.
 
 #### Packet Threshold
 
-The RECOMMENDED initial value for kReorderingThreshold is 3, based on
+The RECOMMENDED initial value for kPacketThreshold is 3, based on
 TCP loss recovery {{?RFC5681}} {{?RFC6675}}. Some networks may exhibit higher
 degrees of reordering, causing a sender to detect spurious losses.
 Implementers MAY use algorithms developed for TCP, such as
@@ -275,10 +275,10 @@ Time threshold loss detection uses a time threshold to determine how much
 reordering to tolerate.  In this document, the threshold is expressed as a
 fraction of an RTT, but implemenantations MAY experiment with absolute
 thresholds. The RECOMMENDED time threshold, expressed as a fraction
-of the round-trip time (kTimeReorderingFraction), is 1/8.
+of the round-trip time (kTimeThreshold), is 1/8.
 
 An endpoint SHOULD declare packets lost no earlier than
-(1 + kTimeReorderingFraction) * max(SRTT, latest_RTT) after when they were
+(1 + kTimeThreshold) * max(SRTT, latest_RTT) after when they were
 sent.  If packets sent prior to the largest acknowledged packet cannot yet
 be declared lost, then a timer SHOULD be set for the remaining time.
 
@@ -562,11 +562,11 @@ kMaxTLPs:
 : Maximum number of tail loss probes before an RTO expires.
   The RECOMMENDED value is 2.
 
-kReorderingThreshold:
+kPacketThreshold:
 : Maximum reordering in packet number space before FACK style loss detection
   considers a packet lost. The RECOMMENDED value is 3.
 
-kTimeReorderingFraction:
+kTimeThreshold:
 : Maximum reordering in time space before time threshold loss detection
   considers a packet lost.  In fraction of an RTT. The RECOMMENDED value
   is 1/8.
@@ -640,12 +640,12 @@ max_ack_delay:
   received ACK frame may be larger due to late timers, reordering,
   or lost ACKs.
 
-reordering_threshold:
+packet_threshold:
 : The largest packet number gap between the largest acknowledged
   retransmittable packet and an unacknowledged
   retransmittable packet before it is declared lost.
 
-time_reordering_fraction:
+time_reordering_threshold:
 : The reordering window as a fraction of max(smoothed_rtt, latest_rtt).
 
 loss_time:
@@ -666,8 +666,8 @@ follows:
    crypto_count = 0
    tlp_count = 0
    rto_count = 0
-   time_reordering_fraction = kTimeReorderingFraction
-   reordering_threshold = kReorderingThreshold
+   time_reordering_fraction = kTimeThreshold
+   packet_threshold = kPacketThreshold
    loss_time = 0
    smoothed_rtt = 0
    rttvar = 0
@@ -878,7 +878,7 @@ DetectLostPackets(largest_acked):
     time_since_sent = now() - unacked.time_sent
     delta = largest_acked.packet_number - unacked.packet_number
     if (time_since_sent > delay_until_lost ||
-        delta > reordering_threshold):
+        delta > packet_threshold):
       sent_packets.remove(unacked.packet_number)
       if (unacked.retransmittable):
         lost_packets.insert(unacked)

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -57,22 +57,18 @@ informative:
         ins: Y. Cheng
         name: Yuchung Cheng
         org: Google
-        role: author
       -
         ins: N. Cardwell
         name: Neal Cardwell
         org: Google
-        role: author
       -
         ins: N. Dukkipati
         name: Nandita Dukkipati
         org: Google
-        role: author
       -
         ins: P. Jha
         name: Priyaranjan Jha
         org: Google
-        role: author
 
 
 --- abstract

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -279,9 +279,9 @@ threshold fast retransmit. The RECOMMENDED time threshold, expressed
 as a fraction of the round-trip time (kTimeReorderingFraction), is 1/8.
 
 An endpoint SHOULD declare packets lost no earlier than
-1.125 * max(SRTT, latest_RTT) after when they were sent.  If packets sent prior
-to the largest acknowledged packet cannot yet be declared lost, then a timer
-SHOULD be set for the remainint time.
+(1 + kTimeReorderingFraction) * max(SRTT, latest_RTT) after when they were
+sent.  If packets sent prior to the largest acknowledged packet cannot yet
+be declared lost, then a timer SHOULD be set for the remainint time.
 
 Using max(SRTT, latest_RTT) protects from the two following cases:
 
@@ -292,10 +292,10 @@ Using max(SRTT, latest_RTT) protects from the two following cases:
 * the latest RTT sample is higher than the SRTT, perhaps due to a sustained
   increase in the actual RTT, but the smoothed SRTT has not yet caught up.
 
-The 1.125 multiplier increases reordering resilience. Implementers MAY
-experiment with using other multipliers, bearing in mind that a lower multiplier
-reduces reordering resilience and increases spurious retransmissions, and a
-higher multiplier increases loss recovery delay.
+Implementers MAY experiment with using other reordering fractoins, bearing
+in mind that a lower multiplier reduces reordering resilience and increases
+spurious retransmissions, and a higher multiplier increases loss recovery
+delay.
 
 ## Timeout Loss Detection
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -332,12 +332,12 @@ they do not use a timer to send probes, but rather to declare packets lost.
 
 ### Fast Retransmit
 
-An unacknowledged packet is marked as lost when an acknowledgment is received
-for a packet sent sufficiently after the unacknowledged packet.
-* The largest acknowledged packet is more than kPacketThreshold packets larger
-  than the unacknowleged packet.
-* The unacknowledged packet was sent more than
-  (1 + kTimeThreshold) * max(SRTT, latest_RTT) ago.
+Fast Retransmit uses two thresholds to mark packets as lost when a packet
+sent later has been acknowledged.  An unacknowledged retransmittable packet
+is declared lost when either:
+* A packet more than kPacketThreshold larger has been acknowledged.
+* (1 + kTimeThreshold) * max(SRTT, latest_RTT) has elapsed since the
+  unacknowledged packet was sent.
 
 Receipt of the acknowledgement indicates that a later packet was received,
 while the reordering threshold provides some tolerance for reordering of

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -163,18 +163,19 @@ across packet number spaces.
 
 ### Monotonically Increasing Packet Numbers
 
-TCP conflates transmission sequence number at the sender with delivery sequence
-number at the receiver, which results in retransmissions of the same data
-carrying the same sequence number, and consequently to problems caused by
-"retransmission ambiguity".  QUIC separates the two: QUIC uses a packet number
-for transmissions, and any application data is sent in one or more streams,
-with delivery order determined by stream offsets encoded within STREAM frames.
+TCP conflates transmission order at the sender with delivery order at the
+receiver, which results in retransmissions of the same data carrying the same
+sequence number, and consequently leads to "retransmission ambiguity".  QUIC
+separates the two: QUIC uses a packet number to indicate transmission order,
+and any application data is sent in one or more streams, with delivery order
+determined by stream offsets encoded within STREAM frames.
 
-QUIC's packet number is strictly increasing, and directly encodes transmission
-order.  A higher QUIC packet number signifies that the packet was sent later,
-and a lower QUIC packet number signifies that the packet was sent earlier.  When
-a packet containing frames is deemed lost, QUIC rebundles necessary frames in a
-new packet with a new packet number, removing ambiguity about which packet is
+QUIC's packet number is strictly increasing within a packet number space,
+and directly encodes transmission order.  A higher packet number signifies
+that the packet was sent later, and a lower packet number signifies that
+the packet was sent earlier.  When a packet containing retransmittable
+frames is detected lost, QUIC rebundles necessary frames in a new packet
+with a new packet number, removing ambiguity about which packet is
 acknowledged when an ACK is received.  Consequently, more accurate RTT
 measurements can be made, spurious retransmissions are trivially detected, and
 mechanisms such as Fast Retransmit can be applied universally, based only on
@@ -240,7 +241,9 @@ underestimation of min RTT, which in turn prevents underestimating smoothed RTT.
 Ack-based loss detection implements the spirit of TCP's Fast Retransmit
 {{?RFC5681}}, Early Retransmit {{?RFC5827}}, FACK, and SACK loss recovery
 {{?RFC6675}}. This section provides an overview of how these algorithms are
-implemented in QUIC.
+implemented in QUIC.  Though both time-based loss detection and early retransmit
+use a timer, they are part of ack-based detection because they do not use a
+timer to send probes, but rather to declare packets lost.
 
 ### Fast Retransmit
 
@@ -251,27 +254,45 @@ the acknowledgement indicates that a later packet was received, while the
 reordering threshold provides some tolerance for reordering of packets in the
 network.
 
+Spuriously declaring packets lost leads to unnecessary retransmissions and
+may result in degraded performance due to the actions of the congestion
+controller upon detecting loss.  Implementations that detect spurious
+retransmissions and increase the reordering threshold in packets or time
+MAY choose to start with smaller initial reordering thresholds to minimize
+recovery latency.
+
+#### Packet Threshold
+
 The RECOMMENDED initial value for kReorderingThreshold is 3, based on
 TCP loss recovery {{?RFC5681}} {{?RFC6675}}. Some networks may exhibit higher
-degrees of reordering, causing a sender to detect spurious losses. Spuriously
-declaring packets lost leads to unnecessary retransmissions and may result in
-degraded performance due to the actions of the congestion controller upon
-detecting loss. Implementers MAY use algorithms developed for TCP, such as
+degrees of reordering, causing a sender to detect spurious losses.
+Implementers MAY use algorithms developed for TCP, such as
 TCP-NCR {{?RFC4653}}, to improve QUIC's reordering resilience.
 
-QUIC implementations can use time-based loss detection to handle reordering
-based on time elapsed since the packet was sent.  This may be used either as
-a replacement for a packet reordering threshold or in addition to it.
-The RECOMMENDED time threshold, expressed as a fraction of the
-round-trip time (kTimeReorderingFraction), is 1/8.
+#### Time-based
+
+Time-based loss detection uses a time threshold to determine how much
+reordering to tolerate.  In this document, the threshold is expressed as a
+fraction of an RTT, but implemenantations MAY experiment with absolute
+thresholds.  This may be used either as a replacement for a packet reordering
+threshold or in addition to it.
+
+When a larger packet is acknowledged, if it was sent more than the threshold
+after any in flight packets, those packets are immediately declared lost.
+Otherwise, a timer is set for the the reordering threshold minus the time
+difference between the earliest in flight packet and the largest newly
+acknowledged packet.  Note that in some cases the timer could become longer when
+packets are acknowleged out of order. The RECOMMENDED time threshold, expressed
+as a fraction of the round-trip time (kTimeReorderingFraction), is 1/8.
 
 ### Early Retransmit
 
 Unacknowledged packets close to the tail may have fewer than
 kReorderingThreshold retransmittable packets sent after them.  Loss of such
-packets cannot be detected via Fast Retransmit. To enable ack-based loss
-detection of such packets, receipt of an acknowledgment for the last outstanding
-retransmittable packet triggers the Early Retransmit process, as follows.
+packets cannot be detected via Packet Threshold Fast Retransmit. To enable
+ack-based loss detection of such packets, receipt of an acknowledgment for
+the last outstanding retransmittable packet triggers the Early Retransmit
+process, as follows.
 
 If there are unacknowledged in-flight packets still pending, they should
 be marked as lost. To compensate for the reduced reordering resilience, the
@@ -302,9 +323,9 @@ prone to spurious retransmissions due to its reduced reordering resilence
 without the timer. This observation led Linux TCP implementers to implement a
 timer for TCP as well, and this document incorporates this advancement.
 
-## Timer-based Detection
+## Timeout Loss Detection
 
-Timer-based loss detection recovers from losses that cannot be handled by
+Timeout loss detection recovers from losses that cannot be handled by
 ack-based loss detection.  It uses a single timer which switches between
 a crypto retransmission timer, a Tail Loss Probe timer and Retransmission
 Timeout mechanisms.
@@ -430,22 +451,22 @@ QUIC's RTO algorithm differs from TCP in that the firing of an RTO timer is not
 considered a strong enough signal of packet loss, so does not result in an
 immediate change to congestion window or recovery state. An RTO timer expires
 only when there's a prolonged period of network silence, which could be caused
-by a change in the underlying network RTT.
+by a change in the network RTT.
 
 QUIC also diverges from TCP by including MaxAckDelay in the RTO period. Since
 QUIC corrects for this delay in its SRTT and RTTVAR computations, it is
 necessary to add this delay explicitly in the TLP and RTO computation.
 
-When an acknowledgment is received for a packet sent on an RTO event, any
-unacknowledged packets with lower packet numbers than those acknowledged MUST be
-marked as lost.  If an acknowledgement for a packet sent on an RTO is received
-at the same time packets sent prior to the first RTO are acknowledged, the RTO
-is considered spurious and standard loss detection rules apply.
+When an ACK is received that acknowledges only one or more packets sent on
+an RTO event, all unacknowledged packets with lower packet numbers MUST be
+marked as lost.  If packets sent prior to the first RTO are acknowledged in
+the same ACK, the RTO is considered spurious and standard loss detection rules
+apply.
 
 A packet sent when an RTO timer expires MAY carry new data if available or
 unacknowledged data to potentially reduce recovery time. Since this packet is
 sent as a probe into the network prior to establishing any packet loss, prior
-unacknowledged packets SHOULD NOT be marked as lost.
+unacknowledged packets SHOULD NOT be marked as lost when the timer expires.
 
 A packet sent on an RTO timer MUST NOT be blocked by the sender's congestion
 controller. A sender MUST however count these packets as being in flight, since
@@ -454,11 +475,10 @@ this packet adds network load without establishing packet loss.
 ## Generating Acknowledgements
 
 QUIC SHOULD delay sending acknowledgements in response to packets, but MUST NOT
-excessively delay acknowledgements of packets containing frames other than ACK.
-Specifically, implementations MUST attempt to enforce a maximum
-ack delay to avoid causing the peer spurious timeouts.  The maximum ack delay
-is communicated in the `max_ack_delay` transport parameter and the default
-value is 25ms.
+excessively delay acknowledgements of retransmittable packets. Specifically,
+implementations MUST attempt to enforce a maximum ack delay to avoid causing
+the peer spurious timeouts.  The maximum ack delay is communicated in the
+`max_ack_delay` transport parameter and the default value is 25ms.
 
 An acknowledgement SHOULD be sent immediately upon receipt of a second
 packet but the delay SHOULD NOT exceed the maximum ack delay. QUIC recovery
@@ -505,13 +525,13 @@ frame may be saved.  When a packet containing an ACK frame is acknowledged, the
 receiver can stop acknowledging packets less than or equal to the largest
 acknowledged in the sent ACK frame.
 
-In cases without ACK frame loss, this algorithm allows for a minimum of 1 RTT of
-reordering. In cases with ACK frame loss, this approach does not guarantee that
-every acknowledgement is seen by the sender before it is no longer included in
-the ACK frame. Packets could be received out of order and all subsequent ACK
-frames containing them could be lost. In this case, the loss recovery algorithm
-may cause spurious retransmits, but the sender will continue making forward
-progress.
+In cases without ACK frame loss, this algorithm allows for a minimum of 1 RTT
+of reordering. In cases with ACK frame loss and reordering, this approach does
+not guarantee that every acknowledgement is seen by the sender before it is no
+longer included in the ACK frame. Packets could be received out of order and
+all subsequent ACK frames containing them could be lost. In this case, the
+loss recovery algorithm may cause spurious retransmits, but the sender will
+continue making forward progress.
 
 ## Tracking Sent Packets {#tracking-sent-packets}
 
@@ -774,16 +794,13 @@ Pseudocode for OnAckReceived and UpdateRtt follow:
 
 ### On Packet Acknowledgment
 
-When a packet is acked for the first time, the following OnPacketAcked function
-is called.  Note that a single ACK frame may newly acknowledge several packets.
-OnPacketAcked must be called once for each of these newly acked packets.
+When a packet is acknowledged for the first time, the following OnPacketAcked
+function is called.  Note that a single ACK frame may newly acknowledge several
+packets. OnPacketAcked must be called once for each of these newly acknowledged
+packets.
 
-OnPacketAcked takes one parameter, acked_packet, which is the struct of the
-newly acked packet.
-
-If this is the first acknowledgement following RTO, check if the smallest newly
-acknowledged packet is one sent by the RTO, and if so, inform congestion control
-of a verified RTO, similar to F-RTO {{?RFC5682}}.
+OnPacketAcked takes one parameter, acked_packet, which is the struct detailed in
+{{sent-packets-fields}}.
 
 Pseudocode for OnPacketAcked follows:
 
@@ -875,15 +892,13 @@ Pseudocode for OnLossDetectionTimeout follows:
 
 ### Detecting Lost Packets
 
-Packets in QUIC are only considered lost once a larger packet number in
-the same packet number space is acknowledged.  DetectLostPackets is called
-every time an ack is received and operates on the sent_packets for that
-packet number space.  If the loss detection timer expires and the loss_time
-is set, the previous largest acked packet is supplied.
+DetectLostPackets is called every time an ACK is received and operates on
+the sent_packets for that packet number space. If the loss detection timer
+expires and the loss_time is set, the previous largest acknowledged packet
+is supplied.
 
-#### Pseudocode
-
-DetectLostPackets takes one parameter, acked, which is the largest acked packet.
+DetectLostPackets takes one parameter, largest_acked, which is the largest
+acked packet.
 
 Pseudocode for DetectLostPackets follows:
 
@@ -974,11 +989,10 @@ congestion window.
 ## Recovery Period
 
 Recovery is a period of time beginning with detection of a lost packet or an
-increase in the ECN-CE counter. Because QUIC retransmits stream data and control
-frames, not packets, it defines the end of recovery as a packet sent after the
-start of recovery being acknowledged. This is slightly different from TCP's
-definition of recovery, which ends when the lost packet that started recovery is
-acknowledged.
+increase in the ECN-CE counter. Because QUIC does not retransmit packets,
+it defines the end of recovery as a packet sent after the start of recovery
+being acknowledged. This is slightly different from TCP's definition of
+recovery, which ends when the lost packet that started recovery is acknowledged.
 
 The recovery period limits congestion window reduction to once per round trip.
 During recovery, the congestion window remains unchanged irrespective of new
@@ -1095,8 +1109,8 @@ variables as follows:
 
 ### On Packet Sent
 
-Whenever a packet is sent, and it contains non-ACK frames,
-the packet increases bytes_in_flight.
+Whenever a packet is sent, and it contains non-ACK frames, the packet
+increases bytes_in_flight.
 
 ~~~
    OnPacketSentCC(bytes_sent):
@@ -1105,7 +1119,7 @@ the packet increases bytes_in_flight.
 
 ### On Packet Acknowledgement
 
-Invoked from loss detection's OnPacketAcked and is supplied with
+Invoked from loss detection's OnPacketAcked and is supplied with the
 acked_packet from sent_packets.
 
 ~~~
@@ -1130,7 +1144,7 @@ acked_packet from sent_packets.
 ### On New Congestion Event
 
 Invoked from ProcessECN and OnPacketsLost when a new congestion event is
-detected. May starts a new recovery period and reduces the congestion
+detected. May start a new recovery period and reduces the congestion
 window.
 
 ~~~


### PR DESCRIPTION
Based on @pravb feedback at tcpm and my anecdotal experience, combining the two should work well.

Fixes #1969, #1212, #934 