### PR TITLE
clarify that old keys should always be dropped

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1108,16 +1108,11 @@ updated keys, it indicates that its peer has updated keys twice without awaiting
 a reciprocal update.  An endpoint MUST treat consecutive key updates as a fatal
 error and abort the connection.
 
-An endpoint SHOULD retain old keys for a short period to allow it to decrypt
-packets with smaller packet numbers than the packet that triggered the key
-update.  This allows an endpoint to consume packets that are reordered around
-the transition between keys.  Packets with higher packet numbers always use the
-updated keys and MUST NOT be decrypted with old keys.
-
-Keys and their corresponding secrets SHOULD be discarded when an endpoint has
-received all packets with packet numbers lower than the lowest packet number
-used for the new key.  An endpoint might discard keys if it determines that the
-length of the delay to affected packets is excessive.
+An endpoint SHOULD retain old keys for a short period, and discard them and
+the corresponding secrets afterwards.  This allows it to decrypt packets with
+smaller packet numbers than the packet that triggered the key update, which are
+reordered around the transition between keys.  Packets with higher packet
+numbers always use the updated keys and MUST NOT be decrypted with old keys.
 
 This ensures that once the handshake is complete, packets with the same
 KEY_PHASE will have the same packet protection keys, unless there are multiple

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1109,11 +1109,11 @@ a reciprocal update.  An endpoint MUST treat consecutive key updates as a fatal
 error and abort the connection.
 
 An endpoint SHOULD retain old keys for a period of no more than three times the
-Retransmitions Timeout (RTO, see {{QUIC-RECOVERY}}).  After this period, old
-keys and their corresponding secrets SHOULD be discarded.  Retaining keys allow
-endpoints to process packets that were sent with old keys and delayed in the
-network.  Packets with higher packet numbers always use the updated keys and
-MUST NOT be decrypted with old keys.
+Probe Timeout (PTO, see {{QUIC-RECOVERY}}).  After this period, old keys and
+their corresponding secrets SHOULD be discarded.  Retaining keys allow endpoints
+to process packets that were sent with old keys and delayed in the network.
+Packets with higher packet numbers always use the updated keys and MUST NOT be
+decrypted with old keys.
 
 This ensures that once the handshake is complete, packets with the same
 KEY_PHASE will have the same packet protection keys, unless there are multiple


### PR DESCRIPTION
The old text said
> Keys and their corresponding secrets SHOULD be discarded when an endpoint has
received all packets with packet numbers lower than the lowest packet number
used for the new key. An endpoint might discard keys if it determines that the
length of the delay to affected packets is excessive.

A peer typically can't know when it received all packets with packet numbers lower than the lowest packet number used for the new key, since packets might have been lost or packet number might have been skipped. Dropping old keys shouldn't be a "might", it should be a SHOULD.