### PR TITLE
allow PING frames in Initial and Handshake packets

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3801,7 +3801,7 @@ Handshake packet sent by a server contains a packet number of 0.
 The payload of this packet type contains CRYPTO frames and could contain
 PADDING, PING and ACK frames. Handshake packets MAY contain CONNECTION_CLOSE
 frames.  Endpoints MUST treat receipt of Handshake packets with other frames as
-a connection error.
+a connection error of type PROTOCOL_VIOLATION.
 
 Like Initial packets (see {{discard-initial}}), data in CRYPTO frames at the
 Handshake encryption level is discarded - and no longer retransmitted - when

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3798,9 +3798,10 @@ includes the connection ID that the sender of the packet wishes to use (see
 Handshake packets are their own packet number space, and thus the first
 Handshake packet sent by a server contains a packet number of 0.
 
-The payload of this packet contains CRYPTO frames and could contain PADDING, or
-ACK frames. Handshake packets MAY contain CONNECTION_CLOSE frames.  Endpoints
-MUST treat receipt of Handshake packets with other frames as a connection error.
+The payload of this packet type contains CRYPTO frames and could contain
+PADDING, PING and ACK frames. Handshake packets MAY contain CONNECTION_CLOSE
+frames.  Endpoints MUST treat receipt of Handshake packets with other frames as
+a connection error.
 
 Like Initial packets (see {{discard-initial}}), data in CRYPTO frames at the
 Handshake encryption level is discarded - and no longer retransmitted - when

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3700,7 +3700,7 @@ server may send multiple Initial packets.  The cryptographic key exchange could
 require multiple round trips or retransmissions of this data.
 
 The payload of an Initial packet includes a CRYPTO frame (or frames) containing
-a cryptographic handshake message, ACK frames, or both.  PADDING and
+a cryptographic handshake message, ACK frames, or both.  PADDING, PING and
 CONNECTION_CLOSE frames are also permitted.  An endpoint that receives an
 Initial packet containing other frames can either discard the packet as spurious
 or treat it as a connection error.


### PR DESCRIPTION
Furthermore, specify the error code to send when encountering invalid frames at the Handshake encryption level.