### PR TITLE
Reword Immediate ACK Recommendation

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -138,7 +138,8 @@ Crypto Packets:
 Out-of-order Packets:
 
 : Packets that do not increase the largest received packet number for its
-cryptographic context by exactly one.
+packet number space by exactly one. Packets usually arrive out of order
+because earlier packets are lost or delayed.
 
 # Design of the QUIC Transmission Machinery
 
@@ -251,7 +252,9 @@ an ACK immediately when receiving a second ack-eliciting packet.
 In order to accelerate loss recovery and reduce timeouts, the receiver SHOULD
 send immediate ACKs for an interval after it receives an out-of-order packet.
 This interval SHOULD NOT exceed 1/8 RTT unless more out-of-order packets arrive
-during the interval.
+during the interval. Therefore, if out-of-order packets consistently arrive
+within one interval of the previous one, the receiver SHOULD continuously send
+immediate ACKs.
 
 Similarly, packets marked with the ECN Congestion Experienced (CE) codepoint in
 the IP header SHOULD be acknowledged immediately, to reduce the peer's response

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -134,7 +134,7 @@ Crypto Packets:
 
 : Packets containing CRYPTO data sent in Initial or Handshake
   packets.
-  
+
 Out-of-order Packets:
 
 : Packets that do not increase the largest received packet number for its

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -138,7 +138,7 @@ Crypto Packets:
 Out-of-order Packets:
 
 : Packets that do not increase the largest received packet number for its
-packet number space by exactly one. Packets usually arrive out of order
+  packet number space by exactly one. Packets arrive out of order
   when earlier packets are lost or delayed.
 
 # Design of the QUIC Transmission Machinery

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -139,7 +139,7 @@ Out-of-order Packets:
 
 : Packets that do not increase the largest received packet number for its
 packet number space by exactly one. Packets usually arrive out of order
-because earlier packets are lost or delayed.
+  when earlier packets are lost or delayed.
 
 # Design of the QUIC Transmission Machinery
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -134,6 +134,11 @@ Crypto Packets:
 
 : Packets containing CRYPTO data sent in Initial or Handshake
   packets.
+  
+Out-of-order Packets:
+
+: Packets that do not increase the largest received packet number for its
+cryptographic context by exactly one.
 
 # Design of the QUIC Transmission Machinery
 
@@ -244,11 +249,9 @@ ack-eliciting packet. QUIC recovery algorithms do not assume the peer sends
 an ACK immediately when receiving a second ack-eliciting packet.
 
 In order to accelerate loss recovery and reduce timeouts, the receiver SHOULD
-send an immediate ACK when it receives a new packet which is not one greater
-than the largest received packet number. A receiver MAY send immediate ACKs
-for the next few ack-eliciting packets that are received, but SHOULD NOT
-send an immediate ACK for more than 1/8 RTT after receiving an out-of-order
-packet.
+send immediate ACKs for an interval after it receives an out-of-order packet.
+This interval SHOULD NOT exceed 1/8 RTT unless more out-of-order packets arrive
+during the interval.
 
 Similarly, packets marked with the ECN Congestion Experienced (CE) codepoint in
 the IP header SHOULD be acknowledged immediately, to reduce the peer's response

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -250,7 +250,7 @@ ack-eliciting packet. QUIC recovery algorithms do not assume the peer sends
 an ACK immediately when receiving a second ack-eliciting packet.
 
 In order to accelerate loss recovery and reduce timeouts, the receiver SHOULD
-send an immediate ACK after it receives an out-of-order packet. it could send
+send an immediate ACK after it receives an out-of-order packet. It could send
 immediate ACKs for in-order packets for a period of time that SHOULD NOT exceed
 1/8 RTT unless more out-of-order packets arrive. If every packet arrives out-of-
 order, then an immediate ACK SHOULD be sent for every received packet.

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -251,10 +251,10 @@ an ACK immediately when receiving a second ack-eliciting packet.
 
 In order to accelerate loss recovery and reduce timeouts, the receiver SHOULD
 send immediate ACKs for an interval after it receives an out-of-order packet.
-This interval SHOULD NOT exceed 1/8 RTT unless more out-of-order packets arrive
-during the interval. Therefore, if out-of-order packets consistently arrive
-within one interval of the previous one, the receiver SHOULD continuously send
-immediate ACKs.
+This interval SHOULD be between zero (immediately acking only out-of-order
+packets) and 1/8 RTT unless more out-of-order packets arrive during the
+interval. If every packet arrives out-of-order, then an immediate ACK would be
+sent for every received packet.
 
 Similarly, packets marked with the ECN Congestion Experienced (CE) codepoint in
 the IP header SHOULD be acknowledged immediately, to reduce the peer's response

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -250,11 +250,10 @@ ack-eliciting packet. QUIC recovery algorithms do not assume the peer sends
 an ACK immediately when receiving a second ack-eliciting packet.
 
 In order to accelerate loss recovery and reduce timeouts, the receiver SHOULD
-send immediate ACKs for an interval after it receives an out-of-order packet.
-This interval SHOULD be between zero (immediately acking only out-of-order
-packets) and 1/8 RTT unless more out-of-order packets arrive during the
-interval. If every packet arrives out-of-order, then an immediate ACK would be
-sent for every received packet.
+send an immediate ACK after it receives an out-of-order packet. it could send
+immediate ACKs for in-order packets for a period of time that SHOULD NOT exceed
+1/8 RTT unless more out-of-order packets arrive. If every packet arrives out-of-
+order, then an immediate ACK SHOULD be sent for every received packet.
 
 Similarly, packets marked with the ECN Congestion Experienced (CE) codepoint in
 the IP header SHOULD be acknowledged immediately, to reduce the peer's response


### PR DESCRIPTION
This is a reword of #2025, as discussed with @ianswett previously.

It cleans up two problems:
1) Strictly speaking, the MAY in the original text is redundant, because receivers MAY do anything except exceed the delayed ack timeout. I think it reads better now.
2) @martinthomson mentioned that the spec was a little ambiguous about how to handle additional OOO packets during the interval. I put down some language, but I'm not sure it's what @ianswett would recommend.
