### PR TITLE
ignore the ack delay in Initial and Handshake packets

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -387,17 +387,20 @@ smoothed_rtt is an exponentially-weighted moving average of an endpoint's RTT
 samples, and rttvar is the endpoint's estimated variance in the RTT samples.
 
 smoothed_rtt uses path latency after adjusting RTT samples for peer-reported
-host delays ({{host-delay}}).  A peer limits any delay in sending an
-acknowledgement for an ack-eliciting packet to no greater than the advertised
-max_ack_delay transport parameter.  Consequently, when a peer reports an Ack
-Delay that is greater than its max_ack_delay, the delay is attributed to reasons
-out of the peer's control, such as scheduler latency at the peer or loss of
-previous ACK frames.  Any delays beyond the peer's max_ack_delay are therefore
-considered effectively part of path delay and incorporated into the smoothed_rtt
-estimate.
+host delays ({{host-delay}}).  For packets sent in the ApplicationData packet
+number space, a peer limits any delay in sending an acknowledgement for an
+ack-eliciting packet to no greater than the advertised max_ack_delay transport
+parameter.  Consequently, when a peer reports an Ack Delay that is greater than
+its max_ack_delay, the delay is attributed to reasons out of the peer's control,
+such as scheduler latency at the peer or loss of previous ACK frames.  Any
+delays beyond the peer's max_ack_delay are therefore considered effectively part
+of path delay and incorporated into the smoothed_rtt estimate.
 
 When adjusting an RTT sample using peer-reported acknowledgement delays, an
 endpoint:
+
+- MUST ignore the Ack Delay field of the ACK frame for packets sent in the
+  Initial and Handshake packet number space.
 
 - MUST use the lesser of the value reported in Ack Delay field of the ACK frame
   and the peer's max_ack_delay transport parameter ({{host-delay}}).

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -386,15 +386,16 @@ due to erroneously-reported delays by the peer.
 smoothed_rtt is an exponentially-weighted moving average of an endpoint's RTT
 samples, and rttvar is the endpoint's estimated variance in the RTT samples.
 
-smoothed_rtt uses path latency after adjusting RTT samples for peer-reported
-host delays ({{host-delay}}).  For packets sent in the ApplicationData packet
-number space, a peer limits any delay in sending an acknowledgement for an
-ack-eliciting packet to no greater than the advertised max_ack_delay transport
-parameter.  Consequently, when a peer reports an Ack Delay that is greater than
-its max_ack_delay, the delay is attributed to reasons out of the peer's control,
-such as scheduler latency at the peer or loss of previous ACK frames.  Any
-delays beyond the peer's max_ack_delay are therefore considered effectively part
-of path delay and incorporated into the smoothed_rtt estimate.
+The calculation of smoothed_rtt uses path latency after adjusting RTT samples
+for host delays ({{host-delay}}).  For packets sent in the ApplicationData
+packet number space, a peer limits any delay in sending an acknowledgement for
+an ack-eliciting packet to no greater than the value it advertised in the
+max_ack_delay transport parameter.  Consequently, when a peer reports an Ack
+Delay that is greater than its max_ack_delay, the delay is attributed to reasons
+out of the peer's control, such as scheduler latency at the peer or loss of
+previous ACK frames.  Any delays beyond the peer's max_ack_delay are therefore
+considered effectively part of path delay and incorporated into the smoothed_rtt
+estimate.
 
 When adjusting an RTT sample using peer-reported acknowledgement delays, an
 endpoint:


### PR DESCRIPTION
This should have been part of #2646.