### PR TITLE
Use TLS abbreviation

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1,5 +1,5 @@
 ---
-title: Using Transport Layer Security (TLS) to Secure QUIC
+title: Using TLS to Secure QUIC
 abbrev: QUIC over TLS
 docname: draft-ietf-quic-tls-latest
 date: {DATE}
@@ -112,8 +112,8 @@ code and issues list for this draft can be found at
 
 # Introduction
 
-This document describes how QUIC {{QUIC-TRANSPORT}} is secured using Transport
-Layer Security (TLS) version 1.3 {{!TLS13=RFC8446}}.  TLS 1.3 provides critical
+This document describes how QUIC {{QUIC-TRANSPORT}} is secured using TLS version
+1.3 {{!TLS13=RFC8446}}.  TLS 1.3 provides critical
 latency improvements for connection establishment over previous versions.
 Absent packet loss, most new connections can be established and secured within a
 single round trip; on subsequent connections between the same client and server,


### PR DESCRIPTION
Now that the RFC editor has added TLS to their [abbreviations list](https://www.rfc-editor.org/materials/abbrev.expansion.txt) there is no need to spell out TLS.  But, I left the abbreviation in the abstract just in case somebody out there who was just reading the abstract doesn't know what TLS is.