### PR TITLE
clarify what happens when consuming CIDs excessively

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -963,13 +963,13 @@ unused connection IDs.  While each endpoint independently chooses how many
 connection IDs to issue, endpoints SHOULD provide and maintain at least eight
 connection IDs.  The endpoint SHOULD do this by supplying a new connection ID
 when a connection ID is retired by its peer or when the endpoint receives a
-packet with a previously unused connection ID.  However, it MAY limit the frequency
-or the total number of connection IDs issued for each connection to avoid the
-risk of running out of connection IDs (see {{reset-token}}).
+packet with a previously unused connection ID.  However, it MAY limit the
+frequency or the total number of connection IDs issued for each connection to
+avoid the risk of running out of connection IDs (see {{reset-token}}).
 
 An endpoint that initiates migration and requires non-zero-length connection IDs
-SHOULD ensure that the pool of connection IDs available to its peer allows
-the peer to use a new connection ID on migration, as the peer will close the
+SHOULD ensure that the pool of connection IDs available to its peer allows the
+peer to use a new connection ID on migration, as the peer will close the
 connection if the pool is exhausted.
 
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -968,8 +968,9 @@ or the total number of connection IDs issued for each connection to avoid the
 risk of running out of connection IDs (see {{reset-token}}).
 
 Endpoints that initiate migration and require non-zero-length connection IDs
-SHOULD provide their peers with new connection IDs before migration, or risk the
-peer closing the connection.
+SHOULD ensure that the pool of connection IDs available to their peers allows
+them to use a new connection ID on migration, as the peer will close the
+connection if the pool is exhausted.
 
 
 ### Consuming and Retiring Connection IDs {#retiring-cids}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -972,8 +972,11 @@ the connection.
 ### Consuming and Retiring Connection IDs {#retiring-cids}
 
 An endpoint can change the connection ID it uses for a peer to another available
-one at any time during the connection.  An endpoint consumes connection IDs in
-response to a migrating peer, see {{migration-linkability}} for more.
+one at any time during the connection, though excessive consumption of
+connection IDs might lead to running out of spares if the issuer limits the
+frequency of issuance or the total number of connection IDs issued for each
+connection.  An endpoint consumes connection IDs in response to a migrating
+peer, see {{migration-linkability}} for more.
 
 An endpoint maintains a set of connection IDs received from its peer, any of
 which it can use when sending packets.  When the endpoint wishes to remove a

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -972,11 +972,8 @@ the connection.
 ### Consuming and Retiring Connection IDs {#retiring-cids}
 
 An endpoint can change the connection ID it uses for a peer to another available
-one at any time during the connection, though excessive consumption of
-connection IDs might lead to running out of spares if the issuer limits the
-frequency of issuance or the total number of connection IDs issued for each
-connection.  An endpoint consumes connection IDs in response to a migrating
-peer, see {{migration-linkability}} for more.
+one at any time during the connection.  An endpoint consumes connection IDs in
+response to a migrating peer, see {{migration-linkability}} for more.
 
 An endpoint maintains a set of connection IDs received from its peer, any of
 which it can use when sending packets.  When the endpoint wishes to remove a

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -961,12 +961,15 @@ cannot expect its peer to store and use all issued connection IDs.
 An endpoint SHOULD ensure that its peer has a sufficient number of available and
 unused connection IDs.  While each endpoint independently chooses how many
 connection IDs to issue, endpoints SHOULD provide and maintain at least eight
-connection IDs.  The endpoint SHOULD do this by always supplying a new
-connection ID when a connection ID is retired by its peer or when the endpoint
-receives a packet with a previously unused connection ID.  Endpoints that
-initiate migration and require non-zero-length connection IDs SHOULD provide
-their peers with new connection IDs before migration, or risk the peer closing
-the connection.
+connection IDs.  The endpoint SHOULD do this by supplying a new connection ID
+when a connection ID is retired by its peer or when the endpoint receives a
+packet with a previously unused connection ID, though it MAY limit the frequency
+or the total number of connection IDs issued for each connection to avoid the
+risk of running out of connection IDs (see {{reset-token}}).
+
+Endpoints that initiate migration and require non-zero-length connection IDs
+SHOULD provide their peers with new connection IDs before migration, or risk the
+peer closing the connection.
 
 
 ### Consuming and Retiring Connection IDs {#retiring-cids}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -969,7 +969,7 @@ risk of running out of connection IDs (see {{reset-token}}).
 
 An endpoint that initiates migration and requires non-zero-length connection IDs
 SHOULD ensure that the pool of connection IDs available to its peer allows
-them to use a new connection ID on migration, as the peer will close the
+the peer to use a new connection ID on migration, as the peer will close the
 connection if the pool is exhausted.
 
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -967,7 +967,7 @@ packet with a previously unused connection ID.  However, it MAY limit the freque
 or the total number of connection IDs issued for each connection to avoid the
 risk of running out of connection IDs (see {{reset-token}}).
 
-Endpoints that initiate migration and require non-zero-length connection IDs
+An endpoint that initiates migration and requires non-zero-length connection IDs
 SHOULD ensure that the pool of connection IDs available to their peers allows
 them to use a new connection ID on migration, as the peer will close the
 connection if the pool is exhausted.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -968,7 +968,7 @@ or the total number of connection IDs issued for each connection to avoid the
 risk of running out of connection IDs (see {{reset-token}}).
 
 An endpoint that initiates migration and requires non-zero-length connection IDs
-SHOULD ensure that the pool of connection IDs available to their peers allows
+SHOULD ensure that the pool of connection IDs available to its peer allows
 them to use a new connection ID on migration, as the peer will close the
 connection if the pool is exhausted.
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -963,7 +963,7 @@ unused connection IDs.  While each endpoint independently chooses how many
 connection IDs to issue, endpoints SHOULD provide and maintain at least eight
 connection IDs.  The endpoint SHOULD do this by supplying a new connection ID
 when a connection ID is retired by its peer or when the endpoint receives a
-packet with a previously unused connection ID, though it MAY limit the frequency
+packet with a previously unused connection ID.  However, it MAY limit the frequency
 or the total number of connection IDs issued for each connection to avoid the
 risk of running out of connection IDs (see {{reset-token}}).
 


### PR DESCRIPTION
While we allow the consumer to start using new CIDs anytime, there are consequences of consuming them excessively, as discussed in #2403 starting from [this comment]( 
https://github.com/quicwg/base-drafts/issues/2403#issuecomment-460255684).

The text clarifies that excessive consumption is not what the issuer needs to support.