### PR TITLE
Initial prioritization of requests

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1007,11 +1007,16 @@ HTTP/3 uses a priority scheme similar to that described in {{!RFC7540}}, Section
 another request, which expresses the preference that the latter stream (the
 "parent" request) be allocated resources before the former stream (the
 "dependent" request). Taken together, the dependencies across all requests in a
-connection form a dependency tree. The structure of the dependency tree changes
-as PRIORITY frames add, remove, or change the dependency links between requests.
+connection form a dependency tree.
 
-The PRIORITY frame {{frame-priority}} identifies a prioritized element. The
-elements which can be prioritized are:
+When a client request is first sent or a placeholder first allocated, the
+element is dependent on the root of the priority tree. Pushed streams are
+initially dependent on the client request on which the PUSH_PROMISE frame was
+sent. In all cases, elements are assigned an initial weight of 16.
+
+The structure of the dependency tree changes as PRIORITY frames modify the
+dependency links between requests. The PRIORITY frame {{frame-priority}}
+identifies a prioritized element. The elements which can be prioritized are:
 
 - Requests, identified by the ID of the request stream
 - Pushes, identified by the Push ID of the promised resource
@@ -1021,6 +1026,10 @@ elements which can be prioritized are:
 An element can depend on another element or on the root of the tree.  A
 reference to an element which is no longer in the tree is treated as a reference
 to the root of the tree.
+
+Due to reordering between streams, an element can also be prioritized which is
+not yet in the tree. Such elements are added to the tree with the requested
+priority.
 
 ### Placeholders
 


### PR DESCRIPTION
Mostly fixes #1959, though there's some ambiguity unless we also take #2072.  If we don't, we'll sort out which PUSH_PROMISE "counts."  Separated from the PR originally in #2072.