### PR TITLE
Allow discarding bad, unauthenticated packets

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1000,6 +1000,12 @@ to more quickly identify when a connection becomes unusable.
 Packets that are matched to an existing connection, but for which the endpoint
 cannot remove packet protection, are discarded.
 
+Invalid packets without packet protection, such as Initial, Retry, or Version
+Negotiation, SHOULD be discarded without altering connection state.  An endpoint
+MUST generate a connection error if it commits changes to state before
+discovering an error.
+
+
 ### Client Packet Handling {#client-pkt-handling}
 
 Valid packets sent to clients always include a Destination Connection ID that

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1001,9 +1001,8 @@ Packets that are matched to an existing connection, but for which the endpoint
 cannot remove packet protection, are discarded.
 
 Invalid packets without packet protection, such as Initial, Retry, or Version
-Negotiation, SHOULD be discarded without altering connection state.  An endpoint
-MUST generate a connection error if it commits changes to state before
-discovering an error.
+Negotiation, MAY be discarded.  An endpoint MUST generate a connection error if
+it commits changes to state before discovering an error.
 
 
 ### Client Packet Handling {#client-pkt-handling}


### PR DESCRIPTION
We already have piecemeal recommendations for discarding in certain circumstances, but a blanket allowance for dropping packets will allow endpoints to do all sorts of nice things if they want better DoS resilience.

This leaves the existing requirements in place.  Some of those are more directly the result of stronger requirements (like the ones against off-path attacks).  This is just a license to back out changes that are made as a result of bad packets.

Closes #2053.