### PR TITLE
Refine minimum DCID length of Initial

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1319,9 +1319,8 @@ abandons the connection attempt and starts a new one. The initial Destination
 Connection ID is used to determine packet protection keys for Initial packets.
 
 A client SHOULD select a Destination Connection ID length long enough to fulfill
-the minimum for every QUIC version it supports. This makes it easier to detect
-version downgrade attacks, by increasing the chance Initial packets are routed
-to the same server.
+the minimum for every QUIC version it supports. This increases the chance
+subsequent Initial packets are routed to the same server.
 
 The client populates the Source Connection ID field with a value of its choosing
 and sets the SCIL field to match.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1318,6 +1318,11 @@ packet is received from the server, the client MUST use the same value unless it
 abandons the connection attempt and starts a new one. The initial Destination
 Connection ID is used to determine packet protection keys for Initial packets.
 
+A client SHOULD select a Destination Connection ID length long enough to fulfill
+the minimum for every QUIC version it supports. This makes it easier to detect
+version downgrade attacks, by increasing the chance Initial packets are routed
+to the same server.
+
 The client populates the Source Connection ID field with a value of its choosing
 and sets the SCIL field to match.
 


### PR DESCRIPTION
This is meant to almost entirely mitigate #1810 by making sure that the reply to a VN packet ends up at the same server. It reduces the spurious downgrade attack signal to a corner case of a corner case.

It is much more lightweight than alternatives, if we're looking for a minimum-footprint change.