### PR TITLE
Reorganize ACK section

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2843,8 +2843,9 @@ discussed in more detail in {{QUIC-RECOVERY}}.
 
 To limit the ranges of acknowledged packet numbers to those that have not yet
 been received by the sender, the receiver SHOULD track which ACK frames have
-been acknowledged by its peer.  Once an ACK frame has been acknowledged, the
-packets it acknowledges SHOULD NOT be acknowledged again.
+been acknowledged by its peer.  The receiver SHOULD exclude already acknowledged
+packets from future ACK frames whenever these packets would unnecessarily
+contribute to the ACK frame size.
 
 Because ACK frames are not sent in response to ACK-only packets, a receiver that
 is only sending ACK frames will only receive acknowledgements for its packets


### PR DESCRIPTION
I was planning to make only two changes here, but there were a few
editorial itches I needed to scratch, so this does:

1. renames ACK Blocks to ACK Ranges

2. moves the First ACK Range field to the top level

3. renames the ECN Section to ECN Counters and adds a description of
   that field

4. uses the field names more consistently (s/Gaps/Gap fields/ and so
   forth)

5. makes figure and list intros more consistent