### PR TITLE
Remove paragraph talking about retaining DCID

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -971,10 +971,6 @@ connection ID from use, it sends a RETIRE_CONNECTION_ID frame to its peer,
 indicating that the peer might bring a new connection ID into circulation using
 the NEW_CONNECTION_ID frame.
 
-An endpoint that retires a connection ID can retain knowledge of that connection
-ID for a period of time after sending the RETIRE_CONNECTION_ID frame, or until
-that frame is acknowledged.
-
 As discussed in {{migration-linkability}}, each connection ID MUST be used on
 packets sent from only one local address.  An endpoint that migrates away from a
 local address SHOULD retire all connection IDs used on that address once it no


### PR DESCRIPTION
The paragraph in question became what it is now in 391641ed60351d5685d5121b261059862dfd8e63.

Before CID sequence numbers, the endpoint that retired CIDs might have wanted to remember the CIDs it retired for some time to deduplicate _NEW_CONNECTION_ID_ frames.  Now this is no longer necessary and this paragraph is an oddity.