### PR TITLE
Call OnPacketAckedCC() for in-flight packets, not just ack-eliciting

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1046,7 +1046,7 @@ Pseudocode for OnPacketAcked follows:
 
 ~~~
    OnPacketAcked(acked_packet, pn_space):
-     if (acked_packet.ack_eliciting):
+     if (acked_packet.in_flight):
        OnPacketAckedCC(acked_packet)
      sent_packets[pn_space].remove(acked_packet.packet_number)
 ~~~


### PR DESCRIPTION
`OnPacketAcked()` calls `OnPacketAckedCC()` (which decreases `bytes_in_flight`)
only when `ack_eliciting` is true, however `OnPacketSentCC()` (which increases
`bytes_in_flight`) is called when `in_flight` is true.

Additionally, `OnPacketsLost()` decreases `bytes_in_flight` for in-flight
lost packets (not just ack-eliciting ones).

So it seems to follow that `OnPacketAcked()` should call `OnPacketAckedCC()`
for all in-flight packets.

---

The whole ack-eliciting vs in-flight distinction is pretty confusing to me (the only difference seems to be that in-flight includes packets with just PADDING, which are not ack-eliciting, is that correct?) so I may be totally wrong here.

But `bytes_in_flight` is increased and decreased based on two different conditions (`ack_eliciting` vs `in_flight`) which seems like a bug in the pseudo-code.

However if this is the intended behaviour, it's be useful to have a clarification as to why it is like that (the text doesn't seem to mention this) or a pointer to a previous discussion about this.