### PR TITLE
fix description of AEAD usage

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -818,8 +818,8 @@ The associated data, A, for the AEAD is the contents of the QUIC header,
 starting from the flags byte in either the short or long header, up to and
 including the unprotected packet number.
 
-The input plaintext, P, for the AEAD is the content of the QUIC frame following
-the header, as described in {{QUIC-TRANSPORT}}.
+The input plaintext, P, for the AEAD is the payload of the QUIC packet, as
+described in {{QUIC-TRANSPORT}}.
 
 The output ciphertext, C, of the AEAD is transmitted in place of P.
 


### PR DESCRIPTION
The input plaintext for the AEAD is the QUIC packet payload, not the first QUIC frame following the header.