### PR TITLE
Include handshake anti-deadlock logic in pseudocode

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1135,10 +1135,10 @@ OnLossDetectionTimeout():
   else if (endpoint is client without 1-RTT keys):
     // Send anti-deadlock packet: padded to earn more anti-
     // amplification credit, unpadded to prove address ownership.
-    if (will send Initial packet):
-       SendOnePaddedPacket()
+    if (has Handshake keys):
+       SendOneHandshakePacket()
      else:
-       SendOnePacket()
+       SendOnePaddedInitialPacket()
     crypto_count++
   else:
     // PTO

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1078,19 +1078,14 @@ GetEarliestLossTime():
   return time, space
 
 SetLossDetectionTimer():
-  // Don't arm timer if there are no ack-eliciting packets
-  // in flight.
-  if (no ack-eliciting packets in flight):
-    loss_detection_timer.cancel()
-    return
-
   loss_time, _ = GetEarliestLossTime()
   if (loss_time != 0):
     // Time threshold loss detection.
     loss_detection_timer.update(loss_time)
     return
 
-  if (crypto packets are in flight):
+  if (crypto packets are in flight
+      || endpoint is client without 1-RTT keys):
     // Crypto retransmission timer.
     if (smoothed_rtt == 0):
       timeout = 2 * kInitialRtt
@@ -1100,6 +1095,12 @@ SetLossDetectionTimer():
     timeout = timeout * (2 ^ crypto_count)
     loss_detection_timer.update(
       time_of_last_sent_crypto_packet + timeout)
+    return
+
+  // Don't arm timer if there are no ack-eliciting packets
+  // in flight.
+  if (no ack-eliciting packets in flight):
+    loss_detection_timer.cancel()
     return
 
   // Calculate PTO duration
@@ -1130,6 +1131,14 @@ OnLossDetectionTimeout():
   else if (crypto packets are in flight):
     // Crypto retransmission timeout.
     RetransmitUnackedCryptoData()
+    crypto_count++
+  else if (endpoint is client without 1-RTT keys):
+    // Send anti-deadlock packet: padded to earn more anti-
+    // amplification credit, unpadded to prove address ownership.
+    if (will send Initial packet):
+       SendOnePaddedPacket()
+     else:
+       SendOnePacket()
     crypto_count++
   else:
     // PTO


### PR DESCRIPTION
Recovery §6.2.1 instructs:
> Because the server could be blocked until more packets are received, the client MUST start the crypto retransmission timer even if there is no unacknowledged CRYPTO data. If the timer expires and the client has no CRYPTO data to retransmit and does not have Handshake keys, it SHOULD send an Initial packet in a UDP datagram of at least 1200 bytes. If the client has Handshake keys, it SHOULD send a Handshake packet.

but this was not reflected in the pseudocode. I think these changes reflect the intended behavior.