### PR TITLE
lost_pn can no longer be negative

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1267,17 +1267,14 @@ DetectLostPackets(pn_space):
   // Packets sent before this time are deemed lost.
   lost_send_time = now() - loss_delay
 
-  // Packets with packet numbers before this are deemed lost.
-  lost_pn = largest_acked_packet[pn_space] - kPacketThreshold
-
   foreach unacked in sent_packets:
     if (unacked.packet_number > largest_acked_packet[pn_space]):
       continue
 
     // Mark packet as lost, or set time when it should be marked.
     if (unacked.time_sent <= lost_send_time ||
-        (largest_acked_packet[pn_space] != infinite &&
-         unacked.packet_number <= lost_pn)):
+        largest_acked_packet[pn_space] >
+          unacked.packet_number + kPacketThreshold):
       sent_packets.remove(unacked.packet_number)
       if (unacked.in_flight):
         lost_packets.insert(unacked)

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1076,8 +1076,11 @@ Pseudocode for OnAckReceived and UpdateRtt follow:
 
 ~~~
 OnAckReceived(ack, pn_space):
-  largest_acked_packet[pn_space] =
-      max(largest_acked_packet[pn_space], ack.largest_acked)
+  if (largest_acked_packet[pn_space] == infinite):
+    largest_acked_packet[pn_space] = ack.largest_acked
+  else:
+    largest_acked_packet[pn_space] =
+        max(largest_acked_packet[pn_space], ack.largest_acked)
 
   // Nothing to do if there are no newly acked packets.
   newly_acked_packets = DetermineNewlyAckedPackets(ack, pn_space)

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1260,6 +1260,7 @@ Pseudocode for DetectLostPackets follows:
 
 ~~~
 DetectLostPackets(pn_space):
+  assert(largest_acked_packet[pn_space] != infinite)
   loss_time[pn_space] = 0
   lost_packets = {}
   loss_delay = kTimeThreshold * max(latest_rtt, smoothed_rtt)

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1036,7 +1036,7 @@ follows:
    time_of_last_sent_ack_eliciting_packet = 0
    time_of_last_sent_crypto_packet = 0
    for pn_space in [ Initial, Handshake, ApplicationData ]:
-     largest_acked_packet[pn_space] = 0
+     largest_acked_packet[pn_space] = infinite
      loss_time[pn_space] = 0
 ~~~
 
@@ -1273,7 +1273,8 @@ DetectLostPackets(pn_space):
 
     // Mark packet as lost, or set time when it should be marked.
     if (unacked.time_sent <= lost_send_time ||
-        unacked.packet_number <= lost_pn):
+        (largest_acked_packet[pn_space] != infinite &&
+         unacked.packet_number <= lost_pn)):
       sent_packets.remove(unacked.packet_number)
       if (unacked.in_flight):
         lost_packets.insert(unacked)

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1273,7 +1273,7 @@ DetectLostPackets(pn_space):
 
     // Mark packet as lost, or set time when it should be marked.
     if (unacked.time_sent <= lost_send_time ||
-        largest_acked_packet[pn_space] >
+        largest_acked_packet[pn_space] >=
           unacked.packet_number + kPacketThreshold):
       sent_packets.remove(unacked.packet_number)
       if (unacked.in_flight):


### PR DESCRIPTION
And 0 is a valid packet number, so defaulting largest_acked_packet to 0 is inherently incorrect.

Fixes #2611