### PR TITLE
New connection IDs are mandatory for intentional migration 

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2089,15 +2089,17 @@ different local addresses, as discussed in {{connection-id}}.  For this to be
 effective endpoints need to ensure that connections IDs they provide cannot be
 linked by any other entity.
 
-This eliminates the use of the connection ID for linking activity from
-the same connection on different networks.  Header protection ensures
-that packet numbers cannot be used to correlate activity.  This does not prevent
-other properties of packets, such as timing and size, from being used to
-correlate activity.
+An endpoint MUST use a new connection ID if it initiates connection migration,
+unless the peer has selected a zero-length connection ID.  This eliminates the
+use of the connection ID for linking activity from the same connection on
+different networks.  Header protection ensures that packet numbers cannot be
+used to correlate activity.  This does not prevent other properties of packets,
+such as timing and size, from being used to correlate activity.
 
 Clients MAY move to a new connection ID at any time based on
 implementation-specific concerns.  For example, after a period of network
-inactivity NAT rebinding might occur when the client begins sending data again.
+inactivity, where NAT rebinding might occur when the client begins sending data
+again.
 
 A client might wish to reduce linkability by employing a new connection ID and
 source UDP port when sending traffic after a period of inactivity.  Changing the
@@ -2108,13 +2110,12 @@ genuine migrations.  Changing port number can cause a peer to reset its
 congestion state (see {{migration-cc}}), so the port SHOULD only be changed
 infrequently.
 
-Endpoints that supply connection IDs with length greater than zero could have
-their activity correlated if their peers keep using the same destination
-connection ID after migration.  To ensure that packets sent on different paths
-cannot be correlated, endpoints SHOULD provide with new connection IDs before
-peers migrate.  To fulfill this privacy requirement, endpoints that initiate
-migration and use connection IDs with length greater than zero SHOULD provide
-their peers with new connection IDs before migration.
+An endpoint cannot migrate to a new path if it does not have a connection ID to
+use on that path.  An endpoint that exhausts available connection IDs can only
+migrate if the peer chooses to use receive packets with zero-length connection
+IDs.  To ensure that migration is possible and packets sent on different paths
+cannot be correlated, endpoints SHOULD provide new connection IDs before peers
+migrate.
 
 
 ## Server's Preferred Address {#preferred-address}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2091,7 +2091,8 @@ different local addresses, as discussed in {{connection-id}}.  For this to be
 effective endpoints need to ensure that connections IDs they provide cannot be
 linked by any other entity.
 
-Endpoints MAY move to a new connection ID at any time.
+At any time, endpoints MAY change the Destination Connection ID they send to a
+value that has not been used on another path.
 
 An endpoint MUST use a new connection ID if it initiates connection migration.
 Using a new connection ID eliminates the use of the connection ID for linking

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2113,9 +2113,10 @@ infrequently.
 An endpoint cannot migrate to a new path if it does not have a connection ID to
 use on that path.  An endpoint that exhausts available connection IDs cannot
 migrate.  If a peer chooses to receive packets with zero-length connection IDs,
-an endpoint can always migrate.  To ensure that migration is possible and
-packets sent on different paths cannot be correlated, endpoints SHOULD provide
-new connection IDs before peers migrate.
+an endpoint can always migrate - zero-length connection IDs provide no
+significant linkability.  To ensure that migration is possible and packets sent
+on different paths cannot be correlated, endpoints SHOULD provide new connection
+IDs before peers migrate.
 
 
 ## Server's Preferred Address {#preferred-address}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1853,9 +1853,9 @@ An endpoint also MUST NOT initiate connection migration if the peer sent the
 `disable_migration` transport parameter during the handshake.  An endpoint which
 has sent this transport parameter, but detects that a peer has nonetheless
 migrated to a different network MAY treat this as a connection error of type
-INVALID_MIGRATION.  Similarly, an endpoint MUST NOT migrate if its peer supplies
-a zero-length connection ID as packets without a Destination Connection ID
-cannot be attributed to a connection based on address tuple.
+INVALID_MIGRATION.  Similarly, an endpoint MUST NOT initiate migration if its
+peer supplies a zero-length connection ID as packets without a Destination
+Connection ID cannot be attributed to a connection based on address tuple.
 
 Not all changes of peer address are intentional migrations. The peer could
 experience NAT rebinding: a change of address due to a middlebox, usually a NAT,

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2089,17 +2089,19 @@ different local addresses, as discussed in {{connection-id}}.  For this to be
 effective endpoints need to ensure that connections IDs they provide cannot be
 linked by any other entity.
 
-An endpoint MUST use a new connection ID if it initiates connection migration,
-unless the peer has selected a zero-length connection ID.  This eliminates the
-use of the connection ID for linking activity from the same connection on
-different networks.  Header protection ensures that packet numbers cannot be
-used to correlate activity.  This does not prevent other properties of packets,
-such as timing and size, from being used to correlate activity.
+Endpoints MAY move to a new connection ID at any time.
 
-Clients MAY move to a new connection ID at any time based on
-implementation-specific concerns.  For example, after a period of network
-inactivity, where NAT rebinding might occur when the client begins sending data
-again.
+An endpoint MUST use a new connection ID if it initiates connection migration,
+unless the peer has selected a zero-length connection ID.  Using a new
+connection ID eliminates the use of the connection ID for linking activity from
+the same connection on different networks.  Header protection ensures that
+packet numbers cannot be used to correlate activity.  This does not prevent
+other properties of packets, such as timing and size, from being used to
+correlate activity.
+
+Unintentional changes in path without a change in connection ID are possible.
+For example, after a period of network inactivity, NAT rebinding might cause
+packets to be sent on a new path when the client resumes sending.
 
 A client might wish to reduce linkability by employing a new connection ID and
 source UDP port when sending traffic after a period of inactivity.  Changing the
@@ -2110,13 +2112,15 @@ genuine migrations.  Changing port number can cause a peer to reset its
 congestion state (see {{migration-cc}}), so the port SHOULD only be changed
 infrequently.
 
-An endpoint cannot migrate to a new path if it does not have a connection ID to
-use on that path.  An endpoint that exhausts available connection IDs cannot
-migrate.  If a peer chooses to receive packets with zero-length connection IDs,
-an endpoint can always migrate - zero-length connection IDs provide no
-significant linkability.  To ensure that migration is possible and packets sent
-on different paths cannot be correlated, endpoints SHOULD provide new connection
-IDs before peers migrate.
+An endpoint MUST NOT intentionally migrate to a new path if it does not have a
+connection ID to use on that path.  An endpoint that exhausts available
+connection IDs cannot migrate.  To ensure that migration is possible and packets
+sent on different paths cannot be correlated, endpoints SHOULD provide new
+connection IDs before peers migrate.
+
+If a peer chooses to receive packets with zero-length connection IDs, an
+endpoint can always migrate - zero-length connection IDs provide no significant
+linkability.
 
 
 ## Server's Preferred Address {#preferred-address}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1853,7 +1853,9 @@ An endpoint also MUST NOT initiate connection migration if the peer sent the
 `disable_migration` transport parameter during the handshake.  An endpoint which
 has sent this transport parameter, but detects that a peer has nonetheless
 migrated to a different network MAY treat this as a connection error of type
-INVALID_MIGRATION.
+INVALID_MIGRATION.  Similarly, an endpoint MUST NOT migrate if its peer supplies
+a zero-length connection ID as packets without a Destination Connection ID
+cannot be attributed to a connection based on address tuple.
 
 Not all changes of peer address are intentional migrations. The peer could
 experience NAT rebinding: a change of address due to a middlebox, usually a NAT,
@@ -2117,10 +2119,6 @@ connection ID to use on that path.  An endpoint that exhausts available
 connection IDs cannot migrate.  To ensure that migration is possible and packets
 sent on different paths cannot be correlated, endpoints SHOULD provide new
 connection IDs before peers migrate.
-
-If a peer chooses to receive packets with zero-length connection IDs, an
-endpoint can always migrate, because  zero-length connection IDs provide no
-significant linkability.
 
 
 ## Server's Preferred Address {#preferred-address}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2111,11 +2111,11 @@ congestion state (see {{migration-cc}}), so the port SHOULD only be changed
 infrequently.
 
 An endpoint cannot migrate to a new path if it does not have a connection ID to
-use on that path.  An endpoint that exhausts available connection IDs can only
-migrate if the peer chooses to use receive packets with zero-length connection
-IDs.  To ensure that migration is possible and packets sent on different paths
-cannot be correlated, endpoints SHOULD provide new connection IDs before peers
-migrate.
+use on that path.  An endpoint that exhausts available connection IDs cannot
+migrate.  If a peer chooses to receive packets with zero-length connection IDs,
+an endpoint can always migrate.  To ensure that migration is possible and
+packets sent on different paths cannot be correlated, endpoints SHOULD provide
+new connection IDs before peers migrate.
 
 
 ## Server's Preferred Address {#preferred-address}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2110,19 +2110,10 @@ infrequently.
 
 Endpoints that use connection IDs with length greater than zero could have their
 activity correlated if their peers keep using the same destination connection ID
-after migration. Endpoints that receive packets with a previously unused
-Destination Connection ID SHOULD change to sending packets with a connection ID
-that has not been used on any other network path.  The goal here is to ensure
-that packets sent on different paths cannot be correlated. To fulfill this
-privacy requirement, endpoints that initiate migration and use connection IDs
-with length greater than zero SHOULD provide their peers with new connection IDs
-before migration.
-
-Caution:
-
-: If both endpoints change connection ID in response to seeing a change in
-  connection ID from their peer, then this can trigger an infinite sequence of
-  changes.
+after migration.  The goal here is to ensure that packets sent on different
+paths cannot be correlated. To fulfill this privacy requirement, endpoints that
+initiate migration and use connection IDs with length greater than zero SHOULD
+provide their peers with new connection IDs before migration.
 
 
 ## Server's Preferred Address {#preferred-address}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2119,8 +2119,8 @@ sent on different paths cannot be correlated, endpoints SHOULD provide new
 connection IDs before peers migrate.
 
 If a peer chooses to receive packets with zero-length connection IDs, an
-endpoint can always migrate - zero-length connection IDs provide no significant
-linkability.
+endpoint can always migrate, because  zero-length connection IDs provide no
+significant linkability.
 
 
 ## Server's Preferred Address {#preferred-address}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2110,7 +2110,7 @@ infrequently.
 
 Endpoints that use connection IDs with length greater than zero could have their
 activity correlated if their peers keep using the same destination connection ID
-after migration.  The goal here is to ensure that packets sent on different
+after migration.  The goal is to ensure that packets sent on different
 paths cannot be correlated. To fulfill this privacy requirement, endpoints that
 initiate migration and use connection IDs with length greater than zero SHOULD
 provide their peers with new connection IDs before migration.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2093,12 +2093,11 @@ linked by any other entity.
 
 Endpoints MAY move to a new connection ID at any time.
 
-An endpoint MUST use a new connection ID if it initiates connection migration,
-unless the peer has selected a zero-length connection ID.  Using a new
-connection ID eliminates the use of the connection ID for linking activity from
-the same connection on different networks.  Header protection ensures that
-packet numbers cannot be used to correlate activity.  This does not prevent
-other properties of packets, such as timing and size, from being used to
+An endpoint MUST use a new connection ID if it initiates connection migration.
+Using a new connection ID eliminates the use of the connection ID for linking
+activity from the same connection on different networks.  Header protection
+ensures that packet numbers cannot be used to correlate activity.  This does not
+prevent other properties of packets, such as timing and size, from being used to
 correlate activity.
 
 Unintentional changes in path without a change in connection ID are possible.
@@ -2114,11 +2113,9 @@ genuine migrations.  Changing port number can cause a peer to reset its
 congestion state (see {{migration-cc}}), so the port SHOULD only be changed
 infrequently.
 
-An endpoint MUST NOT intentionally migrate to a new path if it does not have a
-connection ID to use on that path.  An endpoint that exhausts available
-connection IDs cannot migrate.  To ensure that migration is possible and packets
-sent on different paths cannot be correlated, endpoints SHOULD provide new
-connection IDs before peers migrate.
+An endpoint that exhausts available connection IDs cannot migrate.  To ensure
+that migration is possible and packets sent on different paths cannot be
+correlated, endpoints SHOULD provide new connection IDs before peers migrate.
 
 
 ## Server's Preferred Address {#preferred-address}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2108,12 +2108,13 @@ genuine migrations.  Changing port number can cause a peer to reset its
 congestion state (see {{migration-cc}}), so the port SHOULD only be changed
 infrequently.
 
-Endpoints that use connection IDs with length greater than zero could have their
-activity correlated if their peers keep using the same destination connection ID
-after migration.  The goal is to ensure that packets sent on different
-paths cannot be correlated. To fulfill this privacy requirement, endpoints that
-initiate migration and use connection IDs with length greater than zero SHOULD
-provide their peers with new connection IDs before migration.
+Endpoints that supply connection IDs with length greater than zero could have
+their activity correlated if their peers keep using the same destination
+connection ID after migration.  To ensure that packets sent on different paths
+cannot be correlated, endpoints SHOULD provide with new connection IDs before
+peers migrate.  To fulfill this privacy requirement, endpoints that initiate
+migration and use connection IDs with length greater than zero SHOULD provide
+their peers with new connection IDs before migration.
 
 
 ## Server's Preferred Address {#preferred-address}


### PR DESCRIPTION
Based on #2386, which should merge soon.

Closes #2413.