### PR TITLE
QPACK: Use the term "HTTP/3" in the title

### DIFF
--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -1,5 +1,5 @@
 ---
-title: "QPACK: Header Compression for HTTP over QUIC"
+title: "QPACK: Header Compression for HTTP/3"
 abbrev: QPACK
 docname: draft-ietf-quic-qpack-latest
 date: {DATE}


### PR DESCRIPTION
It seems appropriate given that the term is used elsewhere in the text.
However, I am sorry if there is a specific reason for keeping "HTTP over QUIC" here.