### PR TITLE
Replace recovery epoch with congestion event

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1318,8 +1318,8 @@ window.
 
 ~~~
    CongestionEvent(sent_time):
-     // Start a new congestion event if the sent time is larger
-     // than the start time of the previous congestion event.
+     // Start a new congestion event if packet was sent after the
+     // start of the previous congestion event.
      if (!InRecovery(sent_time)):
        recovery_start_time = Now()
        congestion_window *= kLossReductionFactor

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1319,7 +1319,7 @@ window.
 ~~~
    CongestionEvent(sent_time):
      // Start a new congestion event if the sent time is larger
-     // than the start time of the previous recovery epoch.
+     // than the start time of the previous congestion event.
      if (!InRecovery(sent_time)):
        recovery_start_time = Now()
        congestion_window *= kLossReductionFactor
@@ -1340,7 +1340,7 @@ Invoked when an ACK frame with an ECN section is received from the peer.
        ecn_ce_counter = ack.ce_counter
        // Start a new congestion event if the last acknowledged
        // packet was sent after the start of the previous
-       // recovery epoch.
+       // congestion event.
        CongestionEvent(sent_packets[ack.largest_acked].time_sent)
 ~~~
 
@@ -1366,8 +1366,8 @@ are detected lost.
        bytes_in_flight -= lost_packet.size
      largest_lost_packet = lost_packets.last()
 
-     // Start a new congestion epoch if the last lost packet
-     // is past the end of the previous recovery epoch.
+     // Start a new congestion event if the last lost packet
+     // is past the end of the previous congestion event.
      CongestionEvent(largest_lost_packet.time_sent)
 
      // Collapse congestion window if persistent congestion


### PR DESCRIPTION
Recovery epoch was undefined and congestion event makes more sense for QUIC.

Fixes #2566 