### PR TITLE
Rework Key Update

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1101,7 +1101,7 @@ anticipation of receiving a ClientHello.
 # Key Update {#key-update}
 
 Once the 1-RTT keys are established and confirmed through the use of the
-KEYS_READY frame, it is possible to update the keys used to protect packets.
+KEYS_ACTIVE frame, it is possible to update the keys used to protect packets.
 
 The Key Phase bit is used to indicate which packet protection keys are used to
 protect the packet.  The Key Phase bit is initially set to 0 for the first set
@@ -1124,20 +1124,20 @@ and @N.  Values in brackets \[] indicate the value of Key Phase bit.
    Initiating Peer                    Responding Peer
 
 @M [0] QUIC Packets
-       KEYS_READY
+       KEYS_ACTIVE
                       -------->
                                       QUIC Packets [0] @M
-                                        KEYS_READY
+                                       KEYS_ACTIVE
                       <--------
 ... Update to @N
 @N [1] QUIC Packets
                       -------->
                                          Update to @N ...
                                       QUIC Packets [1] @N
-                                        KEYS_READY
+                                       KEYS_ACTIVE
                       <--------
 @N [1] QUIC Packets
-       KEYS_READY
+       KEYS_ACTIVE
 ... Key Update Permitted
                       -------->
                                  Key Update Permitted ...
@@ -1158,23 +1158,23 @@ corresponding key and IV are created from that secret as defined in
 The endpoint toggles the value of the Key Phase bit, and uses the updated key
 and IV to protect all subsequent packets.
 
-An endpoint MUST NOT initiate a key update prior to having received a KEYS_READY
-frame in a packet from the current key phase.  A subsequent key update can only
-be performed after the endpoint has successfully processed a KEYS_READY frame
-from a packet with a matching key phase.  This ensures that keys are available
-to both peers before another can be initiated.
+An endpoint MUST NOT initiate a key update prior to having received a
+KEYS_ACTIVE frame in a packet from the current key phase.  A subsequent key
+update can only be performed after the endpoint has successfully processed a
+KEYS_ACTIVE frame from a packet with a matching key phase.  This ensures that
+keys are available to both peers before another can be initiated.
 
 Once an endpoint has successfully processed a packet with the same key phase, it
-can send a KEYS_READY frame.  Endpoints MAY defer sending a KEYS_READY frame
+can send a KEYS_ACTIVE frame.  Endpoints MAY defer sending a KEYS_ACTIVE frame
 after a key update (see {{key-update-old-keys}}).
 
 
 ## Responding to a Key Update
 
-An endpoint that sends a KEYS_READY frame can accept further key updates.  A key
-update can happen even without seeing a KEYS_READY frame from the peer.  If a
-packet is received with a key phase that differs from the value the endpoint
-used to protect the packet containing its last KEYS_READY frame, the endpoint
+An endpoint that sends a KEYS_ACTIVE frame can accept further key updates.  A
+key update can happen even without seeing a KEYS_ACTIVE frame from the peer.  If
+a packet is received with a key phase that differs from the value the endpoint
+used to protect the packet containing its last KEYS_ACTIVE frame, the endpoint
 creates a new packet protection secret for reading and the corresponding key and
 IV.  An endpoint uses the same key derivation process as its peer uses to
 generate keys for receiving.
@@ -1182,15 +1182,16 @@ generate keys for receiving.
 If the packet protection is successfully removed using the updated key and IV,
 then the keys the endpoint initiates a key update in response, as described in
 {{key-update-initiate}}.  An endpoint that responds to a key update MUST send a
-KEYS_READY frame to indicate that it is both sending and receiving with updated
+KEYS_ACTIVE frame to indicate that it is both sending and receiving with updated
 keys, though it MAY defer sending the frame (see {{key-update-old-keys}}).
 
 An endpoint does not always need to send packets when it detects that its peer
 has updated keys.  The next packet that it sends use the new keys and include
-the KEYS_READY frame.  If an endpoint detects a second update before it has sent
-any packets with updated keys or a KEYS_READY frame, it indicates that its peer
-has updated keys twice without awaiting a reciprocal update.  An endpoint MUST
-treat consecutive key updates as a connection error of type KEY_UPDATE_ERROR.
+the KEYS_ACTIVE frame.  If an endpoint detects a second update before it has
+sent any packets with updated keys or a KEYS_ACTIVE frame, it indicates that its
+peer has updated keys twice without awaiting a reciprocal update.  An endpoint
+MUST treat consecutive key updates as a connection error of type
+KEY_UPDATE_ERROR.
 
 Endpoints responding to an apparent key update MUST NOT generate a timing
 side-channel signal that might indicate that the Key Phase bit was invalid (see
@@ -1204,12 +1205,12 @@ During a key update, packets protected with older keys might arrive if they were
 delayed by the network.  If those old keys are available, then they can be used
 to remove packet protection.
 
-After a key update, an endpoint MAY delay sending the KEYS_READY frame by up to
+After a key update, an endpoint MAY delay sending the KEYS_ACTIVE frame by up to
 three times the Probe Timeout (PTO, see {{QUIC-RECOVERY}}) to minimize the
 number of active keys it maintains.  During this time, an endpoint can use old
 keys to process delayed packets rather than enabling a new key update.  This
 only applies to key updates that use the Key Phase bit; endpoints MUST NOT defer
-sending of KEYS_READY during and immediately after the handshake.
+sending of KEYS_ACTIVE during and immediately after the handshake.
 
 Even if old keys are available, those keys MUST NOT be used to protect packets
 with packets that have higher packet numbers than packets that were protected

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1115,7 +1115,6 @@ without needing to receive the first packet that triggered the change.  An
 endpoint that notices a changed Key Phase updates keys and decrypts the packet
 that contains the changed value.
 
-
 The high bit of the Key Update field (0x08) is the Key Update Permitted bit.
 Endpoints set this value to 0 until they successfully process a packet with keys
 from the same key phase as they are using to send.  An endpoint MUST NOT
@@ -1229,11 +1228,17 @@ MUST treat this as a connection error of type KEY_UPDATE_ERROR.
 
 An endpoint SHOULD retain old read keys for a period of no more than three times
 the Probe Timeout (PTO, see {{QUIC-RECOVERY}}).  After this period, old read
-keys and their corresponding secrets SHOULD be discarded.  An endpoint MAY keep
-the Key Update Permitted bit set to 0 until it discards old read keys to limit
-the number of keys it maintains.  An endpoint MAY also prevent key update until
-it discards keys from the handshake, including any 0-RTT keys.  An endpoint
-SHOULD set the Key Update Permitted bit when possible.
+keys and their corresponding secrets SHOULD be discarded.
+
+An endpoint MAY keep the Key Update Permitted bit set to 0 until it discards old
+read keys to limit the number of keys it maintains.  An endpoint MAY also
+prevent key update until it discards keys from the handshake, including any
+0-RTT keys.  An endpoint SHOULD set the Key Update Permitted bit when possible.
+
+Once set, the Key Update Permitted bit MUST NOT be cleared for packets protected
+with the same keys.  An endpoint MAY treat receipt of a packet with the Key
+Update Permitted bit cleared as a connection error of type KEY_UPDATE_ERROR if
+the bit was previously set on packets protected with the same keys.
 
 Endpoints MUST NOT generate a timing side-channel signal that might indicate
 that the Key Update field was invalid (see {{header-protect-analysis}}).

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -863,7 +863,7 @@ This protection applies to the least-significant bits of the first byte, plus
 the Packet Number field.  The four least-significant bits of the first byte are
 protected for packets with long headers; the five least significant bits of the
 first byte are protected for packets with short headers.  For both header forms,
-this covers the reserved bits and the Packet Number Length field; the Key Update
+this covers the reserved bits and the Packet Number Length field; the Key Phase
 bit is also protected for packets with a short header.
 
 The same header protection key is used for the duration of the connection, with
@@ -1158,11 +1158,12 @@ corresponding key and IV are created from that secret as defined in
 The endpoint toggles the value of the Key Phase bit, and uses the updated key
 and IV to protect all subsequent packets.
 
-An endpoint MUST NOT initiate a key update prior to having received a
-KEYS_ACTIVE frame in a packet from the current key phase.  A subsequent key
-update can only be performed after the endpoint has successfully processed a
-KEYS_ACTIVE frame from a packet with a matching key phase.  This ensures that
-keys are available to both peers before another can be initiated.
+An endpoint MUST NOT initiate a key update prior to having received and
+processed a KEYS_ACTIVE frame in a packet from the current key phase.  A
+subsequent key update can only be performed after the endpoint has successfully
+received and processed a KEYS_ACTIVE frame from a packet with a matching key
+phase.  This ensures that keys are available to both peers before another can be
+initiated.
 
 Once an endpoint has successfully processed a packet with the same key phase, it
 can send a KEYS_ACTIVE frame.  Endpoints MAY defer sending a KEYS_ACTIVE frame

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1172,8 +1172,12 @@ Note:
   to be discarded when they are no longer needed and - in the case of the first
   1-RTT key phase - to enable the first key update.
 
-Once an endpoint has successfully processed a packet with the same key phase, it
-MUST send a KEYS_ACTIVE frame, though endpoints MAY defer sending the frame (see
+The endpoint that initiates a key update also updates the keys that it uses for
+receiving packets.  These keys will be needed to process packets the peer sends
+after updating.  An endpoint needs to retain old keys so that packets sent by
+the peer prior to receiving the key update can be processed.  Once an endpoint
+has successfully processed a packet using the new keys, it MUST send a
+KEYS_ACTIVE frame, though endpoints MAY defer sending the frame (see
 {{key-update-old-keys}}).
 
 

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1098,7 +1098,7 @@ TLS ClientHello.  The server MAY retain these packets for later decryption in
 anticipation of receiving a ClientHello.
 
 
-# Key Update
+# Key Update {#key-update}
 
 Once the 1-RTT keys are established and the short header is in use, it is
 possible to update the keys used to protect packets. The Key Update field in the
@@ -1131,7 +1131,7 @@ message as a connection error of type 0x10a, equivalent to a fatal TLS alert of
 unexpected_message (see {{tls-errors}}).
 
 {{ex-key-update}} shows a key update process, with keys used identified with @M
-and @N.  Values in brackets [] indicate the value of Key Update bits.
+and @N.  Values in brackets \[] indicate the value of Key Update bits.
 
 ~~~
    Initiating Peer                    Responding Peer

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1103,9 +1103,9 @@ anticipation of receiving a ClientHello.
 Once the 1-RTT keys are established and confirmed through the use of the
 KEYS_ACTIVE frame, it is possible to update the keys used to protect packets.
 
-The Key Phase bit is used to indicate which packet protection keys are used to
-protect the packet.  The Key Phase bit is initially set to 0 for the first set
-of 1-RTT packets.  The Key Phase bit is toggled to signal each key update.
+The Key Phase bit indicates which packet protection keys are used to protect the
+packet.  The Key Phase bit is initially set to 0 for the first set of 1-RTT
+packets and toggled to signal each subsequent key update.
 
 The Key Phase bit allows a recipient to detect a change in keying material
 without needing to receive the first packet that triggered the change.  An
@@ -1155,8 +1155,8 @@ uses the KDF function provided by TLS with a label of "quic ku".  The
 corresponding key and IV are created from that secret as defined in
 {{protection-keys}}.  The header protection key is not updated.
 
-The endpoint toggles the value of the Key Phase bit, and uses the updated key
-and IV to protect all subsequent packets.
+The endpoint toggles the value of the Key Phase bit and uses the updated key and
+IV to protect all subsequent packets.
 
 An endpoint MUST NOT initiate a key update prior to having received and
 successfully processed a KEYS_ACTIVE frame contained in a packet from the
@@ -1186,10 +1186,10 @@ KEYS_ACTIVE frame, though endpoints MAY defer sending the frame (see
 An endpoint that sends a KEYS_ACTIVE frame can accept further key updates.  A
 key update can happen even without seeing a KEYS_ACTIVE frame from the peer.  If
 a packet is received with a key phase that differs from the value the endpoint
-used to protect the packet containing its last KEYS_ACTIVE frame, the endpoint
-creates a new packet protection secret for reading and the corresponding key and
-IV.  An endpoint uses the same key derivation process as its peer uses to
-generate keys for receiving.
+used to protect the last packet it sent, the endpoint creates a new packet
+protection secret for reading and the corresponding key and IV.  An endpoint
+uses the same key derivation process as its peer uses to generate keys for
+receiving.
 
 If the packet is successfully processed using the updated key and IV, then the
 keys the endpoint initiates a key update in response, as described in
@@ -1213,6 +1213,9 @@ will generate no variation in the timing signal produced by attempting to remove
 packet protection, but all packets with an invalid Key Phase bit will be
 rejected.
 
+An endpoint might not receive an acknowledgment for the packet that contains a
+KEYS_ACTIVE before receiving another key update.
+
 
 ## Using Old Keys {#key-update-old-keys}
 
@@ -1232,18 +1235,18 @@ only applies to key updates; endpoints MUST NOT defer sending of KEYS_ACTIVE
 during and immediately after the handshake.
 
 Even if old keys are available, those keys MUST NOT be used to protect packets
-with packets that have higher packet numbers than packets that were protected
-with newer keys.  An endpoint that successfully removes protection with old keys
-when newer keys were used for packets with lower packet numbers MUST treat this
-as a connection error of type KEY_UPDATE_ERROR.
+that have higher packet numbers than packets that were protected with newer
+keys.  An endpoint that successfully removes protection with old keys when newer
+keys were used for packets with lower packet numbers MUST treat this as a
+connection error of type KEY_UPDATE_ERROR.
 
 An endpoint SHOULD retain old read keys for a period of no more than three times
 the current PTO.  After this period, old read keys and their corresponding
 secrets SHOULD be discarded.
 
-An endpoint that receives a packet protected with old keys that includes an
-acknowledgement for a packet protected with newer keys MAY treat that as a
-connection error of type KEY_UPDATE_ERROR.
+An endpoint that receives an acknowledgement for a packet protected with new
+keys in a packet protected with older keys MAY treat that as a connection error
+of type KEY_UPDATE_ERROR.
 
 
 ## Key Update Frequency

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -5025,13 +5025,13 @@ both sent and received, older keys can be safely discarded.
 
 The KEYS_ACTIVE frame contains no additional fields.
 
-The packet that carries a KEYS_ACTIVE frame determines which keys are ready.
-The keys with the same key phase as those used in the packet that carries the
-KEYS_ACTIVE frame are present.
+The packet that carries a KEYS_ACTIVE frame determines which keys are active and
+usable.  The keys with the same key phase as those used in the packet that
+carries the KEYS_ACTIVE frame are active.
 
 An endpoint MUST send a KEYS_ACTIVE packet in the first packet it sends using
-keys, but only after having successfully processed a packet using the
-corresponding keys.
+keys, but only if it is also able to receive packets that are protected using
+the corresponding keys.
 
 KEYS_ACTIVE frames are retransmitted when declared lost, however implementations
 need to take care not to retransmit lost KEYS_ACTIVE frames if they initiate a
@@ -5048,8 +5048,9 @@ endpoint can discard Initial keys.
 A KEYS_ACTIVE frame used after the completion of the handshake in 1-RTT packets
 indicates that Handshake keys are no longer needed.  A client sends this frame
 in its first 1-RTT packet, and a server sends this frame in the first packet it
-sends after completing the handshake.  Note that a server might send 1-RTT keys
-prior to this.
+sends after completing the handshake.  A server might send 1-RTT keys prior to
+this; a server MUST NOT use 1-RTT keys for removing packet protection until the
+cryptographic handshake is complete.
 
 An endpoint uses the KEYS_ACTIVE frame in 1-RTT packets to indicate that it is
 able to receive a key update (see Section 6 of {{QUIC-TLS}}).

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3605,8 +3605,8 @@ Endpoints cease both sending and processing Initial packets when it both sends
 and receives a Handshake or 1-RTT packet containing a KEYS_ACTIVE frame.  Though
 packets might still be in flight or awaiting acknowledgment, no further Initial
 packets need to be exchanged beyond this point.  Initial packet protection keys
-are discarded (see Section 4.10 of {{QUIC-TLS}}) along with any loss recovery and
-congestion control state (see Sections 5.3.1.2 and 6.9 of {{QUIC-RECOVERY}}).
+are discarded (see Section 4.10 of {{QUIC-TLS}}) along with any loss recovery
+and congestion control state (see Sections 5.3.1.2 and 6.9 of {{QUIC-RECOVERY}}).
 
 Any data in CRYPTO frames is discarded - and no longer retransmitted - when
 Initial keys are discarded.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3602,10 +3602,10 @@ subsequent to the first do not need to fit within a single UDP datagram.
 #### Abandoning Initial Packets {#discard-initial}
 
 Endpoints cease both sending and processing Initial packets when it both sends
-and receives a Handshake packet containing a KEYS_ACTIVE frame.  Though packets
-might still be in flight or awaiting acknowledgment, no further Initial packets
-need to be exchanged beyond this point.  Initial packet protection keys are
-discarded (see Section 4.10 of {{QUIC-TLS}}) along with any loss recovery and
+and receives a Handshake or 1-RTT packet containing a KEYS_ACTIVE frame.  Though
+packets might still be in flight or awaiting acknowledgment, no further Initial
+packets need to be exchanged beyond this point.  Initial packet protection keys
+are discarded (see Section 4.10 of {{QUIC-TLS}}) along with any loss recovery and
 congestion control state (see Sections 5.3.1.2 and 6.9 of {{QUIC-RECOVERY}}).
 
 Any data in CRYPTO frames is discarded - and no longer retransmitted - when

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3606,7 +3606,8 @@ and receives a Handshake or 1-RTT packet containing a KEYS_ACTIVE frame.  Though
 packets might still be in flight or awaiting acknowledgment, no further Initial
 packets need to be exchanged beyond this point.  Initial packet protection keys
 are discarded (see Section 4.10 of {{QUIC-TLS}}) along with any loss recovery
-and congestion control state (see Sections 5.3.1.2 and 6.9 of {{QUIC-RECOVERY}}).
+and congestion control state (see Sections 5.3.1.2 and 6.9 of
+{{QUIC-RECOVERY}}).
 
 Any data in CRYPTO frames is discarded - and no longer retransmitted - when
 Initial keys are discarded.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3508,7 +3508,7 @@ Spin Bit (S):
 : The sixth bit (0x20) of byte 0 is the Latency Spin Bit, set as described in
   {{!SPIN=I-D.ietf-quic-spin-exp}}.
 
-Reserved Bits (R):
+Reserved Bit (R):
 
 : The next bit (0x10) of byte 0 is reserved.  This bit is protected using header
   protection (see Section 5.4 of {{QUIC-TLS}}).  The value included prior to

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3480,7 +3480,7 @@ enables packet coalescing ({{packet-coalesce}}).
  0                   1                   2                   3
  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
 +-+-+-+-+-+-+-+-+
-|0|1|S|R|R|K|P P|
+|0|1|S|R| K | P |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                Destination Connection ID (0..144)           ...
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -3510,19 +3510,19 @@ Spin Bit (S):
 
 Reserved Bits (R):
 
-: The next two bits (those with a mask of 0x18) of byte 0 are reserved.  These
-  bits are protected using header protection (see Section 5.4 of
-  {{QUIC-TLS}}).  The value included prior to protection MUST be set to 0.  An
-  endpoint MUST treat receipt of a packet that has a non-zero value for these
-  bits after removing protection as a connection error of type
-  PROTOCOL_VIOLATION.
+: The next bit (0x10) of byte 0 is reserved.  This bit is protected using header
+  protection (see Section 5.4 of {{QUIC-TLS}}).  The value included prior to
+  protection MUST be set to 0.  An endpoint MUST treat receipt of a packet that
+  has a non-zero value for this bit after removing protection as a connection
+  error of type PROTOCOL_VIOLATION.
 
 Key Phase (K):
 
-: The next bit (0x04) of byte 0 indicates the key phase, which allows a
-  recipient of a packet to identify the packet protection keys that are used to
-  protect the packet.  See {{QUIC-TLS}} for details.  This bit is protected
-  using header protection (see Section 5.4 of {{QUIC-TLS}}).
+: The next two bits (those with a mask of 0x0c) of byte 0 indicate the key
+  phase, which allows a recipient of a packet to identify the packet protection
+  keys that are used to protect the packet.  See {{QUIC-TLS}} for details.
+  These bits are protected using header protection (see Section 5.4 of
+  {{QUIC-TLS}}).
 
 Packet Number Length (P):
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1259,14 +1259,14 @@ Client                                                  Server
 Initial[0]: CRYPTO[CH] ->
 
                                  Initial[0]: CRYPTO[SH] ACK[0]
-                       Handshake[0]: CRYPTO[EE, CERT, CV, FIN]
+           Handshake[0]: KEYS_READY, CRYPTO[EE, CERT, CV, FIN]
                                  <- 1-RTT[0]: STREAM[1, "..."]
 
 Initial[1]: ACK[0]
-Handshake[0]: CRYPTO[FIN], ACK[0]
-1-RTT[0]: STREAM[0, "..."], ACK[0] ->
+Handshake[0]: KEYS_READY, CRYPTO[FIN], ACK[0]
+1-RTT[0]: KEYS_READY, STREAM[0, "..."], ACK[0] ->
 
-                           1-RTT[1]: STREAM[55, "..."], ACK[0]
+               1-RTT[1]: KEYS_READY, STREAM[55, "..."], ACK[0]
                                        <- Handshake[1]: ACK[0]
 ~~~~
 {: #tls-1rtt-handshake title="Example 1-RTT Handshake"}
@@ -1283,14 +1283,14 @@ Initial[0]: CRYPTO[CH]
 0-RTT[0]: STREAM[0, "..."] ->
 
                                  Initial[0]: CRYPTO[SH] ACK[0]
-                        Handshake[0] CRYPTO[EE, CERT, CV, FIN]
+           Handshake[0]: KEYS_READY, CRYPTO[EE, CERT, CV, FIN]
                           <- 1-RTT[0]: STREAM[1, "..."] ACK[0]
 
 Initial[1]: ACK[0]
-Handshake[0]: CRYPTO[FIN], ACK[0]
-1-RTT[2]: STREAM[0, "..."] ACK[0] ->
+Handshake[0]: KEYS_READY, CRYPTO[FIN], ACK[0]
+1-RTT[2]: KEYS_READY, STREAM[0, "..."] ACK[0] ->
 
-                         1-RTT[1]: STREAM[55, "..."], ACK[1,2]
+             1-RTT[1]: KEYS_READY, STREAM[55, "..."], ACK[1,2]
                                        <- Handshake[1]: ACK[0]
 ~~~~
 {: #tls-0rtt-handshake title="Example 0-RTT Handshake"}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3414,7 +3414,7 @@ packet type.  While type-specific semantics for this version are described in
 the following sections, several long-header packets in this version of QUIC
 contain these additional fields:
 
-Reserved Bit (R):
+Reserved Bits (R):
 
 : Two bits (those with a mask of 0x0c) of byte 0 are reserved across multiple
   packet types.  These bits are protected using header protection (see Section
@@ -5029,10 +5029,6 @@ The packet that carries a KEYS_ACTIVE frame determines which keys are active and
 usable.  The keys with the same key phase as those used in the packet that
 carries the KEYS_ACTIVE frame are active.
 
-An endpoint MUST send a KEYS_ACTIVE packet in the first packet it sends using
-keys, but only if it is also able to receive packets that are protected using
-the corresponding keys.
-
 KEYS_ACTIVE frames are retransmitted when declared lost, however implementations
 need to take care not to retransmit lost KEYS_ACTIVE frames if they initiate a
 subsequent key update.  This can happen if an acknowledgment for a packet
@@ -5040,17 +5036,17 @@ containing a KEYS_ACTIVE frame is lost.
 
 Endpoints MUST NOT send KEYS_ACTIVE frames in Initial or 0-RTT packets.
 
-A KEYS_ACTIVE frame used during the handshake can be used to indicate the
+A KEYS_ACTIVE frame sent during the handshake can be used to indicate the
 availability of Handshake keys by including it in a Handshake packet.  An
-endpoint sends this frame in its first Handshake packet.  Once received, an
-endpoint can discard Initial keys.
+endpoint MUST send this frame in its first Handshake packet.  Once received, an
+endpoint can discard Initial keys.  An endpoint SHOULD send a KEYS_ACTIVE frame
+in every Handshake packet it sends.
 
-A KEYS_ACTIVE frame used after the completion of the handshake in 1-RTT packets
-indicates that Handshake keys are no longer needed.  A client sends this frame
-in its first 1-RTT packet, and a server sends this frame in the first packet it
-sends after completing the handshake.  A server might send 1-RTT keys prior to
-this; a server MUST NOT use 1-RTT keys for removing packet protection until the
-cryptographic handshake is complete.
+A KEYS_ACTIVE frame sent in 1-RTT packets indicates that Handshake keys are no
+longer needed.  A client MUST send this frame in its first 1-RTT packet, and a
+server MUST send this frame in the first packet it sends after completing the
+handshake.  A server might send 1-RTT packets prior to this; a server MUST NOT
+process 1-RTT packets until the cryptographic handshake is complete.
 
 An endpoint uses the KEYS_ACTIVE frame in 1-RTT packets to indicate that it is
 able to receive a key update (see Section 6 of {{QUIC-TLS}}).


### PR DESCRIPTION
This section was pretty old and it had at least one bug, along with a bunch of editorial lack of clarity.

Substantively, this does two things:

1. It specifies what label to use for the KDF when updating.  The agreement at one time was that we would use a quic-specific label, but that never really got captured properly.  This proposes "quic ku".

2. It takes another bit to signal whether a key update is permitted.  As noted in  #2214, simultaneous updates can result in a deadlock if updates happen too quickly, so endpoints can use this bit to limit the rate at which updates occur.

(Note: this second point was changed based on feedback about the original PR.)

Closes #2214.