### PR TITLE
Push stream data and PUSH_PROMISE reordering clarification

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1207,7 +1207,14 @@ the requests if the requested resource is already being pushed.
 When a server later fulfills a promise, the server push response is conveyed on
 a push stream (see {{push-streams}}). The push stream identifies the Push ID of
 the promise that it fulfills, then contains a response to the promised request
-using the same format described for responses in {{request-response}}.
+using the same format described for responses in {{request-response}}. Due to
+reordering, data on a push stream can arrive before the corresponding
+PUSH_PROMISE, in which case both the associated client request and the pushed
+request headers are unknown. Clients which receive a new push stream with an
+as-yet-unknown Push ID can buffer the stream data in expectation of the matching
+PUSH_PROMISE. A client can use stream flow control (see section 4.1 of
+{{QUIC-TRANSPORT}}) to limit the amount of data a server may commit to the
+pushed stream.
 
 If a promised server push is not needed by the client, the client SHOULD send a
 CANCEL_PUSH frame. If the push stream is already open or opens after sending the

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1210,7 +1210,7 @@ the promise that it fulfills, then contains a response to the promised request
 using the same format described for responses in {{request-response}}. Due to
 reordering, data on a push stream can arrive before the corresponding
 PUSH_PROMISE, in which case both the associated client request and the pushed
-request headers are unknown. Clients which receive a new push stream with an
+request headers are unknown. Clients that receive a new push stream with an
 as-yet-unknown Push ID can buffer the stream data in expectation of the matching
 PUSH_PROMISE. A client can use stream flow control (see section 4.1 of
 {{QUIC-TRANSPORT}}) to limit the amount of data a server may commit to the

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1198,7 +1198,7 @@ DUPLICATE_PUSH frame (see {{frame-duplicate-push}}).  Ordering of a
 DUPLICATE_PUSH in relation to certain parts of the response is similarly
 important.  Due to reordering, DUPLICATE_PUSH frames can arrive before the
 corresponding PUSH_PROMISE frame, in which case the request headers of the push
-would not be immediately available.  Clients which receive a DUPLICATE_PUSH
+would not be immediately available.  Clients that receive a DUPLICATE_PUSH
 frame for an as-yet-unknown Push ID can either delay generating new requests for
 content referenced following the DUPLICATE_PUSH frame until the request headers
 become available, or can initiate requests for discovered resources and cancel


### PR DESCRIPTION
As discussed on Slack, currently the text makes no mention of the case where the PUSH_PROMISE arrives behind (some of) the data on the push stream itself. However, it does mention this situation for the DUPLICATE_PUSH frame. 

This proposed change recommends buffering pushed data for an unknown PUSH_ID and using flow control to prevent this from being a problem. 

I am unsure if more text is needed (e.g., what happens if the PUSH_ID is never resolved (which would mean a misbehaving server)), but I think the proposed change should suffice. 

This is also related to issue #2526.
Thanks to @LPardue for his help. 