### PR TITLE
Simplify kPersistentThreshold

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1215,7 +1215,6 @@ kLossReductionFactor:
   The RECOMMENDED value is 0.5.
 
 kPersistentCongestionThreshold:
-
 : Period of time for persistent congestion to be established, specified as a PTO
   multiplier.  The rationale for this threshold is to enable a sender to use
   initial PTOs for aggressive probing, as TCP does with Tail Loss Probe (TLP)

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -664,7 +664,8 @@ where PTOs do not occur or are substantially delayed.  This duration is computed
 as follows:
 
 ~~~
-(smoothed_rtt + 4 * rttvar + max_ack_delay) * kPersistentCongestionThreshold
+(smoothed_rtt + 4 * rttvar + max_ack_delay) *
+    kPersistentCongestionThreshold
 ~~~
 
 For example, assume:


### PR DESCRIPTION
This simplifies the definition of kPersistentThreshold from an exponent to a PTO multiplier.