### PR TITLE
Allow most frames in 0-RTT

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1447,6 +1447,10 @@ could pose a security risk to an incautious implementer.  An implementation MUST
 ensure that the length of a frame exactly matches the length of the fields it
 contains.
 
+The use of 0-RTT with HTTP/3 creates an exposure to replay attack.  The
+anti-replay mitigations in {{!HTTP-REPLAY=RFC8470}} MUST be applied when using
+HTTP/3 with 0-RTT.
+
 
 # IANA Considerations
 

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -318,10 +318,10 @@ long as they are associated with the same encryption level. For instance, an
 implementation might bundle a Handshake message and an ACK for some Handshake
 data into the same packet.
 
-Each encryption level has a specific list of frames which may appear in it. The
-rules here generalize those of TLS, in that frames associated with establishing
-the connection can usually appear at any encryption level, whereas those
-associated with transferring data can only appear in the 0-RTT and 1-RTT
+Some frames are prohibited in different encryption levels, others cannot be
+sent. The rules here generalize those of TLS, in that frames associated with
+establishing the connection can usually appear at any encryption level, whereas
+those associated with transferring data can only appear in the 0-RTT and 1-RTT
 encryption levels:
 
 - PADDING frames MAY appear in packets of any encryption level.
@@ -333,6 +333,10 @@ encryption levels:
   can only acknowledge packets which appeared in that packet number space.
 
 - All other frame types MUST only be sent in the 0-RTT and 1-RTT levels.
+
+Note that it is not possible to send some frames in 0-RTT for various reasons.
+In addition to ACK, this includes CRYPTO, NEW_TOKEN, PATH_RESPONSE, and
+RETIRE_CONNECTION_ID.
 
 Because packets could be reordered on the wire, QUIC uses the packet type to
 indicate which level a given packet was encrypted under, as shown in
@@ -1318,9 +1322,9 @@ would need to assess whether those uses were vulnerable to replay attack.
 
 Extensions to QUIC might create an additional exposure to replay attack if they
 are used by application protocols.  QUIC extensions SHOULD describe how replay
-attacks affects their operation.  Application protocols MUST either disable
-extensions in 0-RTT or provide replay mitigation strategies for any use of the
-extension.
+attacks affects their operation.  Application protocols MUST either prohibit the
+use of extensions in 0-RTT or provide replay mitigation strategies for those
+extensions that can be used.
 
 
 ## Packet Reflection Attack Mitigation {#reflection}

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -334,9 +334,11 @@ encryption levels:
 - ACK frames MAY appear in packets of any encryption level other than 0-RTT, but
   can only acknowledge packets which appeared in that packet number space.
 
-- STREAM frames MUST ONLY appear in the 0-RTT and 1-RTT levels.
+- All stream- and flow control-related frame types (RESET_STREAM, STOP_SENDING,
+  STREAM, MAX_DATA, MAX_STREAM_DATA, MAX_STREAMS, DATA_BLOCKED,
+  STREAM_DATA_BLOCKED, and STREAM_BLOCKED) MAY appear in the 0-RTT level.
 
-- All other frame types MUST only appear at the 1-RTT levels.
+- All other frame types MAY appear at the 1-RTT levels.
 
 Because packets could be reordered on the wire, QUIC uses the packet type to
 indicate which level a given packet was encrypted under, as shown in

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -326,19 +326,12 @@ encryption levels:
 
 - CRYPTO frames MAY appear in packets of any encryption level except 0-RTT.
 
-- CONNECTION_CLOSE MAY appear in packets of any encryption level other than
-  0-RTT.
-
 - PADDING frames MAY appear in packets of any encryption level.
 
 - ACK frames MAY appear in packets of any encryption level other than 0-RTT, but
   can only acknowledge packets which appeared in that packet number space.
 
-- All stream- and flow control-related frame types (RESET_STREAM, STOP_SENDING,
-  STREAM, MAX_DATA, MAX_STREAM_DATA, MAX_STREAMS, DATA_BLOCKED,
-  STREAM_DATA_BLOCKED, and STREAM_BLOCKED) MAY appear in the 0-RTT level.
-
-- All other frame types MAY appear at the 1-RTT levels.
+- All other frame types MUST be sent in the 0-RTT and 1-RTT levels.
 
 Because packets could be reordered on the wire, QUIC uses the packet type to
 indicate which level a given packet was encrypted under, as shown in
@@ -1281,6 +1274,32 @@ of issues is well captured in the relevant sections of the main text.
 
 Never assume that because it isn't in the security considerations section it
 doesn't affect security.  Most of this document does.
+
+
+## Replay Attacks with 0-RTT
+
+As described in Section 8 of {{!TLS13}}, use of TLS early data comes with an
+exposure to replay attack.  The use of 0-RTT in QUIC is similarly vulnerable to
+replay attack.
+
+The management of QUIC protocol state based on the frame types defined in
+{{QUIC-TRANSPORT}} is not vulnerable to replay.  Processing of QUIC frames is
+idempotent and does not produce invalid states if frames are reordered or lost.
+
+QUIC connections do not produce side-effects, except for those produced by the
+application it serves.  Replay risk in QUIC is therefore limited to those frames
+that carry information that an application protocol consumes: STREAM,
+RESET_STREAM, and STOP_SENDING.
+
+Extensions to QUIC might create an additional exposure to replay attack.  QUIC
+extensions MUST describe how replay attacks affects their operation.  Extensions
+MUST either be disabled in 0-RTT or provide replay mitigation strategies.
+
+An application protocol that uses 0-RTT MUST provide an analysis of the effects
+of replay on that protocol.  An application protocol that uses QUIC MUST
+describe how the protocol uses 0-RTT and the measures that are employed to
+protect against replay attack.  Applications protocols can forbid the use of
+0-RTT.
 
 
 ## Packet Reflection Attack Mitigation {#reflection}

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -331,7 +331,7 @@ encryption levels:
 - ACK frames MAY appear in packets of any encryption level other than 0-RTT, but
   can only acknowledge packets which appeared in that packet number space.
 
-- All other frame types MUST be sent in the 0-RTT and 1-RTT levels.
+- All other frame types MUST only be sent in the 0-RTT and 1-RTT levels.
 
 Because packets could be reordered on the wire, QUIC uses the packet type to
 indicate which level a given packet was encrypted under, as shown in

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1290,40 +1290,38 @@ Endpoints MUST implement and use the replay protections described in {{!TLS13}},
 however it is recognized that these protections are imperfect.  Therefore,
 additional consideration of the risk of replay are needed.
 
-QUIC is not inherently vulnerable to replay attack.  The management of QUIC
-protocol state based on the frame types defined in {{QUIC-TRANSPORT}} is not
-vulnerable to replay.  Processing of QUIC frames is idempotent and cannot result
-in invalid connection states if frames are reordered or lost.  QUIC connections
-do not produce effects that last beyond the lifetime of the connection, except
-for those produced by the application protocol that QUIC serves.
+QUIC is not vulnerable to replay attack, except via the application protocol
+information it might carry.  The management of QUIC protocol state based on the
+frame types defined in {{QUIC-TRANSPORT}} is not vulnerable to replay.
+Processing of QUIC frames is idempotent and cannot result in invalid connection
+states if frames are replayed, reordered or lost.  QUIC connections do not
+produce effects that last beyond the lifetime of the connection, except for
+those produced by the application protocol that QUIC serves.
 
-However, this does not count for costs that endpoints might incur as a result of
-accepting 0-RTT.  A server that accepts 0-RTT is exposed to the cost of handling
-a new connection, plus the cost of processing 0-RTT packets.  If replay
-protections are unable to prevent multiple connections from being initiated,
-this could increase these costs because attackers can send copies of 0-RTT
-packets to different server instances, causing the processing to be repeated.
-Servers MUST ensure that they account for any increase in costs before accepting
-connections or 0-RTT.
+Note:
+
+: TLS session tickets and address validation tokens are used to carry QUIC
+  configuration information between connections.  These MUST NOT be used to
+  carry application state.  The potential for reuse of these tokens means that
+  they require stronger protections against replay.
+
+A server that accepts 0-RTT on a connection incurs a higher cost than accepting
+a connection without 0-RTT.  This includes higher processing and computation
+costs.  Servers need to consider the probability of replay and all associated
+costs when accepting 0-RTT.
 
 Ultimately, the responsibility for managing the risks of replay attacks with
 0-RTT lies with an application protocol.  An application protocol that uses QUIC
 MUST describe how the protocol uses 0-RTT and the measures that are employed to
-protect against replay attack.  Disabling 0-RTT entirely is the most effective
-strategy.
+protect against replay attack.  An analysis of replay risk needs to consider
+all QUIC protocol features carry application semantics.
 
-In the core protocol, particular attention needs to be paid to STREAM frames,
-which carry application data.  If another frame type carries, or could carry,
-application semantics, then the risk from replay attack needs to be considered.
-For instance, though this is likely to be inadvisable, an application that
-attaches semantics to increases in flow control credit or stream cancellation
-would need to assess whether those uses were vulnerable to replay attack.
+Disabling 0-RTT entirely is the most effective defense against replay attack.
 
-Extensions to QUIC might create an additional exposure to replay attack if they
-are used by application protocols.  QUIC extensions SHOULD describe how replay
-attacks affects their operation.  Application protocols MUST either prohibit the
-use of any extensions that carry application semantics in 0-RTT or provide
-replay mitigation strategies.
+QUIC extensions MUST describe how replay attacks affects their operation, or
+prohibit their use in 0-RTT.  Application protocols MUST either prohibit the use
+of extensions that carry application semantics in 0-RTT or provide replay
+mitigation strategies.
 
 
 ## Packet Reflection Attack Mitigation {#reflection}

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1283,24 +1283,44 @@ As described in Section 8 of {{!TLS13}}, use of TLS early data comes with an
 exposure to replay attack.  The use of 0-RTT in QUIC is similarly vulnerable to
 replay attack.
 
-The management of QUIC protocol state based on the frame types defined in
-{{QUIC-TRANSPORT}} is not vulnerable to replay.  Processing of QUIC frames is
-idempotent and does not produce invalid states if frames are reordered or lost.
+Endpoints MUST implement and use the replay protections described in {{!TLS13}},
+however it is recognized that these protections are imperfect.  Therefore,
+additional consideration of the risk of replay are needed.
 
-QUIC connections do not produce side-effects, except for those produced by the
-application it serves.  Replay risk in QUIC is therefore limited to those frames
-that carry information that an application protocol consumes: STREAM,
-RESET_STREAM, and STOP_SENDING.
+QUIC is not inherently vulnerable to replay attack.  The management of QUIC
+protocol state based on the frame types defined in {{QUIC-TRANSPORT}} is not
+vulnerable to replay.  Processing of QUIC frames is idempotent and cannot result
+in invalid connection states if frames are reordered or lost.  QUIC connections
+do not produce effects that last beyond the lifetime of the connection, except
+for those produced by the application protocol that QUIC serves.
 
-Extensions to QUIC might create an additional exposure to replay attack.  QUIC
-extensions MUST describe how replay attacks affects their operation.  Extensions
-MUST either be disabled in 0-RTT or provide replay mitigation strategies.
+However, this does not count for costs that endpoints might incur as a result of
+accepting 0-RTT.  A server that accepts 0-RTT is exposed to the cost of handling
+a new connection, plus the cost of processing 0-RTT packets.  If replay
+protections are unable to prevent multiple connections from being initiated,
+this could increase these costs because attackers can send copies of 0-RTT
+packets to different server instances, causing the processing to be repeated.
+Servers MUST ensure that they account for any increase in costs before accepting
+connections or 0-RTT.
 
-An application protocol that uses 0-RTT MUST provide an analysis of the effects
-of replay on that protocol.  An application protocol that uses QUIC MUST
-describe how the protocol uses 0-RTT and the measures that are employed to
-protect against replay attack.  Applications protocols can forbid the use of
-0-RTT.
+Ultimately, the responsibility for managing the risks of replay attacks with
+0-RTT lies with an application protocol.  An application protocol that uses QUIC
+MUST describe how the protocol uses 0-RTT and the measures that are employed to
+protect against replay attack.  Disabling 0-RTT entirely is the most effective
+strategy.
+
+In the core protocol, particular attention needs to be paid to STREAM frames,
+which carry application data.  If another frame type carries, or could carry,
+application semantics, then the risk from replay attack needs to be considered.
+For instance, though this is likely to be inadvisable, an application that
+attached semantics to increases in flow control credit or stream cancellation
+would need to assess whether those uses were vulnerable to replay attack.
+
+Extensions to QUIC might create an additional exposure to replay attack if they
+are used by application protocols.  QUIC extensions SHOULD describe how replay
+attacks affects their operation.  Application protocols MUST either disable
+extensions in 0-RTT or provide replay mitigation strategies for any use of the
+extension.
 
 
 ## Packet Reflection Attack Mitigation {#reflection}

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -324,10 +324,10 @@ the connection can usually appear at any encryption level, whereas those
 associated with transferring data can only appear in the 0-RTT and 1-RTT
 encryption levels:
 
+- PADDING frames MAY appear in packets of any encryption level.
+
 - CRYPTO and CONNECTION_CLOSE frames MAY appear in packets of any encryption
   level except 0-RTT.
-
-- PADDING frames MAY appear in packets of any encryption level.
 
 - ACK frames MAY appear in packets of any encryption level other than 0-RTT, but
   can only acknowledge packets which appeared in that packet number space.

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -324,7 +324,8 @@ the connection can usually appear at any encryption level, whereas those
 associated with transferring data can only appear in the 0-RTT and 1-RTT
 encryption levels:
 
-- CRYPTO frames MAY appear in packets of any encryption level except 0-RTT.
+- CRYPTO and CONNECTION_CLOSE frames MAY appear in packets of any encryption
+  level except 0-RTT.
 
 - PADDING frames MAY appear in packets of any encryption level.
 

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1322,8 +1322,8 @@ would need to assess whether those uses were vulnerable to replay attack.
 Extensions to QUIC might create an additional exposure to replay attack if they
 are used by application protocols.  QUIC extensions SHOULD describe how replay
 attacks affects their operation.  Application protocols MUST either prohibit the
-use of extensions in 0-RTT or provide replay mitigation strategies for those
-extensions that can be used.
+use of any extensions that carry application semantics in 0-RTT or provide
+replay mitigation strategies.
 
 
 ## Packet Reflection Attack Mitigation {#reflection}

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -334,9 +334,8 @@ encryption levels:
 
 - All other frame types MUST only be sent in the 0-RTT and 1-RTT levels.
 
-Note that it is not possible to send some frames in 0-RTT for various reasons.
-In addition to ACK, this includes CRYPTO, NEW_TOKEN, PATH_RESPONSE, and
-RETIRE_CONNECTION_ID.
+Note that it is not possible to send the following frames in 0-RTT for various
+reasons: ACK, CRYPTO, NEW_TOKEN, PATH_RESPONSE, and RETIRE_CONNECTION_ID.
 
 Because packets could be reordered on the wire, QUIC uses the packet type to
 indicate which level a given packet was encrypted under, as shown in

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1288,7 +1288,7 @@ replay attack.
 
 Endpoints MUST implement and use the replay protections described in {{!TLS13}},
 however it is recognized that these protections are imperfect.  Therefore,
-additional consideration of the risk of replay are needed.
+additional consideration of the risk of replay is needed.
 
 QUIC is not vulnerable to replay attack, except via the application protocol
 information it might carry.  The management of QUIC protocol state based on the
@@ -1302,8 +1302,8 @@ Note:
 
 : TLS session tickets and address validation tokens are used to carry QUIC
   configuration information between connections.  These MUST NOT be used to
-  carry application state.  The potential for reuse of these tokens means that
-  they require stronger protections against replay.
+  carry application semantics.  The potential for reuse of these tokens means
+  that they require stronger protections against replay.
 
 A server that accepts 0-RTT on a connection incurs a higher cost than accepting
 a connection without 0-RTT.  This includes higher processing and computation
@@ -1314,7 +1314,7 @@ Ultimately, the responsibility for managing the risks of replay attacks with
 0-RTT lies with an application protocol.  An application protocol that uses QUIC
 MUST describe how the protocol uses 0-RTT and the measures that are employed to
 protect against replay attack.  An analysis of replay risk needs to consider
-all QUIC protocol features carry application semantics.
+all QUIC protocol features that carry application semantics.
 
 Disabling 0-RTT entirely is the most effective defense against replay attack.
 

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1316,7 +1316,7 @@ In the core protocol, particular attention needs to be paid to STREAM frames,
 which carry application data.  If another frame type carries, or could carry,
 application semantics, then the risk from replay attack needs to be considered.
 For instance, though this is likely to be inadvisable, an application that
-attached semantics to increases in flow control credit or stream cancellation
+attaches semantics to increases in flow control credit or stream cancellation
 would need to assess whether those uses were vulnerable to replay attack.
 
 Extensions to QUIC might create an additional exposure to replay attack if they


### PR DESCRIPTION
In #2344, @kazuho suggests that we could allow RESET_STREAM in 0-RTT.
That seems slightly wrong, because why would someone send something then
give up without receiving anything in return, but that is actually
possible in the presence of packet loss.  And changing your mind is
perfectly acceptable.

But RESET_STREAM doesn't really cover it.  Streams can get blocked,
requests can go out with additional flow control credits, and maybe even
STOP_SENDING makes sense.  And my analysis suggests that the risk from
replay is not made worse from any frame type that doesn't produce application-visible changes.  So this removes the restrictions, aside from the natural restrictions that exist for frames (for instance, there are no cases where ACK, CRYPTO, and even PATH_RESPONSE make sense to send in 0-RTT).

Closes #2344.
Closes #2307.
Fixes #2432.