### PR TITLE
Set the QUIC bit in Version Negotiation

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3497,7 +3497,10 @@ The layout of a Version Negotiation packet is:
 ~~~
 {: #version-negotiation-format title="Version Negotiation Packet"}
 
-The value in the Unused field is selected randomly by the server.
+The value in the Unused field is selected randomly by the server.  Clients MUST
+ignore the value of this field.  Servers SHOULD set the most significant bit of
+this field (0x40) to 1 so that Version Negotiation packets appear to have the
+Fixed Bit field.
 
 The Version field of a Version Negotiation packet MUST be set to 0x00000000.
 


### PR DESCRIPTION
This must be ignored, and should be set to 1.

Closes #2400.