### PR TITLE
add whitespace after semicolon in static header table

### DIFF
--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -1179,7 +1179,7 @@ Code" registry established in {{QUIC-HTTP}}.
 | 51    | content-type                     | text/css                                                    |
 | 52    | content-type                     | text/html; charset=utf-8                                    |
 | 53    | content-type                     | text/plain                                                  |
-| 54    | content-type                     | text/plain;charset=utf-8                                    |
+| 54    | content-type                     | text/plain; charset=utf-8                                    |
 | 55    | range                            | bytes=0-                                                    |
 | 56    | strict-transport-security        | max-age=31536000                                            |
 | 57    | strict-transport-security        | max-age=31536000; includesubdomains                         |


### PR DESCRIPTION
This is the only position where we do not have a whitespace after semicolon, and I assume that it's an editorial error rather than an anomaly in how it's actually used.

Hence the PR.