### PR TITLE
Discard inconsistent packets

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1011,9 +1011,10 @@ cannot be attributed to an existing connection. A stateless reset allows a peer
 to more quickly identify when a connection becomes unusable.
 
 Packets that are matched to an existing connection are discarded if the packets
-are inconsistent with the state of that connection -- for example, if they
-indicate a different protocol version than that of the connection, or if the
-removal of packet protection is unsuccessful once the expected keys are available.
+are inconsistent with the state of that connection.  For example, packets are
+discarded if they indicate a different protocol version than that of the
+connection, or if the removal of packet protection is unsuccessful once the
+expected keys are available.
 
 Invalid packets without packet protection, such as Initial, Retry, or Version
 Negotiation, MAY be discarded.  An endpoint MUST generate a connection error if

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1013,7 +1013,7 @@ to more quickly identify when a connection becomes unusable.
 Packets that are matched to an existing connection are discarded if the packets
 are inconsistent with the state of that connection -- for example, if they
 indicate a different protocol version than that of the connection, or if the
-removal of packet protection is unsuccessful.
+removal of packet protection is unsuccessful once the expected keys are available.
 
 Invalid packets without packet protection, such as Initial, Retry, or Version
 Negotiation, MAY be discarded.  An endpoint MUST generate a connection error if

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1010,8 +1010,10 @@ Endpoints can send a Stateless Reset ({{stateless-reset}}) for any packets that
 cannot be attributed to an existing connection. A stateless reset allows a peer
 to more quickly identify when a connection becomes unusable.
 
-Packets that are matched to an existing connection, but for which the endpoint
-cannot remove packet protection, are discarded.
+Packets that are matched to an existing connection are discarded if the packets
+are inconsistent with the state of that connection -- for example, if they
+indicate a different protocol version than that of the connection, or if the
+endpoint cannot remove packet protection.
 
 Invalid packets without packet protection, such as Initial, Retry, or Version
 Negotiation, MAY be discarded.  An endpoint MUST generate a connection error if

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1013,7 +1013,7 @@ to more quickly identify when a connection becomes unusable.
 Packets that are matched to an existing connection are discarded if the packets
 are inconsistent with the state of that connection -- for example, if they
 indicate a different protocol version than that of the connection, or if the
-endpoint cannot remove packet protection.
+removal of packet protection is unsuccessful.
 
 Invalid packets without packet protection, such as Initial, Retry, or Version
 Negotiation, MAY be discarded.  An endpoint MUST generate a connection error if


### PR DESCRIPTION
Fixes #2397 by discarding packets which are "inconsistent with the state of the connection."  Previously, this was only a failure to remove packet protection; incorrect version is added as another example inconsistency.

Note that this phrasing doesn't rule out upward-VN like #1773, since receiving an expected upgrade is not inconsistent with your local state.