### PR TITLE
Make HTTP frames a TLV format. This has several advantages:

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -402,21 +402,22 @@ All frames have the following format:
  0                   1                   2                   3
  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                           Length (i)                        ...
+|    Type (8)   |               Length (i)
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|    Type (8)   |               Frame Payload (*)             ...
+|                     Frame Payload (*)             ...
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 ~~~~~~~~~~
 {: #fig-frame title="HTTP/3 frame format"}
 
 A frame includes the following fields:
 
+  Type:
+  : An 8-bit type for the frame.
+
+
   Length:
   : A variable-length integer that describes the length of the Frame Payload.
     This length does not include the Type field.
-
-  Type:
-  : An 8-bit type for the frame.
 
   Frame Payload:
   : A payload, the semantics of which are determined by the Type field.


### PR DESCRIPTION
I know this is a late change, but I think it's an improvement....

- You can switch on the frame type before you even read a
  variable-length value
- You can have special-case (negotiated) frame types with no lengths

If this has already been discussed and rejected somewhere, maybe
I missed it.