### PR TITLE
Two Loss bits (Q&R)

### DIFF
--- a/draft-ietf-quic-lossbits-exp.md
+++ b/draft-ietf-quic-lossbits-exp.md
@@ -104,40 +104,24 @@ The proposed mechanisms enable loss measurement from observation points on the n
 
 ## Proposed Short Header Format Including Loss Bits
 
-As of the current editor's version of {{QUIC-TRANSPORT}}, this proposal
-specifies using the seventh most significant bit (0x02) of the first byte in
-the short header for the sQuare bit and the eighth most significant bit (0x01) of the first byte in
-the short header for the Retransmit bit. The sQuare and Retransmit bits are the Loss bits.
+As of the current editor's version of {{QUIC-TRANSPORT}}, two bits are "reserved" in the first byte of short headers. This proposal naturally fits in there, allocating these two bits as Q and R. Of course, the very purpose of Q and R being to enable on-path observation, the current restrictions about their encryption and zero value should be lifted in QUIC versions supporting this proposal.
 
-~~~~~
+## Semantics
 
- 0                   1                   2                   3
- 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-+-+-+-+-+-+-+-+-+
-|0|K|1|1|0|S|Q|R|
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                Destination Connection ID (0..144)           ...
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                      Packet Number (8/16/32)                ...
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                     Protected Payload (*)                   ...
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+The semantics of these bits are as follows:
 
-~~~~~
-{: #fig-short-header title="Short Header Format including proposed Q and R Bit"}
-
-Q: The sQuare bit is toggled every N outgoing packets as explained in {{squarebit}}.
+Q: The sQuare bit is toggled every N outgoing packets as explained below in {{squarebit}}.
 
 R: The Retransmit bit is set to 0 or 1 according to the not-yet-disclosed-lost-packets
-counter, as explained in {{retransmitbit}}.
+counter, as explained below in {{retransmitbit}}.
 
-## Setting the Square Bit on Outgoing Packets {#squarebit}
+### Setting the Square Bit on Outgoing Packets {#squarebit}
 
 Each endpoint independently maintains  a sQuare value, 0 or 1, during a block of N outgoing packets (e.g. N=64), and sets the sQuare  bit in the short header to the currently stored value when a packet with a short header is sent out. The sQuare value is initiated to 0 at each endpoint, client and server, at connection start.
 This mechanism thus delineates slots of N packets with the same marking. Observation points can estimate the  upstream losses  by simply counting the number of packets during a half period of the square signal, as described in {{usage}}.
 
 
-## Setting the Retransmit Bit on Outgoing Packets {#retransmitbit}
+### Setting the Retransmit Bit on Outgoing Packets {#retransmitbit}
 
 Each endpoint, client and server, independently maintains a not-yet-disclosed-lost-packets counter and sets the Retransmit bit of short header packets to 0 or 1 accordingly.
 The not-yet-disclosed-lost-packets counter is initialized to 0 at each endpoint, client and server, at connection start, and reflects packets considered lost by the QUIC machinery, the content of which is pending for retransmission. When a packet is declared lost by the QUIC retransmission machinery (see {{QUIC-RECOVERY}}) the not-yet-disclosed-lost-packets counter is incremented by 1. When a packet with a short header is sent out by an end-point, its retransmit bit is set to 0 when the not-yet-disclosed-lost-packets counter is equal to 0. Otherwise, the packet is sent out with a retransmit bit set to 1 and the not-yet-disclosed-lost-packets counter is decremented by 1.
@@ -145,18 +129,19 @@ The not-yet-disclosed-lost-packets counter is initialized to 0 at each endpoint,
 Observation points can estimate the number of packets considered lost by the QUIC transmission machinery in a given direction by observing the number of packets in this direction with a retransmit bit set to 1.
 
 
-## Resetting sQuare Value 
+### Resetting sQuare Value 
 Each endpoint resets its sQuare value to zero and initiates a new slot of N packets when sending the first
 packet of a given connection with a new connection ID. This reduces the risk that transient sQuare bit state can be used to link flows across connection migration or ID change.
 
 
-## Resetting Retransmit Value 
+### Resetting Retransmit Value 
 The not-yet-disclosed-lost-packets counter is reset at each endpoint when sending the first packet of a given connection with a new connection ID. This reduces the risk that transient Retransmit bit state can be used to link flows across connection migration or ID change.
 
 # Using the loss bits for Passive Loss Measurement {#usage}
 
 ## End-to-end loss 
 The Retransmit bit mechanism merely reflects the number of packets considered lost by the sender QUIC stack with a slight delay. In case of fast retransmit due to repeted acknowlegments of a packet, this delay is at least equal to the one way delay in the reverse direction. It is larger otherwise (eg RTO). The retransmit mechanism alone suffices to estimate the end-to-end losses; similar to TCP passive loss measurement, its accuracy depends on the loss affecting the retransmit-bit-marked packets, which are in themselves proof of previous loss.
+
 ## Upstream loss 
 During a QUIC connection lifetime, the sQuare bit mechanism delineates slots of N packets with the same marking. When focusing on the sQuare bit of consecutive packets in a direction, this mechanism sketches a periodic sQuare signal which toggles every N packets. On-path observers can then estimate the  upstream losses by simply counting the number of packets during a half period (level 0 or level 1) of the square signal.
 Packets with a long header are not marked, but yet taken into account by the sender when counting the N outgoing packets before its next toggle. Observers should assign long header packets to the pending slot if possible (i.e. up to N packets counted in this slot), to the next one otherwise. Thus, slots with less than N packets, whatever their header length, generally denote upstream loss. 
@@ -175,16 +160,18 @@ The slot size N should be carefully chosen : too short, it becomes very sensitiv
  
  Note that observers should perform a loose synchronisation between the sQuare and the Retransmit measurements when accurate evolution of segmental loss over connection lifetime is sought, so as to compare the same portion of the packet stream.
  
- 
- 
-# IANA Considerations
+## Bidirectional flows
 
-This document has no actions for IANA.
+ The Q and R bits sent by one endpoint cover loss of packets sent by the same endpoint, allowing a midpoint observer to estimate loss in that direction; no specific cooperation is needed between the endpoints beyond negotiating a QUIC version that supports this proposal. Hence, the server will be enabling troubleshooting of the download path, and the client will work for the upload path.  This allows to be confident about getting a useful signal in asymmetric situations:  clients may for example implement Q and R improperly, the download path will still be debuggable as long as servers do it right.
+ 
 
 # Security and Privacy Considerations
 
 The loss bits are intended to expose loss to observers along the path, so the privacy considerations for the loss bits are essentially the same as those for passive loss measurement in general. Loss gives no hint on customer geolocalisation; moreover, reset of the loss counting at connection Id change prevent for linkability.
 
+# IANA Considerations
+
+An IANA registry has been suggested for QUIC versions. In support of the fully negotiated status of the proposed extension, a natural way of deploying this feature would be through such a registered version.
 
 # Change Log
 
@@ -196,7 +183,7 @@ The loss bits are intended to expose loss to observers along the path, so the pr
 # Acknowledgments
 {:numbered="false"}
  
-The sQuare Bit was originally specified by Kazuho Oku for RTT measurement.
+The sQuare Bit was originally specified by Kazuho Oku in early proposals for loss measurement.
 
 
 

--- a/draft-ietf-quic-lossbits-exp.md
+++ b/draft-ietf-quic-lossbits-exp.md
@@ -124,9 +124,7 @@ This mechanism thus delineates slots of N packets with the same marking. Observa
 ### Setting the Retransmit Bit on Outgoing Packets {#retransmitbit}
 
 Each endpoint, client and server, independently maintains a not-yet-disclosed-lost-packets counter and sets the Retransmit bit of short header packets to 0 or 1 accordingly.
-The not-yet-disclosed-lost-packets counter is initialized to 0 at each endpoint, client and server, at connection start, and reflects packets considered lost by the QUIC machinery, the content of which is pending for retransmission. When a packet is declared lost by the QUIC retransmission machinery (see {{QUIC-RECOVERY}}) the not-yet-disclosed-lost-packets counter is incremented by 1. When a packet with a short header is sent out by an end-point, its retransmit bit is set to 0 when the not-yet-disclosed-lost-packets counter is equal to 0. Otherwise, the packet is sent out with a retransmit bit set to 1 and the not-yet-disclosed-lost-packets counter is decremented by 1.
-
-Observation points can estimate the number of packets considered lost by the QUIC transmission machinery in a given direction by observing the number of packets in this direction with a retransmit bit set to 1.
+The not-yet-disclosed-lost-packets counter is initialized to 0 at each endpoint, client and server, at connection start, and reflects packets considered lost by the QUIC machinery, the content of which is pending for retransmission. When a packet is declared lost by the QUIC retransmission machinery (see {{QUIC-RECOVERY}}) the not-yet-disclosed-lost-packets counter is incremented by 1. When a packet with a short header is sent out by an end-point, its retransmit bit is set to 0 when the not-yet-disclosed-lost-packets counter is equal to 0. Otherwise, the packet is sent out with a retransmit bit set to 1 and the not-yet-disclosed-lost-packets counter is decremented by 1. Thus, the retransmit bit performs unary encoding of the amount of loss: observation points can estimate the number of packets considered lost by the QUIC transmission machinery in a given direction by counting packets in this direction with a retransmit bit equal to 1.
 
 
 ### Resetting sQuare Value 
@@ -164,6 +162,7 @@ The slot size N should be carefully chosen : too short, it becomes very sensitiv
 
  The Q and R bits sent by one endpoint cover loss of packets sent by the same endpoint, allowing a midpoint observer to estimate loss in that direction; no specific cooperation is needed between the endpoints beyond negotiating a QUIC version that supports this proposal. Hence, the server will be enabling troubleshooting of the download path, and the client will work for the upload path.  This allows to be confident about getting a useful signal in asymmetric situations:  clients may for example implement Q and R improperly, the download path will still be debuggable as long as servers do it right.
  
+ It should also be noted that the method does not suffer from the natural asymmetry in packet rate of a typical download or upload scenario. Indeed, although there are often fewer acknowledgements than payload-bearing packets, the unary encoding by R is borne by the payload stream. This allows to report loss in the important direction in both a timely and accurate fashion without sampling or quantization.
 
 # Security and Privacy Considerations
 

--- a/draft-ietf-quic-lossbits-exp.md
+++ b/draft-ietf-quic-lossbits-exp.md
@@ -63,18 +63,20 @@ normative:
 
 --- abstract
 
-This document specifies the addition of loss bits to the QUIC
-transport protocol and describes how to use them to measure and locate packet loss.
+This  document  specifies  the  addition  of loss  bits  to  the  QUIC
+transport protocol and describes how to use them to measure and locate
+packet loss.
 
 --- note_Note_to_Readers
 
-This document specifies an experimental delta to the QUIC transport protocol.
+This document  specifies an experimental  delta to the  QUIC transport
+protocol.
 
 --- middle
 
 # Introduction
 
-Packet  loss is  a hard  and  pervasive problem  of day-to-day  network
+Packet  loss is  a hard  and pervasive  problem of  day-to-day network
 operation,  and  locating them  is  crucial  to timely  resolution  of
 crippling  end-to-end  throughput  issues.    To  this  effect,  in  a
 TCP-dominated world,  network operators  have been heavily  relying on
@@ -87,78 +89,178 @@ ability to  quickly home in  on the  offending segment, by  moving the
 passive observer around.
 
 In the QUIC context, the equivalent transport headers being encrypted,
-such observation is not possible. To restore network operators' ability
-to maintain QUIC clients experience, this document  adds two explicit loss bits to the QUIC  short header,
-named "Q" (sQuare signal) and "R" (Retransmit). Together, these bits allow the observer to estimate
-upstream and downstream  loss, enabling the same  dichotomic search as
-with TCP.
+such  observation  is  not  possible. To  restore  network  operators'
+ability to  maintain QUIC clients  experience, this document  adds two
+explicit loss bits to the QUIC short header, named "Q" (sQuare signal)
+and  "R" (Retransmit).  Together,  these bits  allow  the observer  to
+estimate upstream  and downstream  loss, enabling the  same dichotomic
+search as with TCP.
 
 # Passive Loss measurement
 
-The proposed mechanisms enable loss measurement from observation points on the network path throughout the lifetime of a connection. End-to end loss as well as segmental loss (upstream or downstream from the observation point) are measurable thanks to two dedicated bits in short packet headers, named loss bits. The loss bits therefore appear only after version negotiation and connection establishment are completed.
+The  proposed  mechanisms  enable loss  measurement  from  observation
+points   on  the   network   path  throughout   the   lifetime  of   a
+connection. End-to  end loss  as well as  segmental loss  (upstream or
+downstream from  the observation point)  are measurable thanks  to two
+dedicated bits in short packet headers, named loss bits. The loss bits
+therefore  appear  only  after   version  negotiation  and  connection
+establishment are completed.
 
 ## Proposed Short Header Format Including Loss Bits
 
-As of the current editor's version of {{QUIC-TRANSPORT}}, two bits are "reserved" in the first byte of short headers. This proposal naturally fits in there, allocating these two bits as Q and R. Of course, the very purpose of Q and R being to enable on-path observation, the current restrictions about their encryption and zero value should be lifted in QUIC versions supporting this proposal.
+As of the current editor's version of {{QUIC-TRANSPORT}}, two bits are
+"reserved" in the first byte of short headers. This proposal naturally
+fits in there,  allocating these two bits  as Q and R.  Of course, the
+very  purpose of  Q and  R being  to enable  on-path observation,  the
+current restrictions about  their encryption and zero  value should be
+lifted in QUIC versions supporting this proposal.
 
 ## Semantics
 
 The semantics of these bits are as follows:
 
-Q: The sQuare bit is toggled every N outgoing packets as explained below in {{squarebit}}.
+Q: The  sQuare bit is  toggled every  N outgoing packets  as explained
+below in {{squarebit}}.
 
-R: The Retransmit bit is set to 0 or 1 according to the not-yet-disclosed-lost-packets
-counter, as explained below in {{retransmitbit}}.
+R:  The   Retransmit  bit  is  set   to  0  or  1   according  to  the
+not-yet-disclosed-lost-packets   counter,   as  explained   below   in
+{{retransmitbit}}.
 
 ### Setting the Square Bit on Outgoing Packets {#squarebit}
 
-Each endpoint independently maintains  a sQuare value, 0 or 1, during a block of N outgoing packets (e.g. N=64), and sets the sQuare  bit in the short header to the currently stored value when a packet with a short header is sent out. The sQuare value is initiated to 0 at each endpoint, client and server, at connection start.
-This mechanism thus delineates slots of N packets with the same marking. Observation points can estimate the  upstream losses  by simply counting the number of packets during a half period of the square signal, as described in {{usage}}.
+Each endpoint independently maintains a sQuare value, 0 or 1, during a
+block of  N outgoing packets (e.g.  N=64), and sets the  sQuare bit in
+the short  header to the currently  stored value when a  packet with a
+short header is sent  out. The sQuare value is initiated  to 0 at each
+endpoint, client and server, at connection start.  This mechanism thus
+delineates  slots of  N  packets with  the  same marking.  Observation
+points can estimate the upstream  losses by simply counting the number
+of packets during a half period  of the square signal, as described in
+{{usage}}.
 
 ### Setting the Retransmit Bit on Outgoing Packets {#retransmitbit}
 
-Each endpoint, client and server, independently maintains a not-yet-disclosed-lost-packets counter and sets the Retransmit bit of short header packets to 0 or 1 accordingly.
-The not-yet-disclosed-lost-packets counter is initialized to 0 at each endpoint, client and server, at connection start, and reflects packets considered lost by the QUIC machinery, the content of which is pending for retransmission. When a packet is declared lost by the QUIC retransmission machinery (see {{QUIC-RECOVERY}}) the not-yet-disclosed-lost-packets counter is incremented by 1. When a packet with a short header is sent out by an end-point, its retransmit bit is set to 0 when the not-yet-disclosed-lost-packets counter is equal to 0. Otherwise, the packet is sent out with a retransmit bit set to 1 and the not-yet-disclosed-lost-packets counter is decremented by 1. Thus, the retransmit bit performs unary encoding of the amount of loss: observation points can estimate the number of packets considered lost by the QUIC transmission machinery in a given direction by counting packets in this direction with a retransmit bit equal to 1.
+Each   endpoint,  client   and  server,   independently  maintains   a
+not-yet-disclosed-lost-packets counter and sets  the Retransmit bit of
+short    header    packets   to    0    or    1   accordingly.     The
+not-yet-disclosed-lost-packets  counter is  initialized to  0 at  each
+endpoint, client and server, at connection start, and reflects packets
+considered lost by the QUIC machinery, the content of which is pending
+for  retransmission.  When a  packet  is  declared  lost by  the  QUIC
+retransmission      machinery     (see      {{QUIC-RECOVERY}})     the
+not-yet-disclosed-lost-packets  counter is  incremented by  1. When  a
+packet with a short header is sent out by an end-point, its retransmit
+bit is  set to  0 when  the not-yet-disclosed-lost-packets  counter is
+equal to  0. Otherwise, the packet  is sent out with  a retransmit bit
+set to 1 and the not-yet-disclosed-lost-packets counter is decremented
+by 1. Thus,  the retransmit bit performs unary encoding  of the amount
+of  loss:  observation  points  can estimate  the  number  of  packets
+considered  lost  by  the  QUIC  transmission  machinery  in  a  given
+direction by counting packets in  this direction with a retransmit bit
+equal to 1.
 
 ### Resetting state on CID change
 
-When sending the first packet of a given connection with a new connection ID, each endpoint resets its sQuare value and not-yet-disclosed-lost-packets counter to zero. This eliminates the possibility for transient sQuare or Retransmit bit state to be used to link flows across connection migration or ID change.
+When  sending the  first  packet  of a  given  connection  with a  new
+connection   ID,   each  endpoint   resets   its   sQuare  value   and
+not-yet-disclosed-lost-packets  counter to  zero. This  eliminates the
+possibility for transient sQuare or Retransmit bit state to be used to
+link flows across connection migration or ID change.
 
 # Using the loss bits for Passive Loss Measurement {#usage}
 
 ## End-to-end loss
-The Retransmit bit mechanism merely reflects the number of packets considered lost by the sender QUIC stack with a slight delay. In case of fast retransmit due to repeted acknowlegments of a packet, this delay is at least equal to the one way delay in the reverse direction. It is larger otherwise (eg RTO). The retransmit mechanism alone suffices to estimate the end-to-end losses; similar to TCP passive loss measurement, its accuracy depends on the loss affecting the retransmit-bit-marked packets, which are in themselves proof of previous loss.
+
+The Retransmit  bit mechanism  merely reflects  the number  of packets
+considered lost by the sender QUIC  stack with a slight delay. In case
+of fast  retransmit due  to repeted acknowlegments  of a  packet, this
+delay  is  at  least  equal  to  the one  way  delay  in  the  reverse
+direction. It is  larger otherwise (eg RTO).  The retransmit mechanism
+alone  suffices to  estimate  the end-to-end  losses;  similar to  TCP
+passive loss measurement,  its accuracy depends on  the loss affecting
+the retransmit-bit-marked  packets, which  are in themselves  proof of
+previous loss.
 
 ## Upstream loss
-During a QUIC connection lifetime, the sQuare bit mechanism delineates slots of N packets with the same marking. When focusing on the sQuare bit of consecutive packets in a direction, this mechanism sketches a periodic sQuare signal which toggles every N packets. On-path observers can then estimate the  upstream losses by simply counting the number of packets during a half period (level 0 or level 1) of the square signal.
-Packets with a long header are not marked, but yet taken into account by the sender when counting the N outgoing packets before its next toggle. Observers should assign long header packets to the pending slot if possible (i.e. up to N packets counted in this slot), to the next one otherwise. Thus, slots with less than N packets, whatever their header length, generally denote upstream loss.
-As with TCP passive detection based on missing sequence numbers, this estimation may become inaccurate in case of packet reordering which blurs the edges of the square signal ; heuristics may be proposed to filter out this noise in the observation points.
 
-The slot size N should be carefully chosen : too short, it becomes very sensitive to packet reordering and loss. Too large, short connections may end before completion of the first square slot, ruining any loss estimation. Slots of 64 packets are suggested as a reasonable trade-off.
+During a QUIC connection lifetime, the sQuare bit mechanism delineates
+slots of N packets with the  same marking. When focusing on the sQuare
+bit of consecutive  packets in a direction, this  mechanism sketches a
+periodic  sQuare  signal  which   toggles  every  N  packets.  On-path
+observers can then estimate the upstream losses by simply counting the
+number of  packets during a  half period (level 0  or level 1)  of the
+square signal.   Packets with a  long header  are not marked,  but yet
+taken into account by the sender  when counting the N outgoing packets
+before its next toggle. Observers should assign long header packets to
+the pending  slot if possible  (i.e. up to  N packets counted  in this
+slot),  to the  next  one  otherwise. Thus,  slots  with  less than  N
+packets, whatever their header length, generally denote upstream loss.
+As with TCP passive detection  based on missing sequence numbers, this
+estimation may  become inaccurate in  case of packet  reordering which
+blurs the edges  of the square signal ; heuristics  may be proposed to
+filter out this noise in the observation points.
+
+The slot  size N should  be carefully chosen  : too short,  it becomes
+very  sensitive  to  packet  reordering and  loss.  Too  large,  short
+connections  may  end before  completion  of  the first  square  slot,
+ruining any  loss estimation. Slots of  64 packets are suggested  as a
+reasonable trade-off.
 
 ## Downstream loss
 
- The Retransmit bit mechanism can be coupled with the sQuare bit mechanism to estimate downstream losses. Indeed, passive observers can infer downstream losses by difference between end-to-end and upstream losses.
- The sQuare bit mechanism allows for observers to compute loss measurement at the end of every half sQuare signal period (level 0 or level 1).
- The Retransmit bit mechanism provides for the end-to-end loss after reaction of the sender stack.
+The  Retransmit bit  mechanism  can  be coupled  with  the sQuare  bit
+mechanism to estimate downstream losses. Indeed, passive observers can
+infer downstream losses by  difference between end-to-end and upstream
+losses.
 
- On-path observers can estimate upstream and downstream loss at various scales, from the square slot level to the connection lifetime level.
+The  sQuare  bit  mechanism  allows  for  observers  to  compute  loss
+measurement at the end of every  half sQuare signal period (level 0 or
+level 1).
 
- Note that observers should perform a loose synchronisation between the sQuare and the Retransmit measurements when accurate evolution of segmental loss over connection lifetime is sought, so as to compare the same portion of the packet stream.
+The Retransmit  bit mechanism provides  for the end-to-end  loss after
+reaction of the sender stack.
+
+On-path observers can estimate upstream and downstream loss at various
+scales, from the square slot level to the connection lifetime level.
+
+Note that observers should perform a loose synchronisation between the
+sQuare  and the  Retransmit  measurements when  accurate evolution  of
+segmental loss  over connection lifetime  is sought, so as  to compare
+the same portion of the packet stream.
 
 ## Bidirectional flows
 
- The Q and R bits sent by one endpoint cover loss of packets sent by the same endpoint, allowing a midpoint observer to estimate loss in that direction; no specific cooperation is needed between the endpoints beyond negotiating a QUIC version that supports this proposal. Hence, the server will be enabling troubleshooting of the download path, and the client will work for the upload path.  This allows to be confident about getting a useful signal in asymmetric situations:  clients may for example implement Q and R improperly, the download path will still be debuggable as long as servers do it right.
+The Q and  R bits sent by  one endpoint cover loss of  packets sent by
+the same  endpoint, allowing a  midpoint observer to estimate  loss in
+that  direction;  no  specific   cooperation  is  needed  between  the
+endpoints  beyond  negotiating  a  QUIC  version  that  supports  this
+proposal. Hence,  the server will  be enabling troubleshooting  of the
+download path,  and the client  will work  for the upload  path.  This
+allows to  be confident  about getting a  useful signal  in asymmetric
+situations: clients may for example  implement Q and R improperly, the
+download path will still be debuggable as long as servers do it right.
 
- It should also be noted that the method does not suffer from the natural asymmetry in packet rate of a typical download or upload scenario. Indeed, although there are often fewer acknowledgements than payload-bearing packets, the unary encoding by R of payload loss is borne by the payload stream itself. This allows to report loss in the important direction in both a timely and accurate fashion without sampling or quantization.
+It  should also  be noted  that the  method does  not suffer  from the
+natural  asymmetry in  packet rate  of  a typical  download or  upload
+scenario.   Indeed, although  there are  often fewer  acknowledgements
+than payload-bearing packets, the unary  encoding by R of payload loss
+is borne by  the payload stream itself. This allows  to report loss in
+the important direction in both  a timely and accurate fashion without
+sampling or quantization.
 
 # Security and Privacy Considerations
 
-The loss bits are intended to expose loss to observers along the path, so the privacy considerations for the loss bits are essentially the same as those for passive loss measurement in general. Loss gives no hint on customer geolocalisation; moreover, reset of loss accounting state on CID changes prevents linkability.
+The loss bits are intended to expose loss to observers along the path,
+so the  privacy considerations for  the loss bits are  essentially the
+same as those  for passive loss measurement in general.  Loss gives no
+hint on  customer geolocalisation; moreover, reset  of loss accounting
+state on CID changes prevents linkability.
 
 # IANA Considerations
 
-An IANA registry has been suggested for QUIC versions. In support of the fully negotiated status of the proposed extension, a natural way of deploying this feature would be through such a registered version.
+An IANA registry  has been suggested for QUIC versions.  In support of
+the fully negotiated  status of the proposed extension,  a natural way
+of deploying this feature would be through such a registered version.
 
 # Change Log
 
@@ -168,4 +270,5 @@ An IANA registry has been suggested for QUIC versions. In support of the fully n
 # Acknowledgments
 {:numbered="false"}
 
-The sQuare Bit was originally specified by Kazuho Oku in early proposals for loss measurement.
+The  sQuare  Bit was  originally  specified  by  Kazuho Oku  in  early
+proposals for loss measurement.

--- a/draft-ietf-quic-lossbits-exp.md
+++ b/draft-ietf-quic-lossbits-exp.md
@@ -46,9 +46,9 @@ normative:
 
   QUIC-RECOVERY:
     title: "QUIC Loss Detection and Congestion Control"
-    abbrev: QUIC Loss Detection 
-    docname: draft-ietf-quic-recovery-latest 
-    date: {DATE} 
+    abbrev: QUIC Loss Detection
+    docname: draft-ietf-quic-recovery-latest
+    date: {DATE}
     author:
       -
         ins: J. Iyengar
@@ -68,7 +68,7 @@ transport protocol and describes how to use them to measure and locate packet lo
 
 --- note_Note_to_Readers
 
-This document specifies an experimental delta to the QUIC transport protocol. 
+This document specifies an experimental delta to the QUIC transport protocol.
 
 --- middle
 
@@ -129,27 +129,27 @@ When sending the first packet of a given connection with a new connection ID, ea
 ## End-to-end loss 
 The Retransmit bit mechanism merely reflects the number of packets considered lost by the sender QUIC stack with a slight delay. In case of fast retransmit due to repeted acknowlegments of a packet, this delay is at least equal to the one way delay in the reverse direction. It is larger otherwise (eg RTO). The retransmit mechanism alone suffices to estimate the end-to-end losses; similar to TCP passive loss measurement, its accuracy depends on the loss affecting the retransmit-bit-marked packets, which are in themselves proof of previous loss.
 
-## Upstream loss 
+## Upstream loss
 During a QUIC connection lifetime, the sQuare bit mechanism delineates slots of N packets with the same marking. When focusing on the sQuare bit of consecutive packets in a direction, this mechanism sketches a periodic sQuare signal which toggles every N packets. On-path observers can then estimate the  upstream losses by simply counting the number of packets during a half period (level 0 or level 1) of the square signal.
-Packets with a long header are not marked, but yet taken into account by the sender when counting the N outgoing packets before its next toggle. Observers should assign long header packets to the pending slot if possible (i.e. up to N packets counted in this slot), to the next one otherwise. Thus, slots with less than N packets, whatever their header length, generally denote upstream loss. 
-As with TCP passive detection based on missing sequence numbers, this estimation may become inaccurate in case of packet reordering which blurs the edges of the square signal ; heuristics may be proposed to filter out this noise in the observation points. 
+Packets with a long header are not marked, but yet taken into account by the sender when counting the N outgoing packets before its next toggle. Observers should assign long header packets to the pending slot if possible (i.e. up to N packets counted in this slot), to the next one otherwise. Thus, slots with less than N packets, whatever their header length, generally denote upstream loss.
+As with TCP passive detection based on missing sequence numbers, this estimation may become inaccurate in case of packet reordering which blurs the edges of the square signal ; heuristics may be proposed to filter out this noise in the observation points.
 
 The slot size N should be carefully chosen : too short, it becomes very sensitive to packet reordering and loss. Too large, short connections may end before completion of the first square slot, ruining any loss estimation. Slots of 64 packets are suggested as a reasonable trade-off.
 
-## Downstream loss 
+## Downstream loss
 
- The Retransmit bit mechanism can be coupled with the sQuare bit mechanism to estimate downstream losses. Indeed, passive observers can infer downstream losses by difference between end-to-end and upstream losses. 
+ The Retransmit bit mechanism can be coupled with the sQuare bit mechanism to estimate downstream losses. Indeed, passive observers can infer downstream losses by difference between end-to-end and upstream losses.
  The sQuare bit mechanism allows for observers to compute loss measurement at the end of every half sQuare signal period (level 0 or level 1).
  The Retransmit bit mechanism provides for the end-to-end loss after reaction of the sender stack.
  
  On-path observers can estimate upstream and downstream loss at various scales, from the square slot level to the connection lifetime level.
 
  Note that observers should perform a loose synchronisation between the sQuare and the Retransmit measurements when accurate evolution of segmental loss over connection lifetime is sought, so as to compare the same portion of the packet stream.
- 
+
 ## Bidirectional flows
 
  The Q and R bits sent by one endpoint cover loss of packets sent by the same endpoint, allowing a midpoint observer to estimate loss in that direction; no specific cooperation is needed between the endpoints beyond negotiating a QUIC version that supports this proposal. Hence, the server will be enabling troubleshooting of the download path, and the client will work for the upload path.  This allows to be confident about getting a useful signal in asymmetric situations:  clients may for example implement Q and R improperly, the download path will still be debuggable as long as servers do it right.
- 
+
  It should also be noted that the method does not suffer from the natural asymmetry in packet rate of a typical download or upload scenario. Indeed, although there are often fewer acknowledgements than payload-bearing packets, the unary encoding by R of payload loss is borne by the payload stream itself. This allows to report loss in the important direction in both a timely and accurate fashion without sampling or quantization.
 
 # Security and Privacy Considerations
@@ -167,5 +167,5 @@ An IANA registry has been suggested for QUIC versions. In support of the fully n
 
 # Acknowledgments
 {:numbered="false"}
- 
+
 The sQuare Bit was originally specified by Kazuho Oku in early proposals for loss measurement.

--- a/draft-ietf-quic-lossbits-exp.md
+++ b/draft-ietf-quic-lossbits-exp.md
@@ -86,14 +86,12 @@ observation point)  is unambiguous;  this is crucial  as it  gives the
 ability to  quickly home in  on the  offending segment, by  moving the
 passive observer around.
 
-
 In the QUIC context, the equivalent transport headers being encrypted,
 such observation is not possible. To restore network operators' ability
 to maintain QUIC clients experience, this document  adds two explicit loss bits to the QUIC  short header,
 named "Q" (sQuare signal) and "R" (Retransmit). Together, these bits allow the observer to estimate
 upstream and downstream  loss, enabling the same  dichotomic search as
 with TCP.
-
 
 # Passive Loss measurement
 
@@ -116,7 +114,6 @@ counter, as explained below in {{retransmitbit}}.
 
 Each endpoint independently maintains  a sQuare value, 0 or 1, during a block of N outgoing packets (e.g. N=64), and sets the sQuare  bit in the short header to the currently stored value when a packet with a short header is sent out. The sQuare value is initiated to 0 at each endpoint, client and server, at connection start.
 This mechanism thus delineates slots of N packets with the same marking. Observation points can estimate the  upstream losses  by simply counting the number of packets during a half period of the square signal, as described in {{usage}}.
-
 
 ### Setting the Retransmit Bit on Outgoing Packets {#retransmitbit}
 
@@ -145,9 +142,8 @@ The slot size N should be carefully chosen : too short, it becomes very sensitiv
  The sQuare bit mechanism allows for observers to compute loss measurement at the end of every half sQuare signal period (level 0 or level 1).
  The Retransmit bit mechanism provides for the end-to-end loss after reaction of the sender stack.
  
- On path observers can estimate upstream and downstream loss at various scales, from the square slot level to the connection lifetime level.
- 
- 
+ On-path observers can estimate upstream and downstream loss at various scales, from the square slot level to the connection lifetime level.
+
  Note that observers should perform a loose synchronisation between the sQuare and the Retransmit measurements when accurate evolution of segmental loss over connection lifetime is sought, so as to compare the same portion of the packet stream.
  
 ## Bidirectional flows
@@ -169,12 +165,7 @@ An IANA registry has been suggested for QUIC versions. In support of the fully n
 > **RFC Editor's Note:**  Please remove this section prior to
 > publication of a final version of this document.
 
-
-
 # Acknowledgments
 {:numbered="false"}
  
 The sQuare Bit was originally specified by Kazuho Oku in early proposals for loss measurement.
-
-
-

--- a/draft-ietf-quic-lossbits-exp.md
+++ b/draft-ietf-quic-lossbits-exp.md
@@ -44,25 +44,22 @@ normative:
         org: Mozilla
         role: editor
 
-normative:
- QUIC-RECOVERY:
-title: "QUIC Loss Detection and Congestion Control"
-abbrev: QUIC Loss Detection 
-docname: draft-ietf-quic-recovery-latest 
-date: {DATE} 
-category: std ipr: trust200902 area: Transport workgroup: QUIC
-stand_alone: yes pi: [toc, sortrefs, symrefs, docmapping]
-author:
-ins: J. Iyengar
-name: Jana Iyengar
-org: Fastly
-email: jri.ietf@gmail.com
-role: editor
-ins: I. Swett name: Ian Swett org: Google email: ianswett@google.com role: editor
-
-
-
-
+  QUIC-RECOVERY:
+    title: "QUIC Loss Detection and Congestion Control"
+    abbrev: QUIC Loss Detection 
+    docname: draft-ietf-quic-recovery-latest 
+    date: {DATE} 
+    author:
+      -
+        ins: J. Iyengar
+        name: Jana Iyengar
+        org: Fastly
+        role: editor
+      -
+        ins: I. Swett
+        name: Ian Swett
+        org: Google
+        role: editor
 
 --- abstract
 

--- a/draft-ietf-quic-lossbits-exp.md
+++ b/draft-ietf-quic-lossbits-exp.md
@@ -126,7 +126,7 @@ When sending the first packet of a given connection with a new connection ID, ea
 
 # Using the loss bits for Passive Loss Measurement {#usage}
 
-## End-to-end loss 
+## End-to-end loss
 The Retransmit bit mechanism merely reflects the number of packets considered lost by the sender QUIC stack with a slight delay. In case of fast retransmit due to repeted acknowlegments of a packet, this delay is at least equal to the one way delay in the reverse direction. It is larger otherwise (eg RTO). The retransmit mechanism alone suffices to estimate the end-to-end losses; similar to TCP passive loss measurement, its accuracy depends on the loss affecting the retransmit-bit-marked packets, which are in themselves proof of previous loss.
 
 ## Upstream loss
@@ -141,7 +141,7 @@ The slot size N should be carefully chosen : too short, it becomes very sensitiv
  The Retransmit bit mechanism can be coupled with the sQuare bit mechanism to estimate downstream losses. Indeed, passive observers can infer downstream losses by difference between end-to-end and upstream losses.
  The sQuare bit mechanism allows for observers to compute loss measurement at the end of every half sQuare signal period (level 0 or level 1).
  The Retransmit bit mechanism provides for the end-to-end loss after reaction of the sender stack.
- 
+
  On-path observers can estimate upstream and downstream loss at various scales, from the square slot level to the connection lifetime level.
 
  Note that observers should perform a loose synchronisation between the sQuare and the Retransmit measurements when accurate evolution of segmental loss over connection lifetime is sought, so as to compare the same portion of the packet stream.

--- a/draft-ietf-quic-lossbits-exp.md
+++ b/draft-ietf-quic-lossbits-exp.md
@@ -93,7 +93,7 @@ passive observer around.
 In the QUIC context, the equivalent transport headers being encrypted,
 such observation is not possible. To restore network operators' ability
 to maintain QUIC clients experience, this document  adds two explicit loss bits to the QUIC  short header,
-named "Q" and "R". Together, these bits allow the observer to estimate
+named "Q" (sQuare signal) and "R" (Retransmit). Together, these bits allow the observer to estimate
 upstream and downstream  loss, enabling the same  dichotomic search as
 with TCP.
 
@@ -126,14 +126,9 @@ This mechanism thus delineates slots of N packets with the same marking. Observa
 Each endpoint, client and server, independently maintains a not-yet-disclosed-lost-packets counter and sets the Retransmit bit of short header packets to 0 or 1 accordingly.
 The not-yet-disclosed-lost-packets counter is initialized to 0 at each endpoint, client and server, at connection start, and reflects packets considered lost by the QUIC machinery, the content of which is pending for retransmission. When a packet is declared lost by the QUIC retransmission machinery (see {{QUIC-RECOVERY}}) the not-yet-disclosed-lost-packets counter is incremented by 1. When a packet with a short header is sent out by an end-point, its retransmit bit is set to 0 when the not-yet-disclosed-lost-packets counter is equal to 0. Otherwise, the packet is sent out with a retransmit bit set to 1 and the not-yet-disclosed-lost-packets counter is decremented by 1. Thus, the retransmit bit performs unary encoding of the amount of loss: observation points can estimate the number of packets considered lost by the QUIC transmission machinery in a given direction by counting packets in this direction with a retransmit bit equal to 1.
 
+### Resetting state on CID change
 
-### Resetting sQuare Value 
-Each endpoint resets its sQuare value to zero and initiates a new slot of N packets when sending the first
-packet of a given connection with a new connection ID. This reduces the risk that transient sQuare bit state can be used to link flows across connection migration or ID change.
-
-
-### Resetting Retransmit Value 
-The not-yet-disclosed-lost-packets counter is reset at each endpoint when sending the first packet of a given connection with a new connection ID. This reduces the risk that transient Retransmit bit state can be used to link flows across connection migration or ID change.
+When sending the first packet of a given connection with a new connection ID, each endpoint resets its sQuare value and not-yet-disclosed-lost-packets counter to zero. This eliminates the possibility for transient sQuare or Retransmit bit state to be used to link flows across connection migration or ID change.
 
 # Using the loss bits for Passive Loss Measurement {#usage}
 
@@ -166,7 +161,7 @@ The slot size N should be carefully chosen : too short, it becomes very sensitiv
 
 # Security and Privacy Considerations
 
-The loss bits are intended to expose loss to observers along the path, so the privacy considerations for the loss bits are essentially the same as those for passive loss measurement in general. Loss gives no hint on customer geolocalisation; moreover, reset of the loss counting at connection Id change prevent for linkability.
+The loss bits are intended to expose loss to observers along the path, so the privacy considerations for the loss bits are essentially the same as those for passive loss measurement in general. Loss gives no hint on customer geolocalisation; moreover, reset of loss accounting state on CID changes prevents linkability.
 
 # IANA Considerations
 

--- a/draft-ietf-quic-lossbits-exp.md
+++ b/draft-ietf-quic-lossbits-exp.md
@@ -162,7 +162,7 @@ The slot size N should be carefully chosen : too short, it becomes very sensitiv
 
  The Q and R bits sent by one endpoint cover loss of packets sent by the same endpoint, allowing a midpoint observer to estimate loss in that direction; no specific cooperation is needed between the endpoints beyond negotiating a QUIC version that supports this proposal. Hence, the server will be enabling troubleshooting of the download path, and the client will work for the upload path.  This allows to be confident about getting a useful signal in asymmetric situations:  clients may for example implement Q and R improperly, the download path will still be debuggable as long as servers do it right.
  
- It should also be noted that the method does not suffer from the natural asymmetry in packet rate of a typical download or upload scenario. Indeed, although there are often fewer acknowledgements than payload-bearing packets, the unary encoding by R is borne by the payload stream. This allows to report loss in the important direction in both a timely and accurate fashion without sampling or quantization.
+ It should also be noted that the method does not suffer from the natural asymmetry in packet rate of a typical download or upload scenario. Indeed, although there are often fewer acknowledgements than payload-bearing packets, the unary encoding by R of payload loss is borne by the payload stream itself. This allows to report loss in the important direction in both a timely and accurate fashion without sampling or quantization.
 
 # Security and Privacy Considerations
 

--- a/draft-ietf-quic-lossbits-exp.md
+++ b/draft-ietf-quic-lossbits-exp.md
@@ -126,7 +126,7 @@ the short header for the Retransmit bit. The sQuare and Retransmit bits are the 
 ~~~~~
 {: #fig-short-header title="Short Header Format including proposed Q and R Bit"}
 
-Q: The sQuare bit is toggled every 64 outgoing packets as explained in {{squarebit}}.
+Q: The sQuare bit is toggled every N outgoing packets as explained in {{squarebit}}.
 
 R: The Retransmit bit is set to 0 or 1 according to the not-yet-disclosed-lost-packets
 counter, as explained in {{retransmitbit}}.

--- a/draft-ietf-quic-lossbits-exp.md
+++ b/draft-ietf-quic-lossbits-exp.md
@@ -72,7 +72,9 @@ transport protocol and describes how to use them to measure and locate packet lo
 --- note_Note_to_Readers
 
 This document specifies an experimental delta to the QUIC transport protocol. 
+
 --- middle
+
 # Introduction
 
 Packet  loss is  a hard  and  pervasive problem  of day-to-day  network

--- a/draft-ietf-quic-lossbits-exp.md
+++ b/draft-ietf-quic-lossbits-exp.md
@@ -142,13 +142,19 @@ As with TCP passive detection based on missing sequence numbers, this estimation
 Value of N 
 N should be carefully chosen : too short, it becomes very sensitive to reordering and loss. Too large, short connections may end before completion of the first square slot, preventing any loss estimation. Slots of 64 packets are suggested.
 
+
+
+
+The Retransmit bit mechanism merely reflects the number of packets considered lost by the sender QUIC stack with a slight delay. In case of fast retransmit due to repeted acknowlegments of a packet, this delay is at least equal to the uplink one way delay. It is larger otherwise.
+The sole retransmit mechanism estimates the end-to-end losses; similar to TCP passive measurement, its accuracy depends on the loss affecting the retransmitt-bit-marked packets, which are in themselves proof of previous loss.
+
+The retransmit bit mechanism may be coupled with the square signal mechanism to estimate segmental losses.
+
+
+
+
+
 Accuracy of the measurement 
-
-Mid point oberservers 
-The Retransmit bit mechanism merely reflects the number of packets considered lost by the sender QUIC stack with a slight delay, at least the uplink one way delay. In case of fast retransmit.
-
-may be coupled with the square signal
-
 Note that this measurement, as with passive RTT measurement for TCP, i). It
 therefore provides devices on path a good instantaneous estimate of the RTT as
 experienced by the application. A simple linear smoothing or moving minimum

--- a/draft-ietf-quic-lossbits-exp.md
+++ b/draft-ietf-quic-lossbits-exp.md
@@ -1,0 +1,243 @@
+---
+title: The QUIC Loss Bits
+abbrev: QUIC Loss Bits
+docname: draft-ietf-quic-lossbits-exp-latest
+date: {DATE}
+category: exp
+
+ipr: trust200902
+workgroup: QUIC
+keyword: Internet-Draft
+
+stand_alone: yes
+pi: [toc, sortrefs, symrefs]
+
+author:
+  -
+    ins: A. Ferrieux
+    role: editor
+    name: Alexandre Ferrieux
+    org: Orange Labs
+    email: alexandre.ferrieux@orange.com
+  -
+    ins: I. Hamchaoui
+    role: editor
+    name: Isabelle Hamchaoui
+    org: Orange Labs
+    email: isabelle.hamchaoui@orange.com
+
+normative:
+  QUIC-TRANSPORT:
+    title: "QUIC: A UDP-Based Multiplexed and Secure Transport"
+    date: {DATE}
+    seriesinfo:
+      Internet-Draft: draft-ietf-quic-transport-latest
+    author:
+      -
+        ins: J. Iyengar
+        name: Jana Iyengar
+        org: Fastly
+        role: editor
+      -
+        ins: M. Thomson
+        name: Martin Thomson
+        org: Mozilla
+        role: editor
+
+--- abstract
+
+This document specifies the addition of loss bits to the QUIC
+transport protocol and describes how to use them to measure and locate packet loss.
+
+--- middle
+
+# Introduction
+
+Packet  loss is  a hard  an  pervasive problem  of day-to-day  network
+operation,  and  locating them  is  crucial  to timely  resolution  of
+crippling  end-to-end  throughput  issues.    To  this  effect,  in  a
+TCP-dominated world,  network operators  have been heavily  relying on
+information   present  in   clear   in  TCP   headers:  sequence   and
+acknowledgement  numbers, and  SACK when  enabled. By  passive on-path
+observation,  these  allow  for   quantitative  estimation  of  packet
+loss. Additionally, the lossy segment (upstream or downstream from the
+observation point)  is unambiguous;  this is crucial  as it  gives the
+ability to  quickly home in  on the  offending segment, by  moving the
+passive observer around.
+
+
+In the QUIC context, the equivalent transport headers being encrypted,
+no such observation is possible. To restore network operators' ability
+to restore quality  efficiently in the presence  of QUIC-only traffic,
+this document  adds two explicit loss  bits to the QUIC  short header,
+named "Q" and "R". Together, these bits allow the observer to estimate
+upstream and downstream  loss, enabling the same  dichotomic search as
+with TCP.
+
+zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz
+
+# The Spin Bit Mechanism
+
+The latency spin bit enables latency monitoring from observation points on the
+network path throughout the duration of a connection. Since it is possible to
+measure handshake RTT without a spin bit, it is sufficient to include the spin
+bit in the short packet header. The spin bit therefore appears only after
+version negotiation and connection establishment are completed.
+
+## Proposed Short Header Format Including Spin Bit
+
+As of the current editor's version of {{QUIC-TRANSPORT}}, this proposal
+specifies using the sixth most significant bit (0x04) of the first byte in
+the short header for the spin bit.
+
+~~~~~
+
+ 0                   1                   2                   3
+ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
++-+-+-+-+-+-+-+-+
+|0|K|1|1|0|S|R R|
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                Destination Connection ID (0..144)           ...
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                      Packet Number (8/16/32)                ...
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                     Protected Payload (*)                   ...
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+~~~~~
+{: #fig-short-header title="Short Header Format including proposed Spin Bit"}
+
+S: The Spin bit is set 0 or 1 depending on the stored spin value that is
+updated on packet reception as explained in {{spinbit}}.
+
+R: Two additional bits are reserved for experimentation in the short header.
+
+## Setting the Spin Bit on Outgoing Packets {#spinbit}
+
+Each endpoint, client and server, maintains a spin value, 0 or 1, for each
+QUIC connection, and sets the spin bit in the short header to the currently
+stored value when a packet with a short header is sent out. The spin value is
+initialized to 0 at each endpoint, client and server, at connection start.
+Each endpoint also remembers the highest packet number seen from its peer on
+the connection.
+
+The spin value is then determined at each endpoint within a single connection
+as follows:
+
+* When the server receives a packet from the client, if that packet has a
+  short header and if it increments the highest packet number seen by the
+  server from the client, the server sets the spin value to the value observed
+  in the spin bit in the received packet.
+
+* When the client receives a packet from the server, if the packet has a short
+  header and if it increments the highest packet number seen by the client
+  from the server, it sets the spin value to the opposite of the spin bit in
+  the received packet.
+
+This procedure will cause the spin bit to change value in each direction once
+per round trip. Observation points can estimate the network latency by
+observing these changes in the latency spin bit, as described in {{usage}}.
+See {{?QUIC-SPIN=I-D.trammell-quic-spin}} for further illustration of this
+mechanism in action.
+
+## Resetting Spin Value State
+
+Each client and server resets it spin value to zero when sending the first
+packet of a given connection with a new connection ID. This reduces the risk
+that transient spin bit state can be used to link flows across connection
+migration or ID change.
+
+# Using the Spin Bit for Passive RTT Measurement {#usage}
+
+When a QUIC flow sends data continuously, the latency spin bit in each
+direction changes value once per round-trip time (RTT). An on-path observer
+can observe the time difference between edges (changes from 1 to 0 or 0 to 1)
+in the spin bit signal in a single direction to measure one sample of
+end-to-end RTT.
+
+An observer can store the largest observed packet number per flow, and reject
+edges that do not have a monotonically increasing packet number (greater than
+the largest observed packet number).  This will avoid detecting spurious edges
+caused by reordering events that include an edge, which would lead to very low
+RTT estimates if not ignored.
+
+If the spin bit edge occurs after a long packet number gap, it should be
+ignored: this filters out high RTT estimates due to loss of an actual edge in
+a burst of lost packets.
+
+Note that this measurement, as with passive RTT measurement for TCP, includes
+any transport protocol delay (e.g., delayed sending of acknowledgements)
+and/or application layer delay (e.g., waiting for a request to complete). It
+therefore provides devices on path a good instantaneous estimate of the RTT as
+experienced by the application. A simple linear smoothing or moving minimum
+filter can be applied to the stream of RTT information to get a more stable
+estimate.
+
+However, application-limited and flow-control-limited senders can have
+application and transport layer delay, respectively, that are much greater
+than network RTT. When the sender is application-limited and e.g. only sends
+small amount of periodic application traffic, where that period is longer than
+the RTT, measuring the spin bit provides information about the application
+period, not the network RTT.
+
+Simple heuristics based on the observed data rate per flow or changes in the
+RTT series can be used to reject bad RTT samples due to application or flow
+control limitation; for example, QoF {{TMA-QOF}} rejects component RTTs
+significantly higher than RTTs over the history of the flow. These heuristics
+may use the handshake RTT as an initial RTT estimate for a given flow.
+
+An on-path observer that can see traffic in both directions (from client to
+server and from server to client) can also use the spin bit to measure
+"upstream" and "downstream" component RTT; i.e, the component of the
+end-to-end RTT attributable to the paths between the observer and the server
+and the observer and the client, respectively. It does this by measuring the
+delay between a spin edge observed in the upstream direction and that observed
+in the downstream direction, and vice versa.
+
+
+# IANA Considerations
+
+This document has no actions for IANA.
+
+# Security and Privacy Considerations
+
+The spin bit is intended to expose end-to-end RTT to observers along the path,
+so the privacy considerations for the latency spin bit are essentially the
+same as those for passive RTT measurement in general. It has been shown
+{{PAM-RTT}} that RTT measurements do not provide more information for
+geolocation than is available in the most basic, freely-available IP address
+based location databases. The risk of exposure of per-flow network RTT to
+on-path devices is therefore negligible.
+
+
+# Change Log
+
+> **RFC Editor's Note:**  Please remove this section prior to
+> publication of a final version of this document.
+
+## Since draft-ietf-spin-exp-00
+
+Nothing yet.
+
+# Acknowledgments
+{:numbered="false"}
+
+This document is derived from {{QUIC-SPIN}}, which was the work
+of the following authors in addition to the editor of this document:
+
+- Piet De Vaere, ETH Zurich
+- Roni Even, Huawei
+- Giuseppe Fioccola, Telecom Italia
+- Thomas Fossati, Nokia
+- Marcus Ihlar, Ericsson
+- Al Morton, AT&T Labs
+- Emile Stephan, Orange
+
+The QUIC Spin Bit was originally specified in a slightly different form by
+Christian Huitema.
+
+This work is partially supported by the European Commission under Horizon 2020
+grant agreement no. 688421 Measurement and Architecture for a Middleboxed
+Internet (MAMI), and by the Swiss State Secretariat for Education, Research,
+and Innovation under contract no. 15.0268. This support does not imply
+endorsement.

--- a/draft-ietf-quic-lossbits-exp.md
+++ b/draft-ietf-quic-lossbits-exp.md
@@ -77,7 +77,7 @@ with TCP.
 
 # Passive Segmental Loss measurement
 
-The proposed mechanism enable loss measurement from observation points on the network path throughout the lifetime of a connection. End-to end loss as well as segmental loss (upstream or downstream from the observation point) are measurable thanks to two dedicated bits in short packet headers. The loss bits therefore appear only after version negotiation and connection establishment are completed.
+The proposed mechanism enable loss measurement from observation points on the network path throughout the lifetime of a connection. End-to end loss as well as segmental loss (upstream or downstream from the observation point) are measurable thanks to two dedicated bits in short packet headers, nammed loss bits. The loss bits therefore appear only after version negotiation and connection establishment are completed.
 
 ## Proposed Short Header Format Including sQuare and Retransmit Bits
 
@@ -110,37 +110,16 @@ counter, as explained in {{retransmitbit}}.
 
 ## Setting the Square Bit on Outgoing Packets {#squarebit}
 
-For a given direction, the sender 
-Each endpoint, client and server, maintains a spin value, 0 or 1, for each
-QUIC connection, and sets the spin bit in the short header to the currently
-stored value when a packet with a short header is sent out. The spin value is
-initialized to 0 at each endpoint, client and server, at connection start.
-Each endpoint also remembers the highest packet number seen from its peer on
-the connection.
+Each endpoint maintains independantly a sQuare value, 0 or 1, during a block of N outgoing packets (e.g.N=64), and sets the sQuare  bit in the short header to the currently stored value when a packet with a short header is sent out. The sQuare value is initiated to 0 at each endpoint, client and server, at connection start.
+This mechanism delineates thus slots of N packets with the same marking. Observation points can estimate the  upstream losses  by simply counting le number of packets during an half period of the square signal, as described in {{usage}}.
 
-The spin value is then determined at each endpoint within a single connection
-as follows:
-
-* When the server receives a packet from the client, if that packet has a
-  short header and if it increments the highest packet number seen by the
-  server from the client, the server sets the spin value to the value observed
-  in the spin bit in the received packet.
-
-* When the client receives a packet from the server, if the packet has a short
-  header and if it increments the highest packet number seen by the client
-  from the server, it sets the spin value to the opposite of the spin bit in
-  the received packet.
-
-This procedure will cause the spin bit to change value in each direction once
-per round trip. Observation points can estimate the network latency by
-observing these changes in the latency spin bit, as described in {{usage}}.
-See {{?QUIC-SPIN=I-D.trammell-quic-spin}} for further illustration of this
-mechanism in action.
 
 ## Setting the Retransmit Bit on Outgoing Packets {#retransmitbit}
 
-For a given direction, the sender 
-Each endpoint, client and server, maintains a spin value, 0 or 1, for each
+Each endpoint, client and server, The Retransmit bit is set to 0 or 1 according to the not-yet-disclosed-lost-packets
+counter
+
+maintains a spin value, 0 or 1, for each
 QUIC connection, and sets the spin bit in the short header to the currently
 stored value when a packet with a short header is sent out. The spin value is
 initialized to 0 at each endpoint, client and server, at connection start.

--- a/draft-ietf-quic-lossbits-exp.md
+++ b/draft-ietf-quic-lossbits-exp.md
@@ -27,6 +27,7 @@ author:
     email: isabelle.hamchaoui@orange.com
 
 normative:
+
   QUIC-TRANSPORT:
     title: "QUIC: A UDP-Based Multiplexed and Secure Transport"
     date: {DATE}
@@ -68,7 +69,7 @@ passive observer around.
 
 In the QUIC context, the equivalent transport headers being encrypted,
 no such observation is possible. To restore network operators' ability
-to restore quality  efficiently in the presence  of QUIC-only traffic,
+to maintain quality  efficiently in the presence  of QUIC-only traffic,
 this document  adds two explicit loss  bits to the QUIC  short header,
 named "Q" and "R". Together, these bits allow the observer to estimate
 upstream and downstream  loss, enabling the same  dichotomic search as

--- a/draft-ietf-quic-lossbits-exp.md
+++ b/draft-ietf-quic-lossbits-exp.md
@@ -79,7 +79,7 @@ with TCP.
 
 The proposed mechanism enable loss measurement from observation points on the network path throughout the lifetime of a connection. End-to end loss as well as segmental loss (upstream or downstream from the observation point) are measurable thanks to two dedicated bits in short packet headers. The loss bits therefore appear only after version negotiation and connection establishment are completed.
 
-## Proposed Short Header Format Including Spin Bit
+## Proposed Short Header Format Including sQuare and Retransmit Bits
 
 As of the current editor's version of {{QUIC-TRANSPORT}}, this proposal
 specifies using the seventh amost significant bit (0x04) of the first byte in
@@ -109,6 +109,35 @@ R: The Retransmit bit is set to 0 or 1 according to the not-yet-disclosed-lost-p
 counter, as explained in {{retransmitbit}}.
 
 ## Setting the Square Bit on Outgoing Packets {#squarebit}
+
+For a given direction, the sender 
+Each endpoint, client and server, maintains a spin value, 0 or 1, for each
+QUIC connection, and sets the spin bit in the short header to the currently
+stored value when a packet with a short header is sent out. The spin value is
+initialized to 0 at each endpoint, client and server, at connection start.
+Each endpoint also remembers the highest packet number seen from its peer on
+the connection.
+
+The spin value is then determined at each endpoint within a single connection
+as follows:
+
+* When the server receives a packet from the client, if that packet has a
+  short header and if it increments the highest packet number seen by the
+  server from the client, the server sets the spin value to the value observed
+  in the spin bit in the received packet.
+
+* When the client receives a packet from the server, if the packet has a short
+  header and if it increments the highest packet number seen by the client
+  from the server, it sets the spin value to the opposite of the spin bit in
+  the received packet.
+
+This procedure will cause the spin bit to change value in each direction once
+per round trip. Observation points can estimate the network latency by
+observing these changes in the latency spin bit, as described in {{usage}}.
+See {{?QUIC-SPIN=I-D.trammell-quic-spin}} for further illustration of this
+mechanism in action.
+
+## Setting the Retransmit Bit on Outgoing Packets {#retransmitbit}
 
 For a given direction, the sender 
 Each endpoint, client and server, maintains a spin value, 0 or 1, for each

--- a/draft-ietf-quic-lossbits-exp.md
+++ b/draft-ietf-quic-lossbits-exp.md
@@ -74,7 +74,6 @@ named "Q" and "R". Together, these bits allow the observer to estimate
 upstream and downstream  loss, enabling the same  dichotomic search as
 with TCP.
 
-zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz
 
 # Passive Segmental Loss measurement
 

--- a/draft-ietf-quic-lossbits-exp.md
+++ b/draft-ietf-quic-lossbits-exp.md
@@ -118,9 +118,9 @@ This mechanism delineates thus slots of N packets with the same marking. Observa
 
 Each endpoint, client and server, sets the Retransmit bit of short header packets to 0 or 1 according to the not-yet-disclosed-lost-packets counter.
 The not-yet-disclosed-lost-packets counter is initialized to 0 at each endpoint, client and server, at connection start. When a packet is declared lost by the QUIC transmission machinery (see https://github.com/quicwg/base-drafts/blob/ac5e4af758cd61329244297737b93c87c3889e3d/draft-ietf-quic-recovery.md#loss-detection )
-the not-yet-disclosed-lost-packets counter is incremented by 1. When a packet with a short header is sent out by an end-point within a single connection, its retransmit bit is set at 0 when the not-yet-disclosed-lost-packets counter is equal to 0. Otherwise, the packet is sent out with a retransmit bit set to 1 and the not-yet-disclosed-lost-packets counter is decremented by 1.
+the not-yet-disclosed-lost-packets counter is incremented by 1. When a packet with a short header is sent out by an end-point, its retransmit bit is set at 0 when the not-yet-disclosed-lost-packets counter is equal to 0. Otherwise, the packet is sent out with a retransmit bit set to 1 and the not-yet-disclosed-lost-packets counter is decremented by 1.
 
-Observation points can estimate the number of packets considered lost by the QUIC transmission machinery by observing the number of packets which retransmit bit is set to 1 in the reverse direction. This estimation is delayed at least by the uplink one way delay in case of fast retransmit. 
+Observation points can estimate the number of packets considered lost by the QUIC transmission machinery by observing the number of packets which retransmit bit is set to 1 in the reverse direction. This estimation is delayed at least by the uplink one way delay (in case of fast retransmit). 
 
 
 

--- a/draft-ietf-quic-lossbits-exp.md
+++ b/draft-ietf-quic-lossbits-exp.md
@@ -51,9 +51,7 @@ abbrev: QUIC Loss Detection
 docname: draft-ietf-quic-recovery-latest 
 date: {DATE} 
 category: std ipr: trust200902 area: Transport workgroup: QUIC
-
 stand_alone: yes pi: [toc, sortrefs, symrefs, docmapping]
-
 author:
 ins: J. Iyengar
 name: Jana Iyengar
@@ -70,6 +68,7 @@ ins: I. Swett name: Ian Swett org: Google email: ianswett@google.com role: edito
 
 This document specifies the addition of loss bits to the QUIC
 transport protocol and describes how to use them to measure and locate packet loss.
+
 --- note_Note_to_Readers
 
 This document specifies an experimental delta to the QUIC transport protocol. 

--- a/draft-ietf-quic-lossbits-exp.md
+++ b/draft-ietf-quic-lossbits-exp.md
@@ -139,20 +139,21 @@ The not-yet-disclosed-lost-packets counter is reset at each endpoint, client and
 The Retransmit bit mechanism merely reflects the number of packets considered lost by the sender QUIC stack with a slight delay. In case of fast retransmit due to repeted acknowlegments of a packet, this delay is at least equal to the uplink one way delay. It is larger otherwise. The retransmit mechanism alone suffices to estimate the end-to-end losses; similar to TCP passive loss measurement, its accuracy depends on the loss affecting the retransmitt-bit-marked packets, which are in themselves proof of previous loss.
 ## Upstream loss 
 During a QUIC connection lifetime, the sQuare bit mechanism delineates slots of N packets with the same marking. When focusing on the sQuare bit of consecutive packets in a direction, this mechanism sketches a periodic sQuare signal which toggles every N packets. On-path observers can then estimate the  upstream losses by simply counting the number of packets during a half period (level 0 or level 1) of the square signal.
-Packets with a long header are not marked, but yet taken into account by the sender when counting the N outgoing packets before it toggles the square. Observers should assign long header packets to the pending slot if possible (i.e. up to N packets counted in this slot), to the next one otherwise. Thus, slots with less than N packets, whatever their header length, generally denote upstream loss. 
+Packets with a long header are not marked, but yet taken into account by the sender when counting the N outgoing packets before its next toggle. Observers should assign long header packets to the pending slot if possible (i.e. up to N packets counted in this slot), to the next one otherwise. Thus, slots with less than N packets, whatever their header length, generally denote upstream loss. 
 As with TCP passive detection based on missing sequence numbers, this estimation may become incaccurate in case of packet reordering which blurs the edges of the square signal ; heuristics may be proposed to filter out this noise in the observation points. 
 
-The packet slot size N should be carefully chosen : too short, it becomes very sensitive to reordering and loss. Too large, short connections may end before completion of the first square slot, preventing any loss estimation. Slots of 64 packets are suggested.
+The slot size N should be carefully chosen : too short, it becomes very sensitive to packet reordering and loss. Too large, short connections may end before completion of the first square slot, preventing any loss estimation. Slots of 64 packets are suggested.
 
 ## Downstream loss 
 
- The retransmit bit mechanism may be coupled with the square bit mechanism to estimate downstream losses. Indeed, passive observers can infer downstream losses by difference between end-to-end and upstream losses. This 
-
+ The retransmit bit mechanism may be coupled with the square bit mechanism to estimate downstream losses. Indeed, passive observers can infer downstream losses by difference between end-to-end and upstream losses. 
+ The sQuare bit mechanism allows for observers to compute loss measurment at the end of every half sQuare signal period (level 0 or level 1).
+ The retransmit bit mechanism provides for the end-to-end loss after reaction of the sender stack.
+ 
+ On path observers can estimate upstream and downstream loss at various scales, from the N slot level to the connection lifetime level.
  
  
- The sQuare bit mechanism allows for observers to compute loss measurment at the end of every half sQuare signal period (level x).
- The retransmit bit mechanism provides for the end-to-end loss after reaction of the sender stack, which may be later ou sooner delay than the previous one.
- On path observers can then estimate upstream and downstream loss at various scales. Note that observers should perform a loose synchronisation between these two measurements when accurate evolution of segmental loss over connection lifetime is sought so as to compare the same portion of the packet stream.
+ Note that observers should perform a loose synchronisation between the sQuare and the retransmit measurements when accurate evolution of segmental loss over connection lifetime is sought so as to compare the same portion of the packet stream.
  
  
  
@@ -162,13 +163,7 @@ This document has no actions for IANA.
 
 # Security and Privacy Considerations
 
-The spin bit is intended to expose end-to-end RTT to observers along the path,
-so the privacy considerations for the latency spin bit are essentially the
-same as those for passive RTT measurement in general. It has been shown
-{{PAM-RTT}} that RTT measurements do not provide more information for
-geolocation than is available in the most basic, freely-available IP address
-based location databases. The risk of exposure of per-flow network RTT to
-on-path devices is therefore negligible.
+The loss bits are intended to expose loss to observers along the path, so the privacy considerations for the loss bits are essentially the same as those for passive loss measurement in general. Loss gives no hint on customer geolocalisation; moreover, reset of the loss counting at conenction Id change prevent for linkability.
 
 
 # Change Log

--- a/draft-ietf-quic-lossbits-exp.md
+++ b/draft-ietf-quic-lossbits-exp.md
@@ -83,15 +83,16 @@ The proposed mechanism enable loss measurement from observation points on the ne
 ## Proposed Short Header Format Including Spin Bit
 
 As of the current editor's version of {{QUIC-TRANSPORT}}, this proposal
-specifies using the sixth most significant bit (0x04) of the first byte in
-the short header for the spin bit.
+specifies using the seventh amost significant bit (0x04) of the first byte in
+the short header for the sQuare bit and the eight amost significant bit (0x04) of the first byte in
+the short header for the Retransmit bit.
 
 ~~~~~
 
  0                   1                   2                   3
  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
 +-+-+-+-+-+-+-+-+
-|0|K|1|1|0|S|R R|
+|0|K|1|1|0|S|Q|R|
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                Destination Connection ID (0..144)           ...
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -101,15 +102,16 @@ the short header for the spin bit.
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 
 ~~~~~
-{: #fig-short-header title="Short Header Format including proposed Spin Bit"}
+{: #fig-short-header title="Short Header Format including proposed Q and R Bit"}
 
-S: The Spin bit is set 0 or 1 depending on the stored spin value that is
-updated on packet reception as explained in {{spinbit}}.
+Q: The sQuare bit is toggled every 64 outgoing packets as explained in {{squarebit}}.
 
-R: Two additional bits are reserved for experimentation in the short header.
+R: The Retransmit bit is set to 0 or 1 according to the not-yet-disclosed-lost-packets
+counter, as explained in {{retransmitbit}}.
 
-## Setting the Spin Bit on Outgoing Packets {#spinbit}
+## Setting the Square Bit on Outgoing Packets {#squarebit}
 
+For a given direction, the sender 
 Each endpoint, client and server, maintains a spin value, 0 or 1, for each
 QUIC connection, and sets the spin bit in the short header to the currently
 stored value when a packet with a short header is sent out. The spin value is

--- a/draft-ietf-quic-lossbits-exp.md
+++ b/draft-ietf-quic-lossbits-exp.md
@@ -27,7 +27,6 @@ author:
     email: isabelle.hamchaoui@orange.com
 
 normative:
-
   QUIC-TRANSPORT:
     title: "QUIC: A UDP-Based Multiplexed and Secure Transport"
     date: {DATE}

--- a/draft-ietf-quic-lossbits-exp.md
+++ b/draft-ietf-quic-lossbits-exp.md
@@ -176,8 +176,7 @@ The loss bits are intended to expose loss to observers along the path, so the pr
 # Acknowledgments
 {:numbered="false"}
  
-
-Kazuho Square signal
+The sQuare Bit was originally specified by Kazuho Oku for RTT measurment.
 
 
 

--- a/draft-ietf-quic-lossbits-exp.md
+++ b/draft-ietf-quic-lossbits-exp.md
@@ -105,7 +105,7 @@ The proposed mechanisms enable loss measurement from observation points on the n
 ## Proposed Short Header Format Including Loss Bits
 
 As of the current editor's version of {{QUIC-TRANSPORT}}, this proposal
-specifies using the seventh amost significant bit (0x02) of the first byte in
+specifies using the seventh most significant bit (0x02) of the first byte in
 the short header for the sQuare bit and the eight amost significant bit (0x01) of the first byte in
 the short header for the Retransmit bit. The sQuare and Retransmit bits constitute the Loss bits.
 
@@ -142,14 +142,12 @@ This mechanism delineates thus slots of N packets with the same marking. Observa
 Each endpoint, client and server, independently maintains a not-yet-disclosed-lost-packets counter and sets the Retransmit bit of short header packets to 0 or 1 accordingly.
 The not-yet-disclosed-lost-packets counter is initialized to 0 at each endpoint, client and server, at connection start, and reflects packets considered lost by the QUIC machinery which content is pending for retranmission. When a packet is declared lost by the QUIC transmission machinery (see {{QUIC-RECOVERY}}) the not-yet-disclosed-lost-packets counter is incremented by 1. When a packet with a short header is sent out by an end-point, its retransmit bit is set at 0 when the not-yet-disclosed-lost-packets counter is equal to 0. Otherwise, the packet is sent out with a retransmit bit set to 1 and the not-yet-disclosed-lost-packets counter is decremented by 1.
 
-Observation points can estimate the number of packets considered lost by the QUIC transmission machinery in a given direction by observing the number of packets which retransmit bit is set to 1 in this direction. This estimation of end-to-end loss is delayed at least by the uplink one way delay (in case of fast retransmit). 
+Observation points can estimate the number of packets considered lost by the QUIC transmission machinery in a given direction by observing the number of packets which retransmit bit is set to 1 in this direction.
 
-
-{{?QUIC-SPIN=I-D.trammell-quic-spin}} 
 
 ## Resetting sQuare Value 
 
-Each client and server resets its sQuare value to zero and initiates a new slot of 64 packets when sending the first
+Each client and server resets its sQuare value to zero and initiates a new slot of N packets when sending the first
 packet of a given connection with a new connection ID. This reduces the risk that transient sQuare bit state can be used to link flows across connection migration or ID change.
 
 
@@ -159,24 +157,24 @@ The not-yet-disclosed-lost-packets counter is reset at each endpoint, client and
 # Using the loss bits for Passive Loss Measurement {#usage}
 
 ## End-to-end loss 
-The Retransmit bit mechanism merely reflects the number of packets considered lost by the sender QUIC stack with a slight delay. In case of fast retransmit due to repeted acknowlegments of a packet, this delay is at least equal to the uplink one way delay. It is larger otherwise. The retransmit mechanism alone suffices to estimate the end-to-end losses; similar to TCP passive loss measurement, its accuracy depends on the loss affecting the retransmitt-bit-marked packets, which are in themselves proof of previous loss.
+The Retransmit bit mechanism merely reflects the number of packets considered lost by the sender QUIC stack with a slight delay. In case of fast retransmit due to repeted acknowlegments of a packet, this delay is at least equal to the one way delay inteh reverse direction. It is larger otherwise. The retransmit mechanism alone suffices to estimate the end-to-end losses; similar to TCP passive loss measurement, its accuracy depends on the loss affecting the retransmitt-bit-marked packets, which are in themselves proof of previous loss.
 ## Upstream loss 
 During a QUIC connection lifetime, the sQuare bit mechanism delineates slots of N packets with the same marking. When focusing on the sQuare bit of consecutive packets in a direction, this mechanism sketches a periodic sQuare signal which toggles every N packets. On-path observers can then estimate the  upstream losses by simply counting the number of packets during a half period (level 0 or level 1) of the square signal.
 Packets with a long header are not marked, but yet taken into account by the sender when counting the N outgoing packets before its next toggle. Observers should assign long header packets to the pending slot if possible (i.e. up to N packets counted in this slot), to the next one otherwise. Thus, slots with less than N packets, whatever their header length, generally denote upstream loss. 
 As with TCP passive detection based on missing sequence numbers, this estimation may become incaccurate in case of packet reordering which blurs the edges of the square signal ; heuristics may be proposed to filter out this noise in the observation points. 
 
-The slot size N should be carefully chosen : too short, it becomes very sensitive to packet reordering and loss. Too large, short connections may end before completion of the first square slot, preventing any loss estimation. Slots of 64 packets are suggested.
+The slot size N should be carefully chosen : too short, it becomes very sensitive to packet reordering and loss. Too large, short connections may end before completion of the first square slot, ruining any loss estimation. Slots of 64 packets are suggested.
 
 ## Downstream loss 
 
- The retransmit bit mechanism may be coupled with the square bit mechanism to estimate downstream losses. Indeed, passive observers can infer downstream losses by difference between end-to-end and upstream losses. 
- The sQuare bit mechanism allows for observers to compute loss measurment at the end of every half sQuare signal period (level 0 or level 1).
- The retransmit bit mechanism provides for the end-to-end loss after reaction of the sender stack.
+ The Retransmit bit mechanism may be coupled with the sQuare bit mechanism to estimate downstream losses. Indeed, passive observers can infer downstream losses by difference between end-to-end and upstream losses. 
+ The sQuare bit mechanism allows for observers to compute loss measurement at the end of every half sQuare signal period (level 0 or level 1).
+ The Retransmit bit mechanism provides for the end-to-end loss after reaction of the sender stack.
  
- On path observers can estimate upstream and downstream loss at various scales, from the N slot level to the connection lifetime level.
+ On path observers can estimate upstream and downstream loss at various scales, from the square slot level to the connection lifetime level.
  
  
- Note that observers should perform a loose synchronisation between the sQuare and the retransmit measurements when accurate evolution of segmental loss over connection lifetime is sought so as to compare the same portion of the packet stream.
+ Note that observers should perform a loose synchronisation between the sQuare and the Retransmit measurements when accurate evolution of segmental loss over connection lifetime is sought so as to compare the same portion of the packet stream.
  
  
  
@@ -186,7 +184,7 @@ This document has no actions for IANA.
 
 # Security and Privacy Considerations
 
-The loss bits are intended to expose loss to observers along the path, so the privacy considerations for the loss bits are essentially the same as those for passive loss measurement in general. Loss gives no hint on customer geolocalisation; moreover, reset of the loss counting at conenction Id change prevent for linkability.
+The loss bits are intended to expose loss to observers along the path, so the privacy considerations for the loss bits are essentially the same as those for passive loss measurement in general. Loss gives no hint on customer geolocalisation; moreover, reset of the loss counting at connection Id change prevent for linkability.
 
 
 # Change Log
@@ -199,7 +197,7 @@ The loss bits are intended to expose loss to observers along the path, so the pr
 # Acknowledgments
 {:numbered="false"}
  
-The sQuare Bit was originally specified by Kazuho Oku for RTT measurment.
+The sQuare Bit was originally specified by Kazuho Oku for RTT measurement.
 
 
 

--- a/draft-ietf-quic-lossbits-exp.md
+++ b/draft-ietf-quic-lossbits-exp.md
@@ -45,6 +45,7 @@ normative:
         org: Mozilla
         role: editor
 
+normative:
  QUIC-RECOVERY:
 title: "QUIC Loss Detection and Congestion Control"
 abbrev: QUIC Loss Detection 
@@ -139,7 +140,7 @@ This mechanism delineates thus slots of N packets with the same marking. Observa
 ## Setting the Retransmit Bit on Outgoing Packets {#retransmitbit}
 
 Each endpoint, client and server, independently maintains a not-yet-disclosed-lost-packets counter and sets the Retransmit bit of short header packets to 0 or 1 accordingly.
-The not-yet-disclosed-lost-packets counter is initialized to 0 at each endpoint, client and server, at connection start, and reflects packets considered lost by the QUIC machinery which content is pending for retranmission. When a packet is declared lost by the QUIC transmission machinery (see https://github.com/quicwg/base-drafts/blob/ac5e4af758cd61329244297737b93c87c3889e3d/draft-ietf-quic-recovery.md#loss-detection) the not-yet-disclosed-lost-packets counter is incremented by 1. When a packet with a short header is sent out by an end-point, its retransmit bit is set at 0 when the not-yet-disclosed-lost-packets counter is equal to 0. Otherwise, the packet is sent out with a retransmit bit set to 1 and the not-yet-disclosed-lost-packets counter is decremented by 1.
+The not-yet-disclosed-lost-packets counter is initialized to 0 at each endpoint, client and server, at connection start, and reflects packets considered lost by the QUIC machinery which content is pending for retranmission. When a packet is declared lost by the QUIC transmission machinery (see {{QUIC-RECOVERY}}) the not-yet-disclosed-lost-packets counter is incremented by 1. When a packet with a short header is sent out by an end-point, its retransmit bit is set at 0 when the not-yet-disclosed-lost-packets counter is equal to 0. Otherwise, the packet is sent out with a retransmit bit set to 1 and the not-yet-disclosed-lost-packets counter is decremented by 1.
 
 Observation points can estimate the number of packets considered lost by the QUIC transmission machinery in a given direction by observing the number of packets which retransmit bit is set to 1 in this direction. This estimation of end-to-end loss is delayed at least by the uplink one way delay (in case of fast retransmit). 
 

--- a/draft-ietf-quic-lossbits-exp.md
+++ b/draft-ietf-quic-lossbits-exp.md
@@ -135,27 +135,25 @@ The not-yet-disclosed-lost-packets counter is reset at each endpoint, client and
 
 # Using the loss bits for Passive Loss Measurement {#usage}
 
-When a QUIC flow sends data continuously, the latency spin bit in each direction changes value once per round-trip time (RTT). An on-path observer can observe the time difference between edges (changes from 1 to 0 or 0 to 1) in the spin bit signal in a single direction to measure one sample of end-to-end RTT.
-
-
-
-During a QUIC connection lifetime, the sQuare bit mechanism delineates slots of N packets with the same marking. When focusing on the sQuare bit of consecutive packets, this mechanism sketches a periodic sQuare signal which toggles every N packets. On-path observation points can then estimate the  upstream losses by simply counting the number of packets during a half period (level 0 or level 1) of the square signal.
-Packets with a long header are not marked, but yet taken into account by the observation point via integration in the closest slot of the sQuare signal. Thus, slots with less than N paquets, whatever their header length, generally denote upstream loss. 
-As with TCP passive detection based on missing sequence numbers, this estimation may become incaccurate in case of packet reordering which blurs the edges of the square signal ; heuristics may be proposed to filter this noise. 
+During a QUIC connection lifetime, the sQuare bit mechanism delineates slots of N packets with the same marking. When focusing on the sQuare bit of consecutive packets in a direction, this mechanism sketches a periodic sQuare signal which toggles every N packets. On-path observation points can then estimate the  upstream losses by simply counting the number of packets during a half period (level 0 or level 1) of the square signal.
+Packets with a long header are not marked, but yet taken into account by the sender when counting down the N outgoing packets before the square toggles. Observation point should assign long header packets to the pending slot if possible (i.e. number of counted packets <N in this slot), to the next one otherwise. Thus, slots with less than N paquets, whatever their header length, generally denote upstream loss. 
+As with TCP passive detection based on missing sequence numbers, this estimation may become incaccurate in case of packet reordering which blurs the edges of the square signal ; heuristics may be proposed to filter this noise in the observation points. 
 
 Value of N 
-N should be carefully chosen : too short, it becomes very sensitive to reordering and thus to spurious loss destection. Too large, short connections may end before completion of the first slot, preventing any loss estimation. Slots of 64 packets are suggested.
+N should be carefully chosen : too short, it becomes very sensitive to reordering and loss. Too large, short connections may end before completion of the first square slot, preventing any loss estimation. Slots of 64 packets are suggested.
 
+Accuracy of the measurement 
 
-Note that this measurement, as with passive RTT measurement for TCP, includes
-any transport protocol delay (e.g., delayed sending of acknowledgements)
-and/or application layer delay (e.g., waiting for a request to complete). It
+Mid point oberservers 
+The Retransmit bit mechanism merely reflects the number of packets considered lost by the sender QUIC stack with a slight delay, at least the uplink one way delay. In case of fast retransmit.
+
+may be coupled with the square signal
+
+Note that this measurement, as with passive RTT measurement for TCP, i). It
 therefore provides devices on path a good instantaneous estimate of the RTT as
 experienced by the application. A simple linear smoothing or moving minimum
 filter can be applied to the stream of RTT information to get a more stable
 estimate.
-
-
 
 Simple heuristics based on the observed data rate per flow or changes in the
 RTT series can be used to reject bad RTT samples due to application or flow

--- a/draft-ietf-quic-lossbits-exp.md
+++ b/draft-ietf-quic-lossbits-exp.md
@@ -110,40 +110,24 @@ counter, as explained in {{retransmitbit}}.
 
 ## Setting the Square Bit on Outgoing Packets {#squarebit}
 
-Each endpoint maintains independantly a sQuare value, 0 or 1, during a block of N outgoing packets (e.g.N=64), and sets the sQuare  bit in the short header to the currently stored value when a packet with a short header is sent out. The sQuare value is initiated to 0 at each endpoint, client and server, at connection start.
+Each endpoint maintains independantly a sQuare value, 0 or 1, during a block of N outgoing packets (e.g. N=64), and sets the sQuare  bit in the short header to the currently stored value when a packet with a short header is sent out. The sQuare value is initiated to 0 at each endpoint, client and server, at connection start.
 This mechanism delineates thus slots of N packets with the same marking. Observation points can estimate the  upstream losses  by simply counting le number of packets during an half period of the square signal, as described in {{usage}}.
 
 
 ## Setting the Retransmit Bit on Outgoing Packets {#retransmitbit}
 
-Each endpoint, client and server, The Retransmit bit is set to 0 or 1 according to the not-yet-disclosed-lost-packets
-counter
+Each endpoint, client and server, sets the Retransmit bit of short header packets to 0 or 1 according to the not-yet-disclosed-lost-packets counter.
+The not-yet-disclosed-lost-packets counter is initialized to 0 at each endpoint, client and server, at connection start. When a packet is declared lost by the QUIC transmission machinery (see https://github.com/quicwg/base-drafts/blob/ac5e4af758cd61329244297737b93c87c3889e3d/draft-ietf-quic-recovery.md#loss-detection )
+the not-yet-disclosed-lost-packets counter is incremented by 1. When a packet with a short header is sent out by an end-point within a single connection, its retransmit bit is set at 0 when the not-yet-disclosed-lost-packets counter is equal to 0. Otherwise, the packet is sent out with a retransmit bit set to 1 and the not-yet-disclosed-lost-packets counter is decremented by 1.
 
-maintains a spin value, 0 or 1, for each
-QUIC connection, and sets the spin bit in the short header to the currently
-stored value when a packet with a short header is sent out. The spin value is
-initialized to 0 at each endpoint, client and server, at connection start.
-Each endpoint also remembers the highest packet number seen from its peer on
-the connection.
+Observation points can estimate the number of packets considered lost by the QUIC transmission machinery by observing the number of packets which retransmit bit is set to 1 in the reverse direction. This estimation is delayed at least by the uplink one way delay in case of fast retransmit. 
 
-The spin value is then determined at each endpoint within a single connection
-as follows:
 
-* When the server receives a packet from the client, if that packet has a
-  short header and if it increments the highest packet number seen by the
-  server from the client, the server sets the spin value to the value observed
-  in the spin bit in the received packet.
 
-* When the client receives a packet from the server, if the packet has a short
-  header and if it increments the highest packet number seen by the client
-  from the server, it sets the spin value to the opposite of the spin bit in
-  the received packet.
 
-This procedure will cause the spin bit to change value in each direction once
-per round trip. Observation points can estimate the network latency by
-observing these changes in the latency spin bit, as described in {{usage}}.
-See {{?QUIC-SPIN=I-D.trammell-quic-spin}} for further illustration of this
-mechanism in action.
+{{?QUIC-SPIN=I-D.trammell-quic-spin}} 
+
+
 
 ## Resetting Spin Value State
 

--- a/draft-ietf-quic-lossbits-exp.md
+++ b/draft-ietf-quic-lossbits-exp.md
@@ -106,8 +106,8 @@ The proposed mechanisms enable loss measurement from observation points on the n
 
 As of the current editor's version of {{QUIC-TRANSPORT}}, this proposal
 specifies using the seventh most significant bit (0x02) of the first byte in
-the short header for the sQuare bit and the eight amost significant bit (0x01) of the first byte in
-the short header for the Retransmit bit. The sQuare and Retransmit bits constitute the Loss bits.
+the short header for the sQuare bit and the eighth most significant bit (0x01) of the first byte in
+the short header for the Retransmit bit. The sQuare and Retransmit bits are the Loss bits.
 
 ~~~~~
 
@@ -134,47 +134,46 @@ counter, as explained in {{retransmitbit}}.
 ## Setting the Square Bit on Outgoing Packets {#squarebit}
 
 Each endpoint independently maintains  a sQuare value, 0 or 1, during a block of N outgoing packets (e.g. N=64), and sets the sQuare  bit in the short header to the currently stored value when a packet with a short header is sent out. The sQuare value is initiated to 0 at each endpoint, client and server, at connection start.
-This mechanism delineates thus slots of N packets with the same marking. Observation points can estimate the  upstream losses  by simply counting the number of packets during an half period of the square signal, as described in {{usage}}.
+This mechanism thus delineates slots of N packets with the same marking. Observation points can estimate the  upstream losses  by simply counting the number of packets during a half period of the square signal, as described in {{usage}}.
 
 
 ## Setting the Retransmit Bit on Outgoing Packets {#retransmitbit}
 
 Each endpoint, client and server, independently maintains a not-yet-disclosed-lost-packets counter and sets the Retransmit bit of short header packets to 0 or 1 accordingly.
-The not-yet-disclosed-lost-packets counter is initialized to 0 at each endpoint, client and server, at connection start, and reflects packets considered lost by the QUIC machinery which content is pending for retranmission. When a packet is declared lost by the QUIC transmission machinery (see {{QUIC-RECOVERY}}) the not-yet-disclosed-lost-packets counter is incremented by 1. When a packet with a short header is sent out by an end-point, its retransmit bit is set at 0 when the not-yet-disclosed-lost-packets counter is equal to 0. Otherwise, the packet is sent out with a retransmit bit set to 1 and the not-yet-disclosed-lost-packets counter is decremented by 1.
+The not-yet-disclosed-lost-packets counter is initialized to 0 at each endpoint, client and server, at connection start, and reflects packets considered lost by the QUIC machinery, the content of which is pending for retransmission. When a packet is declared lost by the QUIC retransmission machinery (see {{QUIC-RECOVERY}}) the not-yet-disclosed-lost-packets counter is incremented by 1. When a packet with a short header is sent out by an end-point, its retransmit bit is set to 0 when the not-yet-disclosed-lost-packets counter is equal to 0. Otherwise, the packet is sent out with a retransmit bit set to 1 and the not-yet-disclosed-lost-packets counter is decremented by 1.
 
-Observation points can estimate the number of packets considered lost by the QUIC transmission machinery in a given direction by observing the number of packets which retransmit bit is set to 1 in this direction.
+Observation points can estimate the number of packets considered lost by the QUIC transmission machinery in a given direction by observing the number of packets in this direction with a retransmit bit set to 1.
 
 
 ## Resetting sQuare Value 
-
-Each client and server resets its sQuare value to zero and initiates a new slot of N packets when sending the first
+Each endpoint resets its sQuare value to zero and initiates a new slot of N packets when sending the first
 packet of a given connection with a new connection ID. This reduces the risk that transient sQuare bit state can be used to link flows across connection migration or ID change.
 
 
 ## Resetting Retransmit Value 
-The not-yet-disclosed-lost-packets counter is reset at each endpoint, client and server, when sending the first packet of a given connection with a new connection ID. This reduces the risk that transient Retransmit bit state can be used to link flows across connection migration or ID change.
+The not-yet-disclosed-lost-packets counter is reset at each endpoint when sending the first packet of a given connection with a new connection ID. This reduces the risk that transient Retransmit bit state can be used to link flows across connection migration or ID change.
 
 # Using the loss bits for Passive Loss Measurement {#usage}
 
 ## End-to-end loss 
-The Retransmit bit mechanism merely reflects the number of packets considered lost by the sender QUIC stack with a slight delay. In case of fast retransmit due to repeted acknowlegments of a packet, this delay is at least equal to the one way delay inteh reverse direction. It is larger otherwise. The retransmit mechanism alone suffices to estimate the end-to-end losses; similar to TCP passive loss measurement, its accuracy depends on the loss affecting the retransmitt-bit-marked packets, which are in themselves proof of previous loss.
+The Retransmit bit mechanism merely reflects the number of packets considered lost by the sender QUIC stack with a slight delay. In case of fast retransmit due to repeted acknowlegments of a packet, this delay is at least equal to the one way delay in the reverse direction. It is larger otherwise (eg RTO). The retransmit mechanism alone suffices to estimate the end-to-end losses; similar to TCP passive loss measurement, its accuracy depends on the loss affecting the retransmit-bit-marked packets, which are in themselves proof of previous loss.
 ## Upstream loss 
 During a QUIC connection lifetime, the sQuare bit mechanism delineates slots of N packets with the same marking. When focusing on the sQuare bit of consecutive packets in a direction, this mechanism sketches a periodic sQuare signal which toggles every N packets. On-path observers can then estimate the  upstream losses by simply counting the number of packets during a half period (level 0 or level 1) of the square signal.
 Packets with a long header are not marked, but yet taken into account by the sender when counting the N outgoing packets before its next toggle. Observers should assign long header packets to the pending slot if possible (i.e. up to N packets counted in this slot), to the next one otherwise. Thus, slots with less than N packets, whatever their header length, generally denote upstream loss. 
-As with TCP passive detection based on missing sequence numbers, this estimation may become incaccurate in case of packet reordering which blurs the edges of the square signal ; heuristics may be proposed to filter out this noise in the observation points. 
+As with TCP passive detection based on missing sequence numbers, this estimation may become inaccurate in case of packet reordering which blurs the edges of the square signal ; heuristics may be proposed to filter out this noise in the observation points. 
 
-The slot size N should be carefully chosen : too short, it becomes very sensitive to packet reordering and loss. Too large, short connections may end before completion of the first square slot, ruining any loss estimation. Slots of 64 packets are suggested.
+The slot size N should be carefully chosen : too short, it becomes very sensitive to packet reordering and loss. Too large, short connections may end before completion of the first square slot, ruining any loss estimation. Slots of 64 packets are suggested as a reasonable trade-off.
 
 ## Downstream loss 
 
- The Retransmit bit mechanism may be coupled with the sQuare bit mechanism to estimate downstream losses. Indeed, passive observers can infer downstream losses by difference between end-to-end and upstream losses. 
+ The Retransmit bit mechanism can be coupled with the sQuare bit mechanism to estimate downstream losses. Indeed, passive observers can infer downstream losses by difference between end-to-end and upstream losses. 
  The sQuare bit mechanism allows for observers to compute loss measurement at the end of every half sQuare signal period (level 0 or level 1).
  The Retransmit bit mechanism provides for the end-to-end loss after reaction of the sender stack.
  
  On path observers can estimate upstream and downstream loss at various scales, from the square slot level to the connection lifetime level.
  
  
- Note that observers should perform a loose synchronisation between the sQuare and the Retransmit measurements when accurate evolution of segmental loss over connection lifetime is sought so as to compare the same portion of the packet stream.
+ Note that observers should perform a loose synchronisation between the sQuare and the Retransmit measurements when accurate evolution of segmental loss over connection lifetime is sought, so as to compare the same portion of the packet stream.
  
  
  

--- a/draft-ietf-quic-lossbits-exp.md
+++ b/draft-ietf-quic-lossbits-exp.md
@@ -45,13 +45,35 @@ normative:
         org: Mozilla
         role: editor
 
+ QUIC-RECOVERY:
+title: "QUIC Loss Detection and Congestion Control"
+abbrev: QUIC Loss Detection 
+docname: draft-ietf-quic-recovery-latest 
+date: {DATE} 
+category: std ipr: trust200902 area: Transport workgroup: QUIC
+
+stand_alone: yes pi: [toc, sortrefs, symrefs, docmapping]
+
+author:
+ins: J. Iyengar
+name: Jana Iyengar
+org: Fastly
+email: jri.ietf@gmail.com
+role: editor
+ins: I. Swett name: Ian Swett org: Google email: ianswett@google.com role: editor
+
+
+
+
+
 --- abstract
 
 This document specifies the addition of loss bits to the QUIC
 transport protocol and describes how to use them to measure and locate packet loss.
+--- note_Note_to_Readers
 
+This document specifies an experimental delta to the QUIC transport protocol. 
 --- middle
-
 # Introduction
 
 Packet  loss is  a hard  and  pervasive problem  of day-to-day  network


### PR DESCRIPTION
Just two bits in clear to enable full on-path loss location