### PR TITLE
New paths may seed initial_rtt

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -522,8 +522,8 @@ resulting in a 1 second initial handshake timeout as recommended in
 {{?RFC6298}}.
 
 A connection MAY use the delay between sending a PATH_CHALLENGE and receiving
-a PATH_RESPONSE to seed initial_rtt for a new path, but MUST not be considered
-an RTT sample.
+a PATH_RESPONSE to seed initial_rtt for a new path, but the delay MUST not be
+considered an RTT sample.
 
 When a crypto packet is sent, the sender MUST set a timer for twice the smoothed
 RTT.  This timer MUST be updated when a new crypto packet is sent and when

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -522,8 +522,8 @@ resulting in a 1 second initial handshake timeout as recommended in
 {{?RFC6298}}.
 
 A connection MAY use the delay between sending a PATH_CHALLENGE and receiving
-a PATH_RESPONSE to seed initial_rtt for a new path, but the delay MUST NOT be
-considered an RTT sample.
+a PATH_RESPONSE to seed initial_rtt for a new path, but the delay SHOULD NOT
+be considered an RTT sample.
 
 When a crypto packet is sent, the sender MUST set a timer for twice the smoothed
 RTT.  This timer MUST be updated when a new crypto packet is sent and when

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -521,6 +521,10 @@ is available, or if the network changes, the initial RTT SHOULD be set to 500ms,
 resulting in a 1 second initial handshake timeout as recommended in
 {{?RFC6298}}.
 
+A new path on an existing connection MAY use the delay between sending a
+PATH_CHALLENGE and receiving a PATH_RESPONSE to seed initial_rtt for a new path,
+but MUST not be considered an RTT sample.
+
 When a crypto packet is sent, the sender MUST set a timer for twice the smoothed
 RTT.  This timer MUST be updated when a new crypto packet is sent and when
 an acknowledgement is received which computes a new RTT sample. Upon timeout,

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -522,7 +522,7 @@ resulting in a 1 second initial handshake timeout as recommended in
 {{?RFC6298}}.
 
 A connection MAY use the delay between sending a PATH_CHALLENGE and receiving
-a PATH_RESPONSE to seed initial_rtt for a new path, but the delay MUST not be
+a PATH_RESPONSE to seed initial_rtt for a new path, but the delay MUST NOT be
 considered an RTT sample.
 
 When a crypto packet is sent, the sender MUST set a timer for twice the smoothed

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -521,9 +521,9 @@ is available, or if the network changes, the initial RTT SHOULD be set to 500ms,
 resulting in a 1 second initial handshake timeout as recommended in
 {{?RFC6298}}.
 
-A new path on an existing connection MAY use the delay between sending a
-PATH_CHALLENGE and receiving a PATH_RESPONSE to seed initial_rtt for a new path,
-but MUST not be considered an RTT sample.
+A connection MAY use the delay between sending a PATH_CHALLENGE and receiving
+a PATH_RESPONSE to seed initial_rtt for a new path, but MUST not be considered
+an RTT sample.
 
 When a crypto packet is sent, the sender MUST set a timer for twice the smoothed
 RTT.  This timer MUST be updated when a new crypto packet is sent and when


### PR DESCRIPTION
Using PATH_CHALLENGE/PATH_RESPONSE

I'm fairly happy with the text, but not that happy with the location.  Especially after the recently filed issues(ie: #2684) on resetting the congestion controller on path changes, I think we may need a section in recovery on that.

Fixes #2644