### PR TITLE
Prohibit other frame types on CONNECT

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -550,8 +550,8 @@ the proxy. Note that the size and number of TCP segments is not guaranteed to
 map predictably to the size and number of HTTP DATA or QUIC STREAM frames.
 
 Once the CONNECT method has completed, only DATA frames are permitted
-to be sent on the stream.  (Extension frames MAY be used, if specifically
-permitted by the extensions definition.)  Receipt of any other frame type
+to be sent on the stream.  Extension frames MAY be used if specifically
+permitted by the definition of the extension.  Receipt of any other frame type
 MUST be treated as a connection error of type HTTP_UNEXPECTED_FRAME.
 
 The TCP connection can be closed by either peer. When the client ends the

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -549,6 +549,11 @@ TCP server; data received from the TCP server is packaged into DATA frames by
 the proxy. Note that the size and number of TCP segments is not guaranteed to
 map predictably to the size and number of HTTP DATA or QUIC STREAM frames.
 
+Once the CONNECT method has completed, only DATA frames are permitted
+to be sent on the stream.  (Extension frames MAY be used, if specifically
+permitted by the extensions definition.)  Receipt of any other frame type
+MUST be treated as a connection error of type HTTP_UNEXPECTED_FRAME.
+
 The TCP connection can be closed by either peer. When the client ends the
 request stream (that is, the receive stream at the proxy enters the "Data Recvd"
 state), the proxy will set the FIN bit on its connection to the TCP server. When


### PR DESCRIPTION
Fixes #2229.

This still seems like a pointless restriction to me, but it's what we agreed in Tokyo, so here it is.