### PR TITLE
Rewrite Packet Size section

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -163,18 +163,19 @@ across packet number spaces.
 
 ### Monotonically Increasing Packet Numbers
 
-TCP conflates transmission sequence number at the sender with delivery sequence
-number at the receiver, which results in retransmissions of the same data
-carrying the same sequence number, and consequently to problems caused by
-"retransmission ambiguity".  QUIC separates the two: QUIC uses a packet number
-for transmissions, and any application data is sent in one or more streams,
-with delivery order determined by stream offsets encoded within STREAM frames.
+TCP conflates transmission order at the sender with delivery order at the
+receiver, which results in retransmissions of the same data carrying the same
+sequence number, and consequently leads to "retransmission ambiguity".  QUIC
+separates the two: QUIC uses a packet number to indicate transmission order,
+and any application data is sent in one or more streams, with delivery order
+determined by stream offsets encoded within STREAM frames.
 
-QUIC's packet number is strictly increasing, and directly encodes transmission
-order.  A higher QUIC packet number signifies that the packet was sent later,
-and a lower QUIC packet number signifies that the packet was sent earlier.  When
-a packet containing frames is deemed lost, QUIC rebundles necessary frames in a
-new packet with a new packet number, removing ambiguity about which packet is
+QUIC's packet number is strictly increasing within a packet number space,
+and directly encodes transmission order.  A higher packet number signifies
+that the packet was sent later, and a lower packet number signifies that
+the packet was sent earlier.  When a packet containing retransmittable
+frames is detected lost, QUIC rebundles necessary frames in a new packet
+with a new packet number, removing ambiguity about which packet is
 acknowledged when an ACK is received.  Consequently, more accurate RTT
 measurements can be made, spurious retransmissions are trivially detected, and
 mechanisms such as Fast Retransmit can be applied universally, based only on
@@ -240,7 +241,9 @@ underestimation of min RTT, which in turn prevents underestimating smoothed RTT.
 Ack-based loss detection implements the spirit of TCP's Fast Retransmit
 {{?RFC5681}}, Early Retransmit {{?RFC5827}}, FACK, and SACK loss recovery
 {{?RFC6675}}. This section provides an overview of how these algorithms are
-implemented in QUIC.
+implemented in QUIC.  Though both time-based loss detection and early retransmit
+use a timer, they are part of ack-based detection because they do not use a
+timer to send probes, but rather to declare packets lost.
 
 ### Fast Retransmit
 
@@ -251,27 +254,45 @@ the acknowledgement indicates that a later packet was received, while the
 reordering threshold provides some tolerance for reordering of packets in the
 network.
 
+Spuriously declaring packets lost leads to unnecessary retransmissions and
+may result in degraded performance due to the actions of the congestion
+controller upon detecting loss.  Implementations that detect spurious
+retransmissions and increase the reordering threshold in packets or time
+MAY choose to start with smaller initial reordering thresholds to minimize
+recovery latency.
+
+#### Packet Threshold
+
 The RECOMMENDED initial value for kReorderingThreshold is 3, based on
 TCP loss recovery {{?RFC5681}} {{?RFC6675}}. Some networks may exhibit higher
-degrees of reordering, causing a sender to detect spurious losses. Spuriously
-declaring packets lost leads to unnecessary retransmissions and may result in
-degraded performance due to the actions of the congestion controller upon
-detecting loss. Implementers MAY use algorithms developed for TCP, such as
+degrees of reordering, causing a sender to detect spurious losses.
+Implementers MAY use algorithms developed for TCP, such as
 TCP-NCR {{?RFC4653}}, to improve QUIC's reordering resilience.
 
-QUIC implementations can use time-based loss detection to handle reordering
-based on time elapsed since the packet was sent.  This may be used either as
-a replacement for a packet reordering threshold or in addition to it.
-The RECOMMENDED time threshold, expressed as a fraction of the
-round-trip time (kTimeReorderingFraction), is 1/8.
+#### Time-based
+
+Time-based loss detection uses a time threshold to determine how much
+reordering to tolerate.  In this document, the threshold is expressed as a
+fraction of an RTT, but implemenantations MAY experiment with absolute
+thresholds.  This may be used either as a replacement for a packet reordering
+threshold or in addition to it.
+
+When a larger packet is acknowledged, if it was sent more than the threshold
+after any in flight packets, those packets are immediately declared lost.
+Otherwise, a timer is set for the the reordering threshold minus the time
+difference between the earliest in flight packet and the largest newly
+acknowledged packet.  Note that in some cases the timer could become longer when
+packets are acknowleged out of order. The RECOMMENDED time threshold, expressed
+as a fraction of the round-trip time (kTimeReorderingFraction), is 1/8.
 
 ### Early Retransmit
 
 Unacknowledged packets close to the tail may have fewer than
 kReorderingThreshold retransmittable packets sent after them.  Loss of such
-packets cannot be detected via Fast Retransmit. To enable ack-based loss
-detection of such packets, receipt of an acknowledgment for the last outstanding
-retransmittable packet triggers the Early Retransmit process, as follows.
+packets cannot be detected via Packet Threshold Fast Retransmit. To enable
+ack-based loss detection of such packets, receipt of an acknowledgment for
+the last outstanding retransmittable packet triggers the Early Retransmit
+process, as follows.
 
 If there are unacknowledged in-flight packets still pending, they should
 be marked as lost. To compensate for the reduced reordering resilience, the
@@ -302,9 +323,9 @@ prone to spurious retransmissions due to its reduced reordering resilence
 without the timer. This observation led Linux TCP implementers to implement a
 timer for TCP as well, and this document incorporates this advancement.
 
-## Timer-based Detection
+## Timeout Loss Detection
 
-Timer-based loss detection recovers from losses that cannot be handled by
+Timeout loss detection recovers from losses that cannot be handled by
 ack-based loss detection.  It uses a single timer which switches between
 a crypto retransmission timer, a Tail Loss Probe timer and Retransmission
 Timeout mechanisms.
@@ -430,22 +451,22 @@ QUIC's RTO algorithm differs from TCP in that the firing of an RTO timer is not
 considered a strong enough signal of packet loss, so does not result in an
 immediate change to congestion window or recovery state. An RTO timer expires
 only when there's a prolonged period of network silence, which could be caused
-by a change in the underlying network RTT.
+by a change in the network RTT.
 
 QUIC also diverges from TCP by including MaxAckDelay in the RTO period. Since
 QUIC corrects for this delay in its SRTT and RTTVAR computations, it is
 necessary to add this delay explicitly in the TLP and RTO computation.
 
-When an acknowledgment is received for a packet sent on an RTO event, any
-unacknowledged packets with lower packet numbers than those acknowledged MUST be
-marked as lost.  If an acknowledgement for a packet sent on an RTO is received
-at the same time packets sent prior to the first RTO are acknowledged, the RTO
-is considered spurious and standard loss detection rules apply.
+When an ACK is received that acknowledges only one or more packets sent on
+an RTO event, all unacknowledged packets with lower packet numbers MUST be
+marked as lost.  If packets sent prior to the first RTO are acknowledged in
+the same ACK, the RTO is considered spurious and standard loss detection rules
+apply.
 
 A packet sent when an RTO timer expires MAY carry new data if available or
 unacknowledged data to potentially reduce recovery time. Since this packet is
 sent as a probe into the network prior to establishing any packet loss, prior
-unacknowledged packets SHOULD NOT be marked as lost.
+unacknowledged packets SHOULD NOT be marked as lost when the timer expires.
 
 A packet sent on an RTO timer MUST NOT be blocked by the sender's congestion
 controller. A sender MUST however count these packets as being in flight, since
@@ -454,11 +475,10 @@ this packet adds network load without establishing packet loss.
 ## Generating Acknowledgements
 
 QUIC SHOULD delay sending acknowledgements in response to packets, but MUST NOT
-excessively delay acknowledgements of packets containing frames other than ACK.
-Specifically, implementations MUST attempt to enforce a maximum
-ack delay to avoid causing the peer spurious timeouts.  The maximum ack delay
-is communicated in the `max_ack_delay` transport parameter and the default
-value is 25ms.
+excessively delay acknowledgements of retransmittable packets. Specifically,
+implementations MUST attempt to enforce a maximum ack delay to avoid causing
+the peer spurious timeouts.  The maximum ack delay is communicated in the
+`max_ack_delay` transport parameter and the default value is 25ms.
 
 An acknowledgement SHOULD be sent immediately upon receipt of a second
 packet but the delay SHOULD NOT exceed the maximum ack delay. QUIC recovery
@@ -505,13 +525,13 @@ frame may be saved.  When a packet containing an ACK frame is acknowledged, the
 receiver can stop acknowledging packets less than or equal to the largest
 acknowledged in the sent ACK frame.
 
-In cases without ACK frame loss, this algorithm allows for a minimum of 1 RTT of
-reordering. In cases with ACK frame loss, this approach does not guarantee that
-every acknowledgement is seen by the sender before it is no longer included in
-the ACK frame. Packets could be received out of order and all subsequent ACK
-frames containing them could be lost. In this case, the loss recovery algorithm
-may cause spurious retransmits, but the sender will continue making forward
-progress.
+In cases without ACK frame loss, this algorithm allows for a minimum of 1 RTT
+of reordering. In cases with ACK frame loss and reordering, this approach does
+not guarantee that every acknowledgement is seen by the sender before it is no
+longer included in the ACK frame. Packets could be received out of order and
+all subsequent ACK frames containing them could be lost. In this case, the
+loss recovery algorithm may cause spurious retransmits, but the sender will
+continue making forward progress.
 
 ## Tracking Sent Packets {#tracking-sent-packets}
 
@@ -774,16 +794,13 @@ Pseudocode for OnAckReceived and UpdateRtt follow:
 
 ### On Packet Acknowledgment
 
-When a packet is acked for the first time, the following OnPacketAcked function
-is called.  Note that a single ACK frame may newly acknowledge several packets.
-OnPacketAcked must be called once for each of these newly acked packets.
+When a packet is acknowledged for the first time, the following OnPacketAcked
+function is called.  Note that a single ACK frame may newly acknowledge several
+packets. OnPacketAcked must be called once for each of these newly acknowledged
+packets.
 
-OnPacketAcked takes one parameter, acked_packet, which is the struct of the
-newly acked packet.
-
-If this is the first acknowledgement following RTO, check if the smallest newly
-acknowledged packet is one sent by the RTO, and if so, inform congestion control
-of a verified RTO, similar to F-RTO {{?RFC5682}}.
+OnPacketAcked takes one parameter, acked_packet, which is the struct detailed in
+{{sent-packets-fields}}.
 
 Pseudocode for OnPacketAcked follows:
 
@@ -875,15 +892,13 @@ Pseudocode for OnLossDetectionTimeout follows:
 
 ### Detecting Lost Packets
 
-Packets in QUIC are only considered lost once a larger packet number in
-the same packet number space is acknowledged.  DetectLostPackets is called
-every time an ack is received and operates on the sent_packets for that
-packet number space.  If the loss detection timer expires and the loss_time
-is set, the previous largest acked packet is supplied.
+DetectLostPackets is called every time an ACK is received and operates on
+the sent_packets for that packet number space. If the loss detection timer
+expires and the loss_time is set, the previous largest acknowledged packet
+is supplied.
 
-#### Pseudocode
-
-DetectLostPackets takes one parameter, acked, which is the largest acked packet.
+DetectLostPackets takes one parameter, largest_acked, which is the largest
+acked packet.
 
 Pseudocode for DetectLostPackets follows:
 
@@ -974,11 +989,10 @@ congestion window.
 ## Recovery Period
 
 Recovery is a period of time beginning with detection of a lost packet or an
-increase in the ECN-CE counter. Because QUIC retransmits stream data and control
-frames, not packets, it defines the end of recovery as a packet sent after the
-start of recovery being acknowledged. This is slightly different from TCP's
-definition of recovery, which ends when the lost packet that started recovery is
-acknowledged.
+increase in the ECN-CE counter. Because QUIC does not retransmit packets,
+it defines the end of recovery as a packet sent after the start of recovery
+being acknowledged. This is slightly different from TCP's definition of
+recovery, which ends when the lost packet that started recovery is acknowledged.
 
 The recovery period limits congestion window reduction to once per round trip.
 During recovery, the congestion window remains unchanged irrespective of new
@@ -1095,8 +1109,8 @@ variables as follows:
 
 ### On Packet Sent
 
-Whenever a packet is sent, and it contains non-ACK frames,
-the packet increases bytes_in_flight.
+Whenever a packet is sent, and it contains non-ACK frames, the packet
+increases bytes_in_flight.
 
 ~~~
    OnPacketSentCC(bytes_sent):
@@ -1105,7 +1119,7 @@ the packet increases bytes_in_flight.
 
 ### On Packet Acknowledgement
 
-Invoked from loss detection's OnPacketAcked and is supplied with
+Invoked from loss detection's OnPacketAcked and is supplied with the
 acked_packet from sent_packets.
 
 ~~~
@@ -1130,7 +1144,7 @@ acked_packet from sent_packets.
 ### On New Congestion Event
 
 Invoked from ProcessECN and OnPacketsLost when a new congestion event is
-detected. May starts a new recovery period and reduces the congestion
+detected. May start a new recovery period and reduces the congestion
 window.
 
 ~~~

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -60,7 +60,7 @@ normative:
         name: Sean Turner
         org: sn3rd
         role: editor
-  
+
   DPLPMTUD:
     title: "Datagram Packetization Layer Path MTU Discovery"
     date: {DATE}
@@ -2997,6 +2997,7 @@ the network path might be corrupting ECN codepoints, the endpoint MAY cease
 setting ECT codepoints in subsequent packets. Doing so allows the connection to
 traverse network elements that drop or corrupt ECN codepoints in the IP header.
 
+
 # Packet Size {#packet-size}
 
 The QUIC packet size includes the QUIC header and integrity check, but not the
@@ -3045,7 +3046,6 @@ path to a destination will support its desired message size without
 fragmentation.
 
 In the absence of these mechanisms, QUIC endpoints SHOULD NOT send IP packets
-<<<<<<< HEAD
 larger than 1280 bytes (assuming the minimum IP header size).  This results in
 a QUIC MPS of 1232 bytes for IPv6 and 1252 bytes for IPv4. A QUIC
 implementation MAY be more conservative in computing the QUIC MPS to allow for
@@ -5694,11 +5694,3 @@ Hamilton, Jana Iyengar, Fedor Kouranov, Charles Krasic, Jo Kulik, Adam Langley,
 Jim Roskind, Robbie Shade, Satyam Shekhar, Cherie Shi, Ian Swett, Raman Tenneti,
 Victor Vasiliev, Antonio Vicente, Patrik Westin, Alyssa Wilk, Dale Worley, Fan
 Yang, Dan Zhang, Daniel Ziegler.
-This new text attempts the following:
-- Fixes to wording to reflect the way things are described in other IETF 
-RFCs.
-- Clarity on how ICMP PTB messages are processed.
-- Improved desctription of IPv4 and IPv6 protocols.
-- Separation of ICMP processing from the method: PMTUD or PLPMTUD.
-- Alignment with what is expected by DPLPMTUD.
-

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3026,12 +3026,12 @@ The PMTU is the maximum size of the entire IP packet including the IP header,
 UDP header, and UDP payload.  The UDP payload includes the QUIC packet header,
 protected payload, and any authentication fields. This can depend upon the
 current path characteristics.  Therefore, the current largest UDP payload an
-implementation will send is referred to as QUIC Maximum Packet Size (MPS).
+implementation will send is referred to as QUIC maximum packet size.
 
 QUIC depends on a PMTU of at least 1280 bytes. This is the IPv6 minimum size
 {{!RFC8200}} and is also supported by most modern IPv4 networks.  All QUIC
-packets (except for PMTU probe packets) SHOULD be sized to fit within the MPS
-to avoid the packet being fragmented or dropped {{!RFC8805}.
+packets (except for PMTU probe packets) SHOULD be sized to fit within the 
+maximum packet size to avoid the packet being fragmented or dropped {{!RFC8805}.
 
 To optimize capacity efficiency, endpoints SHOULD use Datagram Packetization
 Layer PMTU Discovery ({{!DPLPMTUD=I-D.ietf-tsvwg-datagram-plpmtud}}), or
@@ -3041,17 +3041,18 @@ fragmentation.
 
 In the absence of these mechanisms, QUIC endpoints SHOULD NOT send IP packets
 larger than 1280 bytes. Assuming the minimum IP header size, this results in
-a QUIC MPS of 1232 bytes for IPv6 and 1252 bytes for IPv4. A QUIC
-implementation MAY be more conservative in computing the QUIC MPS to allow for
-unknown tunnel overheads or IP header options/extensions.
+a QUIC maximum packet size of 1232 bytes for IPv6 and 1252 bytes for IPv4. A QUIC
+implementation MAY be more conservative in computing the QUIC maximum packet 
+size to allow for unknown tunnel overheads or IP header options/extensions.
 
 Each pair of local and remote addresses could have a different PMTU.  QUIC
 implementations that implement any kind of PMTU discovery therefore SHOULD
-maintain a MPS for each combination of local and remote IP addresses.
+maintain a maximum packet size for each combination of local and remote IP 
+addresses.
 
 If a QUIC endpoint determines that the PMTU between any pair of local and
 remote IP addresses has fallen below the size needed to support the smallest
-allowed MPS, it MUST immediately cease sending QUIC packets on the
+allowed maximum packet size, it MUST immediately cease sending QUIC packets on the
 affected path.  This could result in termination of the connection if an
 alternative path cannot be found.
 
@@ -3099,8 +3100,8 @@ Further validation can also be provided:
 
 The endpoint SHOULD ignore all ICMP messages that are not validated or do not
 carry sufficient quoted packet payload to perform validation.  Any reduction in
-the QUIC MPS MAY be provisional until QUIC's loss detection algorithm
-determines that the quoted packet has actually been lost.
+the QUIC maximum packet size MAY be provisional until QUIC's loss detection 
+algorithm determines that the quoted packet has actually been lost.
 
 ## Considerations for Datagram Packetization Layer PMTU Discovery
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3030,7 +3030,7 @@ implementation will send is referred to as QUIC maximum packet size.
 
 QUIC depends on a PMTU of at least 1280 bytes. This is the IPv6 minimum size
 {{!RFC8200}} and is also supported by most modern IPv4 networks.  All QUIC
-packets (except for PMTU probe packets) SHOULD be sized to fit within the 
+packets (except for PMTU probe packets) SHOULD be sized to fit within the
 maximum packet size to avoid the packet being fragmented or dropped {{!RFC8805}.
 
 To optimize capacity efficiency, endpoints SHOULD use Datagram Packetization
@@ -3042,12 +3042,12 @@ fragmentation.
 In the absence of these mechanisms, QUIC endpoints SHOULD NOT send IP packets
 larger than 1280 bytes. Assuming the minimum IP header size, this results in
 a QUIC maximum packet size of 1232 bytes for IPv6 and 1252 bytes for IPv4. A QUIC
-implementation MAY be more conservative in computing the QUIC maximum packet 
+implementation MAY be more conservative in computing the QUIC maximum packet
 size to allow for unknown tunnel overheads or IP header options/extensions.
 
 Each pair of local and remote addresses could have a different PMTU.  QUIC
 implementations that implement any kind of PMTU discovery therefore SHOULD
-maintain a maximum packet size for each combination of local and remote IP 
+maintain a maximum packet size for each combination of local and remote IP
 addresses.
 
 If a QUIC endpoint determines that the PMTU between any pair of local and
@@ -3079,7 +3079,7 @@ packet as possible without the ICMPv6 packet exceeding 1280 bytes {{!RFC4443}}.
 The size of the quoted packet can actually be smaller, or the information
 unintelligible, for various reasons see Section 1.1 of {{!DPLPMTUD}}.
 
-When a randomized source port is used for a QUIC connection, this can provide 
+When a randomized source port is used for a QUIC connection, this can provide
 some protection from off path attacks that forge ICMP messages. The source port
 in a quoted packet can be checked for TCP {{!RFC6056}}
 and UDP transports {{!RFC8085}}, such as QUIC.  When used, a stack will only
@@ -3100,7 +3100,7 @@ Further validation can also be provided:
 
 The endpoint SHOULD ignore all ICMP messages that are not validated or do not
 carry sufficient quoted packet payload to perform validation.  Any reduction in
-the QUIC maximum packet size MAY be provisional until QUIC's loss detection 
+the QUIC maximum packet size MAY be provisional until QUIC's loss detection
 algorithm determines that the quoted packet has actually been lost.
 
 ## Considerations for Datagram Packetization Layer PMTU Discovery

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2986,23 +2986,20 @@ the network path might be corrupting ECN codepoints, the endpoint MAY cease
 setting ECT codepoints in subsequent packets. Doing so allows the connection to
 traverse network elements that drop or corrupt ECN codepoints in the IP header.
 
-
 # Packet Size {#packet-size}
 
 The QUIC packet size includes the QUIC header and integrity check, but not the
 UDP or IP header.
 
 Clients MUST ensure that the first Initial packet they send is sent in a UDP
-datagram that is at least 1200 bytes. Padding the Initial packet or including a
-0-RTT packet in the same datagram are ways to meet this requirement.  Sending a
-UDP datagram of this size ensures that the network path supports a reasonable
-Maximum Transmission Unit (MTU), and helps reduce the amplitude of amplification
-attacks caused by server responses toward an unverified client address, see
+datagram with a payload of at least 1200 bytes.  The payload of a UDP datagram
+carrying the Initial packet MUST be expanded to at least 1200 bytes, by adding
+PADDING frames to the Initial packet and/or by combining the Initial packet
+with a 0-RTT packet (see {{packet-coalesce}}).  Sending a UDP datagram of this
+size ensures that the network path supports a reasonable Maximum Transmission
+Unit (MTU), and helps reduce the amplitude of amplification attacks caused by
+server responses toward an unverified client address, see
 {{address-validation}}.
-
-The payload of a UDP datagram carrying the Initial packet MUST be expanded to at
-least 1200 bytes, by adding PADDING frames to the Initial packet and/or by
-combining the Initial packet with a 0-RTT packet (see {{packet-coalesce}}).
 
 The datagram containing the first Initial packet from a client MAY exceed 1200
 bytes if the client believes that the Path Maximum Transmission Unit (PMTU)
@@ -3017,86 +3014,107 @@ processed as valid.
 The server MUST also limit the number of bytes it sends before validating the
 address of the client, see {{address-validation}}.
 
+## Path Maximum Transmission Unit (PMTU)
 
-## Path Maximum Transmission Unit
+The PMTU is the maximum size of the entire IP datagram including the IP header,
+UDP header, and UDP payload.  The UDP payload includes the QUIC packet header,
+protected payload, and any authentication fields. This can be depend upon the
+current path characteristics.  Therefore, the current largest UDP payload an
+implementation will send is referred to as QUIC Maximum Packet Size (MPS).
 
-The Path Maximum Transmission Unit (PMTU) is the maximum size of the entire IP
-header, UDP header, and UDP payload. The UDP payload includes the QUIC packet
-header, protected payload, and any authentication fields.
+QUIC depends on a PMTU of at least 1280 bytes. This is the IPv6 minimum size
+{{!RFC8200}} and is also supported by most modern IPv4 networks.  All QUIC
+packets (except for PMTU probe packets) SHOULD be sized to fit within the MPS
+to avoid IP fragmentation or packet drop along the path {{!RFC8805}.
 
-All QUIC packets SHOULD be sized to fit within the estimated PMTU to avoid IP
-fragmentation or packet drops. To optimize bandwidth efficiency, endpoints
-SHOULD use Datagram Packetization Layer PMTU Discovery ({{DPLPMTUD}}).  Endpoints
-MAY use PMTU Discovery ({{!PMTUDv4=RFC1191}}, {{!PMTUDv6=RFC8201}}) for
-detecting the PMTU, setting the PMTU appropriately, and storing the result of
-previous PMTU determinations.
+To optimize capacity efficiency, endpoints SHOULD use Datagram
+Packetization Layer PMTU Discovery ({{DPLPMTUD}}), or implement Path MTU
+Discovery (PMTUD) {{!RFC1191}} {{!RFC8201}} to determine whether the
+path to a destination will support its desired message size without
+fragmentation.
 
 In the absence of these mechanisms, QUIC endpoints SHOULD NOT send IP packets
-larger than 1280 bytes. Assuming the minimum IP header size, this results in a
-QUIC packet size of 1232 bytes for IPv6 and 1252 bytes for IPv4. Some QUIC
-implementations MAY be more conservative in computing allowed QUIC packet size
-given unknown tunneling overheads or IP header options.
+larger than 1280 bytes (assuming the minimum IP header size).  This results in
+a QUIC MPS of 1232 bytes for IPv6 and 1252 bytes for IPv4. A QUIC
+implementation MAY be more conservative in computing the QUIC MPS to allow for
+unknown tunnel overheads or IP header options/extensions.
 
-QUIC endpoints that implement any kind of PMTU discovery SHOULD maintain an
-estimate for each combination of local and remote IP addresses.  Each pairing of
-local and remote addresses could have a different maximum MTU in the path.
+Each pair of local and remote addresses could have a different PMTU.  QUIC
+implementations that implement any kind of PMTU discovery therefore SHOULD
+maintain a MPS for each combination of local and remote IP addresses.
 
-QUIC depends on the network path supporting an MTU of at least 1280 bytes. This
-is the IPv6 minimum MTU and therefore also supported by most modern IPv4
-networks.  An endpoint MUST NOT reduce its MTU below this number, even if it
-receives signals that indicate a smaller limit might exist.
+If a QUIC endpoint determines that the PMTU between any pair of local and
+remote IP addresses has fallen below the size needed to support the smallest
+allowed MPS, it MUST immediately cease sending QUIC packets on the
+affected path.  This could result in termination of the connection if an
+alternative path cannot be found.
 
-If a QUIC endpoint determines that the PMTU between any pair of local and remote
-IP addresses has fallen below 1280 bytes, it MUST immediately cease sending QUIC
-packets on the affected path.  This could result in termination of the
-connection if an alternative path cannot be found.
+### Processing ICMP Messages to reduce the PMTU {#icmp-pmtud}
 
-### IPv4 PMTU Discovery {#v4-pmtud}
+PMTU discovery {{!RFC1191}} {{!RFC8201}} relies on reception of ICMP messages
+(e.g., IPv6 Packet Too Big, PTB, messages) that indicate when a packet is
+dropped because it is larger than the local router MTU. DPLPMTUD can also
+optionally utilise these messages.  This use of ICMP messages is
+potentially vulnerable to off-path attacks that successfully guess the IP
+address 3-tuple and reduce the PMTU to a bandwidth-inefficient value
+{{!RFC8201}}.
 
-Traditional ICMP-based path MTU discovery in IPv4 {{!PMTUDv4}} is potentially
-vulnerable to off-path attacks that successfully guess the IP/port 4-tuple and
-reduce the MTU to a bandwidth-inefficient value. TCP connections mitigate this
-risk by using the (at minimum) 8 bytes of transport header echoed in the ICMP
-message to validate the TCP sequence number as valid for the current
-connection. However, as QUIC operates over UDP, in IPv4 the echoed information
-could consist only of the IP and UDP headers, which usually has insufficient
-entropy to mitigate off-path attacks.
+QUIC endpoints SHOULD provide validation to protect from off-path injection of
+ICMP messages as specified in {{!RFC8201}} and Section 5.2 of {{!RFC8085}}.
+This uses the quoted packet supplied in the payload of an ICMP message, which,
+when present, can be used to associate the message with a corresponding
+transport connection {{!DPLPMTUD}}.
 
-As a result, endpoints that implement PMTUD in IPv4 SHOULD take steps to
-mitigate this risk. For instance, an application could:
+The IPv4 Router requirements {{!RFC1812} state that the quoted
+packet should contain as much of the original datagram as possible without the
+length of the ICMP datagram exceeding 576 bytes. IPv6 routers include as much
+of invoking packet as possible without the ICMPv6 packet exceeding 1280 bytes
+{{!RFC4443}}.  The size of the quoted packet can actually be smaller, or
+the information unintelligible, for various reasons {{!DPLPMTUD}}.
 
-* Set the IPv4 Don't Fragment (DF) bit on a small proportion of packets, so that
-  most invalid ICMP messages arrive when there are no DF packets outstanding,
-  and can therefore be identified as spurious.
+When a randomized source port is used, this can provide some protection from
+off path attacks that forge ICMP messages. The source port
+in a quoted packet can be checked for TCP {{!RFC6056}}
+and UDP transports {{!RFC8085}}, such as QUIC.  When used, a stack will only
+pass ICMP messages to a QUIC endpoint where the port information in quoted
+packet within the ICMP payload matches a port used by QUIC.
 
-* Store additional information from the IP or UDP headers from DF packets (for
-  example, the IP ID or UDP checksum) to further authenticate incoming Datagram
-  Too Big messages.
+As a part of ICMP validation, QUIC endpoints SHOULD validate
+that connection ID information corresponds to an active session.
 
-* Any reduction in PMTU due to a report contained in an ICMP packet is
-  provisional until QUIC's loss detection algorithm determines that the packet
-  is actually lost.
+Further validation can also be provided:
 
+* An IPv4 endpoint could set the Don't Fragment (DF) bit on a small proportion
+  of packets, so that most invalid ICMP messages arrive when there are no DF
+  packets outstanding, and can therefore be identified as spurious.
 
-## Special Considerations for Packetization Layer PMTU Discovery
+* An endpoint could store additional information from the IP or UDP headers to
+  use for validation (for example, the IP ID or UDP checksum).
 
+The endpoint SHOULD ignore all ICMP messages that are not validated or do not
+carry sufficient quoted packet payload to perform validation.  Any reduction in
+the QUIC MPS MAY be provisional until QUIC's loss detection algorithm
+determines that the quoted packet has actually been lost.
 
-The PADDING frame provides a useful option for PMTU probe packets. PADDING
-frames generate acknowledgements, but they need not be delivered reliably. As a
-result, the loss of PADDING frames in probe packets does not require
-delay-inducing retransmission. However, PADDING frames do consume congestion
-window, which may delay the transmission of subsequent application data.
+## Considerations for Datagram Packetization Layer PMTU Discovery
 
-When implementing the algorithm in Section 7.2 of {{!PLPMTUD}}, the initial
-value of search_low SHOULD be consistent with the IPv6 minimum packet size.
-Paths that do not support this size cannot deliver Initial packets, and
-therefore are not QUIC-compliant.
+Section 6.4 of {{DPLPMTUD}} provides considerations for implementing Datagram
+Packetization Layer PMTUD (DPLPMTUD) with QUIC.
 
-Section 7.3 of {{!PLPMTUD}} discusses trade-offs between small and large
-increases in the size of probe packets. As QUIC probe packets need not contain
-application data, aggressive increases in probe size carry fewer consequences.
+When implementing the algorithm in Section 5.3 of {{DPLPMTUD}}, the initial
+value of BASE_PMTU SHOULD be consistent with the minimum QUIC packet size.
 
+A PADDING frame can be used to generate PMTU probe packets. PADDING need not be
+delivered reliably. As a result, the loss of PADDING frames in probe packets
+does not require delay-inducing retransmission. However, PADDING frames do
+consume congestion window, which could delay the transmission of subsequent
+application data.
 
+A QUIC PING frame can be included in a PMTU probe to ensure that a valid
+probe is acknowledged.
+
+The considerations for processing ICMP messages in the previous
+section also apply if these messages are used by DPLPMTUD.
 
 # Versions {#versions}
 
@@ -5666,3 +5684,11 @@ Hamilton, Jana Iyengar, Fedor Kouranov, Charles Krasic, Jo Kulik, Adam Langley,
 Jim Roskind, Robbie Shade, Satyam Shekhar, Cherie Shi, Ian Swett, Raman Tenneti,
 Victor Vasiliev, Antonio Vicente, Patrik Westin, Alyssa Wilk, Dale Worley, Fan
 Yang, Dan Zhang, Daniel Ziegler.
+This new text attempts the following:
+- Fixes to wording to reflect the way things are described in other IETF 
+RFCs.
+- Clarity on how ICMP PTB messages are processed.
+- Improved desctription of IPv4 and IPv6 protocols.
+- Separation of ICMP processing from the method: PMTUD or PLPMTUD.
+- Alignment with what is expected by DPLPMTUD.
+

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3031,7 +3031,7 @@ implementation will send is referred to as QUIC Maximum Packet Size (MPS).
 QUIC depends on a PMTU of at least 1280 bytes. This is the IPv6 minimum size
 {{!RFC8200}} and is also supported by most modern IPv4 networks.  All QUIC
 packets (except for PMTU probe packets) SHOULD be sized to fit within the MPS
-to avoid IP fragmentation or packet drop along the path {{!RFC8805}.
+to avoid the packet being fragmented or dropped {{!RFC8805}.
 
 To optimize capacity efficiency, endpoints SHOULD use Datagram Packetization
 Layer PMTU Discovery ({{!DPLPMTUD=I-D.ietf-tsvwg-datagram-plpmtud}}), or

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3076,7 +3076,7 @@ contain as much of the original datagram as possible without the length of the
 ICMP datagram exceeding 576 bytes. IPv6 routers include as much of invoking
 packet as possible without the ICMPv6 packet exceeding 1280 bytes {{!RFC4443}}.
 The size of the quoted packet can actually be smaller, or the information
-unintelligible, for various reasons {{!DPLPMTUD}}.
+unintelligible, for various reasons see Section 1.1 of {{!DPLPMTUD}}.
 
 When a randomized source port is used, this can provide some protection from
 off path attacks that forge ICMP messages. The source port

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -60,6 +60,12 @@ normative:
         name: Sean Turner
         org: sn3rd
         role: editor
+  
+  DPLPMTUD:
+    title: "Datagram Packetization Layer Path MTU Discovery"
+    date: {DATE}
+    seriesinfo:
+      Internet-Draft: draft-ietf-tsvwg-datagram-plpmtud
 
 informative:
 
@@ -3020,7 +3026,7 @@ header, protected payload, and any authentication fields.
 
 All QUIC packets SHOULD be sized to fit within the estimated PMTU to avoid IP
 fragmentation or packet drops. To optimize bandwidth efficiency, endpoints
-SHOULD use Packetization Layer PMTU Discovery ({{!PLPMTUD=RFC4821}}).  Endpoints
+SHOULD use Datagram Packetization Layer PMTU Discovery ({{DPLPMTUD}}).  Endpoints
 MAY use PMTU Discovery ({{!PMTUDv4=RFC1191}}, {{!PMTUDv6=RFC8201}}) for
 detecting the PMTU, setting the PMTU appropriately, and storing the result of
 previous PMTU determinations.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3078,8 +3078,8 @@ packet as possible without the ICMPv6 packet exceeding 1280 bytes {{!RFC4443}}.
 The size of the quoted packet can actually be smaller, or the information
 unintelligible, for various reasons see Section 1.1 of {{!DPLPMTUD}}.
 
-When a randomized source port is used, this can provide some protection from
-off path attacks that forge ICMP messages. The source port
+When a randomized source port is used for a QUIC connection, this can provide 
+some protection from off path attacks that forge ICMP messages. The source port
 in a quoted packet can be checked for TCP {{!RFC6056}}
 and UDP transports {{!RFC8085}}, such as QUIC.  When used, a stack will only
 pass ICMP messages to a QUIC endpoint where the port information in quoted

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3022,9 +3022,9 @@ address of the client, see {{address-validation}}.
 
 ## Path Maximum Transmission Unit (PMTU)
 
-The PMTU is the maximum size of the entire IP datagram including the IP header,
+The PMTU is the maximum size of the entire IP packet including the IP header,
 UDP header, and UDP payload.  The UDP payload includes the QUIC packet header,
-protected payload, and any authentication fields. This can be depend upon the
+protected payload, and any authentication fields. This can depend upon the
 current path characteristics.  Therefore, the current largest UDP payload an
 implementation will send is referred to as QUIC Maximum Packet Size (MPS).
 
@@ -3040,7 +3040,7 @@ whether the path to a destination will support its desired message size without
 fragmentation.
 
 In the absence of these mechanisms, QUIC endpoints SHOULD NOT send IP packets
-larger than 1280 bytes (assuming the minimum IP header size).  This results in
+larger than 1280 bytes. Assuming the minimum IP header size, this results in
 a QUIC MPS of 1232 bytes for IPv6 and 1252 bytes for IPv4. A QUIC
 implementation MAY be more conservative in computing the QUIC MPS to allow for
 unknown tunnel overheads or IP header options/extensions.
@@ -3055,12 +3055,12 @@ allowed MPS, it MUST immediately cease sending QUIC packets on the
 affected path.  This could result in termination of the connection if an
 alternative path cannot be found.
 
-### Processing ICMP Messages to reduce the PMTU {#icmp-pmtud}
+### Processing ICMP Packet Too Big Messages {#icmp-pmtud}
 
 PMTU discovery {{!RFC1191}} {{!RFC8201}} relies on reception of ICMP messages
-(e.g., IPv6 Packet Too Big, PTB, messages) that indicate when a packet is
+(e.g., IPv6 Packet Too Big messages) that indicate when a packet is
 dropped because it is larger than the local router MTU. DPLPMTUD can also
-optionally utilise these messages.  This use of ICMP messages is
+optionally use these messages.  This use of ICMP messages is
 potentially vulnerable to off-path attacks that successfully guess the IP
 address 3-tuple and reduce the PMTU to a bandwidth-inefficient value
 {{!RFC8201}}.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -61,12 +61,6 @@ normative:
         org: sn3rd
         role: editor
 
-  DPLPMTUD:
-    title: "Datagram Packetization Layer Path MTU Discovery"
-    date: {DATE}
-    seriesinfo:
-      Internet-Draft: draft-ietf-tsvwg-datagram-plpmtud
-
 informative:
 
   QUIC-INVARIANTS:
@@ -3039,10 +3033,10 @@ QUIC depends on a PMTU of at least 1280 bytes. This is the IPv6 minimum size
 packets (except for PMTU probe packets) SHOULD be sized to fit within the MPS
 to avoid IP fragmentation or packet drop along the path {{!RFC8805}.
 
-To optimize capacity efficiency, endpoints SHOULD use Datagram
-Packetization Layer PMTU Discovery ({{DPLPMTUD}}), or implement Path MTU
-Discovery (PMTUD) {{!RFC1191}} {{!RFC8201}} to determine whether the
-path to a destination will support its desired message size without
+To optimize capacity efficiency, endpoints SHOULD use Datagram Packetization
+Layer PMTU Discovery ({{!DPLPMTUD=I-D.ietf-tsvwg-datagram-plpmtud}}), or
+implement Path MTU Discovery (PMTUD) {{!RFC1191}} {{!RFC8201}} to determine
+whether the path to a destination will support its desired message size without
 fragmentation.
 
 In the absence of these mechanisms, QUIC endpoints SHOULD NOT send IP packets
@@ -3072,17 +3066,17 @@ address 3-tuple and reduce the PMTU to a bandwidth-inefficient value
 {{!RFC8201}}.
 
 QUIC endpoints SHOULD provide validation to protect from off-path injection of
-ICMP messages as specified in {{!RFC8201}} and Section 5.2 of {{!RFC8085}}.
-This uses the quoted packet supplied in the payload of an ICMP message, which,
-when present, can be used to associate the message with a corresponding
-transport connection {{!DPLPMTUD}}.
+ICMP messages as specified in {{!RFC8201}} and Section 5.2 of {{!RFC8085}}. This
+uses the quoted packet supplied in the payload of an ICMP message, which, when
+present, can be used to associate the message with a corresponding transport
+connection {{!DPLPMTUD}}.
 
-The IPv4 Router requirements {{!RFC1812} state that the quoted
-packet should contain as much of the original datagram as possible without the
-length of the ICMP datagram exceeding 576 bytes. IPv6 routers include as much
-of invoking packet as possible without the ICMPv6 packet exceeding 1280 bytes
-{{!RFC4443}}.  The size of the quoted packet can actually be smaller, or
-the information unintelligible, for various reasons {{!DPLPMTUD}}.
+The IPv4 Router requirements {{!RFC1812} state that the quoted packet should
+contain as much of the original datagram as possible without the length of the
+ICMP datagram exceeding 576 bytes. IPv6 routers include as much of invoking
+packet as possible without the ICMPv6 packet exceeding 1280 bytes {{!RFC4443}}.
+The size of the quoted packet can actually be smaller, or the information
+unintelligible, for various reasons {{!DPLPMTUD}}.
 
 When a randomized source port is used, this can provide some protection from
 off path attacks that forge ICMP messages. The source port
@@ -3110,11 +3104,12 @@ determines that the quoted packet has actually been lost.
 
 ## Considerations for Datagram Packetization Layer PMTU Discovery
 
-Section 6.4 of {{DPLPMTUD}} provides considerations for implementing Datagram
-Packetization Layer PMTUD (DPLPMTUD) with QUIC.
+Section 6.4 of {{!DPLPMTUD}} provides considerations for
+implementing Datagram Packetization Layer PMTUD (DPLPMTUD) with QUIC.
 
-When implementing the algorithm in Section 5.3 of {{DPLPMTUD}}, the initial
-value of BASE_PMTU SHOULD be consistent with the minimum QUIC packet size.
+When implementing the algorithm in Section 5.3 of
+{{!DPLPMTUD}}, the initial value of BASE_PMTU SHOULD be
+consistent with the minimum QUIC packet size.
 
 A PADDING frame can be used to generate PMTU probe packets. PADDING need not be
 delivered reliably. As a result, the loss of PADDING frames in probe packets
@@ -5011,10 +5006,10 @@ endpoints discard most packets that are not authenticated, greatly limiting the
 ability of an attacker to interfere with existing connections.
 
 Once a connection is established QUIC endpoints might accept some
-unauthenticated ICMP packets (see {{v4-pmtud}}), but the use of these packets is
-extremely limited.  The only other type of packet that an endpoint might accept
-is a stateless reset ({{stateless-reset}}) which relies on the token being kept
-secret until it is used.
+unauthenticated ICMP packets (see {{icmp-pmtud}}), but the use of these packets
+is extremely limited.  The only other type of packet that an endpoint might
+accept is a stateless reset ({{stateless-reset}}) which relies on the token
+being kept secret until it is used.
 
 During the creation of a connection, QUIC only provides protection against
 attack from off the network path.  All QUIC packets contain proof that the

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3108,8 +3108,8 @@ Section 6.4 of {{!DPLPMTUD}} provides considerations for
 implementing Datagram Packetization Layer PMTUD (DPLPMTUD) with QUIC.
 
 When implementing the algorithm in Section 5.3 of
-{{!DPLPMTUD}}, the initial value of BASE_PMTU SHOULD be
-consistent with the minimum QUIC packet size.
+{{!DPLPMTUD}}, the initial value of BASE_PMTU SHOULD be consistent with the 
+minimum QUIC packet size (1232 bytes for IPv6 and 1252 bytes for IPv4).
 
 A PADDING frame can be used to generate PMTU probe packets. PADDING need not be
 delivered reliably. As a result, the loss of PADDING frames in probe packets

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3109,7 +3109,7 @@ Section 6.4 of {{!DPLPMTUD}} provides considerations for
 implementing Datagram Packetization Layer PMTUD (DPLPMTUD) with QUIC.
 
 When implementing the algorithm in Section 5.3 of
-{{!DPLPMTUD}}, the initial value of BASE_PMTU SHOULD be consistent with the 
+{{!DPLPMTUD}}, the initial value of BASE_PMTU SHOULD be consistent with the
 minimum QUIC packet size (1232 bytes for IPv6 and 1252 bytes for IPv4).
 
 A PADDING frame can be used to generate PMTU probe packets. PADDING need not be


### PR DESCRIPTION
Rewrite Packet Size section to make it clearer and to consider ICMP
handling and Datagram PLPMTUD.

- Add normative reference to DPLPMTUD
- Define MPS as the largest UDP Payload that can safely sent right now
- Improved desctription of IPv4 and IPv6 protocols.
- Discuss port numbers and connection ids as a method for verifying ICMP messages
- Separation of ICMP processing from the method: PMTUD or PLPMTUD
- Replace PLPMTUD considerations with DPLPMTUD considerations
- Specify that probes can made from Packets carrying PING and PADDING frames