### PR TITLE
create codec streams only when necessary

### DIFF
--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -581,12 +581,13 @@ HTTP_CLOSED_CRITICAL_STREAM.
 
 An endpoint MUST NOT create an encoder stream if the maximum size of the
 dynamic table permitted by the peer is zero.  Observation of a peer-initiated
-encoder stream when the value is zero MUST be treated as a connection error of
-type HTTP_QPACK_ENCODER_STREAM_ERROR.
+encoder stream without sending a non-zero value for SETTINGS_HEADER_TABLE_SIZE
+zero MUST be treated as a connection error of type
+HTTP_QPACK_ENCODER_STREAM_ERROR.
 
 An endpoint MUST NOT create a decoder stream until the peer opens an encoder
-stream.  Observation of a peer-initiated decoder stream that lacks the
-corresponding encoder stream MUST be treated as a connection error of type
+stream.  Observation of a peer-initiated decoder stream when no encoder stream
+has been initiated locally MUST be treated as a connection error of type
 HTTP_QPACK_DECODER_STREAM_ERROR.
 
 This section describes the instructions which are possible on each stream type.

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -573,11 +573,21 @@ instruction space:
    and push streams reference the QPACK table state.
 
 <!-- s/exactly/no more than/  ? -->
-There MUST be exactly one of each unidirectional stream type in each direction.
+There MUST be at most one of each unidirectional stream type in each direction.
 Receipt of a second instance of either stream type MUST be treated as a
 connection error of HTTP_WRONG_STREAM_COUNT.  Closure of either unidirectional
 stream MUST be treated as a connection error of type
 HTTP_CLOSED_CRITICAL_STREAM.
+
+An endpoint MUST NOT create an encoder stream if the maximum size of the
+dynamic table permitted by the peer is zero.  Observation of a peer-initiated
+encoder stream when the value is zero MUST be treated as a connection error of
+type HTTP_QPACK_ENCODER_STREAM_ERROR.
+
+An endpoint MUST NOT create a decoder stream until the peer opens an encoder
+stream.  Observation of a peer-initiated decoder stream that lacks the
+corresponding encoder stream MUST be treated as a connection error of type
+HTTP_QPACK_DECODER_STREAM_ERROR.
 
 This section describes the instructions which are possible on each stream type.
 


### PR DESCRIPTION
Now that #2038 is being merged, we have the possibility to avoid creating unnecessary encoder / decoder streams.

Avoiding creation them is beneficial for memory-constrained devices, because they can configure the QUIC transport stack to handle at most one unidirectional stream (in each direction) to support HTTP/3 _if_ the QPACK state forbids 1) peer's creation of the encoder stream when endpoint's `SETTINGS_HEADER_TABLE_SIZE:` is zero, and 2) peer's creation of decoder stream is delayed until the endpoint's creation of the encoder stream.

The PR clarifies the two requirements.

With the proposed changes, a memory constrained HTTP/3 stack that sends`SETTINGS_HEADER_TABLE_SIZE` of zero and never opens an encoder stream can be certain that the peer never opens an encoder stream or a decoder stream.

Note that the proposed change has minimal impact to existing implementations; regarding creation of the encoder stream, #2038 states that the stream cannot be used until SETTINGS is being received. This PR only merely clarifies that "use" includes the creation of the stream. The situation is the same for the decoder stream.