### PR TITLE
Fix for off-path migration attack

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1751,14 +1751,15 @@ the one to which the PATH_CHALLENGE was sent, path validation is considered to
 have failed, even if the data matches that sent in the PATH_CHALLENGE.
 
 Additionally, the PATH_RESPONSE frame MUST be received on the same local address
-from which the corresponding PATH_CHALLENGE was sent.  If a PATH_RESPONSE frame
-is received on a different local address than the one from which the
-PATH_CHALLENGE was sent, path validation is not considered to be successful,
-even if the data matches that sent in the PATH_CHALLENGE.  This doesn't result
-in path validation failure, as it might be a result of a forwarded packet (see
-{{off-path-forward}}) or misrouting.  Thus, the endpoint considers the path to
-be valid when a PATH_RESPONSE frame is received on the same path with the same
-payload as the PATH_CHALLENGE frame.
+from which the corresponding PATH_CHALLENGE was sent.  An endpoint considers the
+path to be valid when a PATH_RESPONSE frame is received on the same path with
+the same payload as the PATH_CHALLENGE frame.
+
+If a PATH_RESPONSE frame is received on a different local address than the one
+from which the PATH_CHALLENGE was sent, path validation is not considered to be
+successful, even if the data matches the PATH_CHALLENGE.  This doesn't result in
+path validation failure, as it might be a result of a forwarded packet (see
+{{off-path-forward}}) or misrouting.
 
 
 ## Failed Path Validation

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1970,14 +1970,14 @@ In response to an apparent migration, endpoints MUST validate the previously
 active path using a PATH_CHALLENGE frame.  This induces the sending of new
 packets on that path.  If the path is no longer viable, the validation attempt
 will time out and fail; if the path is viable, but no longer desired, the
-validation will succeed, but only results in a probing packet being sent on the
+validation will succeed, but only results in probing packets being sent on the
 path.
 
 An endpoint that receives a PATH_CHALLENGE on an active path SHOULD send a
 non-probing packet in response.  If the non-probing packet arrives before any
 copy made by an attacker, this results in the connection being migrated back to
-the original path.  Any subsequent migration to another path resets this entire
-process.
+the original path.  Any subsequent migration to another path restarts this
+entire process.
 
 This defense is imperfect, but this is not considered a serious problem. If the
 path via the attack is reliably faster than the original path despite multiple

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1983,6 +1983,12 @@ path via the attack is reliably faster than the original path despite multiple
 attempts to use that original path, it is not possible to distinguish between
 attack and an improvement in routing.
 
+An endpoint could also use heuristics to improve detection of this style of
+attack.  For instance, NAT rebinding is improbable if packets were recently
+received on the old path, similarly rebinding is rare on IPv6 paths.  Endpoints
+can also look for duplicated packets.  Conversely, a change in connection ID is
+more likely to indicate an intentional migration rather than an attack.
+
 
 ## Loss Detection and Congestion Control {#migration-cc}
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1969,7 +1969,7 @@ In response to an apparent migration, endpoints MUST validate the previously
 active path using a PATH_CHALLENGE frame.  This induces the sending of new
 packets on that path.  If the path is no longer viable, the validation attempt
 will time out and fail; if the path is viable, but no longer desired, the
-validation will succeed, but only result in a probing packet being sent on the
+validation will succeed, but only results in a probing packet being sent on the
 path.
 
 An endpoint that receives a PATH_CHALLENGE on an active path SHOULD send a
@@ -1977,9 +1977,6 @@ non-probing packet in response.  If the non-probing packet arrives before any
 copy made by an attacker, this results in the connection being migrated back to
 the original path.  Any subsequent migration to another path resets this entire
 process.
-
-Abandoning this validation attempt before it either succeeds or times out
-increases exposure to the packet copying attack.
 
 This defense is imperfect, but this is not considered a serious problem. If the
 path via the attack is reliably faster than the original path despite multiple
@@ -2014,7 +2011,7 @@ While multiple paths might be used during connection migration, a single
 congestion control context and a single loss recovery context (as described in
 {{QUIC-RECOVERY}}) may be adequate.  For instance, an endpoint might delay
 switching to a new congestion control context until it is confirmed that an old
-path is no longer needed (for the case in {{off-path-forward}}).
+path is no longer needed (such as the case in {{off-path-forward}}).
 
 A sender can make exceptions for probe packets so that their loss detection is
 independent and does not unduly cause the congestion controller to reduce its


### PR DESCRIPTION
This is not an easy attack to defend against, except for
probabilistically.  So what we do is recommend more probing on old paths
to give the endpoint that is apparently migrating more opportunities to
cause the connection to migrate away from the path chosen by an
attacker.

I've tweaked surrounding text a little.  The most interesting being the
3RTO timer on path validation.  It's not the right number, but I don't
think that the right number is attainable, and this is close enough.

This text isn't final. I'd like it to be more accurate AND shorter, but
lack the skills and perspective.

Closes #1278, #1749.