### PR TITLE
Add further guidance related to unidirectional stream TPs

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -331,7 +331,7 @@ remote peers may wish to exercise reserved stream behaviour ({{stream-grease}}).
 To reduce the likelihood of blocking, both clients and servers SHOULD send a
 value of three or greater for the QUIC transport parameter
 `initial_max_uni_streams`, and a value of 1,024 or greater for the QUIC
-transport `initial_max_stream_data_uni`.
+transport parameter `initial_max_stream_data_uni`.
 
 If the stream header indicates a stream type which is not supported by the
 recipient, the remainder of the stream cannot be consumed as the semantics are

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -325,14 +325,12 @@ The performance of HTTP/3 connections in the early phase of their lifetime is
 sensitive to the creation and exchange of data on unidirectional streams.
 Endpoints that set low values for the QUIC transport parameters
 `initial_max_uni_streams` and `initial_max_stream_data_uni` will increase the
-chance that the remote peer reaches the limit early. In particular, the value
-chosen for `initial_max_uni_streams` should consider that remote peers may wish
-to exercise reserved stream behaviour ({{stream-grease}}). Limits can be
-increased post handshake at the cost of additional RTT, for example by
-exchanging `STREAMS_BLOCKED` and `MAX_STREAMS` QUIC frames. To reduce the
-possibility of this situation occuring, both clients and servers SHOULD send a
+chance that the remote peer reaches the limit early and becomes blocked. In
+particular, the value chosen for `initial_max_uni_streams` should consider that
+remote peers may wish to exercise reserved stream behaviour ({{stream-grease}}).
+To reduce the likelihood of blocking, both clients and servers SHOULD send a
 value of three or greater for the QUIC transport parameter
-`initial_max_uni_streams`, and a value of eight or greater for the QUIC
+`initial_max_uni_streams`, and a value of 1,024 or greater for the QUIC
 transport `initial_max_stream_data_uni`.
 
 If the stream header indicates a stream type which is not supported by the

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -321,8 +321,19 @@ defined in this document: control streams ({{control-streams}}) and push streams
 ({{push-streams}}).  Other stream types can be defined by extensions to HTTP/3;
 see {{extensions}} for more details.
 
-Both clients and servers SHOULD send a value of three or greater for the QUIC
-transport parameter `initial_max_uni_streams`.
+The performance of HTTP/3 connections in the early phase of their lifetime is
+sensitive to the creation and exchange of data on unidirectional streams.
+Endpoints that set low values for the QUIC transport parameters
+`initial_max_uni_streams` and `initial_max_stream_data_uni` will increase the
+chance that the remote peer reaches the limit early. In particular, the value
+chosen for `initial_max_uni_streams` should consider that remote peers may wish
+to exercise reserved stream behaviour ({{stream-grease}}). Limits can be
+increased post handshake at the cost of additional RTT, for example by
+exchanging `STREAMS_BLOCKED` and `MAX_STREAMS` QUIC frames. To reduce the
+possibility of this situation occuring, both clients and servers SHOULD send a
+value of three or greater for the QUIC transport parameter
+`initial_max_uni_streams`, and a value of eight or greater for the QUIC
+transport `initial_max_stream_data_uni`.
 
 If the stream header indicates a stream type which is not supported by the
 recipient, the remainder of the stream cannot be consumed as the semantics are


### PR DESCRIPTION
This goes someway to fixing #2559 and #2589.

Setting low values for unidirectional stream transport parameters means that HTTP/3 connections get stuck early. Although client and server can dance around, sending *BLOCKED frames and increasing limits, we should clearly highlight the problem and suggest some sensible, bare minimum, values. 

Fixes #2559.
Fixes #2589.