### PR TITLE
Allow the HTTP/3 DATA frame to extend to the end of the stream

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -447,8 +447,8 @@ connection error ({{errors}}) of type HTTP_WRONG_STREAM.
 {: #fig-data title="DATA frame payload"}
 
 DATA frames MUST contain a non-zero-length payload.  If a DATA frame is received
-with a payload length of zero, the recipient MUST respond with a stream error
-({{errors}}) of type HTTP_MALFORMED_FRAME.
+with a payload length of zero, the payload of the frame extends until the end
+of the stream.
 
 ### HEADERS {#frame-headers}
 

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -446,9 +446,8 @@ connection error ({{errors}}) of type HTTP_WRONG_STREAM.
 ~~~~~~~~~~
 {: #fig-data title="DATA frame payload"}
 
-DATA frames MUST contain a non-zero-length payload.  If a DATA frame is received
-with a payload length of zero, the payload of the frame extends until the end
-of the stream.
+If a DATA frame is received with a payload length of zero, the payload of the
+frame extends until the end of the stream.
 
 ### HEADERS {#frame-headers}
 


### PR DESCRIPTION
Allow the HTTP/3 DATA frame to extend to the end of the stream if the
frame's payload length is 0.

Fixes #1885.