### PR TITLE
Use "Insert Count" rather than "Largest Reference"

### DIFF
--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -800,9 +800,15 @@ HEADERS and PUSH_PROMISE frames on request and push streams reference the
 dynamic table in a particular state without modifying it.  Frames on these
 streams emit the headers for an HTTP request or response.
 
-### Header Data Prefix {#header-prefix}
+### Header Block Prefix {#header-prefix}
 
-Header data is prefixed with two integers, `Required Insert Count` and `Base`.
+Each header block is prefixed with two integers.  The Required Insert Count
+encoded as an integer with an 8-bit prefix after the encoding described in
+{{ric}}).  The Base is encoded as sign-and-modulus integer, using a single sign
+bit and a value with a 7-bit prefix (see {{base}}).
+
+These two values are followed by instructions for compressed headers.  The
+entire block is expected to be framed by the using protocol.
 
 ~~~~~~~~~~  drawing
   0   1   2   3   4   5   6   7
@@ -816,7 +822,7 @@ Header data is prefixed with two integers, `Required Insert Count` and `Base`.
 ~~~~~~~~~~
 {:#fig-base-index title="Frame Payload"}
 
-#### Required Insert Count
+#### Required Insert Count {#ric}
 
 Required Insert Count identifies the state of the dynamic table needed to
 process the header block successfully.  Blocking decoders use the Required
@@ -868,7 +874,7 @@ For example, if the dynamic table is 100 bytes, then the Required Insert Count
 will be encoded modulo 6.  If a decoder has received 10 inserts, then an encoded
 value of 3 indicates that the Required Insert Count is 9 for the header block.
 
-#### Base
+#### Base {#base}
 
 `Base` is used to resolve references in the dynamic table as described in
 {{relative-indexing}}.

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -713,21 +713,21 @@ The Table State Synchronize instruction begins with the '00' two-bit pattern.
 The instruction specifies the total number of dynamic table inserts and
 duplications since the last Table State Synchronize or Header Acknowledgement
 that increased the Known Received Count for the dynamic table (see
-{{known-received-count}}).  This is encoded as a 6-bit prefix integer. The
-encoder uses this value to determine which table entries might cause a stream to
-become blocked, as described in {{state-synchronization}}.
+{{known-received-count}}).  The Insert Count Delta is encoded as a 6-bit prefix
+integer. The encoder uses this value to determine which table entries might
+cause a stream to become blocked, as described in {{state-synchronization}}.
 
 ~~~~~~~~~~ drawing
   0   1   2   3   4   5   6   7
 +---+---+---+---+---+---+---+---+
-| 0 | 0 |   Insert Count (6+)   |
+| 0 | 0 |Insert Count Delta (6+)|
 +---+---+-----------------------+
 ~~~~~~~~~~
 {:#fig-size-sync title="Table State Synchronize"}
 
-An encoder that receives an Insert Count equal to zero or one that increases
-Known Received Count beyond what the encoder has sent MUST treat this as a
-connection error of type `HTTP_QPACK_DECODER_STREAM_ERROR`.
+An encoder that receives an Insert Count Delta equal to zero or one that
+increases the Known Received Count beyond what the encoder has sent MUST treat
+this as a connection error of type `HTTP_QPACK_DECODER_STREAM_ERROR`.
 
 ### Header Acknowledgement
 

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -299,8 +299,8 @@ acknowledgement to maintain the Known Received Count, as described in
 
 To acknowledge dynamic table entries which are not referenced by header blocks,
 for example because the encoder or the decoder have chosen not to risk blocked
-streams, the decoder sends a Table State Synchronize instruction (see
-{{table-state-synchronize}}).
+streams, the decoder sends a Insert Count Increment instruction (see
+{{insert-count-increment}}).
 
 
 ## Decoder
@@ -329,12 +329,12 @@ blocking (see {{blocked-insertion}}).  When a stream is reset or abandoned, the
 indication that these header blocks will never be processed serves a similar
 function; see {{stream-cancellation}}.
 
-The decoder chooses when to emit Table State Synchronize instructions (see
-{{table-state-synchronize}}). Emitting an instruction after adding each new
+The decoder chooses when to emit Insert Count Increment instructions (see
+{{insert-count-increment}}). Emitting an instruction after adding each new
 dynamic table entry will provide the most timely feedback to the encoder, but
-could be redundant with other decoder feedback. By delaying a Table State
-Synchronize instruction, the decoder might be able to coalesce multiple Table
-State Synchronize instructions, or replace them entirely with Header
+could be redundant with other decoder feedback. By delaying a Insert Count
+Increment instruction, the decoder might be able to coalesce multiple Insert
+Count Increment instructions, or replace them entirely with Header
 Acknowledgements (see {{header-acknowledgement}}). However, delaying too long
 may lead to compression inefficiencies if the encoder waits for an entry to be
 acknowledged before using it.
@@ -707,27 +707,27 @@ header blocks and table updates.
 The contents of the decoder stream are an unframed sequence of the following
 instructions.
 
-### Table State Synchronize
+### Insert Count Increment
 
-The Table State Synchronize instruction begins with the '00' two-bit pattern.
+The Insert Count Increment instruction begins with the '00' two-bit pattern.
 The instruction specifies the total number of dynamic table inserts and
-duplications since the last Table State Synchronize or Header Acknowledgement
+duplications since the last Insert Count Increment or Header Acknowledgement
 that increased the Known Received Count for the dynamic table (see
-{{known-received-count}}).  The Insert Count Delta is encoded as a 6-bit prefix
+{{known-received-count}}).  The Increment field is encoded as a 6-bit prefix
 integer. The encoder uses this value to determine which table entries might
 cause a stream to become blocked, as described in {{state-synchronization}}.
 
 ~~~~~~~~~~ drawing
   0   1   2   3   4   5   6   7
 +---+---+---+---+---+---+---+---+
-| 0 | 0 |Insert Count Delta (6+)|
+| 0 | 0 |     Increment (6+)    |
 +---+---+-----------------------+
 ~~~~~~~~~~
-{:#fig-size-sync title="Table State Synchronize"}
+{:#fig-size-sync title="Insert Count Increment"}
 
-An encoder that receives an Insert Count Delta equal to zero or one that
-increases the Known Received Count beyond what the encoder has sent MUST treat
-this as a connection error of type `HTTP_QPACK_DECODER_STREAM_ERROR`.
+An encoder that receives an Increment field equal to zero or one that increases
+the Known Received Count beyond what the encoder has sent MUST treat this as a
+connection error of type `HTTP_QPACK_DECODER_STREAM_ERROR`.
 
 ### Header Acknowledgement
 

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -213,7 +213,7 @@ acknowledged by the decoder.
 An encoder MUST NOT insert an entry into the dynamic table (or duplicate an
 existing entry) if doing so would evict an entry with unacknowledged references.
 For header blocks that might rely on the newly added entry, the encoder can use
-a literal representation and maybe insert the entry later.
+a literal representation.
 
 To ensure that the encoder is not prevented from adding new entries, the encoder
 can avoid referencing entries that are close to eviction.  Rather than

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -452,14 +452,14 @@ referenced by a given relative index will change while interpreting instructions
 on the encoder stream.
 
 ~~~~~ drawing
-      +---+---------------+-----------+
-      | n |      ...      |     d     |  Absolute Index
-      + - +---------------+ - - - - - +
-      | 0 |      ...      | n - d - 1 |  Relative Index
-      +---+---------------+-----------+
-      ^                               |
-      |                               V
-Insertion Point                 Dropping Point
+      +-----+---------------+-------+
+      | n-1 |      ...      |   d   |  Absolute Index
+      + - - +---------------+ - - - +
+      |  0  |      ...      | n-d-1 |  Relative Index
+      +-----+---------------+-------+
+      ^                             |
+      |                             V
+Insertion Point               Dropping Point
 
 n = count of entries inserted
 d = count of entries dropped
@@ -475,7 +475,7 @@ The Base is encoded as a value relative to the Required Insert Count. The Base
 identifies which dynamic table entries can be referenced using relative
 indexing, starting with 0 at the last entry added.
 
-Post-base references are used for entries inserted after base, starting at 0 for
+Post-Base references are used for entries inserted after base, starting at 0 for
 the first entry added after Base, see {{post-base}}.
 
 ~~~~~ drawing
@@ -802,7 +802,7 @@ streams emit the headers for an HTTP request or response.
 
 ### Header Block Prefix {#header-prefix}
 
-Each header block is prefixed with two integers.  The Required Insert Count
+Each header block is prefixed with two integers.  The Required Insert Count is
 encoded as an integer with an 8-bit prefix after the encoding described in
 {{ric}}).  The Base is encoded as sign-and-modulus integer, using a single sign
 bit and a value with a 7-bit prefix (see {{base}}).
@@ -850,7 +850,8 @@ decoder (see {{maximum-table-size}}).
 
 
 The decoder reconstructs the Required Insert Count using the following
-algorithm:
+algorithm, where TotalNumberOfInserts is the total number of inserts into the
+decoder's dynamic table:
 
 ~~~
    if EncodedInsertCount == 0:
@@ -869,9 +870,7 @@ algorithm:
       ReqInsertCount += TotalNumberOfInserts - CurrentWrapped
 ~~~
 
-Where TotalNumberOfInserts is the total number of inserts into the decoder's
-dynamic table.  This encoding limits the length of the prefix on long-lived
-connections.
+This encoding limits the length of the prefix on long-lived connections.
 
 For example, if the dynamic table is 100 bytes, then the Required Insert Count
 will be encoded modulo 6.  If a decoder has received 10 inserts, then an encoded
@@ -908,8 +907,7 @@ Required Insert Count and Base to the same value.  In such case, both the sign
 bit and the Delta Base will be set to zero.
 
 A header block that does not reference the dynamic table can use any value for
-Base; setting both Required Insert Count and Delta Base to zero is the most
-efficient encoding.
+Base; setting Delta Base to zero is the most efficient encoding.
 
 For example, with an Required Insert Count of 9, a decoder receives a S bit of 1
 and a Delta Base of 2.  This sets the Base to 6 and enables post-base indexing

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -466,18 +466,17 @@ d = count of entries dropped
 ~~~~~
 {: title="Example Dynamic Table Indexing - Control Stream"}
 
-Because frames from request streams can be delivered out of order with
-instructions on the encoder stream, relative indices are relative to the Base at
-the beginning of the header block (see {{header-prefix}}). The Base is encoded
-as a value relative to the Required Insert Count. The Base identifies which
-dynamic table entries can be referenced using relative indexing, starting with 0
-at the last entry added.
+Unlike on the encoder stream, relative indices on push and request streams are
+relative to the Base at the beginning of the header block (see
+{{header-prefix}}). This ensures that references are stable even if the dynamic
+table is updated while decoding a header block.
+
+The Base is encoded as a value relative to the Required Insert Count. The Base
+identifies which dynamic table entries can be referenced using relative
+indexing, starting with 0 at the last entry added.
 
 Post-base references are used for entries inserted after base, starting at 0 for
 the first entry added after Base, see {{post-base}}.
-
-Though new entries could be added while processing a header block, the relative
-indices of entries do not change.
 
 ~~~~~ drawing
  Required

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -299,7 +299,7 @@ acknowledgement to maintain the Known Received Count, as described in
 
 To acknowledge dynamic table entries which are not referenced by header blocks,
 for example because the encoder or the decoder have chosen not to risk blocked
-streams, the decoder sends a Insert Count Increment instruction (see
+streams, the decoder sends an Insert Count Increment instruction (see
 {{insert-count-increment}}).
 
 
@@ -332,7 +332,7 @@ function; see {{stream-cancellation}}.
 The decoder chooses when to emit Insert Count Increment instructions (see
 {{insert-count-increment}}). Emitting an instruction after adding each new
 dynamic table entry will provide the most timely feedback to the encoder, but
-could be redundant with other decoder feedback. By delaying a Insert Count
+could be redundant with other decoder feedback. By delaying an Insert Count
 Increment instruction, the decoder might be able to coalesce multiple Insert
 Count Increment instructions, or replace them entirely with Header
 Acknowledgements (see {{header-acknowledgement}}). However, delaying too long

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -481,14 +481,14 @@ the first entry added after the Base, see {{post-base}}.
 ~~~~~ drawing
  Required
   Insert
-  Count      Base
-    |         |
-    V         V
-    +---+-----+-----+-----+-------+
-    | n | n-1 | n-2 | ... |   d   |  Absolute Index
-    +---+-----+  -  +-----+   -   +
-              |  0  | ... | n-d-3 |  Relative Index
-              +-----+-----+-------+
+  Count        Base
+    |           |
+    V           V
+    +-----+-----+-----+-----+-------+
+    | n-1 | n-2 | n-3 | ... |   d   |  Absolute Index
+    +-----+-----+  -  +-----+   -   +
+                |  0  | ... | n-d-3 |  Relative Index
+                +-----+-----+-------+
 
 n = count of entries inserted
 d = count of entries dropped
@@ -507,14 +507,14 @@ as absolute indices, with the zero value being the first entry inserted after
 the Base.
 
 ~~~~~ drawing
-             Base
-              |
-              V
-    +---+-----+-----+-----+-----+
-    | n | n-1 | n-2 | ... |  d  |  Absolute Index
-    +---+-----+-----+-----+-----+
-    | 1 |  0  |                    Post-Base Index
-    +---+-----+
+               Base
+                |
+                V
+    +-----+-----+-----+-----+-----+
+    | n-1 | n-2 | n-3 | ... |  d  |  Absolute Index
+    +-----+-----+-----+-----+-----+
+    |  1  |  0  |                    Post-Base Index
+    +-----+-----+
 
 n = count of entries inserted
 d = count of entries dropped

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -437,7 +437,7 @@ frame.
 
 Each entry possesses both an absolute index which is fixed for the lifetime of
 that entry and a relative index which changes based on the context of the
-reference. The first entry inserted has an absolute index of "1"; indices
+reference. The first entry inserted has an absolute index of "0"; indices
 increase sequentially with each insertion.
 
 ### Relative Indexing
@@ -453,7 +453,7 @@ on the encoder stream.
 
 ~~~~~ drawing
       +---+---------------+-----------+
-      | n |      ...      |   d + 1   |  Absolute Index
+      | n |      ...      |     d     |  Absolute Index
       + - +---------------+ - - - - - +
       | 0 |      ...      | n - d - 1 |  Relative Index
       +---+---------------+-----------+
@@ -485,7 +485,7 @@ the first entry added after Base, see {{post-base}}.
     |         |
     V         V
     +---+-----+-----+-----+-------+
-    | n | n-1 | n-2 | ... |  d+1  |  Absolute Index
+    | n | n-1 | n-2 | ... |   d   |  Absolute Index
     +---+-----+  -  +-----+   -   +
               |  0  | ... | n-d-3 |  Relative Index
               +-----+-----+-------+
@@ -511,7 +511,7 @@ Base.
               |
               V
     +---+-----+-----+-----+-----+
-    | n | n-1 | n-2 | ... | d+1 |  Absolute Index
+    | n | n-1 | n-2 | ... |  d  |  Absolute Index
     +---+-----+-----+-----+-----+
     | 1 |  0  |                    Post-Base Index
     +---+-----+
@@ -526,7 +526,7 @@ d = count of entries dropped
 
 If the decoder encounters a reference on a request or push stream to a dynamic
 table entry which has already been evicted or which has an absolute index
-greater than allowed by the declared Required Insert Count (see
+greater than or equal to the declared Required Insert Count (see
 {{header-prefix}}), it MUST treat this as a stream error of type
 `HTTP_QPACK_DECOMPRESSION_FAILED`.
 
@@ -822,13 +822,16 @@ entire block is expected to be framed by the using protocol.
 ~~~~~~~~~~
 {:#fig-base-index title="Frame Payload"}
 
+
 #### Required Insert Count {#ric}
 
 Required Insert Count identifies the state of the dynamic table needed to
 process the header block successfully.  Blocking decoders use the Required
-Insert Count to determine when it is safe to process the rest of the block.  If
-Required Insert Count is greater than zero, the encoder transforms it as follows
-before encoding:
+Insert Count to determine when it is safe to process the rest of the block.
+
+If no references are made to the dynamic table, a value of 0 is encoded.
+Alternatively, where the Required Insert Count is greater than zero, the encoder
+transforms it as follows before encoding:
 
 ~~~
    EncodedInsertCount = (ReqInsertCount mod (2 * MaxEntries)) + 1

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -996,9 +996,9 @@ static (S=1) or dynamic (S=0) table.
 
 ### Literal Header Field With Post-Base Name Reference
 
-For entries in the dynamic table with an absolute index greater than the Base,
-the header field name is represented using the post-base index of that entry
-(see {{post-base}}) encoded as an integer with a 3-bit prefix.
+For entries in the dynamic table with an absolute index greater than or equal to
+the Base, the header field name is represented using the post-base index of that
+entry (see {{post-base}}) encoded as an integer with a 3-bit prefix.
 
 ~~~~~~~~~~ drawing
      0   1   2   3   4   5   6   7

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -294,7 +294,7 @@ the decoder.  The Known Received Count tracks the total number of acknowledged
 insertions.
 
 When blocking references are permitted, the encoder uses header block
-acknowledgement to identify the Known Received Count, as described in
+acknowledgement to maintain the Known Received Count, as described in
 {{header-acknowledgement}}.
 
 To acknowledge dynamic table entries which are not referenced by header blocks,
@@ -476,7 +476,7 @@ identifies which dynamic table entries can be referenced using relative
 indexing, starting with 0 at the last entry added.
 
 Post-Base references are used for entries inserted after base, starting at 0 for
-the first entry added after Base, see {{post-base}}.
+the first entry added after the Base, see {{post-base}}.
 
 ~~~~~ drawing
  Required
@@ -504,7 +504,7 @@ single pass and include references to entries added while processing this (or
 other) header blocks. Newly added entries are referenced using Post-Base
 instructions. Indices for Post-Base instructions increase in the same direction
 as absolute indices, with the zero value being the first entry inserted after
-Base.
+the Base.
 
 ~~~~~ drawing
              Base
@@ -826,8 +826,8 @@ entire block is expected to be framed by the using protocol.
 #### Required Insert Count {#ric}
 
 Required Insert Count identifies the state of the dynamic table needed to
-process the header block successfully.  Blocking decoders use the Required
-Insert Count to determine when it is safe to process the rest of the block.
+process the header block.  Blocking decoders use the Required Insert Count to
+determine when it is safe to process the rest of the block.
 
 If no references are made to the dynamic table, a value of 0 is encoded.
 Alternatively, where the Required Insert Count is greater than zero, the encoder
@@ -878,14 +878,14 @@ value of 3 indicates that the Required Insert Count is 9 for the header block.
 
 #### Base {#base}
 
-`Base` is used to resolve references in the dynamic table as described in
+The `Base` is used to resolve references in the dynamic table as described in
 {{relative-indexing}}.
 
-To save space, Base is encoded relative to the Insert Count using a one-bit sign
-and the `Delta Base` value.  A sign bit of 0 indicates that the Base is greater
-than or equal to the value of the Insert Count; the value of Delta Base is added
-to the Insert Count to determine the value of the Base.  A sign bit of 1
-indicates that the Base is less than the Insert Count.  That is:
+To save space, the Base is encoded relative to the Insert Count using a one-bit
+sign and the `Delta Base` value.  A sign bit of 0 indicates that the Base is
+greater than or equal to the value of the Insert Count; the value of Delta Base
+is added to the Insert Count to determine the value of the Base.  A sign bit of
+1 indicates that the Base is less than the Insert Count.  That is:
 
 ~~~
    if S == 0:
@@ -899,15 +899,15 @@ the encoder inserted entries in the dynamic table while encoding the header
 block, Required Insert Count will be greater than the Base, so the encoded
 difference is negative and the sign bit is set to 1.  If the header block did
 not reference the most recent entry in the table and did not insert any new
-entries, Base will be greater than the Required Insert Count, so the delta will
-be positive and the sign bit is set to 0.
+entries, the Base will be greater than the Required Insert Count, so the delta
+will be positive and the sign bit is set to 0.
 
 An encoder that produces table updates before encoding a header block might set
-Required Insert Count and Base to the same value.  In such case, both the sign
-bit and the Delta Base will be set to zero.
+Required Insert Count and the Base to the same value.  In such case, both the
+sign bit and the Delta Base will be set to zero.
 
 A header block that does not reference the dynamic table can use any value for
-Base; setting Delta Base to zero is the most efficient encoding.
+the Base; setting Delta Base to zero is the most efficient encoding.
 
 For example, with an Required Insert Count of 9, a decoder receives a S bit of 1
 and a Delta Base of 2.  This sets the Base to 6 and enables post-base indexing
@@ -940,10 +940,11 @@ field is represented as an integer with a 6-bit prefix (see Section 5.1 of
 
 ### Indexed Header Field With Post-Base Index
 
-If the entry is in the dynamic table with an absolute index greater than Base,
-the representation starts with the '0001' 4-bit pattern, followed by the
-post-base index (see {{post-base}}) of the matching header field, represented as
-an integer with a 4-bit prefix (see Section 5.1 of [RFC7541]).
+If the entry is in the dynamic table with an absolute index greater than or
+equal to the Base, the representation starts with the '0001' 4-bit pattern,
+followed by the post-base index (see {{post-base}}) of the matching header
+field, represented as an integer with a 4-bit prefix (see Section 5.1 of
+[RFC7541]).
 
 ~~~~~~~~~~ drawing
   0   1   2   3   4   5   6   7
@@ -963,7 +964,8 @@ table or the dynamic table.
 If the entry is in the static table, or in the dynamic table with an absolute
 index less than the Base, this representation starts with the '01' two-bit
 pattern.  If the entry is in the dynamic table with an absolute index greater
-than the Base, the representation starts with the '0000' four-bit pattern.
+than or equal to the Base, the representation starts with the '0000' four-bit
+pattern.
 
 The following bit, 'N', indicates whether an intermediary is permitted to add
 this header to the dynamic header table on subsequent hops. When the 'N' bit is


### PR DESCRIPTION
The construction of largest reference currently implies the use of
1-based indexing, which is unnatural.  Using the insert count is much
more natural, even if it means the encoding is a little strange and a
tiny bit inefficient (it goes 0, 2, 3, ..., Max-1, 1, 2, ...).

I've gone through and put the references on the boundary between
records, which makes explanations much easier for post-base indexing in
my view.  I've renamed Base Index (which was never really an index) to
Base, which matches that change.  Similarly, renaming Largest Known
Received to Known Received Count makes it match better.

There are also examples added to Insert Count and Base sections.  These
definitions are pretty damned opaque without them.

Closes #2110.