### PR TITLE
Use semicolons for section references

### DIFF
--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -507,7 +507,7 @@ identifies which dynamic table entries can be referenced using relative
 indexing, starting with 0 at the last entry added.
 
 Post-Base references are used for entries inserted after base, starting at 0 for
-the first entry added after the Base, see {{post-base}}.
+the first entry added after the Base; see {{post-base}}.
 
 ~~~~~ drawing
  Required

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -305,7 +305,7 @@ Ack Delay field in an ACK frame.
 
 An endpoint MUST NOT excessively delay acknowledgements of ack-eliciting
 packets.  The maximum ack delay is communicated in the max_ack_delay transport
-parameter, see Section 18.1 of {{QUIC-TRANSPORT}}.  max_ack_delay implies an
+parameter; see Section 18.1 of {{QUIC-TRANSPORT}}.  max_ack_delay implies an
 explicit contract: an endpoint promises to never delay acknowledgments of an
 ack-eliciting packet by more than the indicated value. If it does, any excess
 accrues to the RTT estimate and could result in spurious retransmissions from
@@ -671,7 +671,7 @@ received that newly acknowledges one or more packets.
 A PTO timer expiration event does not indicate packet loss and MUST NOT cause
 prior unacknowledged packets to be marked as lost. When an acknowledgement
 is received that newly acknowledges packets, loss detection proceeds as
-dictated by packet and time threshold mechanisms, see {{ack-loss-detection}}.
+dictated by packet and time threshold mechanisms; see {{ack-loss-detection}}.
 
 
 ## Discussion

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -656,7 +656,7 @@ alerts at the "warning" level.
 After QUIC moves to a new encryption level, packet protection keys for previous
 encryption levels can be discarded.  This occurs several times during the
 handshake, as well as when keys are updated (see {{key-update}}).  Initial
-packet protection keys are treated specially, see {{discard-initial}}.
+packet protection keys are treated specially; see {{discard-initial}}.
 
 Packet protection keys are not discarded immediately when new keys are
 available.  If packets from a lower encryption level contain CRYPTO frames,
@@ -749,10 +749,10 @@ cipher suite.  Other versions of TLS MUST provide a similar function in order to
 be used with QUIC.
 
 The current encryption level secret and the label "quic key" are input to the
-KDF to produce the AEAD key; the label "quic iv" is used to derive the IV, see
-{{aead}}.  The header protection key uses the "quic hp" label, see
+KDF to produce the AEAD key; the label "quic iv" is used to derive the IV; see
+{{aead}}.  The header protection key uses the "quic hp" label; see
 {{header-protect}}.  Using these labels provides key separation between QUIC
-and TLS, see {{key-diversity}}.
+and TLS; see {{key-diversity}}.
 
 The KDF used for initial secrets is always the HKDF-Expand-Label function from
 TLS 1.3 (see {{initial-secrets}}).
@@ -1137,7 +1137,7 @@ a reciprocal update.  An endpoint MUST treat consecutive key updates as a fatal
 error and abort the connection.
 
 An endpoint SHOULD retain old keys for a period of no more than three times the
-Probe Timeout (PTO, see {{QUIC-RECOVERY}}).  After this period, old keys and
+Probe Timeout (PTO; see {{QUIC-RECOVERY}}).  After this period, old keys and
 their corresponding secrets SHOULD be discarded.  Retaining keys allow endpoints
 to process packets that were sent with old keys and delayed in the network.
 Packets with higher packet numbers always use the updated keys and MUST NOT be

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -693,7 +693,7 @@ described in {{controlling-concurrency}}.
 
 Data sent in CRYPTO frames is not flow controlled in the same way as stream
 data.  QUIC relies on the cryptographic protocol implementation to avoid
-excessive buffering of data, see {{QUIC-TLS}}.  The implementation SHOULD
+excessive buffering of data; see {{QUIC-TLS}}.  The implementation SHOULD
 provide an interface to QUIC to tell it about its buffering limits so that there
 is not excessive buffering at multiple layers.
 
@@ -912,7 +912,7 @@ than once on the same connection.
 
 Packets with long headers include Source Connection ID and Destination
 Connection ID fields.  These fields are used to set the connection IDs for new
-connections, see {{negotiating-connection-ids}} for details.
+connections; see {{negotiating-connection-ids}} for details.
 
 Packets with short headers ({{short-header}}) only include the Destination
 Connection ID and omit the explicit length.  The length of the Destination
@@ -984,7 +984,7 @@ connection if the pool is exhausted.
 
 An endpoint can change the connection ID it uses for a peer to another available
 one at any time during the connection.  An endpoint consumes connection IDs in
-response to a migrating peer, see {{migration-linkability}} for more.
+response to a migrating peer; see {{migration-linkability}} for more.
 
 An endpoint maintains a set of connection IDs received from its peer, any of
 which it can use when sending packets.  When the endpoint wishes to remove a
@@ -1112,7 +1112,7 @@ suggested structure:
 
 Version negotiation ensures that client and server agree to a QUIC version
 that is mutually supported. A server sends a Version Negotiation packet in
-response to each packet that might initiate a new connection, see
+response to each packet that might initiate a new connection; see
 {{packet-handling}} for details.
 
 The size of the first packet sent by a client will determine whether a server
@@ -1362,7 +1362,7 @@ problems that might arise from stateless processing of multiple Initial packets
 producing different connection IDs.
 
 The connection ID can change over the lifetime of a connection, especially in
-response to connection migration ({{migration}}), see {{issue-cid}} for details.
+response to connection migration ({{migration}}); see {{issue-cid}} for details.
 
 
 ## Transport Parameters {#transport-parameters}
@@ -2215,7 +2215,7 @@ current Probe Timeout (PTO).
 Each endpoint advertises its own idle timeout to its peer.  An endpoint
 restarts any timer it maintains when a packet from its peer is received and
 processed successfully.  The timer is also restarted when sending a packet
-containing frames other than ACK or PADDING (an ACK-eliciting packet, see
+containing frames other than ACK or PADDING (an ACK-eliciting packet; see
 {{QUIC-RECOVERY}}), but only if no other ACK-eliciting packets have been sent
 since last receiving a packet.  Restarting when sending packets ensures that
 connections do not prematurely time out when initiating new activity.
@@ -2225,7 +2225,7 @@ endpoint is only used to determine whether the connection is live at that
 endpoint.  An endpoint that sends packets near the end of the idle timeout
 period of a peer risks having those packets discarded if its peer enters the
 draining state before the packets arrive.  If a peer could timeout within an
-Probe Timeout (PTO, see Section 6.2.2 of {{QUIC-RECOVERY}}), it is advisable to
+Probe Timeout (PTO; see Section 6.2.2 of {{QUIC-RECOVERY}}), it is advisable to
 test for liveness before sending any data that cannot be retried safely.  Note
 that it is likely that only applications or application protocols will
 know what information can be retried.
@@ -2371,7 +2371,7 @@ Using a randomized connection ID results in two problems:
 
 * The packet might not reach the peer.  If the Destination Connection ID is
   critical for routing toward the peer, then this packet could be incorrectly
-  routed.  This might also trigger another Stateless Reset in response, see
+  routed.  This might also trigger another Stateless Reset in response; see
   {{reset-looping}}.  A Stateless Reset that is not correctly routed is
   an ineffective error detection and recovery mechanism.  In this
   case, endpoints will need to rely on other methods - such as timers - to
@@ -2579,7 +2579,7 @@ corresponding keys.
 The packet number field contains a packet number, which has additional
 confidentiality protection that is applied after packet protection is applied
 (see {{QUIC-TLS}} for details).  The underlying packet number increases with
-each packet sent in a given packet number space, see {{packet-numbers}} for
+each packet sent in a given packet number space; see {{packet-numbers}} for
 details.
 
 
@@ -2906,7 +2906,7 @@ containing that information is acknowledged.
 
 * Similarly, a request to cancel stream transmission, as encoded in a
   STOP_SENDING frame, is sent until the receiving part of the stream enters
-  either a "Data Recvd" or "Reset Recvd" state, see
+  either a "Data Recvd" or "Reset Recvd" state; see
   {{solicited-state-transitions}}.
 
 * Connection close signals, including packets that contain CONNECTION_CLOSE
@@ -3099,7 +3099,7 @@ combining the Initial packet with a 0-RTT packet (see {{packet-coalesce}}).
 Sending a UDP datagram of this size ensures that the network path supports a
 reasonable Maximum Transmission Unit (MTU), and helps reduce the amplitude of
 amplification attacks caused by server responses toward an unverified client
-address, see {{address-validation}}.
+address; see {{address-validation}}.
 
 The datagram containing the first Initial packet from a client MAY exceed 1200
 bytes if the client believes that the Path Maximum Transmission Unit (PMTU)
@@ -3112,7 +3112,7 @@ response, or otherwise behave as if any part of the offending packet was
 processed as valid.
 
 The server MUST also limit the number of bytes it sends before validating the
-address of the client, see {{address-validation}}.
+address of the client; see {{address-validation}}.
 
 
 ## Path Maximum Transmission Unit (PMTU)
@@ -3840,7 +3840,7 @@ message or construct a new one at its discretion.
 A client MAY attempt 0-RTT after receiving a Retry packet by sending 0-RTT
 packets to the connection ID provided by the server.  A client that sends
 additional 0-RTT packets without constructing a new cryptographic handshake
-message MUST NOT reset the packet number to 0 after a Retry packet, see
+message MUST NOT reset the packet number to 0 after a Retry packet; see
 {{packet-0rtt}}.
 
 A server acknowledges the use of a Retry packet for a connection using the
@@ -4061,13 +4061,13 @@ original_connection_id (0x0000):
 
 idle_timeout (0x0001):
 
-: The idle timeout is a value in milliseconds that is encoded as an integer, see
+: The idle timeout is a value in milliseconds that is encoded as an integer; see
   ({{idle-timeout}}).  If this parameter is absent or zero then the idle
   timeout is disabled.
 
 stateless_reset_token (0x0002):
 
-: A stateless reset token is used in verifying a stateless reset, see
+: A stateless reset token is used in verifying a stateless reset; see
   {{stateless-reset}}.  This parameter is a sequence of 16 bytes.  This
   transport parameter is only sent by a server.
 
@@ -4317,11 +4317,11 @@ First ACK Range:
 ACK Ranges:
 
 : Contains additional ranges of packets which are alternately not
-  acknowledged (Gap) and acknowledged (ACK Range), see {{ack-ranges}}.
+  acknowledged (Gap) and acknowledged (ACK Range); see {{ack-ranges}}.
 
 ECN Counts:
 
-: The three ECN Counts, see {{ack-ecn-counts}}.
+: The three ECN Counts; see {{ack-ecn-counts}}.
 
 
 ### ACK Ranges {#ack-ranges}
@@ -5073,7 +5073,7 @@ Error Code:
 : A 16-bit error code which indicates the reason for closing this connection.  A
   CONNECTION_CLOSE frame of type 0x1c uses codes from the space defined in
   {{error-codes}}.  A CONNECTION_CLOSE frame of type 0x1d uses codes from the
-  application protocol error code space, see {{app-error-codes}}
+  application protocol error code space; see {{app-error-codes}}
 
 Frame Type:
 
@@ -5112,7 +5112,7 @@ be sent.  The exception is extension frames that replace or supplement the ACK
 frame.  Extension frames are not included in flow control unless specified
 in the extension.
 
-An IANA registry is used to manage the assignment of frame types, see
+An IANA registry is used to manage the assignment of frame types; see
 {{iana-frames}}.
 
 


### PR DESCRIPTION
"This is a description of something technical; see {{place}} [for more details]." is more correct than "This is a description of something technical, see {{place}} [for more details]." because the "...see {{place}}" is a separate thought.  The comma is appropriate when it's saying "For more details, see {{place}}." because that's a single thought.

We have a mix throughout the documents; this PR attempts to reconcile them.