### PR TITLE
Reference RFC7661 for application limited

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -742,25 +742,13 @@ As an example of a well-known and publicly available implementation of a flow
 pacer, implementers are referred to the Fair Queue packet scheduler (fq qdisc)
 in Linux (3.11 onwards).
 
-
-## Sending data after an idle period
-
-A sender becomes idle if it ceases to send data and has no bytes in flight.  A
-sender's congestion window MUST NOT increase while it is idle.
-
-When sending data after becoming idle, a sender MUST reset its congestion window
-to the initial congestion window (see Section 4.1 of {{?RFC5681}}), unless it
-paces the sending of packets. A sender MAY retain its congestion window if it
-paces the sending of any packets in excess of the initial congestion window.
-
-A sender MAY implement alternate mechanisms to update its congestion window
-after idle periods, such as those proposed for TCP in {{?RFC7661}}.
-
 ## Application Limited Sending
 
-The congestion window should not be increased in slow start or congestion
-avoidance when it is not sufficiently utilized.  The congestion window could
-be under-utilized due to insufficient application data or flow control credit.
+A sender's congestion window MUST NOT increase when no packets are newly
+acknowledged, such as when the connection is idle. The congestion window
+SHOULD NOT be increased in slow start or congestion avoidance when it is not
+sufficiently utilized.  The congestion window could be under-utilized due to
+insufficient application data or flow control credit.
 
 A sender MAY use the pipeACK method described in section 4.3 of {{?RFC7661}}
 to determine if the congestion window is sufficiently utilized.
@@ -770,6 +758,12 @@ and not fully utilize the congestion window due to this delay. A sender
 should not consider itself application limited if it would have fully
 utilized the congestion window without pacing delay.
 
+Sending more than intial window into the network at once may cause losses.
+Implemementations SHOULD use pacing, ACK-clocking, a reduction in CWND and/or
+timers to minimize bursts.
+
+A sender MAY implement alternate mechanisms to update its congestion window
+after idle periods, such as those proposed for TCP in {{?RFC7661}}.
 
 
 # Security Considerations

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -759,8 +759,11 @@ after idle periods, such as those proposed for TCP in {{?RFC7661}}.
 ## Application Limited Sending
 
 The congestion window should not be increased in slow start or congestion
-avoidance when it is not fully utilized.  The congestion window could be
-under-utilized due to insufficient application data or flow control credit.
+avoidance when it is not sufficiently utilized.  The congestion window could
+be under-utilized due to insufficient application data or flow control credit.
+
+A sender MAY use the pipeACK method described in section 4.3 of {{?RFC7661}}
+to determine if the congestion window is sufficiently utilized.
 
 A sender that paces packets (see {{pacing}}) might delay sending packets
 and not fully utilize the congestion window due to this delay. A sender

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -759,7 +759,7 @@ should not consider itself application limited if it would have fully
 utilized the congestion window without pacing delay.
 
 Bursting more than an intial window's worth of data into the network might cause short-term congestion and losses.
-Implemementations SHOULD use pacing, ACK-clocking, a reduction in CWND and/or
+Implemementations SHOULD either use pacing or reduce their congestion window to limit such bursts.
 timers to minimize bursts.
 
 A sender MAY implement alternate mechanisms to update its congestion window

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -742,13 +742,11 @@ As an example of a well-known and publicly available implementation of a flow
 pacer, implementers are referred to the Fair Queue packet scheduler (fq qdisc)
 in Linux (3.11 onwards).
 
-## Application Limited Sending
+## Under-utilizing the Congestion Window
 
-A sender's congestion window MUST NOT increase when no packets are newly
-acknowledged, such as when the connection is idle. The congestion window
-SHOULD NOT be increased in slow start or congestion avoidance when it is not
-sufficiently utilized.  The congestion window could be under-utilized due to
-insufficient application data or flow control credit.
+A congestion window that is under-utilized SHOULD NOT be increased in either
+slow start or congestion avoidance. This can happen due to insufficient
+application data or flow control credit.
 
 A sender MAY use the pipeACK method described in section 4.3 of {{?RFC7661}}
 to determine if the congestion window is sufficiently utilized.

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -758,7 +758,7 @@ and not fully utilize the congestion window due to this delay. A sender
 should not consider itself application limited if it would have fully
 utilized the congestion window without pacing delay.
 
-Sending more than intial window into the network at once may cause losses.
+Bursting more than an intial window's worth of data into the network might cause short-term congestion and losses.
 Implemementations SHOULD use pacing, ACK-clocking, a reduction in CWND and/or
 timers to minimize bursts.
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -763,7 +763,7 @@ Implemementations SHOULD either use pacing or reduce their congestion window to 
 timers to minimize bursts.
 
 A sender MAY implement alternate mechanisms to update its congestion window
-after idle periods, such as those proposed for TCP in {{?RFC7661}}.
+after periods of under-utilization, such as those proposed for TCP in {{?RFC7661}}.
 
 
 # Security Considerations

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -758,12 +758,13 @@ and not fully utilize the congestion window due to this delay. A sender
 should not consider itself application limited if it would have fully
 utilized the congestion window without pacing delay.
 
-Bursting more than an intial window's worth of data into the network might cause short-term congestion and losses.
-Implemementations SHOULD either use pacing or reduce their congestion window to limit such bursts.
-timers to minimize bursts.
+Bursting more than an intial window's worth of data into the network might
+cause short-term congestion and losses. Implemementations SHOULD either use
+pacing or reduce their congestion window to limit such bursts.
 
 A sender MAY implement alternate mechanisms to update its congestion window
-after periods of under-utilization, such as those proposed for TCP in {{?RFC7661}}.
+after periods of under-utilization, such as those proposed for TCP in
+{{?RFC7661}}.
 
 
 # Security Considerations


### PR DESCRIPTION
Combines the section on sending after idle and application limited because they share a lot in common.

Praveen, I think this is better, but tell me if you'd like to add/change something else?

Fixes #2554 and #2555 