### PR TITLE
Fix stale reference and edge case in GOAWAY text

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1318,6 +1318,10 @@ connection to become idle, or MAY initiate an immediate closure of the
 connection.  An endpoint that completes a graceful shutdown SHOULD use the
 HTTP_NO_ERROR code when closing the connection.
 
+If a client has consumed all available bidirectional stream IDs with requests,
+the server need not send a GOAWAY frame; the client is unable to make further
+requests.
+
 ## Immediate Application Closure
 
 An HTTP/3 implementation can immediately close the QUIC connection at any time.

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -831,7 +831,7 @@ The MAX_PUSH_ID frame (type=0xD) is used by clients to control the number of
 server pushes that the server can initiate.  This sets the maximum value for a
 Push ID that the server can use in a PUSH_PROMISE frame.  Consequently, this
 also limits the number of push streams that the server can initiate in addition
-to the limit set by the QUIC MAX_STREAM_ID frame.
+to the limit set by the QUIC MAX_STREAMS frame.
 
 The MAX_PUSH_ID frame is always sent on the control stream.  Receipt of a
 MAX_PUSH_ID frame on any other stream MUST be treated as a connection error of

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1319,7 +1319,7 @@ connection.  An endpoint that completes a graceful shutdown SHOULD use the
 HTTP_NO_ERROR code when closing the connection.
 
 If a client has consumed all available bidirectional stream IDs with requests,
-the server need not send a GOAWAY frame; the client is unable to make further
+the server need not send a GOAWAY frame, since the client is unable to make further
 requests.
 
 ## Immediate Application Closure


### PR DESCRIPTION
Makes two minor fixes in the GOAWAY text, both editorial:
- Correctly references the MAX_STREAMS frame instead of the MAX_STREAM_ID frame
- Notes that servers need not (and cannot) send a GOAWAY if the client has used up all the possible stream IDs; the client simply won't be making any more requests.