### PR TITLE
clarify that INITCWND caps amount of data sent to a server before address validation

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1579,6 +1579,9 @@ the client during connection establishment with a Retry packet (see
 {{validate-retry}}) or in a previous connection using the NEW_TOKEN frame (see
 {{validate-future}}).
 
+The amount of data that a server sends to a client prior to validating the
+address is capped by the initial congestion window.
+
 
 ### Address Validation using Retry Packets {#validate-retry}
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1579,7 +1579,7 @@ the client during connection establishment with a Retry packet (see
 {{validate-retry}}) or in a previous connection using the NEW_TOKEN frame (see
 {{validate-future}}).
 
-The amount of data that a server sends to a client prior to validating the
+The amount of data that a client sends to a server prior to validating the
 address is capped by the initial congestion window.
 
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1579,9 +1579,9 @@ the client during connection establishment with a Retry packet (see
 {{validate-retry}}) or in a previous connection using the NEW_TOKEN frame (see
 {{validate-future}}).
 
-The amount that servers are permitted to send is also constrained by the limit
-set by the congestion avoidance algorithm.  Clients are only constrained in what
-they can send prior to address validation by congestion control.
+In addition to sending limits imposed prior to address validation, servers are
+also constrained in what they can send by the limits set by the congestion
+controller.  Clients are only constrained by the congestion controller.
 
 
 ### Address Validation using Retry Packets {#validate-retry}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1579,8 +1579,9 @@ the client during connection establishment with a Retry packet (see
 {{validate-retry}}) or in a previous connection using the NEW_TOKEN frame (see
 {{validate-future}}).
 
-The amount of data that a client sends to a server prior to validating the
-address is capped by the initial congestion window.
+The amount that servers are permitted to send is also constrained by the limit
+set by the congestion avoidance algorithm.  Clients are only constrained in what
+they can send prior to address validation by congestion control.
 
 
 ### Address Validation using Retry Packets {#validate-retry}


### PR DESCRIPTION
Clarifies how we prohibit a server from sending too many packets to a client prior to validating the address.

Closes #2135.