### PR TITLE
Bikeshed Required Insert Count encoding.

### DIFF
--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -836,12 +836,13 @@ Required Insert Count identifies the state of the dynamic table needed to
 process the header block.  Blocking decoders use the Required Insert Count to
 determine when it is safe to process the rest of the block.
 
-If no references are made to the dynamic table, a value of 0 is encoded.
-Alternatively, where the Required Insert Count is greater than zero, the encoder
-transforms it as follows before encoding:
+The encoder transforms the Required Insert Count as follows before encoding:
 
 ~~~
-   EncodedInsertCount = (ReqInsertCount mod (2 * MaxEntries)) + 1
+   if ReqInsertCount == 0:
+      EncodedInsertCount = 0
+   else:
+     EncodedInsertCount = (ReqInsertCount mod (2 * MaxEntries)) + 1
 ~~~
 
 Here `MaxEntries` is the maximum number of entries that the dynamic table can

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -840,9 +840,9 @@ The encoder transforms the Required Insert Count as follows before encoding:
 
 ~~~
    if ReqInsertCount == 0:
-      EncodedInsertCount = 0
+      EncInsertCount = 0
    else:
-     EncodedInsertCount = (ReqInsertCount mod (2 * MaxEntries)) + 1
+      EncInsertCount = (ReqInsertCount mod (2 * MaxEntries)) + 1
 ~~~
 
 Here `MaxEntries` is the maximum number of entries that the dynamic table can


### PR DESCRIPTION
1. This makes the encoding and decoding pseudo-code more symmetric.
2. "Alternatively" might not be the best word here, because it might imply that the implementation has a choice.
3. In a section about encoding Required Insert Count, it is more pure to talk about Required Insert Count being zero than to talk about whether references are made to the dynamic table.