### PR TITLE
Clarify In-flight

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -102,7 +102,8 @@ In-flight:
 
 : Packets are considered in-flight when they have been sent
   and neither acknowledged nor declared lost, and they are not
-  ACK-only.
+  ACK-only.  Packets are still considered in-flight even if
+  their payloads no longer need to be delivered.
 
 Ack-eliciting Frames:
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -102,8 +102,9 @@ In-flight:
 
 : Packets are considered in-flight when they have been sent
   and neither acknowledged nor declared lost, and they are not
-  ACK-only.  Packets are still considered in-flight even if
-  their payloads no longer need to be delivered.
+  ACK-only.  For example, packets containing STREAM frames are
+  still considered in-flight after the corresponding stream
+  is reset.
 
 Ack-eliciting Frames:
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -661,10 +661,11 @@ Pseudocode for OnPacketSent follows:
    sent_packets[packet_number].time_sent = now
    sent_packets[packet_number].ack_eliciting = ack_eliciting
    sent_packets[packet_number].in_flight = in_flight
-   if (ack_eliciting):
+   if (in_flight):
      if (is_crypto_packet):
        time_of_last_sent_crypto_packet = now
-     time_of_last_sent_ack_eliciting_packet = now
+     if (ack_eliciting):
+       time_of_last_sent_ack_eliciting_packet = now
      OnPacketSentCC(sent_bytes)
      sent_packets[packet_number].size = sent_bytes
      SetLossDetectionTimer()


### PR DESCRIPTION
I'm not sure this is necessary, but I've had at least 2 people be unsure about whether a packet is still in flight if all the stream data in it is cancelled, so maybe it's worth stating this explicitly?