### PR TITLE
HTTP/3 with strict priorities

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -525,7 +525,7 @@ stream.
  0                   1                   2                   3
  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|P|D|W|P| Empty |         [Prioritized Element ID (i)]        ...
+|PT |D|W|P| Empty |       [Prioritized Element ID (i)]        ...
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                     [Placeholder ID (i)]                    ...
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -536,10 +536,10 @@ stream.
 
 The PRIORITY frame payload has the following fields:
 
-  P (Prioritized Element Type):
+  PT (Prioritized Element Type):
   : A one-bit field indicating the type of element being prioritized (see
     {{prioritized-element-types}}). When sent on a request stream, this MUST be
-    set to `0`.
+    set to `11`.
 
   D (Dependent On Placeholder):
   : A one-bit field indicating whether an element depends upon a placeholder
@@ -557,8 +557,9 @@ The PRIORITY frame payload has the following fields:
 
   Prioritized Element ID:
   : A variable-length integer that identifies the element being prioritized.
-    The Push ID of a promised resource, a Placeholder ID of a placeholder,
-    or is absent if sent on the request stream.
+    Depending on the value of Prioritized Type, this contains the Stream ID of a
+    request stream, the Push ID of a promised resource, a Placeholder ID of a
+    placeholder, or is absent.
 
   Element Dependency ID:
   : A variable-length integer that identifies the Placeholder ID on which a
@@ -582,11 +583,12 @@ The values for the Prioritized Element Type ({{prioritized-element-types}}) and
 Element Dependency Type ({{element-dependency-types}}) imply the interpretation
 of the associated Element ID fields.
 
-| P Bit | Type Description | Prioritized Element ID Contents |
-| ----- | ---------------- | ------------------------------- |
-| 0     | Current stream   | Absent                          |
-| 0     | Push stream      | Push ID                         |
-| 1     | Placeholder      | Placeholder ID                  |
+| PT Bits | Type Description | Prioritized Element ID Contents |
+| ------- | ---------------- | ------------------------------- |
+| 00      | Request stream   | Stream ID                       |
+| 01      | Push stream      | Push ID                         |
+| 10      | Placeholder      | Placeholder ID                  |
+| 11      | Current stream   | Absent                          |
 {: #prioritized-element-types title="Prioritized Element Types"}
 
 | D  Bit | Type Description | Placeholder ID Contents |
@@ -604,7 +606,9 @@ situations MUST be treated as a connection error of type HTTP_MALFORMED_FRAME.
 The following situations are examples of invalid PRIORITY frames:
 
 - A PRIORITY frame sent on a request stream with the Prioritized Element Type
-  set to any value other than `0`
+  set to any value other than `11`
+- A PRIORITY frame sent on a control stream with the Prioritized Element Type	
+  set to `11`
 
 A PRIORITY frame with Empty bits not set to zero MAY be treated as a connection
 error of type HTTP_MALFORMED_FRAME.

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -510,8 +510,9 @@ request, server push or placeholder.
 
 A PRIORITY frame identifies an element to prioritize and a placeholder upon
 which it depends, or the root if no placeholder is specified.  A Prioritized
-ID identifies a server push using a Push ID (see {{frame-push-promise}}),
-or a placeholder using a Placeholder ID (see {{placeholders}}).
+ID identifies a client-initiated request using the corresponding stream ID,
+a server push using a Push ID (see {{frame-push-promise}}), or a placeholder
+using a Placeholder ID (see {{placeholders}}).
 
 When a client initiates a request, a PRIORITY frame MAY be sent as the first
 frame of the stream, creating a dependency on an existing element.  In order to

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -508,8 +508,8 @@ HEADERS frames can only be sent on request / push streams.
 The PRIORITY (type=0x2) frame specifies the client-advised priority of a
 request, server push or placeholder.
 
-A PRIORITY frame identifies an element to prioritize, and a placeholder upon
-which it depends or the root if no placeholder is specified.  A Prioritized
+A PRIORITY frame identifies an element to prioritize and a placeholder upon
+which it depends, or the root if no placeholder is specified.  A Prioritized
 ID identifies a server push using a Push ID (see {{frame-push-promise}}),
 or a placeholder using a Placeholder ID (see {{placeholders}}).
 

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1107,9 +1107,9 @@ identifies the element and the dependency. The elements that can be prioritized 
   ({{frame-push-promise}})
 - Placeholders, identified by a Placeholder ID
 
-In HTTP/3, stream dependencies implicitly encoded by dependencies in HTTP/2 are
-explicitly encoded with strict prioritization.  This simplifies priority tree
-management, eliminates potential new race conditions introduced by HTTP/3's
+In HTTP/3, stream dependencies that were implicitly encoded by dependencies in
+HTTP/2 are explicitly encoded with strict prioritization.  This simplifies priority
+tree management, eliminates potential new race conditions introduced by HTTP/3's
 multiple streams, and improves framing efficiency with more than 64 requests.
 
 When a placeholder is reparented or given a new weight or strict priority, all

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1097,27 +1097,23 @@ the RST bit set if it detects an error with the stream or the QUIC connection.
 
 HTTP/3 uses a priority scheme similar to that described in {{!RFC7540}}, Section
 5.3, but replaces streams depending upon streams with strict priorities and
-placeholders.  In the HTTP/3 priority scheme, a given element can be designated
-as dependent upon a placeholder or the root. This information is expressed in
-the PRIORITY frame {{frame-priority}} which identifies the element and the
-dependency. The elements that can be prioritized are:
+placeholders.  In the HTTP/3 priority scheme, a stream can be given a strict
+priority or can be designated as dependent upon a placeholder or the root.
+This information is expressed in the PRIORITY frame {{frame-priority}} which
+identifies the element and the dependency. The elements that can be prioritized are:
 
 - Requests, identified by the stream of the PRIORITY frame
 - Pushes, identified by the Push ID of the promised resource
   ({{frame-push-promise}})
 - Placeholders, identified by a Placeholder ID
 
-In HTTP/3 stream dependencies which implicitly encode strict priorities by
-explicit strict prioritization.  This simplifies priority tree management,
-eliminates race conditions introduced by HTTP/3's multiple streams, and improves
-framing efficiency in the case of a large number of streams.
+In HTTP/3, stream dependencies implicitly encoded by dependencies in HTTP/2 are
+explicitly encoded with strict prioritization.  This simplifies priority tree
+management, eliminates potential new race conditions introduced by HTTP/3's
+multiple streams, and improves framing efficiency with more than 64 requests.
 
-Taken together, the dependencies across all prioritized elements in a connection
-form a dependency tree. An element can only depend on a placeholder or on the root
-of the tree. Because the root and placeholders never disappear, it is impoossible
-to reference an element which is no longer in the tree. The structure of the
-dependency tree changes as PRIORITY frames modify the dependency links between
-prioritized elements.
+When a placeholder is reparented or given a new weight or strict priority, all
+dependent placeholders and streams are also re-prioritized.
 
 When a prioritized element is first created, it has a default initial weight
 of 16, priority of 16, and a default dependency. Requests and placeholders are

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1154,7 +1154,7 @@ of placeholders the server has permitted.
 Like streams, placeholders have priority information associated with them.
 
 When a placeholder is reparented, given a new weight or given a new strict
-priority, all dependent placeholders and streams are also re-prioritized.
+priority, the effective priority of all dependent placeholders and streams is impacted.
 
 ## Server Push
 

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1160,7 +1160,8 @@ of placeholders the server has permitted.
 Like streams, placeholders have priority information associated with them.
 
 When a placeholder is reparented, given a new weight or given a new strict
-priority, the effective priority of all dependent placeholders and streams is impacted.
+priority, the effective priority of all dependent placeholders and streams
+is impacted.
 
 ## Server Push
 

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -573,7 +573,8 @@ The PRIORITY frame payload has the following fields:
   : An optional unsigned 8-bit integer representing a priority weight for the
     prioritized element (see {{!RFC7540}}, Section 5.3). Add one to the value
     to obtain a weight between 1 and 256.  When absent, indicates the resource
-    should be delivered all at once or not at all.
+    should be allocated the full available resources from its parent, as long
+    as it is able to make progress.
 
   Priority:
   : An optional unsigned 8-bit integer representing a strict priority for the

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1106,10 +1106,10 @@ the RST bit set if it detects an error with the stream or the QUIC connection.
 HTTP/3 uses a priority scheme similar to that described in {{!RFC7540}}, Section
 5.3, but replaces streams depending upon streams with strict priorities and
 placeholders.  In the HTTP/3 priority scheme, a stream can be given a strict
-priority or can be designated as dependent upon a placeholder or the root.
-This information is expressed in the PRIORITY frame {{frame-priority}} which
-identifies the element and the dependency. The elements that can be prioritized
-are:
+priority with weights for equal priority elements, or can be designated as
+dependent upon a placeholder or the root.  This information is expressed in the
+PRIORITY frame {{frame-priority}} which identifies the element and the
+dependency. The elements that can be prioritized are:
 
 - Requests, identified by the stream of the PRIORITY frame
 - Pushes, identified by the Push ID of the promised resource
@@ -1117,15 +1117,13 @@ are:
 - Placeholders, identified by a Placeholder ID
 
 In HTTP/3, stream dependencies that were implicitly encoded by dependencies in
-HTTP/2 are explicitly encoded with strict prioritization.  This simplifies
-priority tree management, eliminates potential new race conditions introduced
-by HTTP/3's multiple streams, and improves framing efficiency with more than
-64 requests.
+HTTP/2 are explicitly encoded with strict prioritization.
 
 When a prioritized element is first created, it has a default initial weight
-of 16, priority of 16, and a default dependency. Requests and placeholders are
-dependent on the root of the priority tree; pushes are dependent on the client
-request on which the PUSH_PROMISE frame was sent.
+of 0, priority of 16, and a default dependency. Requests and placeholders are
+dependent on the root of the priority tree; pushes are dependent on the same
+parent as the client request on which the PUSH_PROMISE frame was sent and given
+a priority value one smaller than the request stream.
 
 Requests may override the default initial values by including a PRIORITY frame
 (see {{frame-priority}}) at the beginning of the stream. These priorities
@@ -1133,11 +1131,11 @@ can be updated by sending a PRIORITY frame on the control stream.
 
 Higher priority elements have all available data sent before elements of lower
 priority.  When multiple elements have the same priority, if a weight is
-specified, elements with weights are interleaved.  If a weight is not
-specified, then elements are delivered sequentially and all available data
-from one element is sent before any data from the next.  If a given priority
-level has some elements with weights and some without, the two groups share
-the available bandwidth equally.
+specified, elements with weights are interleaved.  If a weight is 0, either
+because it is the default weight or it was not specified, then elements are
+delivered sequentially and all available data from one element is sent before
+any data from the next.  If a given priority level has some elements with
+weights and some without, the two groups share the available bandwidth equally.
 
 ### Placeholders
 

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -540,9 +540,9 @@ stream.
 The PRIORITY frame payload has the following fields:
 
   PT (Prioritized Element Type):
-  : A one-bit field indicating the type of element being prioritized (see
+  : A two-bit field indicating the type of element being prioritized (see
     {{prioritized-element-types}}). When sent on a request stream, this MUST be
-    set to `11`.
+    set to `11`.  When sent on the control stream, this MUST NOT be set to `11`.
 
   D (Dependent On Placeholder):
   : A one-bit field indicating whether an element depends upon a placeholder

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -542,7 +542,7 @@ The PRIORITY frame payload has the following fields:
     set to `0`.
 
   D (Dependent On Placeholder):
-  : A one-bit field indicating whether a element depends upon a placeholder
+  : A one-bit field indicating whether an element depends upon a placeholder
     or the root of the tree (see {{element-dependency-types}}).
 
   W (Weight Indication):
@@ -1100,7 +1100,8 @@ HTTP/3 uses a priority scheme similar to that described in {{!RFC7540}}, Section
 placeholders.  In the HTTP/3 priority scheme, a stream can be given a strict
 priority or can be designated as dependent upon a placeholder or the root.
 This information is expressed in the PRIORITY frame {{frame-priority}} which
-identifies the element and the dependency. The elements that can be prioritized are:
+identifies the element and the dependency. The elements that can be prioritized
+are:
 
 - Requests, identified by the stream of the PRIORITY frame
 - Pushes, identified by the Push ID of the promised resource
@@ -1108,12 +1109,10 @@ identifies the element and the dependency. The elements that can be prioritized 
 - Placeholders, identified by a Placeholder ID
 
 In HTTP/3, stream dependencies that were implicitly encoded by dependencies in
-HTTP/2 are explicitly encoded with strict prioritization.  This simplifies priority
-tree management, eliminates potential new race conditions introduced by HTTP/3's
-multiple streams, and improves framing efficiency with more than 64 requests.
-
-When a placeholder is reparented or given a new weight or strict priority, all
-dependent placeholders and streams are also re-prioritized.
+HTTP/2 are explicitly encoded with strict prioritization.  This simplifies
+priority tree management, eliminates potential new race conditions introduced
+by HTTP/3's multiple streams, and improves framing efficiency with more than
+64 requests.
 
 When a prioritized element is first created, it has a default initial weight
 of 16, priority of 16, and a default dependency. Requests and placeholders are
@@ -1123,6 +1122,14 @@ request on which the PUSH_PROMISE frame was sent.
 Requests may override the default initial values by including a PRIORITY frame
 (see {{frame-priority}}) at the beginning of the stream. These priorities
 can be updated by sending a PRIORITY frame on the control stream.
+
+Higher priority elements have all available data sent before elements of lower
+priority.  When multiple elements have the same priority, if a weight is
+specified, elements with weights are interleaved.  If a weight is not
+specified, then elements are delivered sequentially and all available data
+from one element is sent before any data from the next.  If a given priority
+level has some elements with weights and some without, the two groups share
+the available bandwidth equally.
 
 ### Placeholders
 
@@ -1145,6 +1152,9 @@ Placeholders are identified by an ID between zero and one less than the number
 of placeholders the server has permitted.
 
 Like streams, placeholders have priority information associated with them.
+
+When a placeholder is reparented, given a new weight or given a new strict
+priority, all dependent placeholders and streams are also re-prioritized.
 
 ## Server Push
 

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -517,7 +517,9 @@ using a Placeholder ID (see {{placeholders}}).
 When a client initiates a request, a PRIORITY frame MAY be sent as the first
 frame of the stream, creating a dependency on an existing element.  In order to
 ensure that prioritization is processed in a consistent order, any subsequent
-PRIORITY frames for that request MUST be sent on the request stream.
+PRIORITY frames for that request MUST be sent on the control stream.  A PRIORITY
+frame received after other frames on a request stream MUST be treated	as a
+connection error of type HTTP_UNEXPECTED_FRAME.
 
 Placeholder and server push streams can only be prioritized on the control
 stream.

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -568,12 +568,14 @@ The PRIORITY frame payload has the following fields:
   Weight:
   : An optional unsigned 8-bit integer representing a priority weight for the
     prioritized element (see {{!RFC7540}}, Section 5.3). Add one to the value
-    to obtain a weight between 1 and 256.  When absent, this value is 16.
+    to obtain a weight between 1 and 256.  When absent, indicates the resource
+    should be delivered all at once or not at all.
   
   Priority:
   : An optional unsigned 8-bit integer representing a strict priority for the
     prioritized element (see {{!RFC7540}}, Section 5.3).  When absent, this
-    value is 16.
+    value is 16.  An element with a higher priority should be delivered before
+    an element of lower priority.
   
 
 The values for the Prioritized Element Type ({{prioritized-element-types}}) and
@@ -1094,16 +1096,21 @@ the RST bit set if it detects an error with the stream or the QUIC connection.
 ## Prioritization {#priority}
 
 HTTP/3 uses a priority scheme similar to that described in {{!RFC7540}}, Section
-5.3, but replaces streams depending upon streams with placeholders and strict
-priorities. In this priority scheme, a given element can be designated as dependent
-upon a placeholder or the root. This information is expressed in the PRIORITY
-frame {{frame-priority}} which identifies the element and the dependency. The
-elements that can be prioritized are:
+5.3, but replaces streams depending upon streams with strict priorities and
+placeholders.  In the HTTP/3 priority scheme, a given element can be designated
+as dependent upon a placeholder or the root. This information is expressed in
+the PRIORITY frame {{frame-priority}} which identifies the element and the
+dependency. The elements that can be prioritized are:
 
 - Requests, identified by the stream of the PRIORITY frame
 - Pushes, identified by the Push ID of the promised resource
   ({{frame-push-promise}})
 - Placeholders, identified by a Placeholder ID
+
+In HTTP/3 stream dependencies which implicitly encode strict priorities by
+explicit strict prioritization.  This simplifies priority tree management,
+eliminates race conditions introduced by HTTP/3's multiple streams, and improves
+framing efficiency in the case of a large number of streams.
 
 Taken together, the dependencies across all prioritized elements in a connection
 form a dependency tree. An element can only depend on a placeholder or on the root

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -570,13 +570,13 @@ The PRIORITY frame payload has the following fields:
     prioritized element (see {{!RFC7540}}, Section 5.3). Add one to the value
     to obtain a weight between 1 and 256.  When absent, indicates the resource
     should be delivered all at once or not at all.
-  
+
   Priority:
   : An optional unsigned 8-bit integer representing a strict priority for the
     prioritized element (see {{!RFC7540}}, Section 5.3).  When absent, this
     value is 16.  An element with a higher priority should be delivered before
     an element of lower priority.
-  
+
 
 The values for the Prioritized Element Type ({{prioritized-element-types}}) and
 Element Dependency Type ({{element-dependency-types}}) imply the interpretation


### PR DESCRIPTION
Replaces streams depending upon streams with a one byte strict priority value.  As much data as possible is sent on Streams with a higher priority before sending data from lower priority streams. 
 Retains weights and placeholders in order to provide functionality equivalent to HTTP/2

Includes the sequential and interleaved delivery idea from Patrick Meenan's recent proposal(https://github.com/pmeenan/http3-prioritization-proposal/blob/master/README.md), when multiple streams share the same priority value.

The goal is to fix #2502 and similar issues, add a single operation(change of strict priority) equivalent to HTTP/2 exclusive reprioritization, which was removed in #2075, and lower the complexity of a compliant priority implementation by allowing a server to specify 0 placeholders, in which case this simplifies to priorities and weights.

Fixes #2502 by removing the ability to depend upon a stream(and therefore an unopened or already closed stream).