### PR TITLE
TLS provides AEAD and KDF

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -727,7 +727,7 @@ Section 7.1 of {{!TLS13}}) is used, using the hash function from the negotiated
 cipher suite.  Other versions of TLS MUST provide a similar function in order to
 be used QUIC.
 
- The current encryption level secret and the label "quic key" are input to the
+The current encryption level secret and the label "quic key" are input to the
 KDF to produce the AEAD key; the label "quic iv" is used to derive the IV, see
 {{aead}}.  The packet number protection key uses the "quic hp" label, see
 {{header-protect}}).  Using these labels provides key separation between QUIC


### PR DESCRIPTION
Phrase this not as having TLS providing a cipher suite, but as TLS
providing functions for protection and key derivation.

It's clear that I had misinterpreted intent from others.  This cleans up the change from #2032 and makes more changes consistent with that principle throughout.  This is a companion to #2044.

Closes #2034.