### PR TITLE
Servers can still CANCEL, too.

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1009,10 +1009,10 @@ partial processing, it SHOULD abort its response stream with the error code
 HTTP_REQUEST_CANCELLED.
 
 When a client sends a STOP_SENDING with HTTP_REQUEST_CANCELLED, a server MAY
-indicate the error code HTTP_REQUEST_REJECTED in the corresponding RESET_STREAM
+send the error code HTTP_REQUEST_REJECTED in the corresponding RESET_STREAM
 if no processing was performed.  Clients MUST NOT reset streams with the
 HTTP_REQUEST_REJECTED error code except in response to a QUIC STOP_SENDING
-frame.
+frame that contains the same code.
 
 If a stream is cancelled after receiving a complete response, the client MAY
 ignore the cancellation and use the response.  However, if a stream is cancelled
@@ -1386,7 +1386,7 @@ HTTP_PUSH_ALREADY_IN_CACHE (0x04):
 : The server has attempted to push content which the client has cached.
 
 HTTP_REQUEST_CANCELLED (0x05):
-: The sender is no longer processing the request or response.
+: The request or its response is cancelled.
 
 HTTP_INCOMPLETE_REQUEST (0x06):
 : The client's stream terminated without containing a fully-formed request.

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1004,11 +1004,15 @@ some higher layer of software that might have taken some action as a result. The
 client can treat requests rejected by the server as though they had never been
 sent at all, thereby allowing them to be retried later on a new connection.
 Servers MUST NOT use the HTTP_REQUEST_REJECTED error code for requests which
-were partially or fully processed.  When a client sends a STOP_SENDING with
-HTTP_REQUEST_CANCELLED, a server MAY indicate the error code
-HTTP_REQUEST_REJECTED in the corresponding RESET_STREAM if no processing was
-performed.  Clients MUST NOT reset streams with the HTTP_REQUEST_REJECTED error
-code except in response to a QUIC STOP_SENDING frame.
+were partially or fully processed.  When a server abandons a response after
+partial processing, it SHOULD abort its response stream with the error code
+HTTP_REQUEST_CANCELLED.
+
+When a client sends a STOP_SENDING with HTTP_REQUEST_CANCELLED, a server MAY
+indicate the error code HTTP_REQUEST_REJECTED in the corresponding RESET_STREAM
+if no processing was performed.  Clients MUST NOT reset streams with the
+HTTP_REQUEST_REJECTED error code except in response to a QUIC STOP_SENDING
+frame.
 
 If a stream is cancelled after receiving a complete response, the client MAY
 ignore the cancellation and use the response.  However, if a stream is cancelled
@@ -1382,7 +1386,7 @@ HTTP_PUSH_ALREADY_IN_CACHE (0x04):
 : The server has attempted to push content which the client has cached.
 
 HTTP_REQUEST_CANCELLED (0x05):
-: The client no longer needs the requested data.
+: The sender is no longer processing the request or response.
 
 HTTP_INCOMPLETE_REQUEST (0x06):
 : The client's stream terminated without containing a fully-formed request.


### PR DESCRIPTION
Fixes #2416.

I *think* this is editorial, as servers were not previously prohibited from using this error code.  This merely suggests when they might do so.