### PR TITLE
Spin per peer

### DIFF
--- a/draft-ietf-quic-spin-exp.md
+++ b/draft-ietf-quic-spin-exp.md
@@ -235,10 +235,16 @@ Implementations SHOULD allow administrators of clients and servers to disable
 the spin bit either globally or on a per-connection basis.
 Even when the spin bit is not disabled by the administrator implementations
 SHOULD disable the spin bit on a randomly chosen
-fraction of connections.  The selection process should be designed such that
-on average the spin bit is disabled for at least 1/8th of the connections.
+fraction of connections.  
 
-When the spin bit is disabled, endpoints SHOULD set the spin bit value to zero,
+The selection process SHOULD be designed such that
+on average the spin bit is disabled for at least 1/8th of the connections, or
+1/8th of the paths when doing migrations. The random choice SHOULD be dependent
+on the address of the peer, so that the spin bit is consistently enables or
+disabled for repeated connections to the same address.
+
+When the spin bit is disabled, endpoints SHOULD set the spin bit value to
+a constant value randomly chosen to be 0 or 1,
 regardless of the values received from their peer. Addendums or revisions to
 this document MAY define alternative behaviors in the future.
 

--- a/draft-ietf-quic-spin-exp.md
+++ b/draft-ietf-quic-spin-exp.md
@@ -244,6 +244,9 @@ on the source and destination addresses of the path,
 so that the spin bit is consistently enabled or
 disabled for repeated use of the same path.
 
+Note that where multiple connections use the same path,
+the use of the spin bit MAY be coordinated by endpoints,
+recognizing that this might not be possible in many cases.
 When the spin bit is disabled, endpoints MAY set the spin bit to any value,
 and MUST accept any incoming value.
 

--- a/draft-ietf-quic-spin-exp.md
+++ b/draft-ietf-quic-spin-exp.md
@@ -240,8 +240,9 @@ fraction of connections.
 The selection process SHOULD be designed such that
 on average the spin bit is disabled for at least 1/8th of the connections, or
 1/8th of the paths when doing migrations. The random choice SHOULD be dependent
-on the address of the peer, so that the spin bit is consistently enables or
-disabled for repeated connections to the same address.
+on the source and destination addresses of the connection,
+so that the spin bit is consistently enabled or
+disabled for repeated connections between the same addresses.
 
 When the spin bit is disabled, endpoints SHOULD set the spin bit value to
 a constant value randomly chosen to be 0 or 1,

--- a/draft-ietf-quic-spin-exp.md
+++ b/draft-ietf-quic-spin-exp.md
@@ -242,7 +242,7 @@ on average the spin bit is disabled for at least one eighth of network paths.
 The random choice SHOULD be dependent
 on the source and destination addresses of the path,
 so that the spin bit is consistently enabled or
-disabled for repeated connections between the same addresses.
+disabled for repeated use of the same path.
 
 When the spin bit is disabled, endpoints SHOULD set the spin bit value to
 a constant value randomly chosen to be 0 or 1,

--- a/draft-ietf-quic-spin-exp.md
+++ b/draft-ietf-quic-spin-exp.md
@@ -235,7 +235,7 @@ Implementations SHOULD allow administrators of clients and servers to disable
 the spin bit either globally or on a per-connection basis.
 Even when the spin bit is not disabled by the administrator implementations
 SHOULD disable the spin bit on a randomly chosen
-fraction of connections.  
+fraction of connections.
 
 The selection process SHOULD be designed such that
 on average the spin bit is disabled for at least 1/8th of the connections, or

--- a/draft-ietf-quic-spin-exp.md
+++ b/draft-ietf-quic-spin-exp.md
@@ -246,7 +246,8 @@ disabled for repeated use of the same path.
 
 When the spin bit is disabled, endpoints SHOULD set the spin bit value to
 a constant value randomly chosen to be 0 or 1,
-regardless of the values received from their peer. Addendums or revisions to
+regardless of the values received from their peer.  Alternatively, endpoints MAY
+change this value when changing connection ID.  Addendums or revisions to
 this document MAY define alternative behaviors in the future.
 
 # IANA Considerations

--- a/draft-ietf-quic-spin-exp.md
+++ b/draft-ietf-quic-spin-exp.md
@@ -251,7 +251,9 @@ the use of the spin bit MAY be coordinated by endpoints,
 recognizing that this might not be possible in many cases.
 
 When the spin bit is disabled, endpoints MAY set the spin bit to any value,
-and MUST accept any incoming value.
+and MUST accept any incoming value. It is RECOMMENDED that they
+set the spin bit to a random value either chosen independently for each packet,
+or chosen independently for each path and kept constant for that path.
 
 # IANA Considerations
 

--- a/draft-ietf-quic-spin-exp.md
+++ b/draft-ietf-quic-spin-exp.md
@@ -239,7 +239,7 @@ fraction of connections.
 
 The selection process SHOULD be designed such that
 on average the spin bit is disabled for at least one eighth of network paths.
-1/8th of the paths when doing migrations. The random choice SHOULD be dependent
+The random choice SHOULD be dependent
 on the source and destination addresses of the connection,
 so that the spin bit is consistently enabled or
 disabled for repeated connections between the same addresses.

--- a/draft-ietf-quic-spin-exp.md
+++ b/draft-ietf-quic-spin-exp.md
@@ -240,7 +240,7 @@ fraction of connections.
 The selection process SHOULD be designed such that
 on average the spin bit is disabled for at least one eighth of network paths.
 The random choice SHOULD be dependent
-on the source and destination addresses of the connection,
+on the source and destination addresses of the path,
 so that the spin bit is consistently enabled or
 disabled for repeated connections between the same addresses.
 

--- a/draft-ietf-quic-spin-exp.md
+++ b/draft-ietf-quic-spin-exp.md
@@ -239,14 +239,17 @@ fraction of connections.
 
 The selection process SHOULD be designed such that
 on average the spin bit is disabled for at least one eighth of network paths.
-The random choice SHOULD be dependent
-on the source and destination addresses of the path,
-so that the spin bit is consistently enabled or
-disabled for repeated use of the same path.
+The selection process SHOULD be externally unpredictable but consistent for
+any given combination of source and destination address/port. For instance,
+the implementation might have a static key which it uses to key a pseudorandom
+function over these values and use the output to determine whether to
+send the spin bit. The selection process performed at the beginning
+of the connection SHOULD be applied for all paths used by the connection.
 
 Note that where multiple connections use the same path,
 the use of the spin bit MAY be coordinated by endpoints,
 recognizing that this might not be possible in many cases.
+
 When the spin bit is disabled, endpoints MAY set the spin bit to any value,
 and MUST accept any incoming value.
 

--- a/draft-ietf-quic-spin-exp.md
+++ b/draft-ietf-quic-spin-exp.md
@@ -238,7 +238,7 @@ SHOULD disable the spin bit on a randomly chosen
 fraction of connections.
 
 The selection process SHOULD be designed such that
-on average the spin bit is disabled for at least 1/8th of the connections, or
+on average the spin bit is disabled for at least one eighth of network paths.
 1/8th of the paths when doing migrations. The random choice SHOULD be dependent
 on the source and destination addresses of the connection,
 so that the spin bit is consistently enabled or

--- a/draft-ietf-quic-spin-exp.md
+++ b/draft-ietf-quic-spin-exp.md
@@ -244,11 +244,8 @@ on the source and destination addresses of the path,
 so that the spin bit is consistently enabled or
 disabled for repeated use of the same path.
 
-When the spin bit is disabled, endpoints SHOULD set the spin bit value to
-a constant value randomly chosen to be 0 or 1,
-regardless of the values received from their peer.  Alternatively, endpoints MAY
-change this value when changing connection ID.  Addendums or revisions to
-this document MAY define alternative behaviors in the future.
+When the spin bit is disabled, endpoints MAY set the spin bit to any value,
+and MUST accept any incoming value.
 
 # IANA Considerations
 


### PR DESCRIPTION
Specify that the enabling/disabling of the spin bit should depend on the peer address. The goal is to create an anonymity set that consistent with avoidance of spin bit for hidden servers.