### PR TITLE
Allow servers to send a preferred address of each address family

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4103,13 +4103,14 @@ preferred_address (0x000d):
   of this transport parameter is the PreferredAddress struct shown in
   {{fig-preffered-address}}.  This transport parameter is only sent by a server.
   Servers MAY choose to only send a preferred address of one address family by
-  sending a zero-length address for the other family.
+  sending an all-zero address and port (0.0.0.0:0 or ::.0) for the other family.
 
 ~~~
    struct {
-     opaque ipv4Address<0..2^8-1>;
-     opaque ipv6Address<0..2^8-1>;
-     uint16 port;
+     opaque ipv4Address[4];
+     uint16 ipv4Port;
+     opaque ipv6Address[16];
+     uint16 ipv6Port;
      opaque connectionId<0..18>;
      opaque statelessResetToken[16];
    } PreferredAddress;

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2173,6 +2173,9 @@ receiving a probe packet from a different address.  Servers MUST NOT send more
 than a minimum congestion window's worth of non-probing packets to the new
 address before path validation is complete.
 
+When a client wishes to migrate to a new local address that is of a different
+address family from the currently used server address, the client can attempt
+migration with the server's preferred address from the matching address family.
 
 # Connection Termination {#termination}
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2119,9 +2119,10 @@ transport parameter in the TLS handshake.
 Servers MAY communicate a preferred address of each address family (IPv4 and
 IPv6) to allow clients to pick the one most suited to their network attachment.
 
-Once the handshake is finished, the client SHOULD initiate path validation (see
-{{migrate-validate}}) of the server's preferred address using the connection ID
-provided in the preferred_address transport parameter.
+Once the handshake is finished, the client SHOULD select one of the two
+server's preferred addresses and initiate path validation (see
+{{migrate-validate}}) of that address using the connection ID provided in the
+preferred_address transport parameter.
 
 If path validation succeeds, the client SHOULD immediately begin sending all
 future packets to the new server address using the new connection ID and
@@ -4101,7 +4102,7 @@ preferred_address (0x000d):
 : The server's preferred address is used to effect a change in server address at
   the end of the handshake, as described in {{preferred-address}}.  The format
   of this transport parameter is the PreferredAddress struct shown in
-  {{fig-preffered-address}}.  This transport parameter is only sent by a server.
+  {{fig-preferred-address}}.  This transport parameter is only sent by a server.
   Servers MAY choose to only send a preferred address of one address family by
   sending an all-zero address and port (0.0.0.0:0 or ::.0) for the other family.
 
@@ -4115,7 +4116,7 @@ preferred_address (0x000d):
      opaque statelessResetToken[16];
    } PreferredAddress;
 ~~~
-{: #fig-preffered-address title="Preferred Address format"}
+{: #fig-preferred-address title="Preferred Address format"}
 
 If present, transport parameters that set initial flow control limits
 (initial_max_stream_data_bidi_local, initial_max_stream_data_bidi_remote, and

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2173,9 +2173,9 @@ receiving a probe packet from a different address.  Servers MUST NOT send more
 than a minimum congestion window's worth of non-probing packets to the new
 address before path validation is complete.
 
-When a client wishes to migrate to a new local address that is of a different
-address family from the currently used server address, the client can attempt
-migration with the server's preferred address from the matching address family.
+A client that migrates to a new address SHOULD use a preferred address from the
+same address family for the server.
+
 
 # Connection Termination {#termination}
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2116,6 +2116,9 @@ packets.
 A server conveys a preferred address by including the preferred_address
 transport parameter in the TLS handshake.
 
+Servers MAY communicate a preferred address of each address family (IPv4 and
+IPv6) to allow clients to pick the one most suited to their network attachment.
+
 Once the handshake is finished, the client SHOULD initiate path validation (see
 {{migrate-validate}}) of the server's preferred address using the connection ID
 provided in the preferred_address transport parameter.
@@ -4099,11 +4102,13 @@ preferred_address (0x000d):
   the end of the handshake, as described in {{preferred-address}}.  The format
   of this transport parameter is the PreferredAddress struct shown in
   {{fig-preffered-address}}.  This transport parameter is only sent by a server.
+  Servers MAY choose to only send a preferred address of one address family by
+  sending a zero-length address for the other family.
 
 ~~~
    struct {
-     enum { IPv4(4), IPv6(6), (15) } ipVersion;
-     opaque ipAddress<4..2^8-1>;
+     opaque ipv4Address<0..2^8-1>;
+     opaque ipv6Address<0..2^8-1>;
      uint16 port;
      opaque connectionId<0..18>;
      opaque statelessResetToken[16];


### PR DESCRIPTION
This change allows servers to send a preferred address of each address family. The previous definition of preferred_address only allowed sending one address family, and this had the disadvantage of picking the non-deterministic address family used by the Initial if the client is performing Happy Eyeballs. Clients may now use the best address family based on their network attachment.

Fixes #2122.