### PR TITLE
Clarify RTT calculations in recovery

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -316,8 +316,8 @@ specifies max_ack_delay. It SHOULD be subtracted from the RTT as long as the
 result is larger than the min_rtt. If the result is smaller than the min_rtt,
 the RTT should be used, but the ack delay field should be ignored.  Ignoring
 ack_delay when it would cause an RTT sample smaller than the current min_rtt
-prevents a peer from manipulating RTT samples below min_rtt at the cost of slightly
-increasing RTT samples in the presence of persistent delayed acks.
+prevents a peer from manipulating RTT samples below min_rtt at the cost of
+inflated RTT samples in the presence of persistent delayed acks.
 
 A sender takes an RTT sample when an ACK frame is received that acknowledges a
 larger packet number than before (see {{on-ack-received}}).  A sender will take

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -331,8 +331,8 @@ ack delay.  Ignoring ack delay for min RTT prevents intentional or unintentional
 underestimation of min RTT, which in turn prevents underestimating smoothed RTT.
 
 A sender calculates both smoothed RTT (SRTT) and RTT variance (RTTVAR) similar
-to those specified in {{?RFC6298}}.  Note that smoothed_rtt does for the first
-RTT sample does not use ack_delay, because doing so would result in a
+to those specified in {{?RFC6298}}.  Note that computing smoothed_rtt does not
+use ack_delay for the first RTT sample, because doing so would result in a
 smoothed_rtt that is smaller than the min_rtt.
 
 On every newly acknowledged ack-eliciting largest acked:

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -340,13 +340,14 @@ latest_rtt = ack_time - send_time_of_largest_acked
 
 First RTT sample:
 ~~~
-min_rtt = min(min_rtt, latest_rtt)
+min_rtt = latest_rtt
 smoothed_rtt = latest_rtt
 rttvar = rtt / 2
 ~~~
 
 Subsequent RTT samples:
 ~~~
+min_rtt = min(min_rtt, latest_rtt)
 ack_delay = min(ack_delay, max_ack_delay)
 if (ack_delay + min_rtt < latest_rtt):
   latest_rtt = raw_rtt - ack_delay


### PR DESCRIPTION
Also clarifies the implications of ignoring ack_delay when it would result in an RTT sample less than min_rtt.

Fixes #2137