### PR TITLE
Add a loss_time per packet number space

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1040,7 +1040,7 @@ SetLossDetectionTimer():
     loss_detection_timer.cancel()
     return
 
-  [loss_time, pn_space] = GetEarliestLossTimer()
+  [loss_time, pn_space] = GetEarliestLossTime()
   if (loss_time != 0):
     // Time threshold loss detection.
     loss_detection_timer.update(loss_time)
@@ -1078,7 +1078,7 @@ Pseudocode for OnLossDetectionTimeout follows:
 
 ~~~
 OnLossDetectionTimeout():
-  [loss_time, pn_space] = GetEarliestLossTimer()
+  [loss_time, pn_space] = GetEarliestLossTime()
   if (loss_time != 0):
     // Time threshold loss Detection
     DetectLostPackets(pn_space)
@@ -1130,7 +1130,7 @@ DetectLostPackets(pn_space):
       sent_packets.remove(unacked.packet_number)
       if (unacked.in_flight):
         lost_packets.insert(unacked)
-    else if (pn_space == ApplicationData):
+    else:
       if (loss_time[pn_space] == 0):
         loss_time[pn_space] = unacked.time_sent + loss_delay
       else:

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1023,7 +1023,7 @@ Pseudocode for SetLossDetectionTimer follows:
 ~~~
 // Returns the earliest loss_time and the packet number
 // space it's from.  Returns 0 if all times are 0.
-GetEarliestLossTimer():
+GetEarliestLossTime():
   time = loss_time[Initial]
   space = Initial
   for pn_space in [ Handshake, ApplicatonData ]:

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1040,7 +1040,7 @@ SetLossDetectionTimer():
     loss_detection_timer.cancel()
     return
 
-  [loss_time, pn_space] = GetEarliestLossTime()
+  loss_time, _ = GetEarliestLossTime()
   if (loss_time != 0):
     // Time threshold loss detection.
     loss_detection_timer.update(loss_time)
@@ -1078,7 +1078,7 @@ Pseudocode for OnLossDetectionTimeout follows:
 
 ~~~
 OnLossDetectionTimeout():
-  [loss_time, pn_space] = GetEarliestLossTime()
+  loss_time, pn_space = GetEarliestLossTime()
   if (loss_time != 0):
     // Time threshold loss Detection
     DetectLostPackets(pn_space)

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1082,7 +1082,8 @@ OnLossDetectionTimeout():
   if (loss_time != 0):
     // Time threshold loss Detection
     DetectLostPackets(pn_space)
-  // Don't retransmit all crypto data if a packet was just lost.
+  // Retransmit crypto data if no packets were lost
+  // and there are still crypto packets in flight.
   else if (crypto packets are in flight):
     // Crypto retransmission timeout.
     RetransmitUnackedCryptoData()

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1066,14 +1066,18 @@ Pseudocode for OnLossDetectionTimeout follows:
 
 ~~~
 OnLossDetectionTimeout():
-  if (crypto packets are in flight):
+  packets_lost = false
+  for pn_space in [ Initial, Handshake, ApplicatonData ]:
+    if (loss_times[pn_space] != 0):
+      // Time threshold loss Detection
+      DetectLostPackets(pn_space)
+      packets_lost = true
+  // Don't retransmit all crypto data if a packet was just lost.
+  if (!packets_lost &&
+      crypto packets are in flight):
     // Crypto retransmission timeout.
     RetransmitUnackedCryptoData()
     crypto_count++
-  else if (loss_time != 0):
-    // Time threshold loss Detection
-    // Only applies to the ApplicationData packet number space.
-    DetectLostPackets(ApplicationData)
   else:
     // PTO
     SendOneOrTwoPackets()

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1030,7 +1030,7 @@ GetEarliestLossTime():
     if loss_time[pn_space] != 0 &&
        (time == 0 || loss_time[pn_space] < time):
       time = loss_time[pn_space];
-      space = Initial
+      space = pn_space
   return [time, space]
 
 SetLossDetectionTimer():

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1082,11 +1082,8 @@ OnLossDetectionTimeout():
   if (loss_time != 0):
     // Time threshold loss Detection
     DetectLostPackets(pn_space)
-    SetLossDetectionTimer()
-    return
   // Don't retransmit all crypto data if a packet was just lost.
-  if (!packets_lost &&
-      crypto packets are in flight):
+  else if (crypto packets are in flight):
     // Crypto retransmission timeout.
     RetransmitUnackedCryptoData()
     crypto_count++

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1031,7 +1031,7 @@ GetEarliestLossTime():
        (time == 0 || loss_time[pn_space] < time):
       time = loss_time[pn_space];
       space = pn_space
-  return [time, space]
+  return time, space
 
 SetLossDetectionTimer():
   // Don't arm timer if there are no ack-eliciting packets


### PR DESCRIPTION
Fixes #2435 

I failed to fully think this through when #2417 landed, but the intent was always that time threshold loss detection apply to Initial and Handshake packet number spaces, as well as ApplicationData.