### PR TITLE
Refactor DetectLostPackets

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -687,8 +687,8 @@ Pseudocode for OnPacketSent follows:
    sent_packets[packet_number].time = now
    sent_packets[packet_number].retransmittable = retransmittable
    sent_packets[packet_number].in_flight = in_flight
-   if retransmittable:
-     if is_crypto_packet:
+   if (retransmittable):
+     if (is_crypto_packet):
        time_of_last_sent_crypto_packet = now
      time_of_last_sent_retransmittable_packet = now
      OnPacketSentCC(sent_bytes)
@@ -716,7 +716,7 @@ Pseudocode for OnAckReceived and UpdateRtt follow:
     for acked_packet in newly_acked_packets:
       OnPacketAcked(acked_packet.packet_number)
 
-    if !newly_acked_packets.empty():
+    if (!newly_acked_packets.empty()):
       // Find the smallest newly acknowledged packet
       smallest_newly_acked =
         FindSmallestNewlyAcked(newly_acked_packets)
@@ -876,7 +876,7 @@ DetectLostPackets(largest_acked):
   lost_pn = largest_acked.packet_number - kPacketThreshold
 
   foreach unacked in sent_packets:
-    if unacked.packet_number > largest_acked.packet_number:
+    if (unacked.packet_number > largest_acked.packet_number):
       continue
 
     // Mark packet as lost, or set time when it should be marked.

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -779,6 +779,9 @@ duration of the timer is based on the timer's mode, which is set in the packet
 and timer events further below.  The function SetLossDetectionTimer defined
 below shows how the single timer is set.
 
+This algorithm may result in the timer being set in the past, particularly if
+timers wake up late. Timers set in the past SHOULD fire immediately.
+
 Pseudocode for SetLossDetectionTimer follows:
 
 ~~~
@@ -895,10 +898,6 @@ DetectLostPackets(largest_acked):
   if (!lost_packets.empty()):
     OnPacketsLost(lost_packets)
 ~~~
-
-This algorithm results in loss_time being set based on the earliest packet that
-is still in flight.  Timers set based on a loss_time that has already passed
-need to fire immediately.
 
 ## Discussion
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -871,7 +871,7 @@ DetectLostPackets(largest_acked):
 
   // Packets sent before this time are deemed lost.
   lost_send_time = now() - loss_delay
-                   
+
   // Packets with packet numbers before this are deemed lost.
   lost_pn = largest_acked.packet_number - kPacketThreshold
 
@@ -888,7 +888,7 @@ DetectLostPackets(largest_acked):
     else if (loss_time == 0):
       loss_time = unacked.time_sent + loss_delay
     else:
-      loss_time = min(loss_time, unacked.time_sent + loss_delay)  
+      loss_time = min(loss_time, unacked.time_sent + loss_delay)
 
   // Inform the congestion controller of lost packets and
   // let it decide whether to retransmit immediately.

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -879,8 +879,8 @@ DetectLostPackets(largest_acked):
     if unacked.packet_number > largest_acked.packet_number:
       continue
 
-    if (unacked.time_sent < lost_send_time ||
-        unacked.packet_number < lost_pn):
+    if (unacked.time_sent <= lost_send_time ||
+        unacked.packet_number <= lost_pn):
       sent_packets.remove(unacked.packet_number)
       if (unacked.retransmittable):
         lost_packets.insert(unacked)


### PR DESCRIPTION
This had a couple of problems that I think this addresses, and some that
it doesn't.

The first is that it isn't clear what is being iterated over and in what
order.  I think that the point here is to iterate over sent_packets,
starting with the oldest.  Correct me if that is wrong.  In any case,
this change doesn't assume an iteration order.  The only reason the
iteration order is important is in setting loss_time, which needs to be
the earliest time (assuming that I'm right).

This simplifies the function, by setting thresholds at the top and doing
a simple comparison.

I've added a note about loss_time potentially being in the past.

The problem that remains is that this appeared to iterate only over
packets that have a packet number less than the largest acknowledged.
I've added that condition to the loop, but I don't think that it's
right.  I think that it's just redundant - and while an implementation
might stop its iteration at the largest acknowledged to save cycles,
this function will operate the same without the extra check.

It's also not clear whether the greater than comparisons here were
correct.  If you assume that firing of the timer cannot take zero time,
this is never an issue, but with discrete intervals on time values,
that's not always going to happen.  As setup, this code could be called
at exactly loss_time for a packet, in which case that packet will not be
declared lost.  I think that this wants >= in the time comparison for
that reason.

Finally, should the early retransmit timer be configurable?  Should it
be set based on kTimeReorderingThreshold?