### PR TITLE
Remove requirement for reciprocal connection ID change

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2110,19 +2110,10 @@ infrequently.
 
 Endpoints that use connection IDs with length greater than zero could have their
 activity correlated if their peers keep using the same destination connection ID
-after migration. Endpoints that receive packets with a previously unused
-Destination Connection ID SHOULD change to sending packets with a connection ID
-that has not been used on any other network path.  The goal here is to ensure
-that packets sent on different paths cannot be correlated. To fulfill this
-privacy requirement, endpoints that initiate migration and use connection IDs
-with length greater than zero SHOULD provide their peers with new connection IDs
-before migration.
-
-Caution:
-
-: If both endpoints change connection ID in response to seeing a change in
-  connection ID from their peer, then this can trigger an infinite sequence of
-  changes.
+after migration.  The goal here is to ensure that packets sent on different
+paths cannot be correlated. To fulfill this privacy requirement, endpoints that
+initiate migration and use connection IDs with length greater than zero SHOULD
+provide their peers with new connection IDs before migration.
 
 
 ## Server's Preferred Address {#preferred-address}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2110,7 +2110,7 @@ infrequently.
 
 Endpoints that use connection IDs with length greater than zero could have their
 activity correlated if their peers keep using the same destination connection ID
-after migration.  The goal here is to ensure that packets sent on different
+after migration.  The goal is to ensure that packets sent on different
 paths cannot be correlated. To fulfill this privacy requirement, endpoints that
 initiate migration and use connection IDs with length greater than zero SHOULD
 provide their peers with new connection IDs before migration.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2108,12 +2108,13 @@ genuine migrations.  Changing port number can cause a peer to reset its
 congestion state (see {{migration-cc}}), so the port SHOULD only be changed
 infrequently.
 
-Endpoints that use connection IDs with length greater than zero could have their
-activity correlated if their peers keep using the same destination connection ID
-after migration.  The goal is to ensure that packets sent on different
-paths cannot be correlated. To fulfill this privacy requirement, endpoints that
-initiate migration and use connection IDs with length greater than zero SHOULD
-provide their peers with new connection IDs before migration.
+Endpoints that supply connection IDs with length greater than zero could have
+their activity correlated if their peers keep using the same destination
+connection ID after migration.  To ensure that packets sent on different paths
+cannot be correlated, endpoints SHOULD provide with new connection IDs before
+peers migrate.  To fulfill this privacy requirement, endpoints that initiate
+migration and use connection IDs with length greater than zero SHOULD provide
+their peers with new connection IDs before migration.
 
 
 ## Server's Preferred Address {#preferred-address}


### PR DESCRIPTION
As discussed in Tokyo, forcing your peer to change a connection ID is still possible, but we would require a change in port in order to effect that.

Closes #1795, #2145.