### PR TITLE
Bound 0-to-1-RTT Transition

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -717,6 +717,11 @@ during the handshake ({{transport-parameters}}).  A receiver sends
 MAX_STREAM_DATA ({{frame-max-stream-data}}) or MAX_DATA ({{frame-max-data}})
 frames to the sender to advertise additional credit.
 
+Additional credit advertised by the server does not apply to data sent in 0-RTT.
+Until the server has received a 1-RTT packet from the client, it SHOULD continue
+to enforce the flow control limits from the remembered transport parameters (see
+{{zerortt-parameters}}).
+
 A receiver advertises credit for a stream by sending a MAX_STREAM_DATA frame
 with the Stream ID field set appropriately.  A MAX_STREAM_DATA frame indicates
 the maximum absolute byte offset of a stream.  A receiver could use the current
@@ -2631,7 +2636,10 @@ number 0.  Subsequent packets sent in the same packet number space MUST increase
 the packet number by at least one.
 
 0-RTT and 1-RTT data exist in the same packet number space to make loss recovery
-algorithms easier to implement between the two packet types.
+algorithms easier to implement between the two packet types.  However, a client
+MUST NOT continue sending 0-RTT packets after beginning to use 1-RTT packets.
+Servers MUST drop 0-RTT packets with greater packet numbers than the lowest
+packet number they have received in a 1-RTT packet.
 
 A QUIC endpoint MUST NOT reuse a packet number within the same packet number
 space in one connection (that is, under the same cryptographic keys).  If the

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -856,6 +856,11 @@ limits are set in the transport parameters (see
 using MAX_STREAMS frames ({{frame-max-streams}}). Separate limits apply to
 unidirectional and bidirectional streams.
 
+Limits advertised by the server using the MAX_STREAMS frame do not apply to
+streams used in 0-RTT. Until the server has received a 1-RTT packet from the
+client, it SHOULD continue to enforce the limits from the remembered transport
+parameters (see {{zerortt-parameters}}).
+
 Endpoints MUST NOT exceed the limit set by their peer.  An endpoint that
 receives a STREAM frame with a stream ID exceeding the limit it has sent MUST
 treat this as a stream error of type STREAM_LIMIT_ERROR ({{error-handling}}).


### PR DESCRIPTION
Taking a stab at @DavidSchinazi's suggested alternative.  In Tokyo, we agreed that flow control and stream IDs advertised in the server's 1-RTT packets and transport parameters don't apply to the client's 0-RTT data.

This makes two changes:
- The client was already prohibited from sending more 0-RTT packets after reaching 1-RTT ([TLS 4.9](https://quicwg.org/base-drafts/draft-ietf-quic-tls.html#rfc.section.4.9), "Though an endpoint might retain older keys, new data MUST be sent at the highest
currently-available encryption level.")  This adds a requirement on the server to drop 0-RTT packets with higher packet numbers than the first 1-RTT packet number from the client.
- Any increases to flow control or stream limits the server sends don't apply to 0-RTT traffic; servers SHOULD enforce the remembered values until at least one 1-RTT packet has been received.

This isn't perfect, as a malicious client could send a high numbered 1-RTT packet to unlock the flow control and save lower packet numbers for 0-RTT traffic which exceeds the initial limits, but it helps.  From discussion on the PR, it sounds like more aggressive enforcement than this is problematic for servers in multiple implementations.

Fixes #2458.
Fixes #2360.