### PR TITLE
Add details of marking packets lost on PTO

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1246,11 +1246,10 @@ OnLossDetectionTimeout():
        SendOnePaddedInitialPacket()
     crypto_count++
   else:
-    // PTO
-    pto_count++
-    // Send data if new data is available, else retransmit old data.
+    // PTO. Send new data if available, else retransmit old data.
     // If neither is available, send PING frames.
     SendOneOrTwoPackets()
+    pto_count++
 
   SetLossDetectionTimer()
 ~~~

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1251,7 +1251,7 @@ OnLossDetectionTimeout():
     crypto_count++
   else:
     // PTO. Send new data if available, else retransmit old data.
-    // If neither is available, send a PING frame.
+    // If neither is available, send a single PING frame.
     SendOneOrTwoPackets()
     pto_count++
 
@@ -1464,7 +1464,7 @@ Invoked when an ACK frame with an ECN section is received from the peer.
 
 ## On Packets Lost
 
-Invoked when packets are deemed lost.
+Invoked when packets are deemed lost in DetectLostPackets.
 
 ~~~
    InPersistentCongestion(largest_lost_packet):

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -631,8 +631,8 @@ due to a single packet loss.
 It is possible that the sender has no new or previously-sent data to send.  For
 example, this can happen when there is no new application data to send and all
 streams with data in flight are reset (see Section 13.2 of {{QUIC-TRANSPORT}}).
-Under these conditions, the sender SHOULD send a PING or another ack-eliciting
-frame, and re-arm the PTO timer.
+Under these conditions, the sender SHOULD send PING or other ack-eliciting
+frames in up to two packets, re-arming the PTO timer.
 
 When there is no data to send, the sender MAY mark any packets still in flight
 as lost instead of sending an additional ack-eliciting packet.  Doing so might

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -638,7 +638,7 @@ or previously-sent data to send.
 When there is no data to send, the sender SHOULD send a PING or other
 ack-eliciting frame in a single packet, re-arming the PTO timer.
 
-Alternatively, instead of sending the ack-eliciting packet, the sender MAY mark
+Alternatively, instead of sending an ack-eliciting packet, the sender MAY mark
 any packets still in flight as lost.  Doing so avoids sending an additional
 packet, but increases the risk that loss is declared too aggressively, resulting
 in an unnecessary rate reduction by the congestion controller.

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1464,7 +1464,7 @@ Invoked when an ACK frame with an ECN section is received from the peer.
 
 ## On Packets Lost
 
-Invoked when packets are deemed lost in DetectLostPackets.
+Invoked from DetectLostPackets when packets are deemed lost.
 
 ~~~
    InPersistentCongestion(largest_lost_packet):

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1251,7 +1251,7 @@ OnLossDetectionTimeout():
     crypto_count++
   else:
     // PTO. Send new data if available, else retransmit old data.
-    // If neither is available, send PING frames.
+    // If neither is available, send a PING frame.
     SendOneOrTwoPackets()
     pto_count++
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1246,7 +1246,7 @@ OnLossDetectionTimeout():
   else:
     // PTO
     pto_count++
-    if (new data, old data, or other ack-eliciting frames available):
+    if (any ack-eliciting frames available to send):
       SendOneOrTwoPackets()
     else:
       // Mark all packets in flight as lost

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -592,7 +592,7 @@ TCP's retransmission timeout period {{?RFC6298}}.
 
 ### Computing PTO
 
-When an ack-eliciting packet is transmitted, the endpoint schedules a timer for
+When an ack-eliciting packet is transmitted, the sender schedules a timer for
 the PTO period as follows:
 
 ~~~
@@ -602,7 +602,7 @@ PTO = smoothed_rtt + max(4*rttvar, kGranularity) + max_ack_delay
 kGranularity, smoothed_rtt, rttvar, and max_ack_delay are defined in
 {{ld-consts-of-interest}} and {{ld-vars-of-interest}}.
 
-The PTO period is the amount of time that an endpoint ought to wait for an
+The PTO period is the amount of time that a sender ought to wait for an
 acknowledgement of a sent packet.  This time period includes the estimated
 network roundtrip-time (smoothed_rtt), the variance in the estimate (4*rttvar),
 and max_ack_delay, to account for the maximum time by which a receiver might
@@ -611,31 +611,30 @@ delay sending an acknowledgement.
 The PTO value MUST be set to at least kGranularity, to avoid the timer expiring
 immediately.
 
-When a PTO timer expires, the endpoint probes the network as described in the
-next section. The PTO period MUST be set to twice its current value. This
-exponential reduction in the endpoint's sending rate is important because the
-PTOs might be caused by loss of packets or acknowledgements due to severe
-congestion.
+When a PTO timer expires, the sender probes the network as described in the next
+section. The PTO period MUST be set to twice its current value. This exponential
+reduction in the sender's rate is important because the PTOs might be caused by
+loss of packets or acknowledgements due to severe congestion.
 
-An endpoint computes its PTO timer every time an ack-eliciting packet is
-sent. An endpoint might choose to optimize this by setting the timer fewer times
-if it knows that more ack-eliciting packets will be sent within a short period
-of time.
+A sender computes its PTO timer every time an ack-eliciting packet is sent. A
+sender might choose to optimize this by setting the timer fewer times if it
+knows that more ack-eliciting packets will be sent within a short period of
+time.
 
 ### Sending Probe Packets
 
-When a PTO timer expires, an endpoint MUST send at least one ack-eliciting
-packet as a probe, unless there are no ack-eliciting frames to send.  An
-endpoint MAY send up to two ack-eliciting packets, to avoid an expensive
-consecutive PTO expiration due to a single packet loss.
+When a PTO timer expires, a sender MUST send at least one ack-eliciting packet
+as a probe, unless there are no ack-eliciting frames to send.  An endpoint MAY
+send up to two ack-eliciting packets, to avoid an expensive consecutive PTO
+expiration due to a single packet loss.
 
-It is possible that the endpoint has no new or previously-sent data or other
-ack-eliciting frames to send.  This can happen for example when there is no new
+It is possible that the sender has no new or previously-sent data or other
+ack-eliciting frames to send.  For example, this can happen when there is no new
 application data to send and all streams with data in flight are reset (see
-Section 13.2 of {{QUIC-TRANSPORT}}).  Under these conditions, the endpoint
-SHOULD mark any packets still in flight as lost.  The endpoint MAY send an
-ack-eliciting packet and re-arm the PTO timer instead, to avoid aggressively
-marking packets as lost (with the resulting congestion controller reaction).
+Section 13.2 of {{QUIC-TRANSPORT}}).  Under these conditions, the sender SHOULD
+mark any packets still in flight as lost.  The sender MAY send an ack-eliciting
+packet and re-arm the PTO timer instead, to avoid aggressively marking packets
+as lost (with the resulting congestion controller reaction).
 
 Consecutive PTO periods increase exponentially, and as a result, connection
 recovery latency increases exponentially as packets continue to be dropped in

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -628,16 +628,20 @@ as a probe, unless there is no data available to send.  An endpoint MAY send up
 to two ack-eliciting packets, to avoid an expensive consecutive PTO expiration
 due to a single packet loss.
 
-It is possible that the sender has no new or previously-sent data to send.  For
-example, this can happen when there is no new application data to send and all
-streams with data in flight are reset (see Section 13.2 of {{QUIC-TRANSPORT}}).
-Under these conditions, the sender SHOULD send PING or other ack-eliciting
-frames in up to two packets, re-arming the PTO timer.
+It is possible that the sender has no new or previously-sent data to send.  As
+an example, consider the following sequence of events: new application data is
+sent in a STREAM frame, deemed lost, then retransmitted in a new packet, and
+then the original transmission is acknowledged.  In the absence of any new
+application data, a PTO timer expiration now would find the sender with no new
+or previously-sent data to send.
 
-When there is no data to send, the sender MAY mark any packets still in flight
-as lost instead of sending an additional ack-eliciting packet.  Doing so might
-cause packets currently in flight to be aggressively marked as lost, with the
-resulting congestion controller reaction.
+When there is no data to send, the sender SHOULD send PING or other
+ack-eliciting frames in a single packet, re-arming the PTO timer.
+
+Alternatively, the sender MAY avoid sending an additional packet by marking any
+packets still in flight as lost. Doing so however increases the risk of the
+sender declaring a packet as lost when it might not be, resulting in unnecessary
+rate reduction by the congestion controller.
 
 Consecutive PTO periods increase exponentially, and as a result, connection
 recovery latency increases exponentially as packets continue to be dropped in


### PR DESCRIPTION
This PR adds text and pseudo-code to clarify what an endpoint should do when PTO fires and there is no data or other ack-eliciting frames to send.

Closes #2493.