### PR TITLE
Fix: detect stateless reset if connection not found

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2420,13 +2420,15 @@ the packet other than the last 16 bytes for carrying data.
 
 ### Detecting a Stateless Reset
 
-An endpoint detects a potential stateless reset when a packet with a short
-header either cannot be decrypted or is marked as a duplicate packet.  The
-endpoint then compares the last 16 bytes of the packet with the Stateless Reset
-Token provided by its peer, either in a NEW_CONNECTION_ID frame or the server's
-transport parameters.  If these values are identical, the endpoint MUST enter
-the draining period and not send any further packets on this connection.  If the
-comparison fails, the packet can be discarded.
+An endpoint detects a potential stateless reset when a incoming packet
+with a short header either cannot be associated with a connection;
+cannot be decrypted; or is marked as a duplicate packet.  The endpoint
+then compares the last 16 bytes of the packet with the Stateless Reset
+Token provided by its peer, either in a NEW_CONNECTION_ID frame or
+the server's transport parameters.  If these values are identical,
+the endpoint MUST enter the draining period and not send any further
+packets on this connection.  If the comparison fails, the packet can be
+discarded.
 
 
 ### Calculating a Stateless Reset Token {#reset-token}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2422,7 +2422,7 @@ the packet other than the last 16 bytes for carrying data.
 
 An endpoint detects a potential stateless reset when a incoming packet
 with a short header either cannot be associated with a connection;
-cannot be decrypted; or is marked as a duplicate packet.  The endpoint
+cannot be decrypted, or is marked as a duplicate packet.  The endpoint
 then compares the last 16 bytes of the packet with the Stateless Reset
 Token provided by its peer, either in a NEW_CONNECTION_ID frame or
 the server's transport parameters.  If these values are identical,

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2421,7 +2421,7 @@ the packet other than the last 16 bytes for carrying data.
 ### Detecting a Stateless Reset
 
 An endpoint detects a potential stateless reset when a incoming packet
-with a short header either cannot be associated with a connection;
+with a short header either cannot be associated with a connection,
 cannot be decrypted, or is marked as a duplicate packet.  The endpoint
 then compares the last 16 bytes of the packet with the Stateless Reset
 Token provided by its peer, either in a NEW_CONNECTION_ID frame or


### PR DESCRIPTION
If connection for incoming packet cannot be found, check whether this is a stateless reset packet.  Fixes #2269.