### PR TITLE
Targeted attacks in Security Considerations

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -5385,11 +5385,11 @@ define a mechanism that is robust against version downgrade attacks.
 ## Targeted Attacks by Routing
 
 Deployments should limit the ability of an attacker to target a new connection
-to a particular server instance.  This means that client-controlled fields, such as the
-initial Destination Connection ID used on Initial and 0-RTT packets SHOULD NOT
-be used by themselves to make routing decisions.  Ideally, routing decisions are made
-independently of client-selected values; a Source Connection ID can be selected
-to route later packets to the same server.
+to a particular server instance.  This means that client-controlled fields, such
+as the initial Destination Connection ID used on Initial and 0-RTT packets
+SHOULD NOT be used by themselves to make routing decisions.  Ideally, routing
+decisions are made independently of client-selected values; a Source Connection
+ID can be selected to route later packets to the same server.
 
 # IANA Considerations
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -5385,11 +5385,11 @@ define a mechanism that is robust against version downgrade attacks.
 ## Targeted Attacks by Routing
 
 Deployments should limit the ability of an attacker to target a new connection
-to a particular instance.  This means that client-controlled fields, such as the
+to a particular server instance.  This means that client-controlled fields, such as the
 initial Destination Connection ID used on Initial and 0-RTT packets SHOULD NOT
-be used to make routing decisions.  Ideally, routing decisions are made
+be used by themselves to make routing decisions.  Ideally, routing decisions are made
 independently of client-selected values; a Source Connection ID can be selected
-to route subsequent packets to the same server.
+to route later packets to the same server.
 
 # IANA Considerations
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -5382,6 +5382,14 @@ Negotiation packets do not contain any mechanism to prevent version downgrade
 attacks.  Future versions of QUIC that use Version Negotiation packets MUST
 define a mechanism that is robust against version downgrade attacks.
 
+## Targeted Attacks by Routing
+
+Deployments should limit the ability of an attacker to target a new connection
+to a particular instance.  This means that client-controlled fields, such as the
+initial Destination Connection ID used on Initial and 0-RTT packets SHOULD NOT
+be used to make routing decisions.  Ideally, routing decisions are made
+independently of client-selected values; a Source Connection ID can be selected
+to route subsequent packets to the same server.
 
 # IANA Considerations
 


### PR DESCRIPTION
I went to fix #2026 and found that the offending text was already removed, so we're most of the way there.  I added a note to the Security Considerations about not letting clients dictate your routing decisions.