### PR TITLE
Servers can't migrate.  Period.

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1811,7 +1811,7 @@ This document limits migration of connections to new client addresses, except as
 described in {{preferred-address}}. Clients are responsible for initiating all
 migrations.  Servers do not send non-probing packets (see {{probing}}) toward a
 client address until they see a non-probing packet from that address.  If a
-client receives packets from an unknown server address, the client MAY discard
+client receives packets from an unknown server address, the client MUST discard
 these packets.
 
 


### PR DESCRIPTION
This was a bit weak in the past, but it is part of our defense strategy for attacks on migration and rebinding.  Not that this totally prevents attack, but it means that an attacker looking to force a migration has to observe and race packets sent by both endpoints if this is true.