### PR TITLE
Clarify time threshold vs crypto timer

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -539,7 +539,7 @@ and otherwise it MUST send an Initial packet in a UDP datagram of at least
 The crypto retransmission timer is not set if the time threshold
 {{time-threshold}} loss detection timer is set.  The time threshold loss
 detection timer is expected to both expire earlier than the crypto
-retransmission timeout and be much less likely to spuriously retransmit data.
+retransmission timeout and be less likely to spuriously retransmit data.
 The Initial and Handshake packet number spaces typically have a small number
 of packets in them, so time threshold loss detection will typically declare
 packets lost before packet threshold.

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -540,10 +540,12 @@ The crypto retransmission timer is not set if the time threshold
 {{time-threshold}} loss detection timer is set.  The time threshold loss
 detection timer is expected to both expire earlier than the crypto
 retransmission timeout and be much less likely to spuriously retransmit data.
-The Initial and Handshake packet number spaces are typically going to have a
-small number of packets in them, so it's expected packet threshold loss
-detection will rarely declare packets lost before time threshold. When the
-crypto retransmission timer is active, the probe timer ({{pto}}) is not active.
+The Initial and Handshake packet number spaces typically have a small number
+of packets in them, so time threshold loss detection will typically declare
+packets lost before packet threshold.
+
+When the crypto retransmission timer is active, the probe timer ({{pto}})
+is not active.
 
 
 ### Retry and Version Negotiation

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -538,7 +538,7 @@ and otherwise it MUST send an Initial packet in a UDP datagram of at least
 
 The crypto retransmission timer is not set if the time threshold
 {{time-threshold}} loss detection timer is set.  The time threshold loss
-detection timer is both expected to expire earlier than the crypto
+detection timer is expected to both expire earlier than the crypto
 retransmission timeout and be much less likely to spuriously retransmit data.
 The Initial and Handshake packet number spaces are typically going to have a
 small number of packets in them, so it's expected packet threshold loss

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -537,8 +537,13 @@ and otherwise it MUST send an Initial packet in a UDP datagram of at least
 1200 bytes.
 
 The crypto retransmission timer is not set if the time threshold
-{{time-threshold}} loss detection timer is set.  When the crypto
-retransmission timer is active, the probe timer ({{pto}}) is not active.
+{{time-threshold}} loss detection timer is set.  The time threshold loss
+detection timer is both expected to expire earlier than the crypto
+retransmission timeout and be much less likely to spuriously retransmit data.
+The Initial and Handshake packet number spaces are typically going to have a
+small number of packets in them, so it's expected packet threshold loss
+detection will rarely declare packets lost before time threshold. When the
+crypto retransmission timer is active, the probe timer ({{pto}}) is not active.
 
 
 ### Retry and Version Negotiation

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -540,9 +540,9 @@ The crypto retransmission timer is not set if the time threshold
 {{time-threshold}} loss detection timer is set.  The time threshold loss
 detection timer is expected to both expire earlier than the crypto
 retransmission timeout and be less likely to spuriously retransmit data.
-The Initial and Handshake packet number spaces typically have a small number
-of packets in them, so time threshold loss detection will typically declare
-packets lost before packet threshold.
+The Initial and Handshake packet number spaces will typically contain a small
+number of packets, so losses are less likely to be detected using
+packet-threshold loss detection.
 
 When the crypto retransmission timer is active, the probe timer ({{pto}})
 is not active.

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1274,14 +1274,14 @@ DetectLostPackets(pn_space):
   // Packets with packet numbers before this are deemed lost.
   lost_pn = largest_acked_packet[pn_space] - kPacketThreshold
 
-  foreach unacked in sent_packets:
+  foreach unacked in sent_packets[pn_space]:
     if (unacked.packet_number > largest_acked_packet[pn_space]):
       continue
 
     // Mark packet as lost, or set time when it should be marked.
     if (unacked.time_sent <= lost_send_time ||
         unacked.packet_number <= lost_pn):
-      sent_packets.remove(unacked.packet_number)
+      sent_packets[pn_space].remove(unacked.packet_number)
       if (unacked.in_flight):
         lost_packets.insert(unacked)
     else:


### PR DESCRIPTION
Adds some explanation about why it's better to arm/fire the time threshold alarm before the crypto retransmission timeout.

Hopefully clarifies comments from #2565