### PR TITLE
Refine Discussion of 0-RTT Transport Parameters

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1378,28 +1378,38 @@ A server MUST include the original_connection_id transport parameter
 ({{transport-parameter-definitions}}) if it sent a Retry packet to enable
 validation of the Retry, as described in {{packet-retry}}.
 
-
 ### Values of Transport Parameters for 0-RTT {#zerortt-parameters}
 
-A client that attempts to send 0-RTT data MUST remember the transport parameters
-used by the server.  The transport parameters that the server advertises during
-connection establishment apply to all connections that are resumed using the
-keying material established during that handshake.  Remembered transport
+The transport parameters that the server advertises during connection
+establishment generally apply to all connections that are resumed using
+the keying material established during that handshake.  Remembered transport
 parameters apply to the new connection until the handshake completes and new
 transport parameters from the server can be provided.
 
-A server can remember the transport parameters that it advertised, or store an
-integrity-protected copy of the values in the ticket and recover the information
-when accepting 0-RTT data.  A server uses the transport parameters in
-determining whether to accept 0-RTT data.
+The value of the server's previous original_connection_id, preferred_address,
+stateless_reset_token, and ack_delay_exponent MUST NOT be used when
+establishing a new connection; rather, the client should wait to observe the
+server's new values in the handshake.
 
-A server MAY accept 0-RTT and subsequently provide different values for
-transport parameters for use in the new connection.  If 0-RTT data is accepted
-by the server, the server MUST NOT reduce any limits or alter any values that
-might be violated by the client with its 0-RTT data.  In particular, a server
-that accepts 0-RTT data MUST NOT set values for the following parameters
-({{transport-parameter-definitions}}) that are smaller
-than the remembered value of those parameters.
+The client MAY store the server's original max_ack_delay and max_packet_size
+transport parameters. The server MAY accept 0-RTT and subsequently provide
+different values for these transport parameters for use in the new connection.
+The client MUST use these values after acknowledging them. If the server does
+not provide a new value, the client MUST use the default value.
+
+A client that attempts to send 0-RTT data MUST remember all other transport
+parameters used by the server, including new transport parameters
+({{new-transport-parameters}}) that it is able to process. The server can
+remember these transport parameters, or store an integrity-protected copy of
+the values in the ticket and recover the information when accepting 0-RTT
+data. A server uses the transport parameters in determining whether to accept
+0-RTT data.
+
+If 0-RTT data is accepted by the server, the server MUST NOT reduce any
+limits or alter any values that might be violated by the client with its
+0-RTT data.  In particular, a server that accepts 0-RTT data MUST NOT set
+values for the following parameters ({{transport-parameter-definitions}})
+that are smaller than the remembered value of those parameters.
 
 * initial_max_data
 * initial_max_stream_data_bidi_local
@@ -1415,15 +1425,10 @@ values for 0-RTT.  This includes initial_max_data and either
 initial_max_streams_bidi and initial_max_stream_data_bidi_remote, or
 initial_max_streams_uni and initial_max_stream_data_uni.
 
-The value of the server's previous preferred_address MUST NOT be used when
-establishing a new connection; rather, the client should wait to observe the
-server's new preferred_address value in the handshake.
-
 A server MUST either reject 0-RTT data or abort a handshake if the implied
 values for transport parameters cannot be supported.
 
-
-### New Transport Parameters
+### New Transport Parameters {#new-transport-parameters}
 
 New transport parameters can be used to negotiate new protocol behavior.  An
 endpoint MUST ignore transport parameters that it does not support.  Absence of


### PR DESCRIPTION
Fixes #2464, but there are some value judgments here. I believe the new layout is much clearer for implementers.

I made max_packet_size optional for reasons that I think are self-evident. I thought saving max_ack_delay might be useful for clients setting loss timers on their 0-RTT stuff. Everything else is required or forbidden.

Per @MikeBishop's suggestion, I put all the new TPs in the required category.

I also specified behavior when the EE msg omits a TP. I thought it would be simpler for servers that spit out a standard set of TPs to do things that way.