### PR TITLE
Repeat tokens in all Initial packets

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1549,8 +1549,8 @@ frame (see {{validate-future}}).
 Upon receiving the client's Initial packet, the server can request address
 validation by sending a Retry packet ({{packet-retry}}) containing a token. This
 token MUST be repeated by the client in all Initial packets it sends after it
-receives the Retry packet.  In response to receiving a token in an Initial
-packet, a server can either abort the connection or permit it to proceed.
+receives the Retry packet.  In response to processing an Initial containing a
+token, a server can either abort the connection or permit it to proceed.
 
 As long as it is not possible for an attacker to generate a valid token for
 its own address (see {{token-integrity}}) and the client is able to return

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1548,9 +1548,9 @@ frame (see {{validate-future}}).
 
 Upon receiving the client's Initial packet, the server can request address
 validation by sending a Retry packet ({{packet-retry}}) containing a token. This
-token MUST be repeated by the client in all Initial packets it sends after it receives the
-Retry packet.  In response to receiving a token in an Initial packet, a server
-can either abort the connection or permit it to proceed.
+token MUST be repeated by the client in all Initial packets it sends after it
+receives the Retry packet.  In response to receiving a token in an Initial
+packet, a server can either abort the connection or permit it to proceed.
 
 As long as it is not possible for an attacker to generate a valid token for
 its own address (see {{token-integrity}}) and the client is able to return

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1548,7 +1548,7 @@ frame (see {{validate-future}}).
 
 Upon receiving the client's Initial packet, the server can request address
 validation by sending a Retry packet ({{packet-retry}}) containing a token. This
-token is repeated by the client in all Initial packets after it receives the
+token MUST be repeated by the client in all Initial packets it sends after it receives the
 Retry packet.  In response to receiving a token in an Initial packet, a server
 can either abort the connection or permit it to proceed.
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1592,7 +1592,8 @@ connections.  The client includes this token in Initial packets to provide
 address validation in a future connection.  The client MUST include the
 token in all Initial packets it sends, unless a Retry replaces the token
 with a newer token. The client MUST NOT use the token provided in a Retry
-for future connections.
+for future connections. Servers MAY discard any Initial packet that does not
+carry the expected token.
 
 Unlike the token that is created for a Retry packet, there might be some time
 between when the token is created and when the token is subsequently used.


### PR DESCRIPTION
The client repeats the token in all Initial packets.  Also clarifies that the token is sent in Initial in a few spots.

https://www.ietf.org/mail-archive/web/quic/current/msg05071.html