### PR TITLE
Move NUM_PLACEHOLDERS out of the HTTP/2-used space

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -659,11 +659,11 @@ HTTP_MALFORMED_FRAME.
 
 The following settings are defined in HTTP/3:
 
-  SETTINGS_NUM_PLACEHOLDERS (0x3):
-  : This value SHOULD be non-zero.  The default value is 16.
-
   SETTINGS_MAX_HEADER_LIST_SIZE (0x6):
   : The default value is unlimited.
+
+  SETTINGS_NUM_PLACEHOLDERS (0x8):
+  : This value SHOULD be non-zero.  The default value is 16.
 
 Setting identifiers of the format `0x?a?a` are reserved to exercise the
 requirement that unknown identifiers be ignored.  Such settings have no defined
@@ -1479,10 +1479,11 @@ The entries in the following table are registered by this document.
 | Setting Name                 | Code   | Specification             |
 | ---------------------------- | :----: | ------------------------- |
 | Reserved                     | 0x2    | N/A                       |
-| NUM_PLACEHOLDERS             | 0x3    | {{settings-parameters}}   |
+| Reserved                     | 0x3    | N/A                       |
 | Reserved                     | 0x4    | N/A                       |
 | Reserved                     | 0x5    | N/A                       |
 | MAX_HEADER_LIST_SIZE         | 0x6    | {{settings-parameters}}   |
+| NUM_PLACEHOLDERS             | 0x8    | {{settings-parameters}}   |
 | ---------------------------- | ------ | ------------------------- |
 
 Additionally, each code of the format `0x?a?a` where each `?` is any four bits


### PR DESCRIPTION
Fixes #1847, but will conflict with #2038.