### PR TITLE
Ignore packet loss when the keys are not available

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -450,7 +450,7 @@ is expected to be infrequent.
 
 During the handshake, some packet protection keys might not be
 available when a packet arrives. In particular, Handshake and 0-RTT packets
-will not be processable until the Initial flight arrives and 1-RTT packets
+can't be processed until the Initial flight arrives and 1-RTT packets
 will not be processable until the handshake completes.  Implementations MAY
 ignore the loss of Handshake, 0-RTT, and 1-RTT packets that arrive before the
 peer has packet protection keys to process those packets.

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -44,6 +44,18 @@ normative:
         org: Mozilla
         role: editor
 
+    QUIC-TLS:
+    title: "Using TLS to Secure QUIC"
+    date: {DATE}
+    seriesinfo:
+      Internet-Draft: draft-ietf-quic-tls-latest
+    author:
+      -
+        ins: M. Thomson
+        name: Martin Thomson
+        org: Mozilla
+        role: editor
+
 informative:
 
   FACK:

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -429,11 +429,12 @@ a subsequent connection attempt to the server.
 
 #### Discarding Keys and Packet State {#discarding-packets}
 
-When packet protection keys are discarded (see Section 4.9 of {{QUIC-TLS}}), recovery state for all in-flight packets sent with
-those keys is discarded.  The packets are removed from the count of
-bytes in flight and no acknowledgements or loss events will occur
-for those packets.  Note that it is expected that keys are discarded after those
-packets would be declared lost, but Initial secrets are destroyed earlier.
+When packet protection keys are discarded (see Section 4.9 of {{QUIC-TLS}}),
+recovery state for all in-flight packets sent with those keys is discarded.
+The packets are removed from the count of bytes in flight and no
+acknowledgements or loss events will occur for those packets.  Note that it
+is expected that keys are discarded after those packets would be declared lost,
+but Initial secrets are destroyed earlier.
 
 As described in Section 17.5.1 of {{QUIC-TRANSPORT}}, endpoints stop sending and
 receiving Initial packets once they start exchanging Handshake packets.  At this

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -451,7 +451,7 @@ is expected to be infrequent.
 During the handshake, some packet protection keys might not be
 available when a packet arrives. In particular, Handshake and 0-RTT packets
 can't be processed until the Initial flight arrives and 1-RTT packets
-will not be processable until the handshake completes.  Implementations MAY
+can't be processed until the handshake completes.  Endpoints MAY
 ignore the loss of Handshake, 0-RTT, and 1-RTT packets that arrive before the
 peer has packet protection keys to process those packets.
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -437,7 +437,7 @@ packets would be declared lost, but Initial secrets are destroyed earlier.
 
 As described in Section 17.5.1 of {{QUIC-TRANSPORT}}, endpoints stop sending and
 receiving Initial packets once they start exchanging Handshake packets.  At this
-point, recovery state for all in-flight Initial packets is discarded. 
+point, recovery state for all in-flight Initial packets is discarded.
 
 When 0-RTT is rejected, recovery state for all in-flight 0-RTT packets is
 discarded.

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -447,16 +447,16 @@ a subsequent connection attempt to the server.
 
 #### Discarding Keys and Packet State {#discarding-packets}
 
-When packet protection keys are discarded (see Section 4.9 of {{QUIC-TLS}}),
-recovery state for all in-flight packets sent with those keys is discarded.
-The packets are removed from the count of bytes in flight and no
-acknowledgements or loss events will occur for those packets.  Note that it
-is expected that keys are discarded after those packets would be declared lost,
-but Initial secrets are destroyed earlier.
+When packet protection keys are discarded (see Section 4.9 of {{QUIC-TLS}}), all
+packets that were sent with those keys can no longer be acknowledged because
+their acknowledgements cannot be processed anymore. The sender considers them no
+longer in flight. That is, the sender SHOULD discard all recovery state
+associated with those packets and MUST remove them from the count of bytes in
+flight.
 
-As described in Section 17.5.1 of {{QUIC-TRANSPORT}}, endpoints stop sending and
-receiving Initial packets once they start exchanging Handshake packets.  At this
-point, recovery state for all in-flight Initial packets is discarded.
+Endpoints stop sending and receiving Initial packets once they start exchanging
+Handshake packets (see Section 17.2.2.1 of {{QUIC-TRANSPORT}}). At this point,
+recovery state for all in-flight Initial packets is discarded.
 
 When 0-RTT is rejected, recovery state for all in-flight 0-RTT packets is
 discarded.
@@ -464,6 +464,12 @@ discarded.
 If a server accepts 0-RTT, but does not buffer 0-RTT packets that arrive
 before Initial packets, early 0-RTT packets will be declared lost, but that
 is expected to be infrequent.
+
+It is expected that keys are discarded after packets encrypted with them would
+be acknowledged or declared lost.  Initial secrets however might be destroyed
+sooner, as soon as handshake keys are available (see Section 4.10 of
+{{QUIC_TLS}}).
+
 
 ### Probe Timeout {#pto}
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -59,7 +59,6 @@ normative:
         ins: S. Turner
         name: Sean Turner
         org: sn3rd
-        email: sean@sn3rd.com
         role: editor
 
 informative:

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -449,7 +449,7 @@ is expected to be infrequent.
 #### Ignoring Loss of Undecryptable Packets
 
 During the handshake, some packet protection keys might not be
-available when the packet arrives. In particular, Handshake and 0-RTT packets
+available when a packet arrives. In particular, Handshake and 0-RTT packets
 will not be processable until the Initial flight arrives and 1-RTT packets
 will not be processable until the handshake completes.  Implementations MAY
 ignore the loss of Handshake, 0-RTT, and 1-RTT packets that arrive before the

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -470,7 +470,7 @@ is expected to be infrequent.
 During the handshake, some packet protection keys might not be
 available when a packet arrives. In particular, Handshake and 0-RTT packets
 cannot be processed until the Initial packets arrive, and 1-RTT packets
-can't be processed until the handshake completes.  Endpoints MAY
+cannot be processed until the handshake completes.  Endpoints MAY
 ignore the loss of Handshake, 0-RTT, and 1-RTT packets that might arrive before the
 peer has packet protection keys to process those packets.
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -979,8 +979,8 @@ During the handshake, some packet protection keys might not be
 available when a packet arrives. In particular, Handshake and 0-RTT packets
 cannot be processed until the Initial packets arrive, and 1-RTT packets
 cannot be processed until the handshake completes.  Endpoints MAY
-ignore the loss of Handshake, 0-RTT, and 1-RTT packets that might arrive before the
-peer has packet protection keys to process those packets.
+ignore the loss of Handshake, 0-RTT, and 1-RTT packets that might arrive before
+the peer has packet protection keys to process those packets.
 
 ## Probe Timeout
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -468,7 +468,7 @@ is expected to be infrequent.
 It is expected that keys are discarded after packets encrypted with them would
 be acknowledged or declared lost.  Initial secrets however might be destroyed
 sooner, as soon as handshake keys are available (see Section 4.10 of
-{{QUIC_TLS}}).
+{{QUIC-TLS}}).
 
 
 ### Probe Timeout {#pto}

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -465,15 +465,6 @@ If a server accepts 0-RTT, but does not buffer 0-RTT packets that arrive
 before Initial packets, early 0-RTT packets will be declared lost, but that
 is expected to be infrequent.
 
-#### Ignoring Loss of Undecryptable Packets
-
-During the handshake, some packet protection keys might not be
-available when a packet arrives. In particular, Handshake and 0-RTT packets
-cannot be processed until the Initial packets arrive, and 1-RTT packets
-cannot be processed until the handshake completes.  Endpoints MAY
-ignore the loss of Handshake, 0-RTT, and 1-RTT packets that might arrive before the
-peer has packet protection keys to process those packets.
-
 ### Probe Timeout {#pto}
 
 A Probe Timeout (PTO) triggers a probe packet when ack-eliciting data is in
@@ -982,6 +973,14 @@ The recovery period limits congestion window reduction to once per round trip.
 During recovery, the congestion window remains unchanged irrespective of new
 losses or increases in the ECN-CE counter.
 
+#### Ignoring Loss of Undecryptable Packets
+
+During the handshake, some packet protection keys might not be
+available when a packet arrives. In particular, Handshake and 0-RTT packets
+cannot be processed until the Initial packets arrive, and 1-RTT packets
+cannot be processed until the handshake completes.  Endpoints MAY
+ignore the loss of Handshake, 0-RTT, and 1-RTT packets that might arrive before the
+peer has packet protection keys to process those packets.
 
 ## Probe Timeout
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -429,7 +429,7 @@ a subsequent connection attempt to the server.
 
 #### Discarding Keys and Packet State {#discarding-packets}
 
-When keys are discarded, recovery state for all in-flight packets sent with
+When packet protection keys are discarded (see Section 4.9 of {{QUIC-TLS}}), recovery state for all in-flight packets sent with
 those keys is discarded.  The packets are removed from the count of
 bytes in flight and no acknowledgements or loss events will occur
 for those packets.  Note that it is expected that keys are discarded after those

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -44,7 +44,7 @@ normative:
         org: Mozilla
         role: editor
 
-    QUIC-TLS:
+  QUIC-TLS:
     title: "Using TLS to Secure QUIC"
     date: {DATE}
     seriesinfo:
@@ -54,6 +54,12 @@ normative:
         ins: M. Thomson
         name: Martin Thomson
         org: Mozilla
+        role: editor
+      -
+        ins: S. Turner
+        name: Sean Turner
+        org: sn3rd
+        email: sean@sn3rd.com
         role: editor
 
 informative:

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -471,7 +471,7 @@ During the handshake, some packet protection keys might not be
 available when a packet arrives. In particular, Handshake and 0-RTT packets
 cannot be processed until the Initial packets arrive, and 1-RTT packets
 can't be processed until the handshake completes.  Endpoints MAY
-ignore the loss of Handshake, 0-RTT, and 1-RTT packets that arrive before the
+ignore the loss of Handshake, 0-RTT, and 1-RTT packets that might arrive before the
 peer has packet protection keys to process those packets.
 
 ### Probe Timeout {#pto}

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -448,7 +448,7 @@ is expected to be infrequent.
 
 #### Ignoring Loss of Undecryptable Packets
 
-During the handshake, the keys to remove packet protection may not yet be
+During the handshake, some packet protection keys might not be
 available when the packet arrives. In particular, Handshake and 0-RTT packets
 will not be processable until the Initial flight arrives and 1-RTT packets
 will not be processable until the handshake completes.  Implementations MAY

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -427,7 +427,7 @@ packet is received.  The client MAY use this value to seed the RTT estimator for
 a subsequent connection attempt to the server.
 
 
-#### Discarding Packet State {#discarding-packets}
+#### Discarding Keys and Packet State {#discarding-packets}
 
 When keys are discarded, recovery state for all in-flight packets sent with
 those keys is discarded.  The packets are removed from the count of

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -973,7 +973,7 @@ The recovery period limits congestion window reduction to once per round trip.
 During recovery, the congestion window remains unchanged irrespective of new
 losses or increases in the ECN-CE counter.
 
-#### Ignoring Loss of Undecryptable Packets
+## Ignoring Loss of Undecryptable Packets
 
 During the handshake, some packet protection keys might not be
 available when a packet arrives. In particular, Handshake and 0-RTT packets

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -469,7 +469,7 @@ is expected to be infrequent.
 
 During the handshake, some packet protection keys might not be
 available when a packet arrives. In particular, Handshake and 0-RTT packets
-can't be processed until the Initial flight arrives and 1-RTT packets
+cannot be processed until the Initial packets arrive, and 1-RTT packets
 can't be processed until the handshake completes.  Endpoints MAY
 ignore the loss of Handshake, 0-RTT, and 1-RTT packets that arrive before the
 peer has packet protection keys to process those packets.


### PR DESCRIPTION
Ignore the loss of Handshake, 0-RTT, and 1-RTT packets if the peer doesn't have the keys to process them.

Also unifies the text on discarding keys and no longer implies that 0-RTT has it's own packet number space.

Fixes #1967  Replaces #2028