### PR TITLE
Allow extra data after self-terminating h3 frames

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -421,10 +421,10 @@ A frame includes the following fields:
   Frame Payload:
   : A payload, the semantics of which are determined by the Type field.
 
-Each frame's payload MUST contain exactly the identified fields.  A frame that
-contains additional bytes after the identified fields or a frame that terminates
+Each frame's payload MUST contain the identified fields.  A frame that terminates
 before the end of the identified fields MUST be treated as a connection error of
-type HTTP_MALFORMED_FRAME.
+type HTTP_MALFORMED_FRAME.  Any additional bytes after the identified fields of
+a given frame MUST be silently ignored, to allow future extensibility.
 
 ## Frame Definitions {#frames}
 

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -421,10 +421,11 @@ A frame includes the following fields:
   Frame Payload:
   : A payload, the semantics of which are determined by the Type field.
 
-Each frame's payload MUST contain the identified fields.  A frame that terminates
-before the end of the identified fields MUST be treated as a connection error of
-type HTTP_MALFORMED_FRAME.  Any additional bytes after the identified fields of
-a given frame MUST be silently ignored, to allow future extensibility.
+Each frame's payload MUST contain the identified fields.  A frame that
+terminates before the end of the identified fields MUST be treated as a
+connection error of type HTTP_MALFORMED_FRAME.  Any additional bytes after
+the identified fields of a given frame MUST be silently ignored, to allow
+future extensibility.
 
 ## Frame Definitions {#frames}
 


### PR DESCRIPTION
The current spec is overly restrictive when it comes to self-terminating h3 frames. If implementations ignore extra data after the expected bytes, this will allow us to add fields down the road without the need to specify new frame types.
Fixes #2291.