### PR TITLE
Restarting from idle

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1042,21 +1042,20 @@ in Linux (3.11 onwards).
 
 ## Restart after idle
 
-A connection is idle if bytes in flight is 0 and there is nothing
-retransmittable to send.  This occurs when the connection is application
-limited and after a verified retransmission timeout.  In order to limit the
-size of bursts sent into the network, the behavior when restarting from idle
-depends upon whether pacing is used.
+A connection is idle if there are no bytes in flight and there is no pending
+retransmittable data to send.  This can occur when the connection is
+application limited or after a retransmission timeout. In order to limit
+the size of bursts sent into the network, the behavior when restarting from
+idle depends upon whether pacing is used.
 
-If pacing is used, the connection should limit the initial burst of packets to
-no more than the initial congestion window and subsequent packets SHOULD be
-paced. The congestion window does not change while the connection is idle.
+If the sender uses pacing, the connection should limit the initial burst of
+packets to no more than the initial congestion window and subsequent packets
+SHOULD be paced. The congestion window does not change while the connection
+is idle.
 
-If pacing is not used, the congestion window SHOULD be reset to the minimum of
-the current congestion window and the initial congestion window.  If the
-slow start threshold is larger than the congestion window, the congestion window
-will grow back to the congestion window prior to idle via slow start.  This
-recommendation is based on Section 4.1 of {{?RFC5681}}.
+A sender that does not use pacing SHOULD reset its congestion window to the
+minimum of the current congestion window and the initial congestion window.
+This recommendation is based on Section 4.1 of {{?RFC5681}}.
 
 ## Pseudocode
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1040,6 +1040,21 @@ As an example of a well-known and publicly available implementation of a flow
 pacer, implementers are referred to the Fair Queue packet scheduler (fq qdisc)
 in Linux (3.11 onwards).
 
+## Resumption from idle
+
+A connection is idle if bytes in flight is 0 and there is nothing retransmittable
+to send.  In order to limit the size of bursts sent into the network, the
+behavior when restarting from idle depends upon whether pacing is used.
+
+If pacing is used, the connection should limit the initial burst of packets to
+no more than the initial congestion window and subsequent packets SHOULD be paced.
+The congestion window does not change while the connection is idle.
+
+If pacing is not used, the congestion window SHOULD be reset to the minimum of
+the current congestion window and the initial congestion window.  If the
+slow start threshold is larger than the congestion window, the congestion window
+will grow back to the congestion window prior to idle via slow start.
+
 ## Pseudocode
 
 ### Constants of interest

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1042,18 +1042,20 @@ in Linux (3.11 onwards).
 
 ## Resumption from idle
 
-A connection is idle if bytes in flight is 0 and there is nothing retransmittable
-to send.  In order to limit the size of bursts sent into the network, the
-behavior when restarting from idle depends upon whether pacing is used.
+A connection is idle if bytes in flight is 0 and there is nothing
+retransmittable to send.  In order to limit the size of bursts sent into the
+network, the behavior when restarting from idle depends upon whether pacing is
+used.
 
 If pacing is used, the connection should limit the initial burst of packets to
-no more than the initial congestion window and subsequent packets SHOULD be paced.
-The congestion window does not change while the connection is idle.
+no more than the initial congestion window and subsequent packets SHOULD be
+paced. The congestion window does not change while the connection is idle.
 
 If pacing is not used, the congestion window SHOULD be reset to the minimum of
 the current congestion window and the initial congestion window.  If the
 slow start threshold is larger than the congestion window, the congestion window
-will grow back to the congestion window prior to idle via slow start.
+will grow back to the congestion window prior to idle via slow start.  This
+recommendation is based on Section 4.1 of {{?RFC5681}}.
 
 ## Pseudocode
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1040,7 +1040,7 @@ As an example of a well-known and publicly available implementation of a flow
 pacer, implementers are referred to the Fair Queue packet scheduler (fq qdisc)
 in Linux (3.11 onwards).
 
-## Resumption from idle
+## Restart after idle
 
 A connection is idle if bytes in flight is 0 and there is nothing
 retransmittable to send.  This occurs when the connection is application

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1043,9 +1043,10 @@ in Linux (3.11 onwards).
 ## Resumption from idle
 
 A connection is idle if bytes in flight is 0 and there is nothing
-retransmittable to send.  In order to limit the size of bursts sent into the
-network, the behavior when restarting from idle depends upon whether pacing is
-used.
+retransmittable to send.  This occurs when the connection is application
+limited and after a verified retransmission timeout.  In order to limit the
+size of bursts sent into the network, the behavior when restarting from idle
+depends upon whether pacing is used.
 
 If pacing is used, the connection should limit the initial burst of packets to
 no more than the initial congestion window and subsequent packets SHOULD be


### PR DESCRIPTION
When restarting from idle, limit the initial burst and pace or reduce the CWND if not pacing.

Fixes #2007