### PR TITLE
Proposed change to #1965

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -498,12 +498,12 @@ priorities.
 
 When a PTO timer expires, new or previously-sent data may not available to send,
 and data may still be in flight.  Under these conditions, a sender MUST mark any
-packets still in flight as lost.  This can happen for example when data is sent on
-a stream which is then reset by a sender, and a PTO timer expires after this stream
-is reset.  A sender can be blocked from sending new data in the future if data is
-left in flight with no PTO armed.  Marking any in-flight packets as lost allows the
-sender to recover any congestion window space that is consumed by the packets still
-in flight.
+packets still in flight as lost.  This can happen for example when data is sent
+on a stream which is then reset by a sender, and a PTO timer expires after this
+stream is reset.  A sender can be blocked from sending new data in the future if
+data is left in flight with no PTO armed.  Marking any in-flight packets as lost
+allows the sender to recover any congestion window space that is consumed by the
+packets still in flight.
 
 
 #### Loss Detection {#pto-loss}

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -497,7 +497,7 @@ including sending new or retransmitted data based on the application's
 priorities.
 
 When a PTO timer expires, new or previously-sent data may not be available to
-send, and packets may still be in flight.  A sender can be blocked from sending
+send and packets may still be in flight.  A sender can be blocked from sending
 new data in the future if packets are left in flight.  Under these conditions, a
 sender SHOULD mark any packets still in flight as lost.  If a sender wishes to
 establish delivery of packets still in flight, it MAY send an ack-eliciting

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -497,13 +497,14 @@ including sending new or retransmitted data based on the application's
 priorities.
 
 When a PTO timer expires, new or previously-sent data may not available to send,
-and data may still be in flight.  Under these conditions, a sender MUST mark any
-packets still in flight as lost.  This can happen for example when data is sent
-on a stream which is then reset by a sender, and a PTO timer expires after this
-stream is reset.  A sender can be blocked from sending new data in the future if
-data is left in flight with no PTO armed.  Marking any in-flight packets as lost
-allows the sender to recover any congestion window space that is consumed by the
-packets still in flight.
+and data may still be in flight.  A sender can be blocked from sending new data
+in the future if data is left in flight with no PTO armed.  Under these
+conditions, a sender SHOULD mark any packets still in flight as lost.  Marking
+any in-flight packets as lost allows the sender to recover any congestion window
+space consumed by them.  Marking all packets as lost might be
+bandwidth-inefficient if a large amount of data is in flight.  A sender MAY
+optimize for bandwidth by sending an ack-eliciting packet and re-arming the PTO
+timer instead of marking all in-flight packets as lost.
 
 
 #### Loss Detection {#pto-loss}

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -497,11 +497,11 @@ including sending new or retransmitted data based on the application's
 priorities.
 
 When a PTO timer expires, new or previously-sent data may not be available to
-send, and data may still be in flight.  A sender can be blocked from sending new
-data in the future if packets are left in flight with no PTO armed.  Under these
-conditions, a sender SHOULD mark any packets still in flight as lost.  If a
-sender wishes to establish delivery of packets still in flight, it MAY send an
-ack-eliciting packet and re-arm the PTO timer instead.
+send, and packets may still be in flight.  A sender can be blocked from sending
+new data in the future if packets are left in flight.  Under these conditions, a
+sender SHOULD mark any packets still in flight as lost.  If a sender wishes to
+establish delivery of packets still in flight, it MAY send an ack-eliciting
+packet and re-arm the PTO timer instead.
 
 
 #### Loss Detection {#pto-loss}

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -496,15 +496,12 @@ MAY use alternate strategies for determining the content of probe packets,
 including sending new or retransmitted data based on the application's
 priorities.
 
-When a PTO timer expires, new or previously-sent data may not available to send,
-and data may still be in flight.  A sender can be blocked from sending new data
-in the future if data is left in flight with no PTO armed.  Under these
-conditions, a sender SHOULD mark any packets still in flight as lost.  Marking
-any in-flight packets as lost allows the sender to recover any congestion window
-space consumed by them.  Marking all packets as lost might be
-bandwidth-inefficient if a large amount of data is in flight.  A sender MAY
-optimize for bandwidth by sending an ack-eliciting packet and re-arming the PTO
-timer instead of marking all in-flight packets as lost.
+When a PTO timer expires, new or previously-sent data may not be available to
+send, and data may still be in flight.  A sender can be blocked from sending new
+data in the future if packets are left in flight with no PTO armed.  Under these
+conditions, a sender SHOULD mark any packets still in flight as lost.  If a
+sender wishes to establish delivery of packets still in flight, it MAY send an
+ack-eliciting packet and re-arm the PTO timer instead.
 
 
 #### Loss Detection {#pto-loss}

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -496,11 +496,14 @@ MAY use alternate strategies for determining the content of probe packets,
 including sending new or retransmitted data based on the application's
 priorities.
 
-If no new data or unacknowledged data is available to send, an ack-eliciting
-packet SHOULD be sent.  Sending a retransmittable frame ensures that any in
-flight packets are acknowledged or declared lost in a timely manner.  If no
-ack-eliciting packet is sent, any packets currently in flight should be
-declared lost to avoid repeatedly arming and firing the PTO timer.
+When a PTO timer expires, new or previously-sent data may not available to send,
+and data may still be in flight.  Under these conditions, a sender MUST mark any
+packets still in flight as lost.  This can happen for example when data is sent on
+a stream which is then reset by a sender, and a PTO timer expires after this stream
+is reset.  A sender can be blocked from sending new data in the future if data is
+left in flight with no PTO armed.  Marking any in-flight packets as lost allows the
+sender to recover any congestion window space that is consumed by the packets still
+in flight.
 
 
 #### Loss Detection {#pto-loss}


### PR DESCRIPTION
A proposal: I think I prefer to mark things as lost instead of suggesting that a sender SHOULD send something when there's really nothing to be sent.  I was starting to rephrase #1965 to say "SHOULD send ack-eliciting packet, but MAY mark as lost", and I needed to explain how a sender makes this choice. I realized that if it's been long enough (PTO is long enough) and there's nothing left to send, then maybe it is sensible to mark anything pending as lost. So, I changed my suggestion to that, which is this PR (against #1965).