### PR TITLE
Reference 8.2 of RFC7540 to explain Server Push

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -944,6 +944,10 @@ able to send stream data first after the cryptographic handshake completes.
 
 ### Push Streams
 
+Server push is an optional feature introduced in HTTP/2 that allows a server to
+initiate a response before a request has been made.  See section 8.2 of
+{{!RFC7540}} for more details.
+
 A push stream is indicated by a stream type of `0x01`, followed by the Push ID
 of the promise that it fulfills, encoded as a variable-length integer. The
 remaining data on this stream consists of HTTP/3 frames, as defined in

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -948,8 +948,8 @@ able to send stream data first after the cryptographic handshake completes.
 ### Push Streams
 
 Server push is an optional feature introduced in HTTP/2 that allows a server to
-initiate a response before a request has been made.  See Section 8.2 of
-{{!RFC7540}} for more details.
+initiate a response before a request has been made.  See {{server-push}} for
+more details.
 
 A push stream is indicated by a stream type of `0x01`, followed by the Push ID
 of the promise that it fulfills, encoded as a variable-length integer. The

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -948,7 +948,7 @@ able to send stream data first after the cryptographic handshake completes.
 ### Push Streams
 
 Server push is an optional feature introduced in HTTP/2 that allows a server to
-initiate a response before a request has been made.  See section 8.2 of
+initiate a response before a request has been made.  See Section 8.2 of
 {{!RFC7540}} for more details.
 
 A push stream is indicated by a stream type of `0x01`, followed by the Push ID

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -662,8 +662,11 @@ NOT declare a dependency on a stream it knows to have been closed.
 
 ## Server Push
 
-HTTP/3 server push is similar to what is described in HTTP/2 {{!HTTP2}}, but
-uses different mechanisms.
+Server push is an interaction mode introduced in HTTP/2 {{!HTTP2}} which permits
+a server to push a request-response exchange to a client in anticipation of the
+client making the indicated request.  This trades off network usage against a
+potential latency gain.  HTTP/3 server push is similar to what is described in
+HTTP/2 {{!HTTP2}}, but uses different mechanisms.
 
 Each server push is identified by a unique Push ID. This Push ID is used in a
 single PUSH_PROMISE frame (see {{frame-push-promise}}) which carries the request


### PR DESCRIPTION
The transition to "Push Streams" has no preceding mention of server push.  This adds a reference to the correct section of RFC7540.