### PR TITLE
Don't arm the handshake timer if there's no data

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -442,8 +442,7 @@ connections over the same network SHOULD use the previous connection's final
 smoothed RTT value as the resumed connection's initial RTT.  If no previous RTT
 is available, or if the network changes, the initial RTT SHOULD be set to 500ms,
 resulting in a 1 second initial handshake timeout as recommended in
-{{?RFC6298}}. When the first acknowledgement is received, an RTT is computed and
-the timer SHOULD be set for twice the newly computed RTT.
+{{?RFC6298}}.
 
 When a crypto packet is sent, the sender MUST set a timer for twice the smoothed
 RTT.  This timer MUST be updated when a new crypto packet is sent and when
@@ -451,7 +450,7 @@ an acknowledgement is received which computes a new RTT sample. Upon timeout,
 the sender MUST retransmit all unacknowledged CRYPTO data if possible.
 
 On each consecutive expiration of the crypto timer without receiving an
-acknowledgement for a new packet, the sender SHOULD double the crypto
+acknowledgement for a new packet, the sender MUST double the crypto
 retransmission timeout and set a timer for this period.
 
 Until the server has validated the client's address on the path, the amount of
@@ -462,12 +461,14 @@ sent, then no alarm should be armed until data has been received from the
 client.
 
 Because the server could be blocked until more packets are received, the client
-MUST ensure the crypto retransmission timer is set if there is unacknowledged
-crypto data and MUST ensure the timer is set until it has 1-RTT keys.
-If the timer expires and the client has no CRYPTO data to retransmit and does
-not have Handshake keys, it MUST send an Initial packet in a UDP datagram of
-at least 1200 bytes.  If the client has Handshake keys, it MUST send a
-Handshake packet.
+MUST ensure that the crypto retransmission timer is set if there is
+unacknowledged crypto data or if the client does not yet have 1-RTT keys.
+If the crypto retransmission timer expires before the client has 1-RTT keys,
+it is possible that the client may not have any crypto data to retransmit.
+The client MUST send a new packet to allow the server to continue sending
+data. If Handshake keys are available to the client, it MUST send a
+Handshake packet, and otherwise it MUST send an Initial packet in a UDP
+datagram of at least 1200 bytes.
 
 The crypto retransmission timer is not set if the time threshold
 {{time-threshold}} loss detection timer is set.  When the crypto

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1121,7 +1121,7 @@ SetLossDetectionTimer():
     loss_detection_timer.update(loss_time)
     return
 
-  if (crypto packets are in flight
+  if (has unacknowledged crypto data
       || endpoint is client without 1-RTT keys):
     // Crypto retransmission timer.
     if (smoothed_rtt == 0):
@@ -1159,7 +1159,7 @@ OnLossDetectionTimeout():
     DetectLostPackets(pn_space)
   // Retransmit crypto data if no packets were lost
   // and there is crypto data to retransmit.
-  else if (has unacked crypto data):
+  else if (has unacknowledged crypto data):
     // Crypto retransmission timeout.
     RetransmitUnackedCryptoData()
     crypto_count++

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -448,7 +448,7 @@ When a crypto packet is sent, the sender MUST set a timer for twice the smoothed
 RTT.  This timer MUST be updated when a new crypto packet is sent and when
 an acknowledgement is received which computes a new RTT sample. Upon timeout,
 the sender MUST retransmit all unacknowledged CRYPTO data if possible.  The
-sender MUST NOT declare in flight crypto packets as lost when the crypto timer
+sender MUST NOT declare in-flight crypto packets as lost when the crypto timer
 expires.
 
 On each consecutive expiration of the crypto timer without receiving an

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -461,8 +461,8 @@ client.
 
 Because the server could be blocked until more packets are received, the client
 MUST ensure the crypto retransmission timer is set if there is unacknowledged
-crypto data and MUST ensure the the timer is set until it has 1RTT keys.
-If the timer expires and the client has no  CRYPTO data to retransmit and does
+crypto data and MUST ensure  the timer is set until it has 1RTT keys.
+If the timer expires and the client has no CRYPTO data to retransmit and does
 not have Handshake keys, it MUST send an Initial packet in a UDP datagram of
 at least 1200 bytes.  If the client has Handshake keys, it MUST send a
 Handshake packet.

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -434,8 +434,12 @@ and larger thresholds increase loss detection delay.
 Data in CRYPTO frames is critical to QUIC transport and crypto negotiation, so a
 more aggressive timeout is used to retransmit it.
 
+MUST start the crypto retransmission timer if there is outstanding CRYPTO data. It MUST also start the crypto retransmission timer until it has 1-RTT keys,
+
 The initial crypto retransmission timeout SHOULD be set to twice the initial
-RTT.
+RTT.  On each consecutive expiration of the crypto timer without receiving an
+acknowledgement for a new packet, the sender SHOULD double the crypto
+retransmission timeout and set a timer for this period.
 
 At the beginning, there are no prior RTT samples within a connection.  Resumed
 connections over the same network SHOULD use the previous connection's final
@@ -458,17 +462,15 @@ sent, then no alarm should be armed until data has been received from the
 client.
 
 Because the server could be blocked until more packets are received, the client
-MUST start the crypto retransmission timer until it has 1RTT keys, even if there
-is no unacknowledged CRYPTO data.  If the timer expires and the client has no
-CRYPTO data to retransmit and does not have Handshake keys, it MUST send an
-Initial packet in a UDP datagram of at least 1200 bytes.  If the client has
-Handshake keys, it MUST send a Handshake packet.
+MUST ensure the crypto retransmission timer is set if there is unacknowledged
+crypto data and MUST ensure the the timer is set until it has 1RTT keys.
+If the timer expires and the client has no  CRYPTO data to retransmit and does
+not have Handshake keys, it MUST send an Initial packet in a UDP datagram of
+at least 1200 bytes.  If the client has Handshake keys, it MUST send a
+Handshake packet.
 
-On each consecutive expiration of the crypto timer without receiving an
-acknowledgement for a new packet, the sender SHOULD double the crypto
-retransmission timeout and set a timer for this period.
-
-When crypto packets are in flight, the probe timer ({{pto}}) is not active.
+When the crypto retransmission timer is active, the probe timer ({{pto}})
+is not active.
 
 
 ### Retry and Version Negotiation

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1118,8 +1118,8 @@ SetLossDetectionTimer():
     loss_detection_timer.update(loss_time)
     return
 
-  if (crypto packets are in flight &&
-      crypto data to send):
+  if (crypto packets are in flight
+      || endpoint is client without 1-RTT keys):
     // Crypto retransmission timer.
     if (smoothed_rtt == 0):
       timeout = 2 * kInitialRtt

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -460,9 +460,9 @@ client.
 Because the server could be blocked until more packets are received, the client
 MUST start the crypto retransmission timer until it has 1RTT keys, even if there
 is no unacknowledged CRYPTO data.  If the timer expires and the client has no
-CRYPTO data to retransmit and does not have Handshake keys, it SHOULD send an
+CRYPTO data to retransmit and does not have Handshake keys, it MUST send an
 Initial packet in a UDP datagram of at least 1200 bytes.  If the client has
-Handshake keys, it SHOULD send a Handshake packet.
+Handshake keys, it MUST send a Handshake packet.
 
 On each consecutive expiration of the crypto timer without receiving an
 acknowledgement for a new packet, the sender SHOULD double the crypto

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -435,22 +435,24 @@ Data in CRYPTO frames is critical to QUIC transport and crypto negotiation, so a
 more aggressive timeout is used to retransmit it.
 
 The initial crypto retransmission timeout SHOULD be set to twice the initial
-RTT.  On each consecutive expiration of the crypto timer without receiving an
-acknowledgement for a new packet, the sender SHOULD double the crypto
-retransmission timeout and set a timer for this period.
+RTT.
 
 At the beginning, there are no prior RTT samples within a connection.  Resumed
 connections over the same network SHOULD use the previous connection's final
 smoothed RTT value as the resumed connection's initial RTT.  If no previous RTT
 is available, or if the network changes, the initial RTT SHOULD be set to 500ms,
 resulting in a 1 second initial handshake timeout as recommended in
-{{?RFC6298}}. When an acknowledgement is received, a new RTT is computed and the
-timer SHOULD be set for twice the newly computed smoothed RTT.
+{{?RFC6298}}. When the first acknowledgement is received, an RTT is computed and
+the timer SHOULD be set for twice the newly computed smoothed RTT.
 
-When a crypto packet is sent, the sender MUST set a timer for the crypto
-timeout period.  This timer MUST be updated when a new crypto packet is sent.
-Upon timeout, the sender MUST retransmit all unacknowledged CRYPTO data if
-possible.
+When a crypto packet is sent, the sender MUST set a timer for twice the smoothed
+RTT.  This timer MUST be updated when a new crypto packet is sent and when
+an acknowledgement is received which computes a new RTT sample. Upon timeout,
+the sender MUST retransmit all unacknowledged CRYPTO data if possible.
+
+On each consecutive expiration of the crypto timer without receiving an
+acknowledgement for a new packet, the sender SHOULD double the crypto
+retransmission timeout and set a timer for this period.
 
 Until the server has validated the client's address on the path, the amount of
 data it can send is limited, as specified in Section 8.1 of {{QUIC-TRANSPORT}}.
@@ -461,7 +463,7 @@ client.
 
 Because the server could be blocked until more packets are received, the client
 MUST ensure the crypto retransmission timer is set if there is unacknowledged
-crypto data and MUST ensure  the timer is set until it has 1RTT keys.
+crypto data and MUST ensure the timer is set until it has 1RTT keys.
 If the timer expires and the client has no CRYPTO data to retransmit and does
 not have Handshake keys, it MUST send an Initial packet in a UDP datagram of
 at least 1200 bytes.  If the client has Handshake keys, it MUST send a

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -463,7 +463,7 @@ client.
 
 Because the server could be blocked until more packets are received, the client
 MUST ensure the crypto retransmission timer is set if there is unacknowledged
-crypto data and MUST ensure the timer is set until it has 1RTT keys.
+crypto data and MUST ensure the timer is set until it has 1-RTT keys.
 If the timer expires and the client has no CRYPTO data to retransmit and does
 not have Handshake keys, it MUST send an Initial packet in a UDP datagram of
 at least 1200 bytes.  If the client has Handshake keys, it MUST send a

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -443,7 +443,7 @@ smoothed RTT value as the resumed connection's initial RTT.  If no previous RTT
 is available, or if the network changes, the initial RTT SHOULD be set to 500ms,
 resulting in a 1 second initial handshake timeout as recommended in
 {{?RFC6298}}. When the first acknowledgement is received, an RTT is computed and
-the timer SHOULD be set for twice the newly computed smoothed RTT.
+the timer SHOULD be set for twice the newly computed RTT.
 
 When a crypto packet is sent, the sender MUST set a timer for twice the smoothed
 RTT.  This timer MUST be updated when a new crypto packet is sent and when

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1229,8 +1229,9 @@ OnLossDetectionTimeout():
     RetransmitUnackedCryptoData()
     crypto_count++
   else if (endpoint is client without 1-RTT keys):
-    // Send anti-deadlock packet: Initial is padded to earn more
-    // anti-amplification credit, Handshake proves address ownership.
+    // Client sends an anti-deadlock packet: Initial is padded
+    // to earn more anti-amplification credit,
+    // a Handshake packet proves address ownership.
     if (has Handshake keys):
        SendOneHandshakePacket()
      else:

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -467,7 +467,7 @@ MUST ensure that the crypto retransmission timer is set if there is
 unacknowledged crypto data or if the client does not yet have 1-RTT keys.
 If the crypto retransmission timer expires before the client has 1-RTT keys,
 it is possible that the client may not have any crypto data to retransmit.
-The client MUST send a new packet to allow the server to continue sending
+However, the client MUST send a new packet, containing only PING or PADDDING frames if necessary, to allow the server to continue sending
 data. If Handshake keys are available to the client, it MUST send a
 Handshake packet, and otherwise it MUST send an Initial packet in a UDP
 datagram of at least 1200 bytes.

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -434,8 +434,6 @@ and larger thresholds increase loss detection delay.
 Data in CRYPTO frames is critical to QUIC transport and crypto negotiation, so a
 more aggressive timeout is used to retransmit it.
 
-MUST start the crypto retransmission timer if there is outstanding CRYPTO data. It MUST also start the crypto retransmission timer until it has 1-RTT keys,
-
 The initial crypto retransmission timeout SHOULD be set to twice the initial
 RTT.  On each consecutive expiration of the crypto timer without receiving an
 acknowledgement for a new packet, the sender SHOULD double the crypto

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -469,8 +469,9 @@ not have Handshake keys, it MUST send an Initial packet in a UDP datagram of
 at least 1200 bytes.  If the client has Handshake keys, it MUST send a
 Handshake packet.
 
-When the crypto retransmission timer is active, the probe timer ({{pto}})
-is not active.
+The crypto retransmission timer is not set if the time threshold
+{{time-threshold}} loss detection timer is set.  When the crypto
+retransmission timer is active, the probe timer ({{pto}}) is not active.
 
 
 ### Retry and Version Negotiation

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1157,7 +1157,7 @@ OnLossDetectionTimeout():
     // Time threshold loss Detection
     DetectLostPackets(pn_space)
   // Retransmit crypto data if no packets were lost
-  // and there are still crypto packets in flight.
+  // and there is crypto data to retransmit.
   else if (crypto packets are in flight &&
            crypto data to send):
     // Crypto retransmission timeout.

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -447,7 +447,9 @@ resulting in a 1 second initial handshake timeout as recommended in
 When a crypto packet is sent, the sender MUST set a timer for twice the smoothed
 RTT.  This timer MUST be updated when a new crypto packet is sent and when
 an acknowledgement is received which computes a new RTT sample. Upon timeout,
-the sender MUST retransmit all unacknowledged CRYPTO data if possible.
+the sender MUST retransmit all unacknowledged CRYPTO data if possible.  The
+sender MUST NOT declare in flight crypto packets as lost when the crypto timer
+expires.
 
 On each consecutive expiration of the crypto timer without receiving an
 acknowledgement for a new packet, the sender MUST double the crypto

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -467,10 +467,11 @@ MUST ensure that the crypto retransmission timer is set if there is
 unacknowledged crypto data or if the client does not yet have 1-RTT keys.
 If the crypto retransmission timer expires before the client has 1-RTT keys,
 it is possible that the client may not have any crypto data to retransmit.
-However, the client MUST send a new packet, containing only PING or PADDDING frames if necessary, to allow the server to continue sending
-data. If Handshake keys are available to the client, it MUST send a
-Handshake packet, and otherwise it MUST send an Initial packet in a UDP
-datagram of at least 1200 bytes.
+However, the client MUST send a new packet, containing only PING or PADDDING
+frames if necessary, to allow the server to continue sending data. If
+Handshake keys are available to the client, it MUST send a Handshake packet,
+and otherwise it MUST send an Initial packet in a UDP datagram of at least
+1200 bytes.
 
 The crypto retransmission timer is not set if the time threshold
 {{time-threshold}} loss detection timer is set.  When the crypto
@@ -1158,8 +1159,7 @@ OnLossDetectionTimeout():
     DetectLostPackets(pn_space)
   // Retransmit crypto data if no packets were lost
   // and there is crypto data to retransmit.
-  else if (crypto packets are in flight &&
-           crypto data to send):
+  else if (has unacked crypto data):
     // Crypto retransmission timeout.
     RetransmitUnackedCryptoData()
     crypto_count++

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -458,11 +458,11 @@ sent, then no alarm should be armed until data has been received from the
 client.
 
 Because the server could be blocked until more packets are received, the client
-MUST start the crypto retransmission timer even if there is no unacknowledged
-CRYPTO data.  If the timer expires and the client has no CRYPTO data to
-retransmit and does not have Handshake keys, it SHOULD send an Initial packet in
-a UDP datagram of at least 1200 bytes.  If the client has Handshake keys, it
-SHOULD send a Handshake packet.
+MUST start the crypto retransmission timer until it has 1RTT keys, even if there
+is no unacknowledged CRYPTO data.  If the timer expires and the client has no
+CRYPTO data to retransmit and does not have Handshake keys, it SHOULD send an
+Initial packet in a UDP datagram of at least 1200 bytes.  If the client has
+Handshake keys, it SHOULD send a Handshake packet.
 
 On each consecutive expiration of the crypto timer without receiving an
 acknowledgement for a new packet, the sender SHOULD double the crypto
@@ -1114,7 +1114,8 @@ SetLossDetectionTimer():
     loss_detection_timer.update(loss_time)
     return
 
-  if (crypto packets are in flight):
+  if (crypto packets are in flight &&
+      crypto data to send):
     // Crypto retransmission timer.
     if (smoothed_rtt == 0):
       timeout = 2 * kInitialRtt
@@ -1151,7 +1152,8 @@ OnLossDetectionTimeout():
     DetectLostPackets(pn_space)
   // Retransmit crypto data if no packets were lost
   // and there are still crypto packets in flight.
-  else if (crypto packets are in flight):
+  else if (crypto packets are in flight &&
+           crypto data to send):
     // Crypto retransmission timeout.
     RetransmitUnackedCryptoData()
     crypto_count++


### PR DESCRIPTION
Rewrites a substantial portion of the Crypto Retransmission Timeout section and specifies that the handshake timer is not armed if the time threshold loss detection timer is set.

Fixes the portion of #1964 not fixed in #2281