### PR TITLE
Server Ignore VN Packets

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1108,7 +1108,9 @@ is a mutually supported version.
 
 If the version selected by the client is not acceptable to the server, the
 server responds with a Version Negotiation packet (see {{packet-version}}).
-This includes a list of versions that the server will accept.
+This includes a list of versions that the server will accept.  A server MUST NOT
+send a Version Negotiation packet in response to receiving a Version Negotiation
+packet because it could trigger and endless back and forth between two servers.
 
 This system allows a server to process packets with unsupported versions without
 retaining state.  Though either the Initial packet or the Version Negotiation

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1110,7 +1110,7 @@ If the version selected by the client is not acceptable to the server, the
 server responds with a Version Negotiation packet (see {{packet-version}}).
 This includes a list of versions that the server will accept.  A server MUST NOT
 send a Version Negotiation packet in response to receiving a Version Negotiation
-packet because it could trigger and endless back and forth between two servers.
+packet.
 
 This system allows a server to process packets with unsupported versions without
 retaining state.  Though either the Initial packet or the Version Negotiation

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1108,9 +1108,9 @@ is a mutually supported version.
 
 If the version selected by the client is not acceptable to the server, the
 server responds with a Version Negotiation packet (see {{packet-version}}).
-This includes a list of versions that the server will accept.  A server MUST NOT
-send a Version Negotiation packet in response to receiving a Version Negotiation
-packet.
+This includes a list of versions that the server will accept.  An endpoint MUST
+NOT send a Version Negotiation packet in response to receiving a Version
+Negotiation packet.
 
 This system allows a server to process packets with unsupported versions without
 retaining state.  Though either the Initial packet or the Version Negotiation


### PR DESCRIPTION
To prevent the possibility of two servers being tricked into sending endless VN packets between themselves, a server should never respond to a VN packet.