### PR TITLE
Stop requiring remote address to match during path validation

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1707,12 +1707,6 @@ meets the following criteria:
   acknowledgment for a packet containing a PATH_CHALLENGE frame is not adequate
   validation, since the acknowledgment can be spoofed by a malicious peer.
 
-- It was sent from the same remote address to which the corresponding
-  PATH_CHALLENGE was sent. If a PATH_RESPONSE frame is received from a different
-  remote address than the one to which the PATH_CHALLENGE was sent, path
-  validation is considered to have failed, even if the data matches that sent in
-  the PATH_CHALLENGE.
-
 - It was received on the same local address from which the corresponding
   PATH_CHALLENGE was sent.
 
@@ -1755,9 +1749,9 @@ initiated while a path validation on the old path is in progress.
 # Connection Migration {#migration}
 
 The use of a connection ID allows connections to survive changes to endpoint
-addresses (that is, IP address and/or port), such as those caused by an endpoint
-migrating to a new network.  This section describes the process by which an
-endpoint migrates to a new address.
+addresses (the two-tuple of IP address and port), such as those caused by an
+endpoint migrating to a new network.  This section describes the process by
+which an endpoint migrates to a new address.
 
 An endpoint MUST NOT initiate connection migration before the handshake is
 finished and the endpoint has 1-RTT keys.  The design of QUIC relies on
@@ -1773,10 +1767,9 @@ Connection ID cannot be attributed to a connection based on address tuple.
 
 Not all changes of peer address are intentional migrations. The peer could
 experience NAT rebinding: a change of address due to a middlebox, usually a NAT,
-allocating a new outgoing port or even a new outgoing IP address for a flow.
-NAT rebinding is not connection migration as defined in this section, though an
-endpoint SHOULD perform path validation ({{migrate-validate}}) if it detects a
-change in the IP address of its peer.
+allocating a new outgoing port or even a new outgoing IP address for a flow.  An
+endpoint MUST perform path validation ({{migrate-validate}}) if it detects any
+change to a peer's address, unless it has previously validated that address.
 
 When an endpoint has no validated path on which to send packets, it MAY discard
 connection state.  An endpoint capable of connection migration MAY wait for a

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1699,11 +1699,6 @@ it can associate the peer's response with the corresponding PATH_CHALLENGE.
 On receiving a PATH_CHALLENGE frame, an endpoint MUST respond immediately by
 echoing the data contained in the PATH_CHALLENGE frame in a PATH_RESPONSE frame.
 
-To ensure that packets can be both sent to and received from the peer, the
-PATH_RESPONSE MUST be sent on the same path as the triggering PATH_CHALLENGE.
-That is, from the same local address on which the PATH_CHALLENGE was received,
-to the same remote address from which the PATH_CHALLENGE was received.
-
 
 ## Successful Path Validation
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1756,7 +1756,7 @@ initiated while a path validation on the old path is in progress.
 # Connection Migration {#migration}
 
 The use of a connection ID allows connections to survive changes to endpoint
-addresses (the two-tuple of IP address and port), such as those caused by an
+addresses (IP address and port), such as those caused by an
 endpoint migrating to a new network.  This section describes the process by
 which an endpoint migrates to a new address.
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1708,14 +1708,9 @@ to the same remote address from which the PATH_CHALLENGE was received.
 ## Successful Path Validation
 
 A new address is considered valid when a PATH_RESPONSE frame is received that
-meets the following criteria:
-
-- It contains the data that was sent in a previous PATH_CHALLENGE. Receipt of an
-  acknowledgment for a packet containing a PATH_CHALLENGE frame is not adequate
-  validation, since the acknowledgment can be spoofed by a malicious peer.
-
-- It was received on the same local address from which the corresponding
-  PATH_CHALLENGE was sent.
+contains the data that was sent in a previous PATH_CHALLENGE. Receipt of an
+acknowledgment for a packet containing a PATH_CHALLENGE frame is not adequate
+validation, since the acknowledgment can be spoofed by a malicious peer.
 
 Note that receipt on a different local address does not result in path
 validation failure, as it might be a result of a forwarded packet (see


### PR DESCRIPTION
This covers a few issues and attempts to clean up the normative text, further editorial rearranging is for a future PR, since we need to agree on some changes to the requirements first.

This removes the requirement that the remote address match between PATH_CHALLENGE/PATH_RESPONSE. 

As @martinduke said in #2582: 
>With PATH_CHALLENGE going out on both paths, these duplicate packets create four outcomes depending on which packets arrive first: both paths appear to be valid, the right path only is valid, the wrong path only is valid, or neither path is valid. The current requirement that the source address of PATH_RESPONSE matches the destination of the PATH_CHALLENGE can cause validation of the correct path to fail.

In #2580, there was some thought around performing path validation as a MUST "unless the endpoint has other means validate the validate the new path". This text is a little stronger, saying that you MUST validate unless you have already done so and remembered --some of the mitigations to attacks being described rely on a guarantee that validation occurs (and on both the old and the new paths). If folks wanted to have a completely separate mechanism for validating paths and considered their server/client to "know better", I'm not saying we should prohibit that, but such a mechanism would need to be analyzed in terms of the possible attacks.

So far, I *think* this closes out the changes to actual requirements that are necessary, and can be followed with an editorial pass to group the requirements in a way that's less confusing to first time readers (and thanks to @martinduke and others who gave this a close read in Prague!).

Closes #2582, closes #2580, closes #2579.