### PR TITLE
Rewrite of RTT estimation section

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -226,7 +226,7 @@ QUIC supports many ACK ranges, opposed to TCP's 3 SACK ranges.  In high loss
 environments, this speeds recovery, reduces spurious retransmits, and ensures
 forward progress without relying on timeouts.
 
-### Explicit Correction For Delayed ACKs {#ack-delay}
+### Explicit Correction For Delayed Acknowledgements {#ack-delay}
 
 An endpoint measures the delay incurred between when a packet is received and
 when the corresponding ACK is sent.  The endpoint encodes this host delay for

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -307,11 +307,11 @@ continue making forward progress.
 
 At a high level, an endpoint measures the time from when a packet was sent to
 when it is acknowledged as a round-trip time (RTT) sample.  The endpoint uses
-RTT samples and peer-reported host delays ({{ack-delay}}, {{generating-acks}}) to
-generate a statistical description of the connection's RTT.  An endpoint
-computes the following three values: the minimum value observed over the
-lifetime of the connection (min_rtt), an exponentially-weighted moving average
-(smoothed_rtt), and the variance in the observed RTT samples (rttvar).
+RTT samples and peer-reported host delays ({{ack-delay}}) to generate a
+statistical description of the connection's RTT.  An endpoint computes the
+following three values: the minimum value observed over the lifetime of the
+connection (min_rtt), an exponentially-weighted moving average (smoothed_rtt),
+and the variance in the observed RTT samples (rttvar).
 
 ## Generating RTT samples {#latest-rtt}
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -350,7 +350,7 @@ largest acknowledged packet.
 
 An RTT sample MUST NOT be generated on receiving an ACK frame that does not
 newly acknowledge at least one ack-eliciting packet.  A peer does not send an
-ACK frame on receiving only non-ack-eliciting packets, and an ACK frame that is
+ACK frame on receiving only non-ack-eliciting packets, so an ACK frame that is
 subsequently sent can include an arbitrarily large Ack Delay field.  Ignoring
 such ACK frames avoids complications in subsequent smoothed_rtt and rttvar
 computations.

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -297,7 +297,7 @@ An endpoint measures the delay incurred between when a packet is received and
 when the corresponding acknowledgment is sent.  The endpoint encodes this host
 delay for the largest acknowledged packet in the Ack Delay field of an ACK frame
 (see Section 19.3 of {{QUIC-TRANSPORT}}).  This allows the receiver of the ACK
-to adjust for any host delays - importantly, for delayed acknowledgements - when
+to adjust for any host delays, which is important for delayed acknowledgements, when
 estimating the path RTT.  In certain deployments, a packet might be held in the
 OS kernel or elsewhere on the host before being processed by the QUIC
 stack. Where possible, an endpoint MAY include these delays when populating the

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -239,13 +239,12 @@ stack. Where possible, an endpoint SHOULD include these delays when populating
 the Ack Delay field in an ACK frame.
 
 An endpoint MUST NOT excessively delay acknowledgements of ack-eliciting
-packets.  Specifically, an endpoint is expected to enforce a maximum delay to
-avoid causing spurious timeouts at the peer.  The maximum ack delay is
-communicated in the max_ack_delay transport parameter, see Section 18.1 of
-{{QUIC-TRANSPORT}}.  max_ack_delay implies an explicit contract: an endpoint
-promises to never delay acknowledgments of an ack-eliciting packet by more than
-the indicated value. If it does, any excess accrues to the RTT estimate and
-could result in spurious retransmissions from the peer.
+packets.  The maximum ack delay is communicated in the max_ack_delay transport
+parameter, see Section 18.1 of {{QUIC-TRANSPORT}}.  max_ack_delay implies an
+explicit contract: an endpoint promises to never delay acknowledgments of an
+ack-eliciting packet by more than the indicated value. If it does, any excess
+accrues to the RTT estimate and could result in spurious retransmissions from
+the peer.
 
 
 # Generating Acknowledgements {#generating-acks}
@@ -410,11 +409,11 @@ On subsequent RTT samples, smoothed_rtt and rttvar evolve as follows:
 
 ~~~
 ack_delay = min(Ack Delay in ACK Frame, max_ack_delay)
-corrected_rtt = latest_rtt
+adjusted_rtt = latest_rtt
 if (min_rtt + ack_delay < latest_rtt):
-  corrected_rtt = latest_rtt - ack_delay
-smoothed_rtt = 7/8 * smoothed_rtt + 1/8 * corrected_rtt
-rttvar_sample = abs(smoothed_rtt - corrected_rtt)
+  adjusted_rtt = latest_rtt - ack_delay
+smoothed_rtt = 7/8 * smoothed_rtt + 1/8 * adjusted_rtt
+rttvar_sample = abs(smoothed_rtt - adjusted_rtt)
 rttvar = 3/4 * rttvar + 1/4 * rttvar_sample
 ~~~
 
@@ -1103,17 +1102,17 @@ UpdateRtt(latest_rtt, ack_delay):
   // Limit ack_delay by max_ack_delay
   ack_delay = min(ack_delay, max_ack_delay)
   // Adjust for ack delay if it's plausible.
-  corrected_rtt = latest_rtt
+  adjusted_rtt = latest_rtt
   if (latest_rtt - min_rtt > ack_delay):
-    corrected_rtt = latest_rtt - ack_delay
+    adjusted_rtt = latest_rtt - ack_delay
   // Based on {{?RFC6298}}.
   if (smoothed_rtt == 0):
-    smoothed_rtt = corrected_rtt
+    smoothed_rtt = adjusted_rtt
     rttvar = latest_rtt / 2
   else:
-    rttvar_sample = abs(smoothed_rtt - corrected_rtt)
+    rttvar_sample = abs(smoothed_rtt - adjusted_rtt)
     rttvar = 3/4 * rttvar + 1/4 * rttvar_sample
-    smoothed_rtt = 7/8 * smoothed_rtt + 1/8 * corrected_rtt
+    smoothed_rtt = 7/8 * smoothed_rtt + 1/8 * adjusted_rtt
 ~~~
 
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -226,25 +226,11 @@ QUIC supports many ACK ranges, opposed to TCP's 3 SACK ranges.  In high loss
 environments, this speeds recovery, reduces spurious retransmits, and ensures
 forward progress without relying on timeouts.
 
-### Encoding Host Delay {#host-delay}
+### Explicit Correction For Delayed Acknowledgements
 
 An endpoint measures the delay incurred between when a packet is received and
-when the corresponding acknowledgment is sent.  The endpoint encodes this host
-delay for the largest acknowledged packet in the Ack Delay field of an ACK frame
-(see Section 19.3 of {{QUIC-TRANSPORT}}).  This allows the receiver of the ACK
-to adjust for any host delays - importantly, for delayed acknowledgements - when
-estimating the path RTT.  In certain deployments, a packet might be held in the
-OS kernel or elsewhere on the host before being processed by the QUIC
-stack. Where possible, an endpoint SHOULD include these delays when populating
-the Ack Delay field in an ACK frame.
-
-An endpoint MUST NOT excessively delay acknowledgements of ack-eliciting
-packets.  The maximum ack delay is communicated in the max_ack_delay transport
-parameter, see Section 18.1 of {{QUIC-TRANSPORT}}.  max_ack_delay implies an
-explicit contract: an endpoint promises to never delay acknowledgments of an
-ack-eliciting packet by more than the indicated value. If it does, any excess
-accrues to the RTT estimate and could result in spurious retransmissions from
-the peer.
+when the corresponding acknowledgment is sent, allowing a peer to maintain a
+more accurate round-trip time estimate (see {{host-delay}}).
 
 
 # Generating Acknowledgements {#generating-acks}
@@ -304,6 +290,26 @@ longer included in the ACK frame. Packets could be received out of order and
 all subsequent ACK frames containing them could be lost. In this case, the
 loss recovery algorithm may cause spurious retransmits, but the sender will
 continue making forward progress.
+
+## Measuring and Reporting Host Delay {#host-delay}
+
+An endpoint measures the delay incurred between when a packet is received and
+when the corresponding acknowledgment is sent.  The endpoint encodes this host
+delay for the largest acknowledged packet in the Ack Delay field of an ACK frame
+(see Section 19.3 of {{QUIC-TRANSPORT}}).  This allows the receiver of the ACK
+to adjust for any host delays - importantly, for delayed acknowledgements - when
+estimating the path RTT.  In certain deployments, a packet might be held in the
+OS kernel or elsewhere on the host before being processed by the QUIC
+stack. Where possible, an endpoint SHOULD include these delays when populating
+the Ack Delay field in an ACK frame.
+
+An endpoint MUST NOT excessively delay acknowledgements of ack-eliciting
+packets.  The maximum ack delay is communicated in the max_ack_delay transport
+parameter, see Section 18.1 of {{QUIC-TRANSPORT}}.  max_ack_delay implies an
+explicit contract: an endpoint promises to never delay acknowledgments of an
+ack-eliciting packet by more than the indicated value. If it does, any excess
+accrues to the RTT estimate and could result in spurious retransmissions from
+the peer.
 
 
 # Estimating the Round-Trip Time {#compute-rtt}

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -300,8 +300,8 @@ delay for the largest acknowledged packet in the Ack Delay field of an ACK frame
 to adjust for any host delays - importantly, for delayed acknowledgements - when
 estimating the path RTT.  In certain deployments, a packet might be held in the
 OS kernel or elsewhere on the host before being processed by the QUIC
-stack. Where possible, an endpoint SHOULD include these delays when populating
-the Ack Delay field in an ACK frame.
+stack. Where possible, an endpoint MAY include these delays when populating the
+Ack Delay field in an ACK frame.
 
 An endpoint MUST NOT excessively delay acknowledgements of ack-eliciting
 packets.  The maximum ack delay is communicated in the max_ack_delay transport
@@ -327,7 +327,7 @@ and the variance in the observed RTT samples (rttvar).
 An endpoint generates an RTT sample on receiving an ACK frame that meets the
 following two conditions:
 
-- the largest acknowledged packet number is higher than any previously seen, and
+- the largest acknowledged packet number is newly acknowledged, and
 
 - at least one of the newly acknowledged packets was ack-eliciting.
 
@@ -1110,9 +1110,9 @@ UpdateRtt(latest_rtt, ack_delay):
   adjusted_rtt = latest_rtt
   if (latest_rtt - min_rtt > ack_delay):
     adjusted_rtt = latest_rtt - ack_delay
-  // Based on {{?RFC6298}}.
+  // First RTT sample.
   if (smoothed_rtt == 0):
-    smoothed_rtt = adjusted_rtt
+    smoothed_rtt = latest_rtt
     rttvar = latest_rtt / 2
   else:
     rttvar_sample = abs(smoothed_rtt - adjusted_rtt)

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -303,7 +303,7 @@ loss recovery algorithm may cause spurious retransmits, but the sender will
 continue making forward progress.
 
 
-# Computing the round-trip time (RTT) estimate {#compute-rtt}
+# Estimating the Round-Trip Time {#compute-rtt}
 
 At a high level, an endpoint measures the time from when a packet was sent to
 when it is acknowledged as a round-trip time (RTT) sample.  The endpoint uses

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -297,9 +297,9 @@ An endpoint measures the delay incurred between when a packet is received and
 when the corresponding acknowledgment is sent.  The endpoint encodes this host
 delay for the largest acknowledged packet in the Ack Delay field of an ACK frame
 (see Section 19.3 of {{QUIC-TRANSPORT}}).  This allows the receiver of the ACK
-to adjust for any host delays, which is important for delayed acknowledgements, when
-estimating the path RTT.  In certain deployments, a packet might be held in the
-OS kernel or elsewhere on the host before being processed by the QUIC
+to adjust for any host delays, which is important for delayed acknowledgements,
+when estimating the path RTT.  In certain deployments, a packet might be held in
+the OS kernel or elsewhere on the host before being processed by the QUIC
 stack. Where possible, an endpoint MAY include these delays when populating the
 Ack Delay field in an ACK frame.
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -229,7 +229,7 @@ forward progress without relying on timeouts.
 ### Explicit Correction For Delayed Acknowledgements {#ack-delay}
 
 An endpoint measures the delay incurred between when a packet is received and
-when the corresponding ACK is sent.  The endpoint encodes this host delay for
+when the corresponding acknowledgment is sent.  The endpoint encodes this host delay for
 the largest acknowledged packet in the Ack Delay field of an ACK frame (see
 Section 19.3 of {{QUIC-TRANSPORT}}).  This allows the receiver of the ACK to
 adjust for any host delays - importantly, for delayed acknowledgements - when

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -338,13 +338,11 @@ acknowledged packet was sent:
 latest_rtt = ack_time - send_time_of_largest_acked
 ~~~
 
-An endpoint uses only locally observed times in generating RTT samples and does
-not adjust for any host delays reported by the peer ({{host-delay}}).
-
-A peer reports host delays for only the largest acknowledged packet in an ACK
-frame, which is assumed by subsequent computations of smoothed_rtt and rttvar in
-adjusting for host delays.  As a result, an RTT sample is only generated using
-the largest acknowledged packet in the received ACK frame.
+An RTT sample is generated using only the largest acknowledged packet in the
+received ACK frame.  This is because a peer reports host delays for only the
+largest acknowledged packet in an ACK frame.  While the reported host delay is
+not used by the RTT sample measurement, it is used to adjust the RTT sample in
+subsequent computations of smoothed_rtt and rttvar {{smoothed-rtt}}.
 
 To avoid generating multiple RTT samples using the same packet, an ACK frame
 SHOULD NOT be used to update RTT estimates if it does not newly acknowledge the

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -228,7 +228,7 @@ forward progress without relying on timeouts.
 
 ### Explicit Correction For Delayed Acknowledgements
 
-An endpoint measures the delay incurred between when a packet is received and
+QUIC endpoints measure the delay incurred between when a packet is received and
 when the corresponding acknowledgment is sent, allowing a peer to maintain a
 more accurate round-trip time estimate (see {{host-delay}}).
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1063,10 +1063,15 @@ OnAckReceived(ack, pn_space):
   largest_acked_packet[pn_space] =
       max(largest_acked_packet[pn_space], ack.largest_acked)
 
+  // Nothing to do if there are no newly acked packets.
+  newly_acked_packets = DetermineNewlyAckedPackets(ack, pn_space)
+  if (newly_acked_packets.empty()):
+    return
+
   // If the largest acknowledged is newly acked and
-  // ack-eliciting, update the RTT.
+  // at least one ack-eliciting was newly acked, update the RTT.
   if (sent_packets[pn_space][ack.largest_acked] &&
-      sent_packets[pn_space][ack.largest_acked].ack_eliciting):
+      IncludesAckEliciting(newly_acked_packets))
     latest_rtt =
       now - sent_packets[pn_space][ack.largest_acked].time_sent
     UpdateRtt(latest_rtt, ack.ack_delay)
@@ -1074,11 +1079,6 @@ OnAckReceived(ack, pn_space):
   // Process ECN information if present.
   if (ACK frame contains ECN information):
       ProcessECN(ack)
-
-  // Find all newly acked packets in this ACK frame
-  newly_acked_packets = DetermineNewlyAckedPackets(ack, pn_space)
-  if (newly_acked_packets.empty()):
-    return
 
   for acked_packet in newly_acked_packets:
     OnPacketAcked(acked_packet.packet_number, pn_space)


### PR DESCRIPTION
I started with trying to introduce rationale for why only ack-eliciting packets are used for RTT computation, and ended up restructuring the section.

Closes #2567, #2568.