### PR TITLE
Amplification attack using retry tokens and spoofed addresses

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1637,9 +1637,13 @@ able to reuse a token.  To avoid attacks that exploit this property, a server
 can limit its use of tokens to only the information needed validate client
 addresses.
 
-Fraudulently obtained tokens could enable attackers to use servers as amplifiers
-in DDOS attacks. Servers SHOULD protect against such attacks by ensuring that
-tokens are used by clients only once.
+Attackers could replay tokens to use servers as amplifiers in DDoS attacks. To
+protect against such attacks, servers SHOULD ensure that tokens sent in Retry
+packets are only accepted for a short time. Tokens that are provided in
+NEW_TOKEN frames (see {{frame-new-token}}) need to be valid for longer, but
+SHOULD NOT be accepted multiple times in a short period. Servers are encouraged
+to allow tokens to be used only once, if possible.
+
 
 ### Address Validation Token Integrity {#token-integrity}
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1637,7 +1637,7 @@ able to reuse a token.  To avoid attacks that exploit this property, a server
 can limit its use of tokens to only the information needed validate client
 addresses.
 
-Fraudulently obtained tokens could enable botnets to use servers as amplifiers
+Fraudulently obtained tokens could enable attackers to use servers as amplifiers
 in DDOS attacks. Servers SHOULD protect against such attacks by ensuring that
 tokens are used by clients only once.
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1637,6 +1637,9 @@ able to reuse a token.  To avoid attacks that exploit this property, a server
 can limit its use of tokens to only the information needed validate client
 addresses.
 
+Fraudulently obtained tokens could enable botnets to use servers as amplifiers
+in DDOS attacks. Servers SHOULD protect against such attacks by ensuring that
+tokens are used by clients only once.
 
 ### Address Validation Token Integrity {#token-integrity}
 


### PR DESCRIPTION
We designed the Address Validation procedures to prevent QUIC servers from being used for UDP based DOS amplification attacks. By default, sending an Initial packet to a QUIC server results in up to 3 full size UDP packets sent back to the originating address, and perhaps several more if the server repeats packets on timeout. With address validation turned on, the server will only answer to Initial packets carrying a proof of origin, in the form of a "token". Once address is validated, servers are free to send many more than 3 packets in response to the Initial packets. I am concerned that the validation procedure can be bypassed with a replay attack.

Let's imagine that an attacker manages to locate itself close enough to its target to be able to observe an Initial/Retry exchange between the source address and a remote server, and obtain a copy of the Retry packet. The attacker now has enough information to manufacture an Initial packet that will pass address validation at the server, if sent from the spoofed address of the target. The attacker could then pass that information to a botnet. A large number of bots can send spoofed packets to the server, resulting in a massive attack against the target.

Whether the attack is plausible or not depends on how the server performs address validation. The current draft presents little guidance about that. If a server implementation simply verifies that the token was associated with the source address of the client, the botnet can run unimpeded. If the token also has some time to live, the attack will run unimpeded until that time. The attack will only be blocked if the server enforces that tokens are used only once, but the current draft does not require that.

I looked at how to modify the Picoquic implementation and protect against this attack. The simplest defense that I found was to embed in the ticket the Connection ID of the server. The connection ID is provided to the client as part of the retry packet, so that change is easy. Tokens could also be provided in New Token frames and sent by clients in Initial packet; the server could extract the CID from the token, and chose that for the new connection. The "server CID defense" is not perfect, but it ensures that the botnet will only be able to create one connection at a time. If tokens have a limited time to live, the attack is effectively thwarted.

I am not saying that all implementations should adopt the server CID defense. The goal is to prevent token reuse at the server, and there are certainly other ways to achieve that. I am just asking that we ask servers to prevent multiple reuses of the same token.