### PR TITLE
use the STREAM_STATE_ERROR for stream-related errors

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4374,7 +4374,7 @@ of STREAM frames on the identified stream.  A receiver of RESET_STREAM can
 discard any data that it already received on that stream.
 
 An endpoint that receives a RESET_STREAM frame for a send-only stream MUST
-terminate the connection with error PROTOCOL_VIOLATION.
+terminate the connection with error STREAM_STATE_ERROR.
 
 The RESET_STREAM frame is as follows:
 
@@ -4418,9 +4418,9 @@ Receipt of a STOP_SENDING frame is invalid for a locally-initiated stream that
 has not yet been created or is in the "Ready" state (see
 {{stream-send-states}}). Receiving a STOP_SENDING frame for a locally-initiated
 stream that is "Ready" or not yet created MUST be treated as a connection error
-of type PROTOCOL_VIOLATION.  An endpoint that receives a STOP_SENDING frame for
+of type STREAM_STATE_ERROR.  An endpoint that receives a STOP_SENDING frame for
 a receive-only stream MUST terminate the connection with error
-PROTOCOL_VIOLATION.
+STREAM_STATE_ERROR.
 
 The STOP_SENDING frame is as follows:
 
@@ -4547,7 +4547,7 @@ are present in the frame.
   marks the end of the stream.
 
 An endpoint that receives a STREAM frame for a send-only stream MUST terminate
-the connection with error PROTOCOL_VIOLATION.
+the connection with error STREAM_STATE_ERROR.
 
 The STREAM frames are as follows:
 
@@ -4633,10 +4633,10 @@ The MAX_STREAM_DATA frame (type=0x11) is used in flow control to inform a peer
 of the maximum amount of data that can be sent on a stream.
 
 An endpoint that receives a MAX_STREAM_DATA frame for a receive-only stream
-MUST terminate the connection with error PROTOCOL_VIOLATION.
+MUST terminate the connection with error STREAM_STATE_ERROR.
 
 An endpoint that receives a MAX_STREAM_DATA frame for a send-only stream
-it has not opened MUST terminate the connection with error PROTOCOL_VIOLATION.
+it has not opened MUST terminate the connection with error STREAM_STATE_ERROR.
 
 Note that an endpoint may legally receive a MAX_STREAM_DATA frame on a
 bidirectional stream it has not opened.
@@ -4749,7 +4749,7 @@ send data, but is unable to due to stream-level flow control.  This frame is
 analogous to DATA_BLOCKED ({{frame-data-blocked}}).
 
 An endpoint that receives a STREAM_DATA_BLOCKED frame for a send-only stream
-MUST terminate the connection with error PROTOCOL_VIOLATION.
+MUST terminate the connection with error STREAM_STATE_ERROR.
 
 The STREAM_DATA_BLOCKED frame is as follows:
 


### PR DESCRIPTION
So far, we didn't use the STREAM_STATE_ERROR at all