### PR TITLE
Clarify when to signal error on incorrect Required Insert Count.

### DIFF
--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -253,7 +253,16 @@ received.
 Each header block contains a Required Insert Count, the lowest possible value
 for the Insert Count with which the header block can be decoded. For a header
 block with no references to the dynamic table, the Required Insert Count is
-zero.
+zero.  For a header block with references to the dynamic table, the Required
+Insert Count is one larger than the largest Absolute Index of all referenced
+dynamic table entries.
+
+If the decoder encounters a header block with a Required Insert Count value
+larger than defined here, it MAY treat this as a stream error of type
+HTTP_QPACK_DECOMPRESSION_FAILED.  If the decoder encounters a header block with
+a Required Insert Count value smaller than defined here, it MUST treat this as a
+stream error of type HTTP_QPACK_DECOMPRESSION_FAILED as prescribed in
+{{invalid-references}}.
 
 When the Required Insert Count is zero, the frame contains no references to the
 dynamic table and can always be processed immediately.
@@ -264,10 +273,6 @@ SHOULD remain in the blocked stream's flow control window.  A stream becomes
 unblocked when the Insert Count becomes greater than or equal to the Required
 Insert Count for all header blocks the decoder has started reading from the
 stream.
-
-If the decoder encounters a header block where the largest Absolute Index used
-is not equal to the largest value permitted by the Required Insert Count, it MAY
-treat this as a stream error of type HTTP_QPACK_DECOMPRESSION_FAILED.
 
 The SETTINGS_QPACK_BLOCKED_STREAMS setting (see {{configuration}}) specifies an
 upper bound on the number of streams which can be blocked. An encoder MUST limit

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -252,16 +252,16 @@ received.
 
 Each header block contains a Required Insert Count, the lowest possible value
 for the Insert Count with which the header block can be decoded. For a header
-block with no references to the dynamic table, the Required Insert Count is
-zero.  For a header block with references to the dynamic table, the Required
-Insert Count is one larger than the largest Absolute Index of all referenced
-dynamic table entries.
+block with references to the dynamic table, the Required Insert Count is one
+larger than the largest Absolute Index of all referenced dynamic table
+entries. For a header block with no references to the dynamic table, the
+Required Insert Count is zero.
 
 If the decoder encounters a header block with a Required Insert Count value
-larger than defined here, it MAY treat this as a stream error of type
+larger than defined above, it MAY treat this as a stream error of type
 HTTP_QPACK_DECOMPRESSION_FAILED.  If the decoder encounters a header block with
-a Required Insert Count value smaller than defined here, it MUST treat this as a
-stream error of type HTTP_QPACK_DECOMPRESSION_FAILED as prescribed in
+a Required Insert Count value smaller than defined above, it MUST treat this as
+a stream error of type HTTP_QPACK_DECOMPRESSION_FAILED as prescribed in
 {{invalid-references}}.
 
 When the Required Insert Count is zero, the frame contains no references to the


### PR DESCRIPTION
Currently the draft is inconsistent: if the Required Insert Count value in a header block is smaller than dictated by the referenced dynamic table entries, {{overview-hol-avoidance}} says the decoder MAY treat this as a stream error, while {{invalid-references}} says it MUST.  This PR seeks to clarify this.