### PR TITLE
Exceeding 2^62-1 is a flow control error

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4615,7 +4615,10 @@ When a Stream Data field has a length of 0, the offset in the STREAM frame is
 the offset of the next byte that would be sent.
 
 The first byte in the stream has an offset of 0.  The largest offset delivered
-on a stream - the sum of the offset and data length - MUST be less than 2^62.
+on a stream - the sum of the offset and data length - cannot exceed 2^62-1, as
+it is not possible to provide flow control credit for that data.  Receipt of a
+frame that exceeds this limit will be treated as a connection error of type
+FLOW_CONTROL_ERROR.
 
 
 ## MAX_DATA Frame {#frame-max-data}


### PR DESCRIPTION
Fixes #2538.

The text here had a MUST prohibiting data+offset from exceeding 2^62-1.
But that is redundant with flow control, which can't express a limit
greater than this anyway.  So just point to FLOW_CONTROL_ERROR.