### PR TITLE
Interaction of FIN and message parsing

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -874,13 +874,12 @@ After sending a request, a client SHOULD close the stream for sending; after
 sending a final response, the server SHOULD close the stream for sending. At
 this point, the QUIC stream is fully closed.
 
-Changes to the state of a request stream do not directly affect message
-processing.  Endpoints MUST process complete HTTP messages without relying on
-stream closure as an end-of-message signal.  For example, servers do not abort a
-response in progress solely due to a state change on the request stream.
-However, if a client stream terminates without containing a usable HTTP message,
-the server SHOULD abort its response with the error code
-HTTP_INCOMPLETE_REQUEST.
+When a stream is closed, this indicates the end of an HTTP message.
+Because some messages are large or unbounded, endpoints SHOULD begin processing
+partial HTTP messages once enough of the message has been received to make
+progress.  If a client stream terminates without enough of the HTTP message to
+provide a complete response, the server SHOULD abort its response with the error
+code HTTP_INCOMPLETE_REQUEST.
 
 A server can send a complete response prior to the client sending an entire
 request if the response does not depend on any portion of the request that has

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -870,16 +870,18 @@ response to the same request.  Non-final responses do not contain a payload body
 or trailers.
 
 An HTTP request/response exchange fully consumes a bidirectional QUIC stream.
-After sending a request, a client MUST close the stream for sending; after
-sending a final response, the server MUST close the stream for sending. At
-this point, the QUIC stream is fully closed.
+After sending a request, a client MUST close the stream for sending; clients
+MUST NOT make stream closure dependent on receiving a response to their request,
+unless using the CONNECT method (see {{the-connect-method}}). After sending a
+final response, the server MUST close the stream for sending. At this point, the
+QUIC stream is fully closed.
 
-When a stream is closed, this indicates the end of an HTTP message.
-Because some messages are large or unbounded, endpoints SHOULD begin processing
-partial HTTP messages once enough of the message has been received to make
-progress.  If a client stream terminates without enough of the HTTP message to
-provide a complete response, the server SHOULD abort its response with the error
-code HTTP_INCOMPLETE_REQUEST.
+When a stream is closed, this indicates the end of an HTTP message. Because some
+messages are large or unbounded, endpoints SHOULD begin processing partial HTTP
+messages once enough of the message has been received to make progress.  If a
+client stream terminates without enough of the HTTP message to provide a
+complete response, the server SHOULD abort its response with the error code
+HTTP_INCOMPLETE_REQUEST.
 
 A server can send a complete response prior to the client sending an entire
 request if the response does not depend on any portion of the request that has

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -870,11 +870,11 @@ response to the same request.  Non-final responses do not contain a payload body
 or trailers.
 
 An HTTP request/response exchange fully consumes a bidirectional QUIC stream.
-After sending a request, a client MUST close the stream for sending; clients
-MUST NOT make stream closure dependent on receiving a response to their request,
-unless using the CONNECT method (see {{the-connect-method}}). After sending a
-final response, the server MUST close the stream for sending. At this point, the
-QUIC stream is fully closed.
+After sending a request, a client MUST close the stream for sending.  Unless
+using the CONNECT method (see {{the-connect-method}}), clients MUST NOT make
+stream closure dependent on receiving a response to their request. After sending
+a final response, the server MUST close the stream for sending. At this point,
+the QUIC stream is fully closed.
 
 When a stream is closed, this indicates the end of an HTTP message. Because some
 messages are large or unbounded, endpoints SHOULD begin processing partial HTTP

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -870,8 +870,8 @@ response to the same request.  Non-final responses do not contain a payload body
 or trailers.
 
 An HTTP request/response exchange fully consumes a bidirectional QUIC stream.
-After sending a request, a client SHOULD close the stream for sending; after
-sending a final response, the server SHOULD close the stream for sending. At
+After sending a request, a client MUST close the stream for sending; after
+sending a final response, the server MUST close the stream for sending. At
 this point, the QUIC stream is fully closed.
 
 When a stream is closed, this indicates the end of an HTTP message.


### PR DESCRIPTION
Fixes #1972.

While the discussion on the issue wasn't conclusive in either direction, I think the presence of CONNECT and early response means servers will need to be processing HTTP messages as they arrive, rather than waiting for the FIN as an end-of-message signal.  Also, if the message is large, the alternative risks deadlock on a large POST.

This PR expands on the "stream state change isn't part of the message framing" language to clarify that both peers MUST be able to process complete HTTP messages regardless of whether the stream has been closed or not.