### PR TITLE
Initials carrying different first ClientHello are considered as belonging to different connections

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1037,8 +1037,17 @@ Servers MUST drop other packets that contain unsupported versions.
 
 Packets with a supported version, or no version field, are matched to a
 connection using the connection ID or - for packets with zero-length connection
-IDs - the address tuple.  If the packet doesn't match an existing connection,
-the server continues below.
+IDs - the address tuple, with the following exception.
+
+A server that uses a non-zero-length connection ID SHOULD handle Initial packets
+that share the same address tuple, Source and Destination Connection IDs, but
+contain different first ClientHello messages as belonging to different
+connections, so that an attacker racing a spoofed Initial packet to the server
+cannot disrupt the handshake.  The requirement can be met by remembering the
+length and the hashed payload of the CRYPTO frame starting at offset of zero for
+each connection, and by comparing the values against newly received packets.
+
+If the packet doesn't match an existing connection, the server continues below.
 
 If the packet is an Initial packet fully conforming with the specification, the
 server proceeds with the handshake ({{handshake}}). This commits the server to

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1042,7 +1042,7 @@ IDs - the address tuple, with the following exception.
 A server that uses a non-zero-length connection ID SHOULD handle Initial packets
 that share the same address tuple, Source and Destination Connection IDs, but
 contain different first ClientHello messages as belonging to different
-connections, so that an attacker racing a spoofed Initial packet to the server
+connections. This might be used by a client to defend against attacks that race spoofed Initial packets with legitimate ones.  A server can treat every Initial packet containing a CRYPTO frame at an offset of 0 as potentially creating a new connection, discarding any packet that has the same Destination Connection ID and CRYPTO frame content as one that has been answered.
 cannot disrupt the handshake.  The requirement can be met by remembering the
 length and the hashed payload of the CRYPTO frame starting at offset of zero for
 each connection, and by comparing the values against newly received packets.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1042,10 +1042,11 @@ IDs - the address tuple, with the following exception.
 A server that uses a non-zero-length connection ID SHOULD handle Initial packets
 that share the same address tuple, Source and Destination Connection IDs, but
 contain different first ClientHello messages as belonging to different
-connections. This might be used by a client to defend against attacks that race spoofed Initial packets with legitimate ones.  A server can treat every Initial packet containing a CRYPTO frame at an offset of 0 as potentially creating a new connection, discarding any packet that has the same Destination Connection ID and CRYPTO frame content as one that has been answered.
-cannot disrupt the handshake.  The requirement can be met by remembering the
-length and the hashed payload of the CRYPTO frame starting at offset of zero for
-each connection, and by comparing the values against newly received packets.
+connections.  This might be used by a client to defend against attacks that race
+spoofed Initial packets with legitimate ones.  A server can treat every Initial
+packet containing a CRYPTO frame at an offset of 0 as potentially creating a new
+connection, discarding any packet that has the same Destination Connection ID
+and CRYPTO frame content as one that has been answered.
 
 If the packet doesn't match an existing connection, the server continues below.
 


### PR DESCRIPTION
Based on https://www.ietf.org/mail-archive/web/quic/current/msg05093.html, implements countermeasures to prevent a man-on-the-side attacker disrupting the handshake by sending spoofed packets _to the server_.

The intent of the PR is to give the client (that is willing to pay the cost of complexity) the freehand to complete the handshake thereby establishing a connection even in the case where the attacker sends a spoofed packet to either of or both the endpoints.

Some notes:
* The PR says "SHOULD". This defense does not work for servers that uses zero-length CIDs, so I do not think we need to make it a MUST.
* The PR uses H(ClientHello) to distinguish connections instead of the alternative design suggested by @martinthomson to simply consider every Initial packet that contains a CRYPTO frame starting at offset zero as new connection. The reasoning is that we should better avoid creating multiple connection contexts on the server-side when the RTT is huge that a client sends multiple Initials.
* Adoption of #2053 is a prerequisite. We might want to change that PR to allow dropping individual frames rather than dropping per packet, because in the defense proposed here, the server's Initial that corresponds to the client's legitimate Initial might contain an ACK with an invalid PN. That happens when an attacker successfully races a spoofed packet with an identical CRYPTO frame but with a different PN.