### PR TITLE
Avoid having multiple ways to encode Delta Base Index of zero

### DIFF
--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -758,7 +758,7 @@ indicates that the Base Index is less than the Largest Reference.  That is:
    if sign == 0:
       baseIndex = largestReference + deltaBaseIndex
    else:
-      baseIndex = largestReference - deltaBaseIndex
+      baseIndex = largestReference - deltaBaseIndex - 1
 ~~~
 
 A single-pass encoder is expected to determine the absolute value of Base Index
@@ -770,10 +770,8 @@ not insert any new entries, Base Index will be greater than the Largest
 Reference, so the delta will be positive and the sign bit is set to 0.
 
 An encoder that produces table updates before encoding a header block might set
-Largest Reference and Base Index to the same value.  When Largest Reference and
-Base Index are equal, the Delta Base Index is encoded with a zero sign bit.  A
-sign bit set to 1 when the Delta Base Index is 0 MUST be treated as a decoder
-error.
+Largest Reference and Base Index to the same value.  In such case, both the sign
+bit and the Delta Base Index will be set to zero.
 
 A header block that does not reference the dynamic table can use any value for
 Base Index; setting both Largest Reference and Base Index to zero is the most


### PR DESCRIPTION
As discussed in #2002, there are two ways to encode Delta Base Index of zero at the wire level; i.e. (sign-bit, delta-base-index)=(0, 0) and (1, 0).

To avoid having multiple ways to represent one value, currently, we prohibit the latter form from being used.  A receiver is required to raise an error when it sees the latter.

This is not only an unnecessary complexity but also contradicts from the approach we use for Post-Base Indexes.  In case of Post-Base Indexes, we introduce an offset of one so that the Post-Base
Index of zero and a non-Post-Base Index of zero do not overlap.

The commit adopts the approach to Delta Base Index; giving us consistency in the design and also removing an error check at the cost of requiring one subtraction.