### PR TITLE
Output of the discard keys design team

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1101,6 +1101,7 @@ decrypt 1-RTT packets from the client.
 Even though 1-RTT keys are available to a server after receiving the first
 handshake messages from a client, it is missing assurances on the state of the
 client:
+
 - The client is not authenticated (unless the server has chosen to use a
 pre-shared key and validated the client's pre-shared key binder (see
 Section 4.2.11 of [TLS13]).

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -385,11 +385,11 @@ the handshake being complete from the perspective of the endpoint in question.
 
 In this document, the TLS handshake is considered confirmed when both of the
 following two conditions are met: the handshake is complete and the endpoint
-has received an ACK for a packet sent with 1-RTT keys.  This second condition
-can be implemented by tracking the lowest packet number sent with 1-RTT keys,
-and the highest value of the Largest Acknowledged field in any received 1-RTT
-ACK frame: once the latter is higher than the former, the handshake is
-confirmed.
+has received an acknowledgment for a packet sent with 1-RTT keys.  This second
+condition can be implemented by tracking the lowest packet number sent with
+1-RTT keys, and the highest value of the Largest Acknowledged field in any
+received 1-RTT ACK frame: once the latter is higher than the former, the
+handshake is confirmed.
 
 
 ### Sending and Receiving Handshake Messages
@@ -708,11 +708,11 @@ and ignoring any outstanding Initial packets.
 An endpoint MUST NOT discard its handshake keys until the TLS handshake is
 confirmed ({{handshake-confirmed}}).  An endpoint SHOULD discard its handshake
 keys as soon as it has confirmed the handshake.  Most applications protocols
-will send data after the handshake, ensuring the peer can discard their
-handshake keys promptly.  Applications protocols that do not MAY send
-ACK-eliciting frames encrypted with 1-RTT keys as soon as they have installed
-those send keys and until they receive an acknowledgment for one of them,
-ensuring the peer can discard their handshake keys.
+will send data after the handshake, generating acknowledgements and ensuring
+that both endpoints can discard their handshake keys promptly.  Endpoints that
+do not have reason to send immediately after completing the handshake MAY send
+ack-eliciting frames, such as PING, which will cause the handshake to be
+confirmed when they are acknowledged.
 
 
 ### Discarding 0-RTT Keys
@@ -723,14 +723,13 @@ they have no use after that moment.
 Clients do not send 0-RTT packets after sending a 1-RTT
 packet ({{using-early-data}}).  Therefore a server MAY discard 0-RTT keys as
 soon as it receives a 1-RTT packet.  However, due to packet reordering, a
-client's valid 0-RTT packet could arrive after a 1-RTT packet.  Servers MAY
-temporarily retain 0-RTT keys to allow decrypting reordered packets without
-requiring their contents to be retransmitted with 1-RTT keys.  There is a bound
-on how long these keys can be temporarily retained: servers MUST have discarded
-0-RTT keys once three times the Probe Timeout (PTO, see {{QUIC-RECOVERY}}) has
-elapsed after receiving a 1-RTT packet.  Servers MAY also keep track of
-received 0-RTT packet numbers as an indication that all of them have been
-received which allows them to discard 0-RTT keys earlier.
+0-RTT packet could arrive after a 1-RTT packet.  Servers MAY temporarily retain
+0-RTT keys to allow decrypting reordered packets without requiring their
+contents to be retransmitted with 1-RTT keys.  Servers MUST discard 0-RTT keys
+within three times the Probe Timeout (PTO, see {{QUIC-RECOVERY}}) after
+receiving a 1-RTT packet.  A server MAY discard 0-RTT keys earlier if it
+determines that it has received all 0-RTT packets, which can be done by
+keeping track of packet numbers.
 
 
 # Packet Protection {#packet-protection}
@@ -1102,16 +1101,16 @@ Even though 1-RTT keys are available to a server after receiving the first
 handshake messages from a client, it is missing assurances on the state of the
 client:
 
-- The client is not authenticated (unless the server has chosen to use a
-pre-shared key and validated the client's pre-shared key binder (see
-Section 4.2.11 of [TLS13]).
+- The client is not authenticated, unless the server has chosen to use a
+pre-shared key and validated the client's pre-shared key binder; see
+Section 4.2.11 of {{!TLS13}}.
 - The client has not demonstrated liveness.
 - Any received 0-RTT data that the server responds to might be due to a replay
 attack.
 
 Therefore, the server's use of 1-RTT keys is limited before the handshake is
 complete.  A server MUST NOT process data from incoming 1-RTT
-protected packets before the TLS handshake is complete.  Note that, since
+protected packets before the TLS handshake is complete.  Because
 sending acknowledgments indicates that all frames in a packet have been
 processed, this means that a server cannot send acknowledgments for 1-RTT
 packets until the TLS handshake is complete.  Received packets protected with
@@ -1149,18 +1148,18 @@ unexpected_message (see {{tls-errors}}).
 
 An endpoint MUST NOT initiate the first key update until the handshake is
 confirmed ({{handshake-confirmed}}). An endpoint MUST NOT initiate a subsequent
-key update until it has received an ACK for a packet sent at the previous
-KEY_PHASE.  This can be implemented by tracking the lowest packet number sent
-with the previous KEY_PHASE, and the highest value of the Largest Acknowledged
-field in any received 1-RTT ACK frame: once the latter is higher than the
-former, another key update can be initiated.
+key update until it has received an acknowledgment for a packet sent at the
+current KEY_PHASE.  This can be implemented by tracking the lowest packet
+number sent with each KEY_PHASE, and the highest acknowledged packet number
+in the 1-RTT space: once the latter is higher than the former, another key
+update can be initiated.
 
 Endpoints only need to maintain the two latest sets of packet protection keys
 and MAY discard older keys.  Updating keys multiple times rapidly can cause
 packets to be effectively lost if packets are significantly delayed.
 Therefore, an endpoint SHOULD NOT initiate a key update until three times the
 PTO after it has last updated keys. This avoids valid reordered packets being
-dropped by the peer because the peer could have discarded older keys.
+dropped by the peer as a result of the peer discarding older keys.
 
 A receiving endpoint detects an update when the KEY_PHASE bit does not match
 what it is expecting.  It creates a new secret (see Section 7.2 of {{!TLS13}})

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -729,7 +729,7 @@ reordered packets without requiring their contents to be retransmitted with
 1-RTT keys.  Servers MUST discard 0-RTT keys within three times the Probe
 Timeout (PTO, see {{QUIC-RECOVERY}}) after receiving a 1-RTT packet.  A server
 MAY discard 0-RTT keys earlier if it determines that it has received all 0-RTT
-packets, which can be done by keeping track of packet numbers.
+packets, which can be done by keeping track of missing packet numbers.
 
 
 # Packet Protection {#packet-protection}
@@ -1103,7 +1103,7 @@ handshake messages from a client, it is missing assurances on the client state:
 - The client is not authenticated, unless the server has chosen to use a
 pre-shared key and validated the client's pre-shared key binder; see
 Section 4.2.11 of {{!TLS13}}.
-- The client has not demonstrated liveness.
+- The client has not demonstrated liveness, unless a RETRY packet was used.
 - Any received 0-RTT data that the server responds to might be due to a replay
 attack.
 
@@ -1111,10 +1111,9 @@ Therefore, the server's use of 1-RTT keys is limited before the handshake is
 complete.  A server MUST NOT process data from incoming 1-RTT
 protected packets before the TLS handshake is complete.  Because
 sending acknowledgments indicates that all frames in a packet have been
-processed, this means that a server cannot send acknowledgments for 1-RTT
-packets until the TLS handshake is complete.  Received packets protected with
-1-RTT keys MAY be stored and later decrypted and used once the handshake is
-complete.
+processed, a server cannot send acknowledgments for 1-RTT packets until the
+TLS handshake is complete.  Received packets protected with 1-RTT keys MAY be
+stored and later decrypted and used once the handshake is complete.
 
 The requirement for the server to wait for the client Finished message creates
 a dependency on that message being delivered.  A client can avoid the
@@ -1156,7 +1155,7 @@ another key update can be initiated.
 Endpoints MAY limit the number of sets of keys they retain to two sets for
 removing packet protection and one set for protecting packets.  Older keys
 can be discarded.  Updating keys multiple times rapidly can cause
-packets to be effectively lost if packets are significantly delayed.
+packets to be effectively lost if packets are significantly reordered.
 Therefore, an endpoint SHOULD NOT initiate a key update until three times the
 PTO after it has last updated keys. This avoids valid reordered packets being
 dropped by the peer as a result of the peer discarding older keys.

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -373,12 +373,12 @@ Additional functions might be needed to configure TLS.
 
 In this document, the TLS handshake is considered complete when the TLS stack
 has reported that the handshake is complete.  This happens when the TLS stack
-has verified the peer's Finished message.  Verifying the peer's Finished
-provides endpoints with an assurance that previous handshake messages have not
-been modified.  Note that the handshake does not complete on both endpoints
-simultaneously, therefore any requirements placed on endpoints based on the
-completion of the handshake are specific to the handshake being complete from
-the perspective of the endpoint in question.
+has both sent a Finished message and verified the peer's Finished message.
+Verifying the peer's Finished provides endpoints with an assurance that
+previous handshake messages have not been modified.  Note that the handshake
+does not complete on both endpoints simultaneously, therefore any requirements
+placed on endpoints based on the completion of the handshake are specific to
+the handshake being complete from the perspective of the endpoint in question.
 
 
 ### Handshake Confirmed {#handshake-confirmed}
@@ -707,10 +707,12 @@ and ignoring any outstanding Initial packets.
 
 An endpoint MUST NOT discard its handshake keys until the TLS handshake is
 confirmed ({{handshake-confirmed}}).  An endpoint SHOULD discard its handshake
-keys as soon as it has confirmed the handshake.  Endpoints SHOULD repeatedly
-send ACK-eliciting frames encrypted with 1-RTT keys as soon as they have
-installed those send keys and until they receive an acknowledgment for one of
-them.
+keys as soon as it has confirmed the handshake.  Most applications protocols
+will send data after the handshake, ensuring the peer can discard their
+handshake keys promptly.  Applications protocols that do not MAY send
+ACK-eliciting frames encrypted with 1-RTT keys as soon as they have installed
+those send keys and until they receive an acknowledgment for one of them,
+ensuring the peer can discard their handshake keys.
 
 
 ### Discarding 0-RTT Keys

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -386,7 +386,7 @@ perspective of the endpoint in question.
 In this document, the TLS handshake is considered confirmed at an endpoint when
 the following two conditions are met: the handshake is complete, and the
 endpoint has received an acknowledgment for a packet sent with 1-RTT keys.
-This second condition can be implemented by tracking the lowest packet number
+This second condition can be implemented by recording the lowest packet number
 sent with 1-RTT keys, and the highest value of the Largest Acknowledged field
 in any received 1-RTT ACK frame: once the latter is higher than or equal to the
 former, the handshake is confirmed.

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -697,7 +697,7 @@ highest value of the Largest Acknowledged field in any received 1-RTT ACK
 frame: once the latter is higher than the former, the handshake is confirmed.
 
 An endpoint MUST NOT discard its handshake keys until the TLS handshake is
-confirmed from its perspective.  An endpoint MAY discard its handshake keys
+confirmed from its perspective.  An endpoint SHOULD discard its handshake keys
 as soon as it has confirmed the handshake.  Endpoints SHOULD repeatedly send
 ACK-eliciting frames encrypted with 1-RTT keys as soon as they have installed
 those send keys and until they receive an acknowledgment for one of them.


### PR DESCRIPTION
This PR is the output of the discard keys design team, and has reached consensus amongst design team members (modulo wordsmithing). It describes methods for discarding QUIC packet protection keys, and adds normative text to ensure that this mechanism is not vulnerable to deadlocks. This PR also formalizes the concept of handshake complete and handshake confirmed. Finally, this PR also moved some text around to avoid repetitions.

We believe that this PR prevents the potential deadlocks discussed in issues #2214 and #2267.

Fixes #2214, fixes #2267.