### PR TITLE
First byte changes

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -940,6 +940,10 @@ sample_offset = 6 + len(destination_connection_id) +
 if packet_type == Initial:
     sample_offset += len(token_length) +
                      len(token)
+
+if sample_offset + sample_length > packet_length then
+    sample_offset = packet_length - sample_length
+sample = packet[sample_offset..sample_offset+sample_length]
 ~~~
 
 To ensure that this process does not sample the packet number, header protection

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -833,20 +833,20 @@ Header protection is applied after packet protection is applied (see {{aead}}).
 The ciphertext of the packet is sampled and used as input to an encryption
 algorithm.  The algorithm used depends on the negotiated AEAD.
 
-The output of this algorithm is 5 bytes of mask which are applied to the
-protected using exclusive OR.  The least significant bits of the first byte of
+The output of this algorithm is a 5 byte mask which is applied to the
+protected header fields using exclusive OR.  The least significant bits of the first byte of
 the packet are masked by the first mask byte, and the packet number is masked
 with the remaining bytes.
 
 {{pseudo-hp}} shows a sample algorithm for applying header protection. Removing
-protection only differs in the order in which the packet number length
+header protection only differs in the order in which the packet number length
 (pn_length) is determined.
 
 ~~~
 mask = header_protection(hp_key, sample)
 
 pn_length = (packet[0] & 0x03) + 1
-if packet[0] & 0x80 == 0x80:
+if (packet[0] & 0x80) == 0x80:
    # Long header: 4 bits masked
    packet[0] ^= mask[0] & 0x0f
 else:
@@ -940,7 +940,7 @@ if packet_type == Initial:
 ~~~
 
 To ensure that this process does not sample the packet number, header protection
-algorithms MUST NOT require sample that is longer than the minimum expansion of
+algorithms MUST NOT require a sample size larger than the minimum expansion of
 the corresponding AEAD.
 
 

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -977,7 +977,7 @@ pseudocode:
 ~~~
 counter = DecodeLE(sample[0..3])
 nonce = DecodeLE(sample[4..7], sample[8..11], sample[12..15])
-mask = ChaCha20(pn_key, counter, nonce, 0)
+mask = ChaCha20(pn_key, counter, nonce, {0,0,0,0,0})
 ~~~
 
 

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -940,8 +940,8 @@ if packet_type == Initial:
 ~~~
 
 To ensure that this process does not sample the packet number, header protection
-algorithms MUST NOT sample more ciphertext than the minimum expansion of the
-corresponding AEAD.
+algorithms MUST NOT require sample that is longer than the minimum expansion of
+the corresponding AEAD.
 
 
 ### AES-Based Header Protection

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -833,10 +833,11 @@ Header protection is applied after packet protection is applied (see {{aead}}).
 The ciphertext of the packet is sampled and used as input to an encryption
 algorithm.  The algorithm used depends on the negotiated AEAD.
 
-The output of this algorithm is a 5 byte mask which is applied to the
-protected header fields using exclusive OR.  The least significant bits of the first byte of
-the packet are masked by the first mask byte, and the packet number is masked
-with the remaining bytes.
+The output of this algorithm is a 5 byte mask which is applied to the protected
+header fields using exclusive OR.  The least significant bits of the first byte
+of the packet are masked by the least significant bits of the first mask byte,
+and the packet number is masked with the remaining bytes.  Any unused bytes of
+mask that might result from a shorter packet number encoding are unused.
 
 {{pseudo-hp}} shows a sample algorithm for applying header protection. Removing
 header protection only differs in the order in which the packet number length

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -894,7 +894,9 @@ Before a TLS ciphersuite can be used with QUIC, a header protection algorithm
 MUST be specified for the AEAD used with that ciphersuite.  This document
 defines algorithms for AEAD_AES_128_GCM, AEAD_AES_128_CCM, AEAD_AES_256_GCM,
 AEAD_AES_256_CCM (all AES AEADs are defined in {{!AEAD=RFC5116}}), and
-AEAD_CHACHA20_POLY1305 {{!CHACHA=RFC8439}}.
+AEAD_CHACHA20_POLY1305 {{!CHACHA=RFC8439}}.  Prior to TLS selecting a
+ciphersuite, AES header protection is used ({{hp-aes}}), matching the
+AEAD_AES_128_GCM packet protection.
 
 
 ### Header Protection Sample {#hp-sample}
@@ -945,7 +947,7 @@ algorithms MUST NOT require a sample size larger than the minimum expansion of
 the corresponding AEAD.
 
 
-### AES-Based Header Protection
+### AES-Based Header Protection {#hp-aes}
 
 This section defines the packet protection algorithm for AEAD_AES_128_GCM,
 AEAD_AES_128_CCM, AEAD_AES_256_GCM, and AEAD_AES_256_CCM. AEAD_AES_128_GCM and
@@ -961,7 +963,7 @@ mask = AES-ECB(pn_key, sample)
 ~~~
 
 
-### ChaCha20-Based Header Protection
+### ChaCha20-Based Header Protection {#hp-chacha}
 
 When AEAD_CHACHA20_POLY1305 is in use, header protection uses the raw ChaCha20
 function as defined in Section 2.4 of {{!CHACHA}}.  This uses a 256-bit key and

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2269,8 +2269,10 @@ following layout:
 This design ensures that a stateless reset packet is - to the extent possible -
 indistinguishable from a regular packet with a short header.
 
-The message consists of the first two fixed bits of the packet header, followed
-by an arbitrary number of random bytes, followed by a Stateless Reset Token.
+A stateless reset uses an entire UDP datagram, starting with the first two bits
+of the packet header.  The remainder of the first byte and an an arbitrary
+number of random bytes following it are set to unpredictable values.  The last
+16 bytes of the datagram contain a Stateless Reset Token.
 
 A stateless reset will be interpreted by a recipient as a packet with a short
 header.  For the packet to appear as valid, the Random Bytes field needs to

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3181,7 +3181,7 @@ value of fields.
 
 ## Packet Number Encoding and Decoding {#packet-encoding}
 
-Packet numbers in long and short packet headers are encoded in 1 to 4 octets.
+Packet numbers in long and short packet headers are encoded in 1 to 4 bytes.
 The number of bits required to represent the packet number is reduced by
 including the least significant bits of the packet number.
 
@@ -3285,7 +3285,7 @@ Packet Number Length (P):
 
 Version:
 
-: The QUIC Version is a 32-bit field that follows the first octet.  This field
+: The QUIC Version is a 32-bit field that follows the first byte.  This field
   indicates which version of QUIC is in use and determines how the rest of the
   protocol fields are interpreted.
 
@@ -3343,7 +3343,7 @@ The following packet types are defined:
 
 The header form bit, connection ID lengths byte, Destination and Source
 Connection ID fields, and Version fields of a long header packet are
-version-independent. The other fields in the first octet, plus the Length and
+version-independent. The other fields in the first byte, plus the Length and
 Packet Number fields are version-specific.  See {{QUIC-INVARIANTS}} for details
 on how packets from different versions of QUIC are interpreted.
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2252,10 +2252,8 @@ following layout:
 ~~~
  0                   1                   2                   3
  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-+-+-+-+-+-+-+-+-+
-|0|K|1|1|0|0|0|0|
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                      Random Bytes (160..)                   ...
+|0|1|                   Random Bytes (166..)                  ...
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                                                               |
 +                                                               +
@@ -2271,8 +2269,8 @@ following layout:
 This design ensures that a stateless reset packet is - to the extent possible -
 indistinguishable from a regular packet with a short header.
 
-The message consists of a header byte, followed by an arbitrary number of random
-bytes, followed by a Stateless Reset Token.
+The message consists of the first two fixed bits of the packet header, followed
+by an arbitrary number of random bytes, followed by a Stateless Reset Token.
 
 A stateless reset will be interpreted by a recipient as a packet with a short
 header.  For the packet to appear as valid, the Random Bytes field needs to

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3182,8 +3182,8 @@ value of fields.
 ## Packet Number Encoding and Decoding {#packet-encoding}
 
 Packet numbers in long and short packet headers are encoded in 1 to 4 octets.
-The number of bits required to represent the packet number is reduced by including
-the least significant bits of the packet number.
+The number of bits required to represent the packet number is reduced by
+including the least significant bits of the packet number.
 
 The encoded packet number is protected as described in Section 5.4 of
 {{QUIC-TLS}}.
@@ -3260,7 +3260,7 @@ Header Form:
 Fixed Bit:
 
 : The next bit (0x40) of byte 0 is set to 1.  Packets containing a zero value
-  for this bit are not valid packets in this version.
+  for this bit are not valid packets in this version and MUST be discarded.
 
 Long Packet Type (T):
 
@@ -3353,9 +3353,9 @@ following sections.
 
 The end of the packet is determined by the Length field.  The Length field
 covers both the Packet Number and Payload fields, both of which are
-confidentiality protected and initially of unknown length.  The size of the
-Payload field is learned once the header protection is removed.  The Length
-field enables packet coalescing ({{packet-coalesce}}).
+confidentiality protected and initially of unknown length.  The length of the
+Payload field is learned once header protection is removed.  The Length field
+enables packet coalescing ({{packet-coalesce}}).
 
 
 ## Short Header Packet {#short-header}
@@ -3385,7 +3385,7 @@ Header Form:
 Fixed Bit:
 
 : The next bit (0x40) of byte 0 is set to 1.  Packets containing a zero value
-  for this bit are not valid packets in this version.
+  for this bit are not valid packets in this version and MUST be discarded.
 
 Spin Bit (S):
 
@@ -3426,7 +3426,7 @@ Packet Number:
 : The packet number field is 1 to 4 bytes long. The packet number has
   confidentiality protection separate from packet protection, as described in
   Section 5.4 of {{QUIC-TLS}}. The length of the packet number field is encoded
-  in the plaintext packet number. See {{packet-encoding}} for details.
+  in Packet Number Length field. See {{packet-encoding}} for details.
 
 Protected Payload:
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3181,8 +3181,8 @@ value of fields.
 
 ## Packet Number Encoding and Decoding {#packet-encoding}
 
-Packet numbers in long and short packet headers are encoded on 1 to 4 octets.
-The number of bits required to represent the packet number reduced by including
+Packet numbers in long and short packet headers are encoded in 1 to 4 octets.
+The number of bits required to represent the packet number is reduced by including
 the least significant bits of the packet number.
 
 The encoded packet number is protected as described in Section 5.4 of
@@ -3197,7 +3197,7 @@ SHOULD use a large enough packet number encoding to allow the packet number to
 be recovered even if the packet arrives after packets that are sent afterwards.
 
 As a result, the size of the packet number encoding is at least one bit more
-than the base 2 logarithm of the number of contiguous unacknowledged packet
+than the base-2 logarithm of the number of contiguous unacknowledged packet
 numbers, including the new packet.
 
 For example, if an endpoint has received an acknowledgment for packet 0xabe8bc,


### PR DESCRIPTION
This is a first draft of the changes that we discussed, first in NYC, then confirmed in Bangkok.

I had to recast "packet number protection" as header protection, but I took the opportunity to expand the text and organize it some more.  I'm not especially happy with the picture, and could probably drop that, but I think that the changes clarify the process more.

The changes are all exactly as discussed, except that I ended up moving the ODCIL field from the Retry packet, which conveniently fit into four bits that I was struggling to describe what to do with.  The low four bits in Retry can't be protected because Retry packets aren't protected.  This seemed like a neat way of handling that.

I'm not certain that these are the only changes needed, but I think that this is essentially complete.  It's good to get everything nailed down finally.