### PR TITLE
Pad rather than shift the header protection offset

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -913,10 +913,10 @@ sample.
 To ensure that sufficient data is available for sampling, packets are padded so
 that the combined lengths of the encoded packet number and protected payload is
 at least 4 bytes longer than the sample required for header protection.  For the
-AEAD functions defined in {{?TLS13}}, which have 16 byte expansion and 16 byte
+AEAD functions defined in {{?TLS13}}, which have 16-byte expansions and 16-byte
 header protection samples, this results in needing at least 3 bytes of frames in
 the unprotected payload if the packet number is encoded on a single byte, or 2
-bytes of frames for a 2 byte packet number encoding.
+bytes of frames for a 2-byte packet number encoding.
 
 The sampled ciphertext for a packet with a short header can be determined by the
 following pseudocode:

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -905,10 +905,18 @@ of the ciphertext from the packet Payload field.
 The same number of bytes are always sampled, but an allowance needs to be made
 for the endpoint removing protection, which will not know the length of the
 Packet Number field.  In sampling the packet ciphertext, the Packet Number field
-is assumed to be 4 bytes long (its maximum possible encoded length), unless
-there is insufficient space in the packet for a complete sample.  The starting
-offset for the sample is set to 4 bytes after the start of the Packet Number
-field, then is reduced until there are enough bytes to sample.
+is assumed to be 4 bytes long (its maximum possible encoded length).
+
+An endpoint MUST discard packets that are not long enough to contain a complete
+sample.
+
+To ensure that sufficient data is available for sampling, packets are padded so
+that the combined lengths of the encoded packet number and protected payload is
+at least 4 bytes longer than the sample required for header protection.  For the
+AEAD functions defined in {{?TLS13}}, which have 16 byte expansion and 16 byte
+header protection samples, this results in needing at least 3 bytes of frames in
+the unprotected payload if the packet number is encoded on a single byte, or 2
+bytes of frames for a 2 byte packet number encoding.
 
 The sampled ciphertext for a packet with a short header can be determined by the
 following pseudocode:
@@ -916,16 +924,12 @@ following pseudocode:
 ~~~
 sample_offset = 1 + len(connection_id) + 4
 
-if sample_offset + sample_length > packet_length then
-    sample_offset = packet_length - sample_length
 sample = packet[sample_offset..sample_offset+sample_length]
 ~~~
 
 For example, for a packet with a short header, an 8 byte connection ID, and
 protected with AEAD_AES_128_GCM, the sample takes bytes 13 to 28 inclusive
-(using zero-based indexing) as long as the packet is at least 29 bytes long.
-The shortest packet that can be produced with this configuration is 27 bytes
-long, in which case bytes 11 to 26 are sampled.
+(using zero-based indexing).
 
 A packet with a long header is sampled in the same way, noting that multiple
 QUIC packets might be included in the same UDP datagram and that each one is
@@ -939,14 +943,8 @@ if packet_type == Initial:
     sample_offset += len(token_length) +
                      len(token)
 
-if sample_offset + sample_length > packet_length then
-    sample_offset = packet_length - sample_length
 sample = packet[sample_offset..sample_offset+sample_length]
 ~~~
-
-To ensure that this process does not sample the packet number, header protection
-algorithms MUST NOT require a sample size larger than the minimum expansion of
-the corresponding AEAD.
 
 
 ### AES-Based Header Protection {#hp-aes}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2263,7 +2263,7 @@ following layout:
  0                   1                   2                   3
  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|0|1|                   Random Bytes (166..)                  ...
+|0|1|                   Random Bits (190..)                  ...
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                                                               |
 +                                                               +
@@ -2285,18 +2285,18 @@ number of random bytes following it are set to unpredictable values.  The last
 16 bytes of the datagram contain a Stateless Reset Token.
 
 A stateless reset will be interpreted by a recipient as a packet with a short
-header.  For the packet to appear as valid, the Random Bytes field needs to
-include at least 20 bytes of random or unpredictable values.  This is intended
-to allow for a destination connection ID of the maximum length permitted, a
-packet number, and minimal payload.  The Stateless Reset Token corresponds to
-the minimum expansion of the packet protection AEAD.  More random bytes might be
-necessary if the endpoint could have negotiated a packet protection scheme with
-a larger minimum AEAD expansion.
+header.  For the packet to appear as valid, the Random Bits field needs to
+include at least 190 bits of random or unpredictable values (or 24 bytes, less
+the two fixed bits).  This is intended to allow for a destination connection ID
+of the maximum length permitted, with a minimal packet number, and payload.  The
+Stateless Reset Token corresponds to the minimum expansion of the packet
+protection AEAD.  More random bytes might be necessary if the endpoint could
+have negotiated a packet protection scheme with a larger minimum AEAD expansion.
 
 An endpoint SHOULD NOT send a stateless reset that is significantly larger than
 the packet it receives.  Endpoints MUST discard packets that are too small to be
 valid QUIC packets.  With the set of AEAD functions defined in {{QUIC-TLS}},
-packets less than 19 bytes long are never valid.
+packets less than 21 bytes long are never valid.
 
 An endpoint MAY send a stateless reset in response to a packet with a long
 header.  This would not be effective if the stateless reset token was not yet

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2263,7 +2263,7 @@ following layout:
  0                   1                   2                   3
  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|0|1|                   Random Bits (190..)                  ...
+|0|1|                   Random Bits (182..)                  ...
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                                                               |
 +                                                               +
@@ -2286,7 +2286,7 @@ number of random bytes following it are set to unpredictable values.  The last
 
 A stateless reset will be interpreted by a recipient as a packet with a short
 header.  For the packet to appear as valid, the Random Bits field needs to
-include at least 190 bits of random or unpredictable values (or 24 bytes, less
+include at least 182 bits of random or unpredictable values (or 24 bytes, less
 the two fixed bits).  This is intended to allow for a destination connection ID
 of the maximum length permitted, with a minimal packet number, and payload.  The
 Stateless Reset Token corresponds to the minimum expansion of the packet

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2296,7 +2296,7 @@ have negotiated a packet protection scheme with a larger minimum AEAD expansion.
 An endpoint SHOULD NOT send a stateless reset that is significantly larger than
 the packet it receives.  Endpoints MUST discard packets that are too small to be
 valid QUIC packets.  With the set of AEAD functions defined in {{QUIC-TLS}},
-packets less than 21 bytes long are never valid.
+packets that are smaller than 21 bytes are never valid.
 
 An endpoint MAY send a stateless reset in response to a packet with a long
 header.  This would not be effective if the stateless reset token was not yet


### PR DESCRIPTION
This simplifies a little, so it's a net win in my view.

Note that a naive implementation does very little to comply with this.  Always sending a 3 or 4 octet packet number is the easy way to comply.  Always padding to at least 3 octets is the other way, which in most cases will be unnecessary.  Dynamically padding is possible too, but we're talking about 2 octets.

Closes #1575.