### PR TITLE
Add missing warning about ODCIL encoding

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -5486,6 +5486,7 @@ Issue and pull request numbers are listed with a leading octothorp.
   - Add spin bit to short header (#631, #1988)
   - Encrypt the remainder of the first byte (#1322)
   - Move packet number length to first byte
+  - Move ODCIL to first byte of retry packets
   - Simplify packet number protection (#1575)
 - Allow STOP_SENDING to open a remote bidirectional stream (#1797, #2013)
 - Added mitigation for off-path migration attacks (#1278, #1749, #2033)


### PR DESCRIPTION
In draft 17, ODCIL is encoded as bottom 4 bits of first byte of retry packets. This is a change from draft 16, but was not noted in the change list. At least 2 implementers consequently failed to notice it.