### PR TITLE
introduce a version alias mechanism

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4134,8 +4134,8 @@ version_aliases (0x000e):
 
 : A list of version numbers that the server accepts as an alias for the
   currently used versions. This transport parameter is only sent by the server.
-  Every version alias contains a lifetime in milliseconds. The alias is only valid
-  for that lifetime, clients MUST NOT use it after expiry.
+  Every version alias contains a lifetime in milliseconds. The alias is only
+  valid for that lifetime, clients MUST NOT use it after expiry.
 
 ~~~
    struct {

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3251,12 +3251,17 @@ using for private experimentation on the GitHub wiki at
 In order to avoid ossification of the version number defined by this draft,
 servers announce a list of version numbers that they interpret as aliases for
 the version number used in this draft. Alias versions MUST NOT be a reserved
-version. Servers SHOULD send at least one version alias, and SHOULD frequently
-change the value that they announce. Each version alias contains a lifetime,
-which indicates how long the server will accept this version alias. It also
-contains an initial salt, which is used instead of the initial salt as defined
-in section 5.2 of {{QUIC-TLS}}. The list of version aliases is sent in the
-server's Transport Parameters (see {{transport-parameter-definitions}}).
+version. A server MUST NOT advertise an alias version number for a version that
+it actually supports. If the server advertises an alias version number that the
+client actually supports, the client MUST assume the server doesn't support
+that version and ignore the alias.
+
+Servers SHOULD send at least one version alias, and SHOULD frequently change the
+value that they announce. Each version alias contains a lifetime, which
+indicates how long the server will accept this version alias. It also contains
+an initial salt, which is used instead of the initial salt as defined in section
+5.2 of {{QUIC-TLS}}. The list of version aliases is sent in the server's
+Transport Parameters (see {{transport-parameter-definitions}}).
 
 Clients SHOULD remember the list of aliases and use it for subsequent
 connections to the same server in the future. This applies to both 0-RTT

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4134,7 +4134,7 @@ version_aliases (0x000e):
 
 : A list of version numbers that the server accepts as an alias for the
   currently used versions. This transport parameter is only sent by the server.
-  Every version alias contains a lifetime in seconds. The alias is only valid
+  Every version alias contains a lifetime in milliseconds. The alias is only valid
   for that lifetime, clients MUST NOT use it after expiry.
 
 ~~~

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3249,7 +3249,7 @@ using for private experimentation on the GitHub wiki at
 ## Version Aliases
 
 In order to avoid ossification of the version number defined by this draft,
-servers announce a list of version numbers that they interpret as an alias for
+servers announce a list of version numbers that they interpret as aliases for
 the version number used in this draft. Alias versions MUST NOT be a reserved
 version. Servers SHOULD send at least one version alias, and SHOULD frequently
 change the value that they announce. Each version alias contains a lifetime,
@@ -3258,9 +3258,9 @@ contains an initial salt, which is used instead of the initial salt as defined
 in section 5.2 of {{QUIC-TLS}}. The list of version aliases is sent in the
 server's Transport Parameters (see {{transport-parameter-definitions}}).
 
-Clients SHOULD remember the aliases and use it for subsequent connections to the
-same server in the future. This applies to both 0-RTT connection as well as
-connections that don't use 0-RTT.
+Clients SHOULD remember the list of aliases and use it for subsequent
+connections to the same server in the future. This applies to both 0-RTT
+connection as well as connections that don't use 0-RTT.
 
 # Variable-Length Integer Encoding {#integer-encoding}
 
@@ -4132,10 +4132,10 @@ preferred_address (0x000d):
 
 version_aliases (0x000e):
 
-: A list of version numbers that the server accepts as an alias for the
-  currently used versions. This transport parameter is only sent by the server.
+: A list of version numbers that the server accepts as aliases for the
+  currently used version. This transport parameter is only sent by the server.
   Every version alias contains a lifetime in milliseconds. The alias is only
-  valid for that lifetime, clients MUST NOT use it after expiry.
+  valid for that lifetime. Clients MUST NOT use an expired alias.
 
 ~~~
    struct {

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3253,9 +3253,10 @@ servers announce a list of version numbers that they interpret as an alias for
 the version number used in this draft. Alias versions MUST NOT be a reserved
 version. Servers SHOULD send at least one version alias, and SHOULD frequently
 change the value that they announce. Each version alias contains a lifetime,
-which indicates how long the server will accept this version alias. The list
-of version aliases is sent in the server's Transport Parameters (see
-{{transport-parameter-definitions}}).
+which indicates how long the server will accept this version alias. It also
+contains an initial salt, which is used instead of the initial salt as defined
+in section 5.2 of {{QUIC-TLS}}. The list of version aliases is sent in the
+server's Transport Parameters (see {{transport-parameter-definitions}}).
 
 Clients SHOULD remember the aliases and use it for subsequent connections to the
 same server in the future. This applies to both 0-RTT connection as well as
@@ -4140,6 +4141,7 @@ version_aliases (0x000e):
    struct {
      uint32 VersionNumber;
      uint32 Lifetime;
+     opaque InitialSecret<20>;
    } VersionAlias;
 
    VersionAliases VersionAlias<0..2^16-1>;

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4140,7 +4140,7 @@ version_aliases (0x000e):
 ~~~
    struct {
      uint32 VersionNumber;
-     uint32 Lifetime;
+     varint Lifetime;
      opaque InitialSecret<20>;
    } VersionAlias;
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3246,7 +3246,20 @@ Implementors are encouraged to register version numbers of QUIC that they are
 using for private experimentation on the GitHub wiki at
 \<https://github.com/quicwg/base-drafts/wiki/QUIC-Versions\>.
 
+## Version Aliases
 
+In order to avoid ossification of the version number defined by this draft,
+servers announce a list of version numbers that they interpret as an alias for
+the version number used in this draft. Alias versions MUST NOT be a reserved
+version. Servers SHOULD send at least one version alias, and SHOULD frequently
+change the value that they announce. Each version alias contains a lifetime,
+which indicates how long the server will accept this version alias. The list
+of version aliases is sent in the server's Transport Parameters (see
+{{transport-parameter-definitions}}).
+
+Clients SHOULD remember the aliases and use it for subsequent connections to the
+same server in the future. This applies to both 0-RTT connection as well as
+connections that don't use 0-RTT.
 
 # Variable-Length Integer Encoding {#integer-encoding}
 
@@ -3955,6 +3968,7 @@ language from Section 3 of {{!TLS13=RFC8446}}.
       max_ack_delay(11),
       disable_migration(12),
       preferred_address(13),
+      version_aliases(14),
       (65535)
    } TransportParameterId;
 
@@ -4114,6 +4128,24 @@ preferred_address (0x000d):
    } PreferredAddress;
 ~~~
 {: #fig-preferred-address title="Preferred Address format"}
+
+version_aliases (0x000e):
+
+: A list of version numbers that the server accepts as an alias for the
+  currently used versions. This transport parameter is only sent by the server.
+  Every version alias contains a lifetime in seconds. The alias is only valid
+  for that lifetime, clients MUST NOT use it after expiry.
+
+~~~
+   struct {
+     uint32 VersionNumber;
+     uint32 Lifetime;
+   } VersionAlias;
+
+   VersionAliases VersionAlias<0..2^16-1>;
+~~~
+{: #fig-version-aliases title="Version Aliases format"}
+
 
 If present, transport parameters that set initial flow control limits
 (initial_max_stream_data_bidi_local, initial_max_stream_data_bidi_remote, and

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4140,7 +4140,7 @@ version_aliases (0x000e):
 ~~~
    struct {
      uint32 VersionNumber;
-     varint Lifetime;
+     uint32 lifetime_ms;
      opaque InitialSecret<20>;
    } VersionAlias;
 


### PR DESCRIPTION
This is an attempt to solve the QUIC version ossification that was discussed in Prague. Fixes #2496.

Servers can announce a list of version aliases in the transport parameters. A version alias can be any valid QUIC version number, and the server guarantees to accept this version number as an alias for the currently used version. Each version alias comes with a lifetime for which it is valid, as well as a salt for the encryption of the Initial.
On subsequent connections, clients can use a version alias to establish a connection to the same server.

If widely deployed, middleboxes will get used to version numbers from the whole version number space being used for QUIC connections. Since they are unaware of the Initial salt being used for alias versions, they can't even decrypt the Initial packet.

In the current form, this PR lacks some text about the privacy implications of this proposal. A version alias is (yet another) cookie, so it should have the same properties as a token, i.e. a client shouldn't use the same version alias more than once, in order to avoid being identifiable to on-path observers.