### PR TITLE
Push ID limit checking in DUPLICATE_PUSH

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -890,7 +890,11 @@ of a DUPLICATE_PUSH frame as a connection error of type HTTP_UNEXPECTED_FRAME.
 
 The DUPLICATE_PUSH frame carries a single variable-length integer that
 identifies the Push ID of a resource that the server has previously promised
-(see {{frame-push-promise}}).
+(see {{frame-push-promise}}), though that promise might not be received before
+this frame.  A server MUST NOT use a Push ID that is larger than the client has
+provided in a MAX_PUSH_ID frame ({{frame-max-push-id}}).  A client MUST treat
+receipt of a PUSH_PROMISE that contains a larger Push ID than the client has
+advertised as a connection error of type HTTP_MALFORMED_FRAME.
 
 This frame allows the server to use the same server push in response to multiple
 concurrent requests.  Referencing the same server push ensures that a promise

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -894,7 +894,7 @@ identifies the Push ID of a resource that the server has previously promised
 this frame.  A server MUST NOT use a Push ID that is larger than the client has
 provided in a MAX_PUSH_ID frame ({{frame-max-push-id}}).  A client MUST treat
 receipt of a PUSH_PROMISE that contains a larger Push ID than the client has
-advertised as a connection error of type HTTP_MALFORMED_FRAME.
+advertised as a connection error of type HTTP_LIMIT_EXCEEDED.
 
 This frame allows the server to use the same server push in response to multiple
 concurrent requests.  Referencing the same server push ensures that a promise

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -893,8 +893,8 @@ identifies the Push ID of a resource that the server has previously promised
 (see {{frame-push-promise}}), though that promise might not be received before
 this frame.  A server MUST NOT use a Push ID that is larger than the client has
 provided in a MAX_PUSH_ID frame ({{frame-max-push-id}}).  A client MUST treat
-receipt of a PUSH_PROMISE that contains a larger Push ID than the client has
-advertised as a connection error of type HTTP_LIMIT_EXCEEDED.
+receipt of a DUPLICATE_PUSH that contains a larger Push ID than the client has
+advertised as a connection error of type HTTP_MALFORMED_FRAME.
 
 This frame allows the server to use the same server push in response to multiple
 concurrent requests.  Referencing the same server push ensures that a promise


### PR DESCRIPTION
Fixes #2681.

Skirts the editorial/design line.  Previously, DUPLICATE_PUSH referred to a Push ID in a previously-sent PUSH_PROMISE frame; that frame would have caused a connection error on arrival.  This says that the error should be sent regardless of which frame arrives first.

May need reconciling with #2662.