### PR TITLE
Push SHOULD precede reference

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -689,7 +689,7 @@ DUPLICATE_PUSH frame (see {{frame-duplicate-push}}).
 
 Ordering of a PUSH_PROMISE or DUPLICATE_PUSH in relation to certain parts of the
 response is important. The server SHOULD send PUSH_PROMISE or DUPLICATE_PUSH
-frames prior to sending any frames that reference the promised responses.  This
+frames prior to sending HEADERS or DATA frames that reference the promised responses.  This
 reduces the chance that a client requests a resource that will be pushed by the
 server.
 

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -410,8 +410,8 @@ An HTTP message (request or response) consists of:
 3. optionally, one HEADERS frame containing the trailer-part, if present (see
    {{!RFC7230}}, Section 4.1.2).
 
-A server MAY interleave one or more PUSH_PROMISE frames (see
-{{frame-push-promise}}) with the frames of a response message. These
+A server MAY send one or more PUSH_PROMISE frames (see {{frame-push-promise}})
+before, after, or interleaved with the frames of a response message. These
 PUSH_PROMISE frames are not part of the response; see {{server-push}} for more
 details.
 
@@ -681,15 +681,17 @@ type HTTP_LIMIT_EXCEEDED.
 
 The header of the request message is carried by a PUSH_PROMISE frame (see
 {{frame-push-promise}}) on the request stream which generated the push. This
-allows the server push to be associated with a client request. Ordering of a
-PUSH_PROMISE in relation to certain parts of the response is important (see
-Section 8.2.1 of {{!HTTP2}}).  Promised requests MUST conform to the
-requirements in Section 8.2 of {{!HTTP2}}.
+allows the server push to be associated with a client request.  Promised
+requests MUST conform to the requirements in Section 8.2 of {{!HTTP2}}.
 
 The same server push can be associated with additional client requests using a
-DUPLICATE_PUSH frame (see {{frame-duplicate-push}}).  Ordering of a
-DUPLICATE_PUSH in relation to certain parts of the response is similarly
-important.
+DUPLICATE_PUSH frame (see {{frame-duplicate-push}}).
+
+Ordering of a PUSH_PROMISE or DUPLICATE_PUSH in relation to certain parts of the
+response is important. The server SHOULD send PUSH_PROMISE or DUPLICATE_PUSH
+frames prior to sending any frames that reference the promised responses.  This
+avoids a race where clients issue requests prior to receiving any PUSH_PROMISE
+frames.
 
 When a server later fulfills a promise, the server push response is conveyed on
 a push stream (see {{push-streams}}). The push stream identifies the Push ID of

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -690,8 +690,8 @@ DUPLICATE_PUSH frame (see {{frame-duplicate-push}}).
 Ordering of a PUSH_PROMISE or DUPLICATE_PUSH in relation to certain parts of the
 response is important. The server SHOULD send PUSH_PROMISE or DUPLICATE_PUSH
 frames prior to sending any frames that reference the promised responses.  This
-avoids a race where clients issue requests prior to receiving any PUSH_PROMISE
-frames.
+reduces the chance that a client requests a resource that will be pushed by the
+server.
 
 When a server later fulfills a promise, the server push response is conveyed on
 a push stream (see {{push-streams}}). The push stream identifies the Push ID of


### PR DESCRIPTION
Fixes #2230's remaining issue by importing text from HTTP/2.  PUSH_PROMISE and DUPLICATE_PUSH SHOULD precede the piece of the response that references the resource, but MAY come at any point in the server's response, including between the trailers and the end of the stream.  That's exceptionally stupid server behavior, but not illegal.

I consider this editorial, because no MUSTs are modified and the SHOULD was already incorporated by reference to 7540.