### PR TITLE
update the pseudo code to include packet number spaces

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -819,10 +819,10 @@ kGranularity:
 kInitialRtt:
 : The RTT used before an RTT sample is taken. The RECOMMENDED value is 100ms.
 
-pn_space:
+kPacketNumberSpace:
 : An enum to enumerate the three packet number spaces.
 ~~~
-  enum pn_space {
+  enum kPacketNumberSpace {
     Initial,
     Handshake,
     1-RTT,
@@ -850,10 +850,10 @@ time_of_last_sent_ack_eliciting_packet:
 time_of_last_sent_crypto_packet:
 : The time the most recent crypto packet was sent.
 
-largest_sent_packet[pn_space]:
+largest_sent_packet[kPacketNumberSpace]:
 : The packet number of the most recently sent packet in the packet number space.
 
-largest_acked_packet[pn_space]:
+largest_acked_packet[kPacketNumberSpace]:
 : The largest packet number acknowledged in the packet number space so far.
 
 latest_rtt:
@@ -881,7 +881,7 @@ loss_time:
   exceeding the reordering window in time. Only applies to the 1-RTT packet
   number space.
 
-sent_packets[pn_space]:
+sent_packets[kPacketNumberSpace]:
 : An association of packet numbers in a packet number space to information
   about them.  Described in detail above in {{tracking-sent-packets}}.
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -825,7 +825,7 @@ kPacketNumberSpace:
   enum kPacketNumberSpace {
     Initial,
     Handshake,
-    Application data,
+    ApplicationData,
   }
 ~~~
 
@@ -878,7 +878,7 @@ max_ack_delay:
 
 loss_time:
 : The time at which the next packet will be considered lost based on
-  exceeding the reordering window in time. Only applies to the Application data
+  exceeding the reordering window in time. Only applies to the ApplicationData
   packet number space.
 
 sent_packets[kPacketNumberSpace]:
@@ -1047,7 +1047,7 @@ SetLossDetectionTimer():
     return
   if (loss_time != 0):
     // Time threshold loss detection.
-    // Only applies to the Application data packet number space.
+    // Only applies to the ApplicationData packet number space.
     loss_detection_timer.update(loss_time)
     return
 
@@ -1077,8 +1077,8 @@ OnLossDetectionTimeout():
     crypto_count++
   else if (loss_time != 0):
     // Time threshold loss Detection
-    // Only applies to the Application data packet number space.
-    DetectLostPackets(Application data)
+    // Only applies to the ApplicationData packet number space.
+    DetectLostPackets(ApplicationData)
   else:
     // PTO
     SendOneOrTwoPackets()
@@ -1099,7 +1099,7 @@ Pseudocode for DetectLostPackets follows:
 
 ~~~
 DetectLostPackets(pn_space):
-  if (pn_space == Application data):
+  if (pn_space == ApplicationData):
     loss_time = 0
   lost_packets = {}
   loss_delay = kTimeThreshold * max(latest_rtt, smoothed_rtt)
@@ -1120,7 +1120,7 @@ DetectLostPackets(pn_space):
       sent_packets.remove(unacked.packet_number)
       if (unacked.in_flight):
         lost_packets.insert(unacked)
-    else if (pn_space == Application data):
+    else if (pn_space == ApplicationData):
       if (loss_time == 0):
         loss_time = unacked.time_sent + loss_delay
       else:

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -819,6 +819,16 @@ kGranularity:
 kInitialRtt:
 : The RTT used before an RTT sample is taken. The RECOMMENDED value is 100ms.
 
+pn_space:
+: An enum to enumerate the three packet number spaces.
+~~~
+  enum pn_space {
+    Initial,
+    Handshake,
+    1-RTT,
+  }
+~~~
+
 ## Variables of interest {#ld-vars-of-interest}
 
 Variables required to implement the congestion control mechanisms
@@ -891,7 +901,7 @@ follows:
    min_rtt = infinite
    time_of_last_sent_ack_eliciting_packet = 0
    time_of_last_sent_crypto_packet = 0
-   for pn_space in packet number spaces:
+   for pn_space in [ Initial, Handshake, 1-RTT ]:
      largest_sent_packet[pn_space] = 0
      largest_acked_packet[pn_space] = 0
 ~~~

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -918,9 +918,11 @@ Pseudocode for OnPacketSent follows:
  OnPacketSent(packet_number, pn_space, ack_eliciting,
               in_flight, is_crypto_packet, sent_bytes):
    largest_sent_packet[pn_space] = packet_number
-   sent_packets[pn_space][packet_number].packet_number = packet_number
+   sent_packets[pn_space][packet_number].packet_number =
+                                            packet_number
    sent_packets[pn_space][packet_number].time_sent = now
-   sent_packets[pn_space][packet_number].ack_eliciting = ack_eliciting
+   sent_packets[pn_space][packet_number].ack_eliciting =
+                                            ack_eliciting
    sent_packets[pn_space][packet_number].in_flight = in_flight
    if (in_flight):
      if (is_crypto_packet):
@@ -940,54 +942,54 @@ When an ACK frame is received, it may newly acknowledge any number of packets.
 Pseudocode for OnAckReceived and UpdateRtt follow:
 
 ~~~
-  OnAckReceived(ack, pn_space):
-    largest_acked_packet[pn_space] = max(largest_acked_packet,
-                               ack.largest_acked)
+OnAckReceived(ack, pn_space):
+  largest_acked_packet[pn_space] = max(largest_acked_packet,
+                              ack.largest_acked)
 
-    // If the largest acknowledged is newly acked and
-    // ack-eliciting, update the RTT.
-    if (sent_packets[pn_space][ack.largest_acked] &&
-        sent_packets[pn_space][ack.largest_acked].ack_eliciting):
-      latest_rtt =
-        now - sent_packets[pn_space][ack.largest_acked].time_sent
-      UpdateRtt(latest_rtt, ack.ack_delay)
+  // If the largest acknowledged is newly acked and
+  // ack-eliciting, update the RTT.
+  if (sent_packets[pn_space][ack.largest_acked] &&
+      sent_packets[pn_space][ack.largest_acked].ack_eliciting):
+    latest_rtt =
+      now - sent_packets[pn_space][ack.largest_acked].time_sent
+    UpdateRtt(latest_rtt, ack.ack_delay)
 
-    // Process ECN information if present.
-    if (ACK frame contains ECN information):
-       ProcessECN(ack)
+  // Process ECN information if present.
+  if (ACK frame contains ECN information):
+      ProcessECN(ack)
 
-    // Find all newly acked packets in this ACK frame
-    newly_acked_packets = DetermineNewlyAckedPackets(ack, pn_space)
-    if (newly_acked_packets.empty()):
-      return
+  // Find all newly acked packets in this ACK frame
+  newly_acked_packets = DetermineNewlyAckedPackets(ack, pn_space)
+  if (newly_acked_packets.empty()):
+    return
 
-    for acked_packet in newly_acked_packets:
-      OnPacketAcked(acked_packet.packet_number, pn_space)
+  for acked_packet in newly_acked_packets:
+    OnPacketAcked(acked_packet.packet_number, pn_space)
 
-    DetectLostPackets(pn_space)
+  DetectLostPackets(pn_space)
 
-    crypto_count = 0
-    pto_count = 0
+  crypto_count = 0
+  pto_count = 0
 
-    SetLossDetectionTimer()
+  SetLossDetectionTimer()
 
 
-  UpdateRtt(latest_rtt, ack_delay):
-    // min_rtt ignores ack delay.
-    min_rtt = min(min_rtt, latest_rtt)
-    // Limit ack_delay by max_ack_delay
-    ack_delay = min(ack_delay, max_ack_delay)
-    // Adjust for ack delay if it's plausible.
-    if (latest_rtt - min_rtt > ack_delay):
-      latest_rtt -= ack_delay
-    // Based on {{?RFC6298}}.
-    if (smoothed_rtt == 0):
-      smoothed_rtt = latest_rtt
-      rttvar = latest_rtt / 2
-    else:
-      rttvar_sample = abs(smoothed_rtt - latest_rtt)
-      rttvar = 3/4 * rttvar + 1/4 * rttvar_sample
-      smoothed_rtt = 7/8 * smoothed_rtt + 1/8 * latest_rtt
+UpdateRtt(latest_rtt, ack_delay):
+  // min_rtt ignores ack delay.
+  min_rtt = min(min_rtt, latest_rtt)
+  // Limit ack_delay by max_ack_delay
+  ack_delay = min(ack_delay, max_ack_delay)
+  // Adjust for ack delay if it's plausible.
+  if (latest_rtt - min_rtt > ack_delay):
+    latest_rtt -= ack_delay
+  // Based on {{?RFC6298}}.
+  if (smoothed_rtt == 0):
+    smoothed_rtt = latest_rtt
+    rttvar = latest_rtt / 2
+  else:
+    rttvar_sample = abs(smoothed_rtt - latest_rtt)
+    rttvar = 3/4 * rttvar + 1/4 * rttvar_sample
+    smoothed_rtt = 7/8 * smoothed_rtt + 1/8 * latest_rtt
 ~~~
 
 
@@ -998,9 +1000,9 @@ function is called.  Note that a single ACK frame may newly acknowledge several
 packets. OnPacketAcked must be called once for each of these newly acknowledged
 packets.
 
-OnPacketAcked takes two parameters: acked_packet, which is the struct detailed in
-{{sent-packets-fields}}, and the packet number space that this ACK frame was sent
-for.
+OnPacketAcked takes two parameters: acked_packet, which is the struct detailed
+in {{sent-packets-fields}}, and the packet number space that this ACK frame was
+sent for.
 
 Pseudocode for OnPacketAcked follows:
 
@@ -1122,7 +1124,8 @@ DetectLostPackets(pn_space):
       if (loss_time == 0):
         loss_time = unacked.time_sent + loss_delay
       else:
-        loss_time = min(loss_time, unacked.time_sent + loss_delay)
+        loss_time = min(loss_time, unacked.time_sent +
+                                              loss_delay)
 
   // Inform the congestion controller of lost packets and
   // let it decide whether to retransmit immediately.

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -901,7 +901,7 @@ follows:
    min_rtt = infinite
    time_of_last_sent_ack_eliciting_packet = 0
    time_of_last_sent_crypto_packet = 0
-   for pn_space in [ Initial, Handshake, Applicaton data ]:
+   for pn_space in [ Initial, Handshake, ApplicatonData ]:
      largest_sent_packet[pn_space] = 0
      largest_acked_packet[pn_space] = 0
 ~~~
@@ -1045,6 +1045,7 @@ SetLossDetectionTimer():
     loss_detection_timer.update(
       time_of_last_sent_crypto_packet + timeout)
     return
+
   if (loss_time != 0):
     // Time threshold loss detection.
     // Only applies to the ApplicationData packet number space.


### PR DESCRIPTION
This is an ongoing attempt to resolve #2405.
In the current state this PR is nowhere near complete, but I hope it gets the discussion going about the necessary changes. I will update it accordingly.

So far, this PR makes the following changes:

- makes it explicit that the variables `largest_sent_packet`, `largest_acked_packet` and `sent_packets` are kept for every packet number space. By indexing these variables with their respective packet number space, we can immediately see where we need to pass a packet number space variable around,
- makes it explicit that `OnPacketAcked` and `DetectLostPackets` are packet-number-space dependent,
- I realized that `loss_time` would also apply to every packet number space, if we didn't have special treatment for crypto packets. Since we have that, we never run early retransmit for crypto packets, so `loss_time` only applies to the 1-RTT packet number space.
  - I'm not sure if is this a bug or a feature. The only way to declare crypto packets lost now is using the crypto timer. Contrary to what we say in the text, this is *less* aggressive than the logic we use for packets sent after completion of the handshake.

Edit: CI fails due to line lengths. I'll defer fixing this until we agree if this is the right way forward.