### PR TITLE
Fix to ECN section regarding validation

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3043,7 +3043,8 @@ retransmission timeout due to the absence of acknowledgments from the peer (see
 {{QUIC-RECOVERY}}), or if an endpoint has reason to believe that an element on
 the network path might be corrupting ECN codepoints, the endpoint MAY cease
 setting ECT codepoints in subsequent packets. Doing so allows the connection to
-traverse network elements that drop or corrupt ECN codepoints in the IP header.
+traverse network elements that drop IP packets with ECT or CE markings or
+corrupt ECN codepoints in the IP header.
 
 
 # Packet Size {#packet-size}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3028,9 +3028,13 @@ frame is received:
   Not-ECT.
 
 If the sender does not have state to determine if a particular packet number is
-newly acknowledged or not, then the comparison SHOULD NOT be performed. By the
-end of the verification process the local reference counter must have be updated
-to include the newly acknowledged packets.
+newly acknowledged or not, then the verifications using this acknowledgement
+cannot be performed. If an acknowledgement arrive with a packet number that
+isn't the highest to arrived so far, i.e. some reordering has occured, then the
+verification may fail erronously. To prevent this the sender MUST NOT perform
+ECN verification using older acknwoeldgements. By the end of the verification
+process the local reference counter must have be updated to include the newly
+acknowledged packets.
 
 An endpoint could miss acknowledgements for a packet when ACK frames are lost.
 It is therefore possible for the total increase in ECT(0), ECT(1), and CE

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3019,18 +3019,18 @@ frame is received:
 
 * The increase in ECT(0) and ECT(1) counters MUST be at least the number of QUIC
   packets newly acknowledged that were sent with the corresponding codepoint
-  minus the increase in the CE counter. This detects network remarking
-  between ECT(0) and ECT(1).
+  minus the increase in the CE counter. This detects network remarking between
+  ECT(0) and ECT(1).
 
 * The total increase in ECT(0), ECT(1), and CE counters reported in the ACK
   frame MUST be at least the total number of QUIC packets newly acknowledged in
-  this ACK frame. This detects if the network remark ECT(0), ECT(1) or CE to
+  this ACK frame. This detects if the network changes ECT(0), ECT(1) or CE to
   Not-ECT.
 
-If a sender receives an ACK that contains no new acknowledgments, for example
-due to reordering of the ACKs, then ECN counter comparison SHOULD NOT be
-performed. If the sender does not have state to determine if a particular PSN
-is newly acknowledged or not, then the comparison SHOULD NOT be performed.
+If the sender does not have state to determine if a particular packet number is
+newly acknowledged or not, then the comparison SHOULD NOT be performed. By the
+end of the verification process the local reference counter must have be updated
+to include the newly acknowledged packets.
 
 An endpoint could miss acknowledgements for a packet when ACK frames are lost.
 It is therefore possible for the total increase in ECT(0), ECT(1), and CE

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3019,11 +3019,13 @@ frame is received:
 
 * The increase in ECT(0) and ECT(1) counters MUST be at least the number of QUIC
   packets newly acknowledged that were sent with the corresponding codepoint
-  minus the increase in the CE counter.
+  minus the increase in the CE counter. Detects network remarking
+  between ECT(0) and ECT(1).
 
 * The total increase in ECT(0), ECT(1), and CE counters reported in the ACK
   frame MUST be at least the total number of QUIC packets newly acknowledged in
-  this ACK frame.
+  this ACK frame. Detects if the network remark ECT(0), ECT(1) or CE to
+  Not-ECT.
 
 An endpoint could miss acknowledgements for a packet when ACK frames are lost.
 It is therefore possible for the total increase in ECT(0), ECT(1), and CE

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3013,9 +3013,9 @@ an ACK frame without ECN feedback, the endpoint stops setting ECT codepoints in
 subsequent IP packets, with the expectation that either the network path or the
 peer no longer supports ECN.
 
-To protect the connection from arbitrary corruption of ECN codepoints by
-elements on the network path, an endpoint verifies the following when an ACK
-frame is received:
+To reduce the risk of non-standard compliant ECN markings affecting the
+operation of an endpoint, an endpoint verifies the counts it receives when it
+receives new acknowledgements:
 
 * The increase in ECT(0) and ECT(1) counters MUST be at least the number of QUIC
   packets newly acknowledged that were sent with the corresponding codepoint
@@ -3027,14 +3027,13 @@ frame is received:
   this ACK frame. This detects if the network changes ECT(0), ECT(1) or CE to
   Not-ECT.
 
-If the sender does not have state to determine if a particular packet number is
-newly acknowledged or not, then the verifications using this acknowledgement
-cannot be performed. If an acknowledgement arrive with a packet number that
-isn't the highest to arrived so far, i.e. some reordering has occured, then the
-verification may fail erronously. To prevent this the sender MUST NOT perform
-ECN verification using older acknwoeldgements. By the end of the verification
-process the local reference counter must have be updated to include the newly
-acknowledged packets.
+This validation is only performed if the ACK frame increases the largest
+received packet number. Reordered acknowledgments could have lower counter
+values and might not be successfully validated as a result.
+
+These counts might be inflated if acknowledgments are never received for packets
+that were successfully delivered. If validation succeeds, an endpoint MUST
+increase its expected counter values to those it receives.
 
 An endpoint could miss acknowledgements for a packet when ACK frames are lost.
 It is therefore possible for the total increase in ECT(0), ECT(1), and CE

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3018,7 +3018,8 @@ elements on the network path, an endpoint verifies the following when an ACK
 frame is received:
 
 * The increase in ECT(0) and ECT(1) counters MUST be at least the number of QUIC
-  packets newly acknowledged that were sent with the corresponding codepoint.
+  packets newly acknowledged that were sent with the corresponding codepoint
+  minus the increase in the CE counter.
 
 * The total increase in ECT(0), ECT(1), and CE counters reported in the ACK
   frame MUST be at least the total number of QUIC packets newly acknowledged in

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3027,6 +3027,11 @@ frame is received:
   this ACK frame. Detects if the network remark ECT(0), ECT(1) or CE to
   Not-ECT.
 
+If a sender receives an ACK that contains no new acknowledgments, for example
+due to reordering of the ACKs, then ECN counter comparison SHOULD NOT be
+performed. Also if sender do not have state to determine if a particular PSN
+is newly acknowledge or not, then the comparison SHOULD NOT be performed.
+
 An endpoint could miss acknowledgements for a packet when ACK frames are lost.
 It is therefore possible for the total increase in ECT(0), ECT(1), and CE
 counters to be greater than the number of packets acknowledged in an ACK frame.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3019,18 +3019,18 @@ frame is received:
 
 * The increase in ECT(0) and ECT(1) counters MUST be at least the number of QUIC
   packets newly acknowledged that were sent with the corresponding codepoint
-  minus the increase in the CE counter. Detects network remarking
+  minus the increase in the CE counter. This detects network remarking
   between ECT(0) and ECT(1).
 
 * The total increase in ECT(0), ECT(1), and CE counters reported in the ACK
   frame MUST be at least the total number of QUIC packets newly acknowledged in
-  this ACK frame. Detects if the network remark ECT(0), ECT(1) or CE to
+  this ACK frame. This detects if the network remark ECT(0), ECT(1) or CE to
   Not-ECT.
 
 If a sender receives an ACK that contains no new acknowledgments, for example
 due to reordering of the ACKs, then ECN counter comparison SHOULD NOT be
-performed. Also if sender do not have state to determine if a particular PSN
-is newly acknowledge or not, then the comparison SHOULD NOT be performed.
+performed. If the sender does not have state to determine if a particular PSN
+is newly acknowledged or not, then the comparison SHOULD NOT be performed.
 
 An endpoint could miss acknowledgements for a packet when ACK frames are lost.
 It is therefore possible for the total increase in ECT(0), ECT(1), and CE


### PR DESCRIPTION
An issue with validation was identified. The first bullet of validation is intended to check so that the ECT code point (0 or 1) are not changed to the other. However, when an ACK includes new CE marks the comparison must deduct those CE marks to not wrongly report a mismatch. 

Also fixed a sentence indicating that is unclear about what is dropped. ECN field value of not-ect could rarely result in that the IP packet to be dropped. 