### PR TITLE
Default settings in HTTP

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -658,10 +658,11 @@ HTTP_MALFORMED_FRAME.
 The following settings are defined in HTTP/3:
 
   SETTINGS_NUM_PLACEHOLDERS (0x3):
-  : This value SHOULD be non-zero.  The default value is 0.
+  : The default value is 0.  However, this value SHOULD be set to a non-zero
+    value by servers.  See {{placeholders}} for usage.
 
   SETTINGS_MAX_HEADER_LIST_SIZE (0x6):
-  : The default value is unlimited.
+  : The default value is unlimited.  See {{header-formatting}} for usage.
 
 Setting identifiers of the format `0x?a?a` are reserved to exercise the
 requirement that unknown identifiers be ignored.  Such settings have no defined
@@ -679,14 +680,13 @@ Additional settings MAY be defined by extensions to HTTP/3.
 An HTTP implementation MUST NOT send frames or requests which would be invalid
 based on its current understanding of the peer's settings.  All settings begin
 at an initial value, and are updated upon receipt of a SETTINGS frame.  For
-servers, the initial values of the client's settings are the defaults of each
-setting.
+servers, the initial value of each client setting is the default value.
 
-For clients using a 1-RTT QUIC connection, the initial values of the server's
-settings are the defaults of each setting. When a 0-RTT QUIC connection is being
-used, the initial values are the values used in the previous session.  Clients
-MUST store the settings the server provided in the session being resumed and
-MUST comply with stored settings until the server's current settings are
+For clients using a 1-RTT QUIC connection, the initial value of each server
+setting is the default value. When a 0-RTT QUIC connection is being used, the
+initial value of each server setting is the value used in the previous session.
+Clients MUST store the settings the server provided in the session being resumed
+and MUST comply with stored settings until the current server settings are
 received.
 
 A server can remember the settings that it advertised, or store an
@@ -894,7 +894,7 @@ containing a usable HTTP request, the server SHOULD abort its response with the
 error code HTTP_INCOMPLETE_REQUEST.
 
 
-### Header Formatting and Compression
+### Header Formatting and Compression {#header-formatting}
 
 HTTP message headers carry information as a series of key-value pairs, called
 header fields. For a listing of registered HTTP header fields, see the "Message

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -316,7 +316,8 @@ header is determined by the stream type.
 
 Some stream types are reserved ({{stream-grease}}).  Two stream types are
 defined in this document: control streams ({{control-streams}}) and push streams
-({{push-streams}}).  Other stream types can be defined by extensions to HTTP/3.
+({{push-streams}}).  Other stream types can be defined by extensions to HTTP/3;
+see {{extensions}} for more details.
 
 Both clients and servers SHOULD send a value of three or greater for the QUIC
 transport parameter `initial_max_uni_streams`.
@@ -673,7 +674,8 @@ receipt.
 Because the setting has no defined meaning, the value of the setting can be any
 value the implementation selects.
 
-Additional settings MAY be defined by extensions to HTTP/3.
+Additional settings can be defined by extensions to HTTP/3; see {{extensions}}
+for more details.
 
 #### Initialization
 

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -922,12 +922,13 @@ HPACK which allows the flexibility to avoid header-compression-induced
 head-of-line blocking.  See that document for additional details.
 
 An HTTP/3 implementation MAY impose a limit on the maximum size of the header it
-will accept on an individual HTTP message.  This limit is conveyed as a number
-of bytes in the `SETTINGS_MAX_HEADER_LIST_SIZE` parameter. The size of a header
-list is calculated based on the uncompressed size of header fields, including
-the length of the name and value in bytes plus an overhead of 32 bytes for each
-header field.  Encountering a message header larger than this value SHOULD be
-treated as a stream error of type `HTTP_EXCESSIVE_LOAD`.
+will accept on an individual HTTP message; encountering a larger message header
+SHOULD be treated as a stream error of type `HTTP_EXCESSIVE_LOAD`.  If an
+implementation wishes to advise its peer of this limit, it can be conveyed as a
+number of bytes in the `SETTINGS_MAX_HEADER_LIST_SIZE` parameter. The size of a
+header list is calculated based on the uncompressed size of header fields,
+including the length of the name and value in bytes plus an overhead of 32 bytes
+for each header field.
 
 ### Request Cancellation
 

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -1014,12 +1014,12 @@ represented as an 8-bit prefix string literal.
 QPACK defines two settings which are included in the HTTP/QUIC SETTINGS frame.
 
   SETTINGS_HEADER_TABLE_SIZE (0x1):
-  : An integer with a maximum value of 2^30 - 1.  The default value is 4,096
+  : An integer with a maximum value of 2^30 - 1.  The default value is zero
     bytes.  See {{table-dynamic}} for usage.
 
   SETTINGS_QPACK_BLOCKED_STREAMS (0x7):
-  : An integer with a maximum value of 2^16 - 1.  The default value is 100.  See
-    {{overview-hol-avoidance}}.
+  : An integer with a maximum value of 2^16 - 1.  The default value is zero.
+    See {{overview-hol-avoidance}}.
 
 
 # Error Handling {#error-handling}


### PR DESCRIPTION
Fixes #1846.

This is an attempt to remove the head-of-line blocking on SETTINGS in HTTP.  The principle is:

- The default value of each setting should always be acceptable to the remote endpoint (i.e. minimal)
- Only send what you know the peer is willing to consume

This results in most settings defaulting to zero.  A client or server can wait for the SETTINGS frame to arrive (for example, in hopes of learning that the peer supports a non-zero QPACK table), or can proceed based on what it knows -- i.e. no QPACK table, no placeholders.

I expanded the discussion of how negotiation works in a purely declarative world, noting that there's no synchronization marker unless the extension itself creates one.  (For an incompatible frame type, the marker would obviously be that you start using it.  For a change to an existing frame type, things get complicated.  Don't do that.)

(It's worth noting that we could go a step further -- if an endpoint doesn't want to change from the initial values, it currently MUST still send an empty SETTINGS frame as the first frame of the control stream.  We could instead say that if the first frame isn't SETTINGS, the initial values become final.)

The sole setting that breaks this pattern is SETTINGS_MAX_HEADER_LIST_SIZE -- the default is unlimited, and a change from the default will clearly be less permissive, which is otherwise prohibited.  But defaulting it to zero would prohibit sending any requests until the SETTINGS frame is received.  7540 terms this setting as "advisory," so I've expanded text noting that this is purely a courtesy to the other side and not binding.