### PR TITLE
QPACK: Clarify how maximum dynamic table capacity can be set

### DIFF
--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -391,7 +391,7 @@ without Huffman encoding applied.
 ### Dynamic Table Capacity and Eviction {#eviction}
 
 The encoder sets the capacity of the dynamic table, which serves as the upper
-limit on its size.
+limit on its size.  The initial capcity of the dynamic table is zero.
 
 Before a new entry is added to the dynamic table, entries are evicted from the
 end of the dynamic table until the size of the dynamic table is less than or
@@ -430,8 +430,8 @@ it can choose to use a lower dynamic table capacity (see
 For clients using 0-RTT data in HTTP/3, the maximum table capacity is the
 remembered value of the setting. If the remembered value is not present or is 0,
 the server MAY set it to a non-zero value in its SETTINGS frame. If the
-remembered value is non-zero, the server MUST send this value in its SETTINGS
-frame.  If it specifies any other value, or omits
+remembered value is non-zero, the server MUST send the same non-zero value in
+its SETTINGS frame.  If it specifies any other value, or omits
 SETTINGS_QPACK_MAX_TABLE_CAPACITY from SETTINGS, the encoder must treat this as
 a connection error of type `HTTP_QPACK_DECODER_STREAM_ERROR`.
 

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -427,13 +427,14 @@ The encoder MUST not set a dynamic table capacity that exceeds this maximum, but
 it can choose to use a lower dynamic table capacity (see
 {{set-dynamic-capacity}}).
 
-For clients using 0-RTT data in HTTP/3, the maximum table capacity is the
-remembered value of the setting. If the remembered value is not present or is 0,
-the server MAY set it to a non-zero value in its SETTINGS frame. If the
-remembered value is non-zero, the server MUST send the same non-zero value in
-its SETTINGS frame.  If it specifies any other value, or omits
-SETTINGS_QPACK_MAX_TABLE_CAPACITY from SETTINGS, the encoder must treat this as
-a connection error of type `HTTP_QPACK_DECODER_STREAM_ERROR`.
+For clients using 0-RTT data in HTTP/3, the server's maximum table capacity is
+the remembered value of the setting, or zero if the value was not previously
+sent.  When the client's 0-RTT value of the SETTING is 0, the server MAY set it
+to a non-zero value in its SETTINGS frame. If the remembered value is non-zero,
+the server MUST send the same non-zero value in its SETTINGS frame.  If it
+specifies any other value, or omits SETTINGS_QPACK_MAX_TABLE_CAPACITY from
+SETTINGS, the encoder must treat this as a connection error of type
+`HTTP_QPACK_DECODER_STREAM_ERROR`.
 
 For HTTP/3 servers and HTTP/3 clients when 0-RTT is not attempted or is
 rejected, the maximum table capacity is 0 until the encoder processes a SETTINGS

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -427,16 +427,20 @@ The encoder MUST not set a dynamic table capacity that exceeds this maximum, but
 it can choose to use a lower dynamic table capacity (see
 {{set-dynamic-capacity}}).
 
+For clients using 0-RTT data in HTTP/3, the maximum table capacity is the
+remembered value of the setting. If the remembered value is not present or is 0,
+the server MAY set it to a non-zero value in its SETTINGS frame. If the
+remembered value is non-zero, the server MUST send this value in its SETTINGS
+frame.  If it specifies any other value, or omits
+SETTINGS_QPACK_MAX_TABLE_CAPACITY from SETTINGS, the encoder must treat this as
+a connection error of type `HTTP_QPACK_DECODER_STREAM_ERROR`.
 
-### Initial Dynamic Table Capacity
+For HTTP/3 servers and HTTP/3 clients when 0-RTT is not attempted or is
+rejected, the maximum table capacity is 0 until the encoder processes a SETTINGS
+frame with a non-zero value of SETTINGS_QPACK_MAX_TABLE_CAPACITY.
 
-The initial dynamic table capacity is determined by the corresponding setting
-when HTTP requests or responses are first permitted to be sent.  For clients
-using 0-RTT data in HTTP/3, the initial table capacity is the remembered value
-of the setting, even if the server later specifies a larger maximum dynamic
-table capacity in its SETTINGS frame.  For HTTP/3 servers and HTTP/3 clients
-when 0-RTT is not attempted or is rejected, the initial table capacity is the
-value of the setting in the peer's SETTINGS frame.
+When the maximum table capacity is 0, the encoder MUST NOT insert entries into
+the dynamic table, and MUST NOT send any instructions on the encoder stream.
 
 
 ### Absolute Indexing {#indexing}


### PR DESCRIPTION
0-RTT client
 Use remembered value
 If 0, server can increase in SETTINGS
 otherwise server must use this value in SETTINGS

Everyone else
 Starts at 0
 Can be set to non-zero by SETTINGS

This started as a modification of #2257, but the differences were significant enough I split it off.

Fixes #2276
Fixes #2330 