### PR TITLE
only require RESET_STREAM on STOP_SENDING in Ready and Sent state

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -647,10 +647,10 @@ upon receipt.
 
 A STOP_SENDING frame requests that the receiving endpoint send a RESET_STREAM
 frame.  An endpoint that receives a STOP_SENDING frame MUST send a RESET_STREAM
-frame for that stream.  An endpoint SHOULD copy the error code from the
-STOP_SENDING frame, but MAY use any application error code.  The endpoint
-that sends a STOP_SENDING frame can ignore the error code carried in any
-RESET_STREAM frame it receives.
+frame for that stream, if the stream is in the Ready or the Send state.  An
+endpoint SHOULD copy the error code from the STOP_SENDING frame, but MAY use
+any application error code.  The endpoint that sends a STOP_SENDING frame can
+ignore the error code carried in any RESET_STREAM frame it receives.
 
 If the STOP_SENDING frame is received on a stream that is already in the
 "Data Sent" state, an endpoint that wishes to cease retransmission of


### PR DESCRIPTION
When all data has already been sent on a stream, we allow two responses to receiving a STOP_SENDING:
> If the STOP_SENDING frame is received on a stream that is already in the “Data Sent” state, an endpoint that wishes to cease retransmission of previously-sent STREAM frames on that stream MUST first send a RESET_STREAM frame.

The two options:
1. reliably deliver all STREAM frames
2. cease retransmission of STREAM frames, and send a RESET_STREAM instead

In case 1., it's not necessary to send a RESET_STREAM frame, since the peer will learn about the final offset of the stream from the STREAM frame with the FIN bit.