### PR TITLE
STOP_SENDING opens streams

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4280,8 +4280,8 @@ An endpoint uses a STOP_SENDING frame (type=0x05) to communicate that incoming
 data is being discarded on receipt at application request.  This signals a peer
 to abruptly terminate transmission on a stream.
 
-Receipt of a STOP_SENDING frame is invalid for a locally-initiated stream which
-does not exist or is in the "Ready" state (see {{stream-send-states}}).
+Receipt of a STOP_SENDING frame is invalid for a locally-initiated stream that
+has not yet been created or is in the "Ready" state (see {{stream-send-states}}).
 Receiving a STOP_SENDING frame for a locally-initiated send stream that is
 "Ready" or non-existent MUST be treated as a connection error of type
 PROTOCOL_VIOLATION.  An endpoint that receives a STOP_SENDING frame for a

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4281,11 +4281,12 @@ data is being discarded on receipt at application request.  This signals a peer
 to abruptly terminate transmission on a stream.
 
 Receipt of a STOP_SENDING frame is invalid for a locally-initiated stream that
-has not yet been created or is in the "Ready" state (see {{stream-send-states}}).
-Receiving a STOP_SENDING frame for a locally-initiated send stream that is
-"Ready" or non-existent MUST be treated as a connection error of type
-PROTOCOL_VIOLATION.  An endpoint that receives a STOP_SENDING frame for a
-receive-only stream MUST terminate the connection with error PROTOCOL_VIOLATION.
+has not yet been created or is in the "Ready" state (see
+{{stream-send-states}}). Receiving a STOP_SENDING frame for a locally-initiated
+send stream that is "Ready" or non-existent MUST be treated as a connection
+error of type PROTOCOL_VIOLATION.  An endpoint that receives a STOP_SENDING
+frame for a receive-only stream MUST terminate the connection with error
+PROTOCOL_VIOLATION.
 
 The STOP_SENDING frame is as follows:
 


### PR DESCRIPTION
Fixes #1797, hopefully for real this time.

This is working with the existing text, but frankly, it feels a little wonky to say that receiving a frame for the sending part opens the receiving part, which opens the sending part, so the frame on the sending part is now valid to have received.

I'm not certain there's a better way to frame that, but we might think about it.