### PR TITLE
draft-tls typo: replace mention of packet number protection with header protection

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1370,7 +1370,7 @@ The QUIC packet protection keys and IVs are derived using a different label than
 the equivalent keys in TLS.
 
 To preserve this separation, a new version of QUIC SHOULD define new labels for
-key derivation for packet protection key and IV, plus the packet number
+key derivation for packet protection key and IV, plus the header
 protection keys.
 
 The initial secrets also use a key that is specific to the negotiated QUIC


### PR DESCRIPTION
draft-tls typo: replace mention of packet number protection with header protection