### PR TITLE
Add spin bit to transport draft

### DIFF
--- a/draft-ietf-quic-spin-exp.md
+++ b/draft-ietf-quic-spin-exp.md
@@ -3,7 +3,7 @@ title: The QUIC Latency Spin Bit
 abbrev: QUIC Spin Bit
 docname: draft-ietf-quic-spin-exp-latest
 date: {DATE}
-category: exp
+category: std
 
 ipr: trust200902
 workgroup: QUIC

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3411,7 +3411,7 @@ Google QUIC Demultiplexing Bit:
 Spin Bit:
 
 : The sixth bit (0x4) of byte 0 is the Latency Spin Bit, set as described in
-{{!SPIN:I-D.ietf-quic-spin-exp}}.
+{{!SPIN=I-D.ietf-quic-spin-exp}}.
 
 Reserved:
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3358,7 +3358,7 @@ Length field enables packet coalescing ({{packet-coalesce}}).
  0                   1                   2                   3
  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
 +-+-+-+-+-+-+-+-+
-|0|K|1|1|0|R R R|
+|0|K|1|1|0|S|R R|
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                Destination Connection ID (0..144)           ...
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -3408,9 +3408,14 @@ Google QUIC Demultiplexing Bit:
   specification when Google QUIC has finished transitioning to the new header
   format.
 
+Spin Bit:
+
+: The sixth bit (0x4) of byte 0 is the Latency Spin Bit, set as described in
+{{!SPIN:I-D.ietf-quic-spin-exp}}.
+
 Reserved:
 
-: The sixth, seventh, and eighth bits (0x7) of byte 0 are reserved for
+: The seventh and eighth bits (0x3) of byte 0 are reserved for
   experimentation.  Endpoints MUST ignore these bits on packets they receive
   unless they are participating in an experiment that uses these bits.  An
   endpoint not actively using these bits SHOULD set the value randomly on


### PR DESCRIPTION
This PR adds the spin bit to the short header in the transport draft, referring to draft-ietf-quic-spin-exp for details. This reference is temporary, while the details of the spin bit are worked out in that document. The intention is then to take the content of spin-exp and incorporate it into the transport and manageability drafts. 

It also changes the status of spin-exp to Standards Track, to avoid a downref from -transport to an Experimental draft.

Note that the details of which bit is the spin bit will change when the first octet discussion resolves; this PR is only meant to establish the reference.