### PR TITLE
Fix PTO calculation in pseudo-code

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1103,8 +1103,7 @@ SetLossDetectionTimer():
 
   // Calculate PTO duration
   timeout =
-    smoothed_rtt + 4 * rttvar + max_ack_delay
-  timeout = max(timeout, kGranularity)
+    smoothed_rtt + max(4 * rttvar, kGranularity) + max_ack_delay
   timeout = timeout * (2 ^ pto_count)
 
   loss_detection_timer.update(


### PR DESCRIPTION
Maybe I'm missing something, but it seems #2480 forgot to update the pseudo-code where PTO is used.

Also, should the PTO calculated in `InPersistentCongestion()` also use `kGranularity`?