### PR TITLE
Changelog for -19

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1960,6 +1960,8 @@ Error codes need to be defined for HTTP/2 and HTTP/3 separately.  See
   - Modified associated reserved values
 - Frame layout switched from Length-Type-Value to Type-Length-Value
   (#2395,#2235)
+- Specified error code for servers receiving DUPLICATE_PUSH (#2497)
+- Use connection error for invalid PRIORITY (#2507, #2508)
 
 ## Since draft-ietf-quic-http-17
 

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -1328,6 +1328,10 @@ return controlBuffer, prefixBuffer + streamBuffer
 > **RFC Editor's Note:** Please remove this section prior to publication of a
 > final version of this document.
 
+## Since draft-ietf-quic-qpack-06
+
+- Clarify initial dynamic table capacity maximums (#2276, #2330, #2330)
+
 ## Since draft-ietf-quic-qpack-05
 
 - Introduced the terms dynamic table capacity and maximum dynamic table

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1600,6 +1600,11 @@ cb54df7884
 Issue and pull request numbers are listed with a leading octothorp.
 
 
+## Since draft-ietf-quic-tls-18
+
+- Increased the set of permissible frames in 0-RTT (#2344, #2355)
+
+
 ## Since draft-ietf-quic-tls-17
 
 - Endpoints discard initial keys as soon as handshake keys are available (#1951,

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -5494,6 +5494,22 @@ DecodePacketNumber(largest_pn, truncated_pn, pn_nbits):
 
 Issue and pull request numbers are listed with a leading octothorp.
 
+## Since draft-ietf-quic-transport-18
+
+- Removed version negotation; version negotiation, including authentication of
+  the result, will be addressed in the next version of QUIC (#1773, #2313)
+- Added discussion of the use of IPv6 flow labels (#2348, #2399)
+- A connection ID can't be retired in a packet that uses that connection ID
+  (#2101, #2420)
+- Idle timeout transport parameter is in milliseconds (from seconds) (#2453,
+  #2454)
+- Endpoints are required to use new connnection IDs when they use new network
+  paths (#2413, #2414)
+- Increased the set of permissible frames in 0-RTT (#2344, #2355)
+- Prohibit the use of MAX_STREAM_ID/max_stream_id of greater than 2^60 (#2487,
+  #2499)
+- Failing to negotiate ALPN is a fatal error (#2495, #2483)
+
 ## Since draft-ietf-quic-transport-17
 
 - Stream-related errors now use STREAM_STATE_ERROR (#2305)


### PR DESCRIPTION
I will merge this very soon, but I haven't done the recovery bits, which is where most of the changes are.  Ian and Jana, that needs to be done today.

The changes I see are [here](https://quicwg.org/base-drafts/issues.html#closed_since(2019-01-22)%20merged%20not(label(editorial))), where the unlabelled ones are recovery.

