### PR TITLE
Allow not creating QPACK codec streams

### DIFF
--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -619,13 +619,21 @@ QPACK defines two unidirectional stream types:
    It carries an unframed sequence of decoder instructions from decoder
    to encoder.
 
-<!-- s/exactly/no more than/  ? -->
 HTTP/3 endpoints contain a QPACK encoder and decoder. Each endpoint MUST
-initiate a single encoder stream and decoder stream. Receipt of a second
-instance of either stream type be MUST treated as a connection error of type
+initiate at most one encoder stream and one decoder stream. Receipt of a second
+instance of either stream type MUST be treated as a connection error of type
 HTTP_WRONG_STREAM_COUNT. These streams MUST NOT be closed. Closure of either
 unidirectional stream type MUST be treated as a connection error of type
 HTTP_CLOSED_CRITICAL_STREAM.
+
+An endpoint MAY avoid creating its own encoder stream if the maximum size of
+the dynamic table permitted by the peer is zero.
+
+An endpoint MAY avoid creating its own decoder stream if the maximum size of
+its own dynamic table is zero.
+
+An endpoint MUST allow its peer to create both encoder and decoder streams
+even if the connection's settings prevent their use.
 
 ## Encoder Instructions {#encoder-instructions}
 

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -620,10 +620,10 @@ QPACK defines two unidirectional stream types:
    to encoder.
 
 HTTP/3 endpoints contain a QPACK encoder and decoder. Each endpoint MUST
-initiate at most one encoder stream and one decoder stream. Receipt of a second
-instance of either stream type MUST be treated as a connection error of type
-HTTP_WRONG_STREAM_COUNT. These streams MUST NOT be closed. Closure of either
-unidirectional stream type MUST be treated as a connection error of type
+initiate at most one encoder stream and at most one decoder stream. Receipt of a
+second instance of either stream type MUST be treated as a connection error of
+type HTTP_WRONG_STREAM_COUNT. These streams MUST NOT be closed. Closure of
+either unidirectional stream type MUST be treated as a connection error of type
 HTTP_CLOSED_CRITICAL_STREAM.
 
 An endpoint MAY avoid creating its own encoder stream if it's not going to be

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -626,8 +626,9 @@ HTTP_WRONG_STREAM_COUNT. These streams MUST NOT be closed. Closure of either
 unidirectional stream type MUST be treated as a connection error of type
 HTTP_CLOSED_CRITICAL_STREAM.
 
-An endpoint MAY avoid creating its own encoder stream if the maximum size of
-the dynamic table permitted by the peer is zero.
+An endpoint MAY avoid creating its own encoder stream if it's not going to be
+used (for example if the endpoint doesn't wish to use the dynamic table, or if
+the maximum size of the dynamic table permitted by the peer is zero).
 
 An endpoint MAY avoid creating its own decoder stream if the maximum size of
 its own dynamic table is zero.


### PR DESCRIPTION
As discussed in Tokyo, we should allow endpoints to avoid creating the
QPACK control streams if they are unnecessary, but endpoints should be
allowed to create them either way.

Fixes #2100