### PR TITLE
Clarify when a dynamic table entry can be evicted.

### DIFF
--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -210,10 +210,18 @@ acknowledged by the decoder.
 
 ### Blocked Dynamic Table Insertions {#blocked-insertion}
 
+The encoder considers a dynamic table entry to be blocking if it has not yet
+received acknowledgement of insertion of the entry, or if it has not yet
+received acknowledgement of all references to the entry.  Note that a dynamic
+table entry that has never been referenced can still be blocking.  Also note
+that a blocking entry cannot be evicted, which is unrelated to a blocked stream,
+which cannot be decoded.  In particular, dynamic table entries can be blocking
+even if blocked streams are not allowed.
+
 An encoder MUST NOT insert an entry into the dynamic table (or duplicate an
-existing entry) if doing so would evict an entry with unacknowledged references.
-For header blocks that might rely on the newly added entry, the encoder can use
-a literal representation.
+existing entry) if doing so would evict a blocking entry.  For header blocks
+that would rely on the newly added entry, the encoder can instead use a literal
+representation.
 
 To ensure that the encoder is not prevented from adding new entries, the encoder
 can avoid referencing entries that are close to eviction.  Rather than
@@ -223,7 +231,7 @@ reference such an entry, the encoder can emit a Duplicate instruction (see
 Determining which entries are too close to eviction to reference is an encoder
 preference.  One heuristic is to target a fixed amount of available space in the
 dynamic table: either unused space or space that can be reclaimed by evicting
-unreferenced entries.  To achieve this, the encoder can maintain a draining
+non-blocking entries.  To achieve this, the encoder can maintain a draining
 index, which is the smallest absolute index in the dynamic table that it will
 emit a reference for.  As new entries are inserted, the encoder increases the
 draining index to maintain the section of the table that it will not reference.
@@ -324,10 +332,9 @@ permit the encoder to track the decoder's state.  These events are:
 
 Knowledge that a header block with references to the dynamic table has been
 processed permits the encoder to evict entries to which no unacknowledged
-references remain, regardless of whether those references were potentially
-blocking (see {{blocked-insertion}}).  When a stream is reset or abandoned, the
-indication that these header blocks will never be processed serves a similar
-function; see {{stream-cancellation}}.
+references remain; see {{blocked-insertion}}.  When a stream is reset or
+abandoned, the indication that these header blocks will never be processed
+serves a similar function; see {{stream-cancellation}}.
 
 The decoder chooses when to emit Insert Count Increment instructions (see
 {{insert-count-increment}}). Emitting an instruction after adding each new
@@ -396,8 +403,8 @@ limit on its size.
 Before a new entry is added to the dynamic table, entries are evicted from the
 end of the dynamic table until the size of the dynamic table is less than or
 equal to (table capacity - size of new entry) or until the table is empty. The
-encoder MUST NOT evict a dynamic table entry unless it has first been
-acknowledged by the decoder.
+encoder MUST NOT evict a blocking dynamic table entry (see
+{{blocked-insertion}}).
 
 If the size of the new entry is less than or equal to the dynamic table
 capacity, then that entry is added to the table.  It is an error if the encoder
@@ -698,9 +705,9 @@ that exceeds this limit as a connection error of type
 `HTTP_QPACK_ENCODER_STREAM_ERROR`.
 
 Reducing the dynamic table capacity can cause entries to be evicted (see
-{{eviction}}).  This MUST NOT cause the eviction of entries with outstanding
-references (see {{reference-tracking}}).  Changing the capacity of the dynamic
-table is not acknowledged as this instruction does not insert an entry.
+{{eviction}}).  This MUST NOT cause the eviction of blocking entries (see
+{{blocked-insertion}}).  Changing the capacity of the dynamic table is not
+acknowledged as this instruction does not insert an entry.
 
 
 ## Decoder Stream

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -210,18 +210,20 @@ acknowledged by the decoder.
 
 ### Blocked Dynamic Table Insertions {#blocked-insertion}
 
-The encoder considers a dynamic table entry to be blocking if it has not yet
-received acknowledgement of insertion of the entry, or if it has not yet
-received acknowledgement of all references to the entry.  Note that a dynamic
-table entry that has never been referenced can still be blocking.  Also note
-that a blocking entry cannot be evicted, which is unrelated to a blocked stream,
-which cannot be decoded.  In particular, dynamic table entries can be blocking
-even if blocked streams are not allowed.
+A dynamic table entry is considered blocking and cannot be evicted until its
+insertion has been acknowledged and there are no outstanding unacknowledged
+references to the entry.  In particular, a dynamic table entry that has never
+been referenced can still be blocking.
+
+Note:
+: A blocking entry is unrelated to a blocked stream, which is a stream that a
+  decoder cannot decode as a result of references to entries that are not yet
+  available.  Any encoder that uses the dynamic table has to keep track of
+  blocked entries, whereas blocked streams are optional.
 
 An encoder MUST NOT insert an entry into the dynamic table (or duplicate an
-existing entry) if doing so would evict a blocking entry.  For header blocks
-that would rely on the newly added entry, the encoder can instead use a literal
-representation.
+existing entry) if doing so would evict a blocking entry.  In this case, the
+encoder can send literal representations of header fields.
 
 To ensure that the encoder is not prevented from adding new entries, the encoder
 can avoid referencing entries that are close to eviction.  Rather than
@@ -332,9 +334,9 @@ permit the encoder to track the decoder's state.  These events are:
 
 Knowledge that a header block with references to the dynamic table has been
 processed permits the encoder to evict entries to which no unacknowledged
-references remain; see {{blocked-insertion}}.  When a stream is reset or
+references remain (see {{blocked-insertion}}).  When a stream is reset or
 abandoned, the indication that these header blocks will never be processed
-serves a similar function; see {{stream-cancellation}}.
+serves a similar function (see {{stream-cancellation}}).
 
 The decoder chooses when to emit Insert Count Increment instructions (see
 {{insert-count-increment}}). Emitting an instruction after adding each new


### PR DESCRIPTION
A dynamic table entry that has not been acknowledged by the decoder must not be
evicted by the encoder, even if there has never been any references to it.  This
is already alluded to in the current spec at
https://quicwg.org/base-drafts/draft-ietf-quic-qpack.html#eviction by the phrase
"acknowledged by the decoder", but since "acknowledged" is used interchangeably
for acknowledging the insertion instruction and acknowledging references, a
reader could understand this to mean "all references acknowledged".  In
addition, at three other places eviction of entries with unacknowledged
references are banned, with unambigously no ban on eviction of unacknowledged
entries with no references.  I argue that more explicit language would be
beneficial.

This issue has already been discussed at
https://github.com/quicwg/base-drafts/issues/1644#issuecomment-411894178
and below.

Note that avoiding this kind of corruption could also be achieved by banning an
encoder from inserting entries that it does not immediately reference, but this
is probably way too restrictive.  For example, an encoder might wish to achieve
best latency and speculatively improve future compression ratio at the expense
of potentially wasting current bandwidth by encoding header fields as literals
while inserting them at the same time for potiential future use.  This is
already alluded to in the spec at multiple places.

Below is a specific scenario when this issue might cause corruption:

Suppose MaxEntries is 5.

Suppose that there is a fresh connection, with an empty dynamic table, and there
is a header list to be sent that has two header fields which fit in the dynamic
table together.

Suppose one encoder implementation inserts these two header fields into the
dynamic table, and encodes the header list using two Indexed Header Field
instructions, referring to absolute indices 1 and 2.  This header block will
have an abstract Largest Reference value of 2, which is encoded as 3 on the
wire.  A spec compliant decoder should have no difficultly correctly decoding
this header block.

Suppose another encoder implementation starts by adding 10 unique entries, all
different from the two header fields in the header list to be sent, to the
dynamic table, but does not emit references to any of them.   Of course in the
end only the last couple will stay in the dynamic table, the rest will be
evicted.  This can be considered spec compliant depending on how one interprets
the spec, see above.  Suppose that after this, this encoder implementation
encodes our header list by inserting both header fields into the dynamic table,
with absolute indices 11 and 12, and using two Indexed Header Field instructions
on the request stream.  The abstract Largest Reference value is 12, which is
encoded as 3 on the wire since 2 * MaxEntries == 10.

Now suppose that out of the 12 instructions on the encoder stream, only the
first two arrive before all the request stream data are received.  The remaining
10 instructions on the encoder stream are delayed on the wire.  Now a spec
compliant decoder sees the same header block on the request stream, bit by bit,
as above, and two insertions on the encoder stream.  It will emit dynamic table
entires 1 and 2, which are different from the encoded header list.