### PR TITLE
always use "tls13 " prefix for Initial packets

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -753,6 +753,10 @@ thus ensuring that the keys are different for each version of QUIC. This
 prevents a middlebox that only recognizes one version of QUIC from seeing or
 modifying the contents of handshake packets from future versions.
 
+The HKDF function defined in TLS 1.3 MUST be used even in case the minimum TLS
+version that the endpoint is willing to use is greater, so as to assure that
+the peer can decrypt the packet.
+
 Note:
 
 : The Destination Connection ID is of arbitrary length, and it could be zero


### PR DESCRIPTION
With #1991 being merged, we now always use the HKDF function defined in TLS as-is. We also allow the endpoints to use a TLS version greater than that (see [section 4.2](https://quicwg.org/base-drafts/draft-ietf-quic-tls.html#rfc.section.4.2)).

Now the corner case is what the correct prefix of the HKDF function is for the Initial packet, when the client's minimum TLS version is 1.4.

I think it's worth clarifying that it is the one defined in TLS 1.3 with the "tls13 " prefix, because otherwise the peer cannot decrypt the packet.

Hence the PR.