### PR TITLE
Clarify server CONNECTION_CLOSE with Handshake

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2307,10 +2307,14 @@ signal closure.
 If the connection has been successfully established, endpoints MUST send any
 CONNECTION_CLOSE frames in a 1-RTT packet.  Prior to connection establishment a
 peer might not have 1-RTT keys, so endpoints SHOULD send CONNECTION_CLOSE frames
-in a Handshake packet.  If the endpoint does not have Handshake keys, or it is
-not certain that the peer has Handshake keys, it MAY send CONNECTION_CLOSE
-frames in an Initial packet.  If multiple packets are sent, they can be
-coalesced (see {{packet-coalesce}}) to facilitate retransmission.
+in a Handshake packet.If the endpoint does not have Handshake keys, it MAY
+send CONNECTION_CLOSE frames in an Initial packet.
+
+The server can have Handshake keys but not know that the client has Handshake
+keys.  In order to guarantee a CONNECTION_CLOSE is processed, it has to send
+a CONNECTION_CLOSE in both Handshake and Initial, because the client discards
+Initial keys as soon as it has Handshake keys. If multiple packets are sent,
+they can be coalesced (see {{packet-coalesce}}) to facilitate retransmission.
 
 
 ## Stateless Reset {#stateless-reset}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2307,7 +2307,7 @@ signal closure.
 If the connection has been successfully established, endpoints MUST send any
 CONNECTION_CLOSE frames in a 1-RTT packet.  Prior to connection establishment a
 peer might not have 1-RTT keys, so endpoints SHOULD send CONNECTION_CLOSE frames
-in a Handshake packet.If the endpoint does not have Handshake keys, it MAY
+in a Handshake packet.  If the endpoint does not have Handshake keys, it MAY
 send CONNECTION_CLOSE frames in an Initial packet.
 
 The server can have Handshake keys but not know that the client has Handshake

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2311,7 +2311,7 @@ the handshake, it is possible that more advanced packet protection keys are not
 available to the peer, so the frame MAY be replicated in a packet that uses a
 lower packet protection level.
 
-If the handshake is confirmed, endpoints MUST send any CONNECTION_CLOSE frames
+When the handshake is confirmed, an endpoint MUST send any CONNECTION_CLOSE frames
 in a 1-RTT packet.  Prior to handshake confirmation, the peer might not have
 1-RTT keys, so the endpoint SHOULD send CONNECTION_CLOSE frames in a Handshake
 packet.  If the endpoint does not have Handshake keys, it SHOULD send

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2307,14 +2307,14 @@ signal closure.
 If the connection has been successfully established, endpoints MUST send any
 CONNECTION_CLOSE frames in a 1-RTT packet.  Prior to connection establishment a
 peer might not have 1-RTT keys, so endpoints SHOULD send CONNECTION_CLOSE frames
-in a Handshake packet.  If the endpoint does not have Handshake keys, it MAY
+in a Handshake packet.  If the endpoint does not have Handshake keys, it SHOULD
 send CONNECTION_CLOSE frames in an Initial packet.
 
-The server can have Handshake keys but not know that the client has Handshake
-keys.  In order to guarantee a CONNECTION_CLOSE is processed, it has to send
-a CONNECTION_CLOSE in both Handshake and Initial, because the client discards
-Initial keys as soon as it has Handshake keys. If multiple packets are sent,
-they can be coalesced (see {{packet-coalesce}}) to facilitate retransmission.
+The server may not know whether the client has Handshake keys.  In order to
+guarantee a CONNECTION_CLOSE is processed, it SHOULD send a CONNECTION_CLOSE
+in both Handshake and Initial, because the client discards Initial keys as soon
+as it has Handshake keys. If multiple packets are sent, they can be coalesced
+(see {{packet-coalesce}}).
 
 
 ## Stateless Reset {#stateless-reset}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2308,7 +2308,7 @@ When sending CONNECTION_CLOSE, the goal is to ensure that the peer will process
 the frame.  Generally, this means sending the frame in a packet with the highest
 level of packet protection to avoid the packet being discarded.  However, during
 the handshake, it is possible that more advanced packet protection keys are not
-available to a peer, so the frame MAY be replicated in a packet that uses a
+available to the peer, so the frame MAY be replicated in a packet that uses a
 lower packet protection level.
 
 If the handshake is confirmed, endpoints MUST send any CONNECTION_CLOSE frames

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2311,10 +2311,10 @@ the handshake, it is possible that more advanced packet protection keys are not
 available to the peer, so the frame MAY be replicated in a packet that uses a
 lower packet protection level.
 
-When the handshake is confirmed, an endpoint MUST send any CONNECTION_CLOSE frames
-in a 1-RTT packet.  Prior to handshake confirmation, the peer might not have
-1-RTT keys, so the endpoint SHOULD send CONNECTION_CLOSE frames in a Handshake
-packet.  If the endpoint does not have Handshake keys, it SHOULD send
+After the handshake is confirmed, an endpoint MUST send any CONNECTION_CLOSE
+frames in a 1-RTT packet.  Prior to handshake confirmation, the peer might not
+have 1-RTT keys, so the endpoint SHOULD send CONNECTION_CLOSE frames in a
+Handshake packet.  If the endpoint does not have Handshake keys, it SHOULD send
 CONNECTION_CLOSE frames in an Initial packet.
 
 A client will always know whether the server has Handshake keys

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2321,8 +2321,8 @@ A client will always know whether the server has Handshake keys
 (see {{discard-initial}}), but it is possible that a server does not know
 whether the client has Handshake keys.  Under these circumstances, a server
 SHOULD send a CONNECTION_CLOSE frame in both Handshake and Initial packets
-to ensure that at least one of them is processable by the client. These packets
-can be coalesced into a single UDP datagram (see {{packet-coalesce}}).
+to ensure that at least one of them is processable by the client.  These
+packets can be coalesced into a single UDP datagram (see {{packet-coalesce}}).
 
 
 ## Stateless Reset {#stateless-reset}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2317,7 +2317,7 @@ in a 1-RTT packet.  Prior to handshake confirmation, a peer might not have
 packet.  If the endpoint does not have Handshake keys, it SHOULD send
 CONNECTION_CLOSE frames in an Initial packet.
 
-The server may not know whether the client has Handshake keys.  In order to
+A client will always know whether the server has Handshake keys (see {{discard-initial}}), but it is possible that a server does not know whether the client has Handshake keys.
 guarantee a CONNECTION_CLOSE is processed, it SHOULD send a CONNECTION_CLOSE
 in both Handshake and Initial, because the client discards Initial keys as soon
 as it has Handshake keys. If multiple packets are sent, they can be coalesced

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2317,11 +2317,12 @@ in a 1-RTT packet.  Prior to handshake confirmation, a peer might not have
 packet.  If the endpoint does not have Handshake keys, it SHOULD send
 CONNECTION_CLOSE frames in an Initial packet.
 
-A client will always know whether the server has Handshake keys (see {{discard-initial}}), but it is possible that a server does not know whether the client has Handshake keys.
-guarantee a CONNECTION_CLOSE is processed, it SHOULD send a CONNECTION_CLOSE
-in both Handshake and Initial, because the client discards Initial keys as soon
-as it has Handshake keys. If multiple packets are sent, they can be coalesced
-(see {{packet-coalesce}}).
+A client will always know whether the server has Handshake keys
+(see {{discard-initial}}), but it is possible that a server does not know
+whether the client has Handshake keys.  Under these circumstances, a server
+SHOULD send a CONNECTION_CLOSE frame in both Handshake and Initial packets
+to ensure that at least one of them is processable by the client. These packets
+can be coalesced into a single UDP datagram (see {{packet-coalesce}}).
 
 
 ## Stateless Reset {#stateless-reset}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2312,7 +2312,7 @@ available to the peer, so the frame MAY be replicated in a packet that uses a
 lower packet protection level.
 
 If the handshake is confirmed, endpoints MUST send any CONNECTION_CLOSE frames
-in a 1-RTT packet.  Prior to handshake confirmation, a peer might not have
+in a 1-RTT packet.  Prior to handshake confirmation, the peer might not have
 1-RTT keys, so endpoints SHOULD send CONNECTION_CLOSE frames in a Handshake
 packet.  If the endpoint does not have Handshake keys, it SHOULD send
 CONNECTION_CLOSE frames in an Initial packet.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2311,11 +2311,11 @@ the handshake, it is possible that more advanced packet protection keys are not
 available to a peer, so the frame MAY be replicated in a packet that uses a
 lower packet protection level.
 
-If the connection has been successfully established, endpoints MUST send any
-CONNECTION_CLOSE frames in a 1-RTT packet.  Prior to connection establishment a
-peer might not have 1-RTT keys, so endpoints SHOULD send CONNECTION_CLOSE frames
-in a Handshake packet.  If the endpoint does not have Handshake keys, it SHOULD
-send CONNECTION_CLOSE frames in an Initial packet.
+If the handshake is confirmed, endpoints MUST send any CONNECTION_CLOSE frames
+in a 1-RTT packet.  Prior to handshake confirmation, a peer might not have
+1-RTT keys, so endpoints SHOULD send CONNECTION_CLOSE frames in a Handshake
+packet.  If the endpoint does not have Handshake keys, it SHOULD send
+CONNECTION_CLOSE frames in an Initial packet.
 
 The server may not know whether the client has Handshake keys.  In order to
 guarantee a CONNECTION_CLOSE is processed, it SHOULD send a CONNECTION_CLOSE

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2313,7 +2313,7 @@ lower packet protection level.
 
 If the handshake is confirmed, endpoints MUST send any CONNECTION_CLOSE frames
 in a 1-RTT packet.  Prior to handshake confirmation, the peer might not have
-1-RTT keys, so endpoints SHOULD send CONNECTION_CLOSE frames in a Handshake
+1-RTT keys, so the endpoint SHOULD send CONNECTION_CLOSE frames in a Handshake
 packet.  If the endpoint does not have Handshake keys, it SHOULD send
 CONNECTION_CLOSE frames in an Initial packet.
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2304,6 +2304,13 @@ the application requests that the connection be closed.  The application
 protocol can use an CONNECTION_CLOSE frame with an appropriate error code to
 signal closure.
 
+When sending CONNECTION_CLOSE, the goal is to ensure that a peer will process
+the frame.  Generally, this means sending the frame in a packet with the highest
+level of packet protection to avoid the packet being discarded.  However, during
+the handshake, it is possible that more advanced packet protection keys are not
+available to a peer, so the frame MAY be replicated in a packet that uses a
+lower packet protection level.
+
 If the connection has been successfully established, endpoints MUST send any
 CONNECTION_CLOSE frames in a 1-RTT packet.  Prior to connection establishment a
 peer might not have 1-RTT keys, so endpoints SHOULD send CONNECTION_CLOSE frames

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2304,7 +2304,7 @@ the application requests that the connection be closed.  The application
 protocol can use an CONNECTION_CLOSE frame with an appropriate error code to
 signal closure.
 
-When sending CONNECTION_CLOSE, the goal is to ensure that a peer will process
+When sending CONNECTION_CLOSE, the goal is to ensure that the peer will process
 the frame.  Generally, this means sending the frame in a packet with the highest
 level of packet protection to avoid the packet being discarded.  However, during
 the handshake, it is possible that more advanced packet protection keys are not


### PR DESCRIPTION
Clarifies that if the server wants the client to process a connection close, it SHOULD send one in Initial and Handshake.

It seemed odd to me to say MAY send a CONNECTION_CLOSE in Initial, so I changed that to a SHOULD.  I can revert that and the other SHOULD, but I think the current PR makes more sense.

Came up in discussion on #2541 and I believe may be necessary to fully address #2541.  If not, I can open another issue.

Closes #2151