### PR TITLE
Invalid Largest Reference is a stream error.

### DIFF
--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -864,13 +864,13 @@ decoder's dynamic table:
    if EncodedInsertCount == 0:
       ReqInsertCount = 0
    else:
-      InsertCount = EncodedInsertCount - 1
+      ReqInsertCount = EncodedInsertCount - 1
       CurrentWrapped = TotalNumberOfInserts mod (2 * MaxEntries)
 
-      if CurrentWrapped >= InsertCount + MaxEntries:
+      if CurrentWrapped >= ReqInsertCount + MaxEntries:
          # Insert Count wrapped around 1 extra time
          ReqInsertCount += 2 * MaxEntries
-      else if CurrentWrapped + MaxEntries < InsertCount:
+      else if CurrentWrapped + MaxEntries < ReqInsertCount:
          # Decoder wrapped around 1 extra time
          CurrentWrapped += 2 * MaxEntries
 

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -864,6 +864,9 @@ decoder's dynamic table:
    if EncodedInsertCount == 0:
       ReqInsertCount = 0
    else:
+      if EncodedInsertCount > 2 * MaxEntries:
+         Error
+
       ReqInsertCount = EncodedInsertCount - 1
       CurrentWrapped = TotalNumberOfInserts mod (2 * MaxEntries)
 
@@ -875,7 +878,13 @@ decoder's dynamic table:
          CurrentWrapped += 2 * MaxEntries
 
       ReqInsertCount += TotalNumberOfInserts - CurrentWrapped
+
+      if ReqInsertCount <= 0:
+         Error
 ~~~
+
+An error detected by the decoding algorithm indicates invalid input, and MUST be
+treated as a stream error of type `HTTP_QPACK_DECOMPRESSION_FAILED`.
 
 This encoding limits the length of the prefix on long-lived connections.
 


### PR DESCRIPTION
If Largest Reference does not figure, then the decoded Base Index will probably be bogus, resulting in corrupt entries.  I think it's better to close the connection with an error.