### PR TITLE
skip draining period in case of idle timeout

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2276,10 +2276,10 @@ source address.
 
 ## Idle Timeout {#idle-timeout}
 
-If the idle timeout is enabled, a connection is closed when it remains idle for
-longer than the larger of the advertised idle timeout (see
-{{transport-parameter-definitions}}) or three times the current Probe Timeout
-(PTO).  The connection state is discarded immediately when the timeout expires.
+If the idle timeout is enabled, a connection is silently closed and the state is
+discarded immediately when it remains idle for longer than both the advertised
+idle timeout (see {{transport-parameter-definitions}}) and three times the
+current Probe Timeout (PTO).
 
 Each endpoint advertises its own idle timeout to its peer.  An enpdpoint
 restarts any timer it maintains when a packet from its peer is received and

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2276,9 +2276,10 @@ source address.
 
 ## Idle Timeout {#idle-timeout}
 
-If the idle timeout is enabled, a connection that remains idle for longer than
-the advertised idle timeout (see {{transport-parameter-definitions}}) is closed.
-A connection enters the draining state when the idle timeout expires.
+If the idle timeout is enabled, a connection is closed when it remains idle for
+longer than the larger of the advertised idle timeout (see
+{{transport-parameter-definitions}}) or three times the current Probe Timeout
+(PTO).  The connection state is discarded immediately when the timeout expires.
 
 Each endpoint advertises its own idle timeout to its peer.  An enpdpoint
 restarts any timer it maintains when a packet from its peer is received and

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2277,7 +2277,7 @@ source address.
 ## Idle Timeout {#idle-timeout}
 
 If the idle timeout is enabled, a connection is silently closed and the state is
-discarded immediately when it remains idle for longer than both the advertised
+discarded when it remains idle for longer than both the advertised
 idle timeout (see {{transport-parameter-definitions}}) and three times the
 current Probe Timeout (PTO).
 


### PR DESCRIPTION
Changes are:
* define idle timeout as `max(TP.idle_timeout, 3*PTO)`
* skip draining period when idle timeout expires

closes #2347