### PR TITLE
Define initial PRIORITY frame and remove exclusive dependencies

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -551,10 +551,10 @@ the interpretation of the associated Element ID fields.
 
 Note that the root of the tree cannot be referenced using a Stream ID of 0, as
 in {{!RFC7540}}; QUIC stream 0 carries a valid HTTP request.  The root of the
-tree cannot be reprioritized. A PRIORITY frame that prioritizes the root of the
-tree or the control stream MUST be treated as a connection error of type
-HTTP_MALFORMED_FRAME.  A PRIORITY frame sent on a request stream that
+tree cannot be reprioritized. A PRIORITY frame sent on a request stream that
 prioritizes any other stream MUST be treated as a stream error of type
+HTTP_MALFORMED_FRAME.  Likewise, a PRIORITY frame sent on a control stream that
+prioritizes the current stream MUST be treated as a connection error of type
 HTTP_MALFORMED_FRAME.
 
 When a PRIORITY frame claims to reference a request, the associated ID MUST

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -469,12 +469,13 @@ HEADERS frames can only be sent on request / push streams.
 ### PRIORITY {#frame-priority}
 
 The PRIORITY (type=0x02) frame specifies the client-advised priority of a
-stream.  When opening a new request stream, a PRIORITY frame MAY be sent as the
-first frame of the stream.  In order to ensure that prioritization is processed
-in a consistent order, any subsequent PRIORITY frames MUST be sent on the
-control stream.  A PRIORITY frame received on a push stream, received after
-other frames on a request stream, or received by a client MUST be treated as a
-stream error of type HTTP_UNEXPECTED_FRAME.
+stream.
+
+When opening a new request stream, a PRIORITY frame MAY be sent as the first
+frame of the stream.  In order to ensure that prioritization is processed in a
+consistent order, any subsequent PRIORITY frames MUST be sent on the control
+stream.  A PRIORITY frame received after other frames on a request stream MUST
+be treated as a stream error of type HTTP_UNEXPECTED_FRAME.
 
 Subsequent PRIORITY frames sent on the control stream might arrive before
 PRIORITY frames sent on a request stream due to reordering.  PRIORITY frames on
@@ -565,6 +566,11 @@ A PRIORITY frame that references a non-existent Push ID or a Placeholder ID
 greater than the server's limit MUST be treated as an HTTP_MALFORMED_FRAME
 error.
 
+A PRIORITY frame received on any stream other than a request or control stream
+MUST be treated as a connection error of type HTTP_WRONG_STREAM.
+
+PRIORITY frames received by a client MUST be treated as a stream error of type
+HTTP_UNEXPECTED_FRAME.
 
 ### CANCEL_PUSH {#frame-cancel-push}
 

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -472,10 +472,11 @@ The PRIORITY (type=0x02) frame specifies the client-advised priority of a
 stream.
 
 When opening a new request stream, a PRIORITY frame MAY be sent as the first
-frame of the stream.  In order to ensure that prioritization is processed in a
-consistent order, any subsequent PRIORITY frames MUST be sent on the control
-stream.  A PRIORITY frame received after other frames on a request stream MUST
-be treated as a stream error of type HTTP_UNEXPECTED_FRAME.
+frame of the stream creating a dependency on an existing element.  In order to
+ensure that prioritization is processed in a consistent order, any subsequent
+PRIORITY frames MUST be sent on the control stream.  A PRIORITY frame received
+after other frames on a request stream MUST be treated as a stream error of type
+HTTP_UNEXPECTED_FRAME.
 
 Subsequent PRIORITY frames sent on the control stream might arrive before
 PRIORITY frames sent on a request stream due to reordering.  PRIORITY frames on
@@ -552,10 +553,11 @@ the interpretation of the associated Element ID fields.
 Note that the root of the tree cannot be referenced using a Stream ID of 0, as
 in {{!RFC7540}}; QUIC stream 0 carries a valid HTTP request.  The root of the
 tree cannot be reprioritized. A PRIORITY frame sent on a request stream that
-prioritizes any other stream MUST be treated as a stream error of type
-HTTP_MALFORMED_FRAME.  Likewise, a PRIORITY frame sent on a control stream that
-prioritizes the current stream MUST be treated as a connection error of type
-HTTP_MALFORMED_FRAME.
+prioritizes any other stream or expresses a dependency on a request with a
+greater Stream ID than the current stream MUST be treated as a stream error of
+type HTTP_MALFORMED_FRAME.  Likewise, a PRIORITY frame sent on a control stream
+that prioritizes the current stream MUST be treated as a connection error of
+type HTTP_MALFORMED_FRAME.
 
 When a PRIORITY frame claims to reference a request, the associated ID MUST
 identify a client-initiated bidirectional stream.  A server MUST treat receipt

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -552,12 +552,12 @@ the interpretation of the associated Element ID fields.
 
 Note that the root of the tree cannot be referenced using a Stream ID of 0, as
 in {{!RFC7540}}; QUIC stream 0 carries a valid HTTP request.  The root of the
-tree cannot be reprioritized. A PRIORITY frame sent on a request stream that
-prioritizes any other stream or expresses a dependency on a request with a
-greater Stream ID than the current stream MUST be treated as a stream error of
-type HTTP_MALFORMED_FRAME.  Likewise, a PRIORITY frame sent on a control stream
-that prioritizes the current stream MUST be treated as a connection error of
-type HTTP_MALFORMED_FRAME.
+tree cannot be reprioritized. A PRIORITY frame sent on a request stream with the
+Prioritized Element Type set to any value other than `11` or which expresses a
+dependency on a request with a greater Stream ID than the current stream MUST be
+treated as a stream error of type HTTP_MALFORMED_FRAME.  Likewise, a PRIORITY
+frame sent on a control stream with the Prioritized Element Type set to `11`
+MUST be treated as a connection error of type HTTP_MALFORMED_FRAME.
 
 When a PRIORITY frame claims to reference a request, the associated ID MUST
 identify a client-initiated bidirectional stream.  A server MUST treat receipt


### PR DESCRIPTION
Fixes #1865.  The observations from the issue discussion are:
- HTTP/2's "exclusive" prioritization (which make the prioritized element the sole child of the parent, making all current parents children of the prioritized element instead) is the cause of many ordering headaches and actually makes it impossible to guarantee an eventually-consistent view of priority between client and server.  Fundamentally, it changes the priority of elements which aren't mentioned in the frame, and that's annoying.
- If a PRIORITY frame gets delayed and a request is quickly processed, it may be processed immediately (default is pretty high) and only later be discovered to be unimportant.

In the absence of exclusive dependencies, it's possible for a request stream to carry its own initial priority, as @dtikhonov proposed.  This is guaranteed to be the first time that a priority is assigned to this request, and subsequent PRIORITY frames always override it.  (If a PRIORITY frame gets reordered ahead, this initial PRIORITY is ignored.)

This is a further departure from RFC 7540's priority scheme, but as it appears exclusive priorities and reordering are somewhat incompatible, I believe is still within our design space.