### PR TITLE
Elaborate on the ALPN requirement

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1215,7 +1215,9 @@ QUIC requires that the cryptographic handshake provide authenticated protocol
 negotiation.  TLS uses Application Layer Protocol Negotiation (ALPN)
 {{!RFC7301}} to select an application protocol.  Unless another mechanism is
 used for agreeing on an application protocol, endpoints MUST use ALPN for this
-purpose.
+purpose.  Specifically, the client MUST send the ALPN extension, the server MUST
+reply with the selected protocol, and the peers MUST abort the connection if the
+preceeding requirements are violated.
 
 An application-layer protocol MAY restrict the QUIC versions that it can operate
 over.  Servers MUST select an application protocol compatible with the QUIC

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1219,6 +1219,11 @@ properties:
 * authenticated negotiation of an application protocol (TLS uses ALPN
   {{?RFC7301}} for this purpose)
 
+The negotiation of the application protocol is not merely available in QUIC, but
+is REQUIRED.  Without it, the peers would infer the protocol used from context
+(e.g. UDP port number), which could potentially lead to the situation in which
+they disagree on the application protocol without being aware of it.
+
 The first CRYPTO frame from a client MUST be sent in a single packet.  Any
 second attempt that is triggered by address validation (see
 {{validate-handshake}}) MUST also be sent within a single packet. This avoids


### PR DESCRIPTION
- Explain why it's there.
- Write down the specific requirements for TLS ALPN.