### PR TITLE
Recommend of per-connection ID randomness for spin bit

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3975,8 +3975,7 @@ measurement points.
 
 When the spin bit is disabled, endpoints MAY set the spin bit to any value, and
 MUST ignore any incoming value. It is RECOMMENDED that endpoints set the spin
-bit to a random value either chosen independently for each packet or chosen
-independently for each connection ID.
+bit to a random value chosen independently for each connection ID.
 
 If the spin bit is enabled for the connection, the endpoint maintains a spin
 value and sets the spin bit in the short header to the currently stored


### PR DESCRIPTION
This was discussed on the original PR. While it is perfectly okay for an endpoint to set a per-packet random value (because there is also nothing we could even do to avoid that), I strongly think that this document should RECOMMEND per-flow/conn-ID randomness.