### PR TITLE
Fix formatting of kPacketNumberSpace enum

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -889,6 +889,7 @@ kInitialRtt:
 
 kPacketNumberSpace:
 : An enum to enumerate the three packet number spaces.
+
 ~~~
   enum kPacketNumberSpace {
     Initial,


### PR DESCRIPTION
Without the newline it doesn't get rendered properly in the HTML.