### PR TITLE
Unify TLP and RTO into Probe Timeout

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -371,8 +371,7 @@ increases loss detection delay.
 
 Timeout loss detection recovers from losses that cannot be handled by
 ack-based loss detection.  It uses a single timer which switches between
-a crypto retransmission timer, a Tail Loss Probe timer and Retransmission
-Timeout mechanisms.
+a crypto retransmission timer and a Probe timer.
 
 ### Crypto Retransmission Timeout
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -433,7 +433,7 @@ flight but an acknowledgement is not received within the expected period of
 time.  A PTO enables a connection to recover from loss of tail packets or acks.
 The PTO algorithm used in QUIC implements the reliability functions of Tail Loss
 Probe {{?TLP=I-D.dukkipati-tcpm-tcp-loss-probe}}, RTO {{?RFC5681}} and F-RTO
-algorithms for TCP {{?RFC5682}}, and the computation is based on TCP's
+algorithms for TCP {{?RFC5682}}, and the timeout computation is based on TCP's
 retransmission timeout period {{?RFC6298}}.
 
 #### Computing PTO
@@ -475,14 +475,15 @@ consecutive PTO expiration due to a single packet loss.
 Consecutive PTO periods increase exponentially, and as a result, connection
 recovery latency increases exponentially as packets continue to be dropped in
 the network.  Sending two packets on PTO expiration increases resilience to
-packet drop, thus reducing the probability of consecutive PTO events.
+packet drops, thus reducing the probability of consecutive PTO events.
 
 Probe packets sent on a PTO MUST be ack-eliciting.  A probe packet SHOULD carry
 new data when possible.  A probe packet MAY carry retransmitted unacknowledged
 data when new data is unavailable, when flow control does not permit new data to
-be sent, or to opportunistically reduce loss recovery delay.  Implementers MAY
-use alternate strategies for determining the content of probe packets, including
-sending new or retransmitted data based on the application's priorities.
+be sent, or to opportunistically reduce loss recovery delay.  Implementations
+MAY use alternate strategies for determining the content of probe packets,
+including sending new or retransmitted data based on the application's
+priorities.
 
 
 #### Loss Detection {#pto-loss}

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -768,7 +768,7 @@ Pseudocode for SetLossDetectionTimer follows:
         timeout = 2 * kInitialRtt
       else:
         timeout = 2 * smoothed_rtt
-      timeout = max(timeout, granularity)
+      timeout = max(timeout, kGranularity)
       timeout = timeout * (2 ^ crypto_count)
       loss_detection_timer.set(
         time_of_last_sent_crypto_packet + timeout)
@@ -781,7 +781,7 @@ Pseudocode for SetLossDetectionTimer follows:
     // Calculate PTO duration
     timeout =
       smoothed_rtt + 4 * rttvar + max_ack_delay
-    timeout = max(timeout, granularity)
+    timeout = max(timeout, kGranularity)
     timeout = timeout * (2 ^ pto_count)
 
     loss_detection_timer.set(

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -432,9 +432,9 @@ A Probe Timeout (PTO) triggers a probe packet when ack-eliciting data is in
 flight but an acknowledgement is not received within the expected period of
 time.  A PTO enables a connection to recover from loss of tail packets or acks.
 The PTO algorithm used in QUIC implements the reliability functions of Tail Loss
-Probe {{?TLP=I-D.dukkipati-tcpm-tcp-loss-probe}}, RTO {{?RFC5681}} and F-RTO
-algorithms for TCP {{?RFC5682}}, and the timeout computation is based on TCP's
-retransmission timeout period {{?RFC6298}}.
+Probe {{?TLP=I-D.dukkipati-tcpm-tcp-loss-probe}} {{?RACK}}, RTO {{?RFC5681}} and
+F-RTO algorithms for TCP {{?RFC5682}}, and the timeout computation is based on
+TCP's retransmission timeout period {{?RFC6298}}.
 
 #### Computing PTO
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -429,11 +429,10 @@ a subsequent connection attempt to the server.
 
 A Probe Timeout (PTO) triggers a probe packet when ack-eliciting data is in
 flight but an acknowledgement is not received within the expected period of
-time.  A PTO enables a connection to recover from loss of tail packets or acks,
-where acks of subsequent packets are not available to trigger ack-based loss
-detection.  The PTO algorithm used in QUIC implements the reliability functions
-of Tail Loss Probe {{?TLP=I-D.dukkipati-tcpm-tcp-loss-probe}}, RTO {{?RFC5681}}
-and F-RTO algorithms for TCP {{?RFC5682}}, and the computation is based on TCP's
+time.  A PTO enables a connection to recover from loss of tail packets or acks.
+The PTO algorithm used in QUIC implements the reliability functions of Tail Loss
+Probe {{?TLP=I-D.dukkipati-tcpm-tcp-loss-probe}}, RTO {{?RFC5681}} and F-RTO
+algorithms for TCP {{?RFC5682}}, and the computation is based on TCP's
 retransmission timeout period {{?RFC6298}}.
 
 #### Computing PTO
@@ -441,7 +440,9 @@ retransmission timeout period {{?RFC6298}}.
 When an ack-eliciting packet is transmitted, the sender schedules a timer for
 the PTO period as follows:
 
+~~~
 PTO = max(smoothed_rtt + 4*rttvar + max_ack_delay, kGranularity)
+~~~
 
 kGranularity, smoothed_rtt, rttvar, and max_ack_delay are defined in
 {{ld-consts-of-interest}} and {{ld-vars-of-interest}}.
@@ -452,8 +453,8 @@ network roundtrip-time (smoothed_rtt), the variance in the estimate (4*rttvar),
 and max_ack_delay, to account for the maximum time by which a receiver might
 delay sending an acknowledgement.
 
-There is no requirement on the clock granularity. The PTO value MUST be set to
-at least kGranularity, to avoid the timer expiring immediately.
+The PTO value MUST be set to at least kGranularity, to avoid the timer expiring
+immediately.
 
 When a PTO timer expires, the PTO period MUST be set to twice its current value.
 This exponential reduction in the sender's rate is important because the PTOs
@@ -473,8 +474,7 @@ consecutive PTO expiration due to a single packet loss.
 Consecutive PTO periods increase exponentially, and as a result, connection
 recovery latency increases exponentially as packets continue to be dropped in
 the network.  Sending two packets on PTO expiration increases resilience to
-packet drop in both directions, thus reducing the probability of consecutive PTO
-events.
+packet drop, thus reducing the probability of consecutive PTO events.
 
 Probe packets sent on a PTO MUST be ack-eliciting.  A probe packet SHOULD carry
 new data when possible.  A probe packet MAY carry retransmitted unacknowledged
@@ -486,9 +486,8 @@ sending new or retransmitted data based on the application's priorities.
 
 #### Loss Detection {#pto-loss}
 
-Delivery or loss of packets in flight is established when an acknowledgement is
-received that newly acknowledges one or more packets.  An endpoint might receive
-an acknowledgement after multiple consecutive PTO periods.
+Delivery or loss of packets in flight is established when an ACK frame is
+received that newly acknowledges one or more packets.
 
 A PTO timer expiration event does not indicate packet loss and MUST NOT cause
 prior unacknowledged packets to be marked as lost.  After a PTO timer has
@@ -569,7 +568,7 @@ kTimeThreshold:
 
 kGranularity:
 
-: Clock granularity. This is a system-dependent value.  However, implementations
+: Timer granularity. This is a system-dependent value.  However, implementations
   SHOULD use a value no smaller than 1ms.
 
 kDelayedAckTimeout:
@@ -820,7 +819,7 @@ Pseudocode for OnLossDetectionTimeout follows:
        DetectLostPackets(largest_acked_packet)
      else:
        // PTO.
-       if (pto_count == 0)
+       if (pto_count == 0):
          largest_sent_before_pto = largest_sent_packet
        SendTwoPackets()
        pto_count++

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1197,8 +1197,12 @@ This document has no IANA actions.  Yet.
 > **RFC Editor's Note:**  Please remove this section prior to
 > publication of a final version of this document.
 
+Issue and pull request numbers are listed with a leading octothorp.
+
 ## Since draft-ietf-quic-recovery-16
 
+- Unify TLP and RTO into a single PTO; eliminate min RTO, min TLP and min crypto
+  timeouts; eliminate timeout validation (#2114, #2166, #2168, #1017)
 - Redefine how congestion avoidance in terms of when the period starts (#1928,
   #1930)
 - Document what needs to be tracked for packets that are in flight (#765, #1724,

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -935,7 +935,7 @@ packets might cause the sender's bytes in flight to exceed the congestion window
 until an acknowledgement is received that establishes loss or delivery of
 packets.
 
-If two consecutive PTOs have occurred (pto_count is at least 2), the network is
+If two consecutive PTOs have occurred (pto_count is at least 3), the network is
 considered to be experiencing persistent congestion, and the sender's congestion
 window MUST be reduced to the minimum congestion window.
 
@@ -1095,7 +1095,7 @@ window.
        congestion_window = max(congestion_window, kMinimumWindow)
        ssthresh = congestion_window
        // Collapse congestion window if persistent congestion
-       if (pto_count >= 2):
+       if (pto_count > 2):
          congestion_window = kMinimumWindow
 ~~~
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -937,9 +937,9 @@ until an acknowledgement is received that establishes loss or delivery of
 packets.
 
 If a threshold number of consecutive PTOs have occurred (pto_count is at least
-kPersistentCongestion, see {{cc-consts-of-interest}}), the network is considered
-to be experiencing persistent congestion, and the sender's congestion window
-MUST be reduced to the minimum congestion window.
+kPersistentCongestionThreshold, see {{cc-consts-of-interest}}), the network is
+considered to be experiencing persistent congestion, and the sender's congestion
+window MUST be reduced to the minimum congestion window.
 
 ## Pacing
 
@@ -1004,15 +1004,16 @@ kLossReductionFactor:
 : Reduction in congestion window when a new loss event is detected.
   The RECOMMENDED value is 0.5.
 
-kPersistentCongestion:
+kPersistentCongestionThreshold:
 : Number of consecutive PTOs after which network is considered to be
   experiencing persistent congestion.  The rationale for this threshold is to
   enable a sender to use initial PTOs for aggressive probing, similar to Tail
   Loss Probe (TLP) in TCP {{TLP}} {{RACK}}.  Once the number of consecutive PTOs
   reaches this threshold - that is, persistent congestion is established - the
-  sender responds by collapsing its congestion window, similar to a
-  Retransmission Timeout (RTO) in TCP {{RFC5681}}.  The RECOMMENDED value is 3,
-  equivalent to having two TLPs followed by an RTO in TCP.
+  sender responds by collapsing its congestion window to kMinimumWindow, similar
+  to a Retransmission Timeout (RTO) in TCP {{RFC5681}}.  The RECOMMENDED value
+  for kPersistentCongestionThreshold is 3, which is equivalent to having two
+  TLPs followed by an RTO in TCP.
 
 ### Variables of interest {#vars-of-interest}
 
@@ -1107,7 +1108,7 @@ window.
        congestion_window = max(congestion_window, kMinimumWindow)
        ssthresh = congestion_window
        // Collapse congestion window if persistent congestion
-       if (pto_count >= kPersistentCongestion):
+       if (pto_count >= kPersistentCongestionThreshold):
          congestion_window = kMinimumWindow
 ~~~
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -936,7 +936,7 @@ packets might cause the sender's bytes in flight to exceed the congestion window
 until an acknowledgement is received that establishes loss or delivery of
 packets.
 
-If a threshold number of consecutive PTOs have occurred (pto_count is at least
+If a threshold number of consecutive PTOs have occurred (pto_count is more than
 kPersistentCongestionThreshold, see {{cc-consts-of-interest}}), the network is
 considered to be experiencing persistent congestion, and the sender's congestion
 window MUST be reduced to the minimum congestion window.
@@ -1012,8 +1012,8 @@ kPersistentCongestionThreshold:
   reaches this threshold - that is, persistent congestion is established - the
   sender responds by collapsing its congestion window to kMinimumWindow, similar
   to a Retransmission Timeout (RTO) in TCP {{RFC5681}}.  The RECOMMENDED value
-  for kPersistentCongestionThreshold is 3, which is equivalent to having two
-  TLPs followed by an RTO in TCP.
+  for kPersistentCongestionThreshold is 2, which is equivalent to having two
+  TLPs before an RTO in TCP.
 
 ### Variables of interest {#vars-of-interest}
 
@@ -1108,7 +1108,7 @@ window.
        congestion_window = max(congestion_window, kMinimumWindow)
        ssthresh = congestion_window
        // Collapse congestion window if persistent congestion
-       if (pto_count >= kPersistentCongestionThreshold):
+       if (pto_count > kPersistentCongestionThreshold):
          congestion_window = kMinimumWindow
 ~~~
 


### PR DESCRIPTION
Closes #2166, #2168, #1017.

This PR builds on #1974 and simplifies QUIC's timeout-based loss detection mechanisms. Unfortunately, this PR cuts through text in many places, so I'm summarizing the key changes here.  The compiled version of the draft, [here](https://quicwg.org/base-drafts/pto/draft-ietf-quic-recovery.html), might be easier to read than the diffs.

The high-order description is that TLP and RTO are combined in this PR into a single "Probe Timeout" (PTO). Consecutive PTOs are exponentially longer, just like RTO used to be.  The rationale for calling this a "Probe" Timeout is that loss detection in QUIC only happens when an ack is received, and this timer and timeout only cause probe packets to be sent out to elicit acks. This unification is made possible by the following constituent changes.

- (Issue #1017) There was general agreement in #1017 that adding a max_ack_delay should allow us to remove the minRTO. max_ack_delay has since been added to QUIC in a transport parameter, which allows us to include it in the PTO computation and remove minRTO/minTLP.

- Timer granularity is added for both crypto and PTO timeouts, ensuring that even when the computed network RTT might be too small and represented as 0, timeouts are set for at least 1 clock tick. This is in keeping with use of granularity in TCP (RFC 6298). A min granularity of 1ms is recommended.

- (Issue #2166) In line with the resolution above for removing min RTO, min TLP and min crypto timeout values are now removed.

- (Issue #2168) PTO validation has been removed.  PTOs cause congestion window collapse to min cwnd only after 3 consecutive PTOs to retain parity with current behavior, where an RTO collapses the window after 2 TLPs.

One side-effect to note is that a single timer will start exponentially backing off right from the first PTO, as against TLP and RTO where the TLP timers did not back off at all, and the RTO timer started exponentially backing off after the TLPs. I can restore this by adjusting the backoff expression in SetLossDetectionTimer(), but I'm not convinced this is necessary.