### PR TITLE
Specify HEADERS on control stream error.

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1113,7 +1113,9 @@ QPACK. See [QPACK] for more details.
 ~~~~~~~~~~
 {: #fig-headers title="HEADERS frame payload"}
 
-HEADERS frames can only be sent on request / push streams.
+HEADERS frames can only be sent on request / push streams.  If a HEADERS frame
+is received on a control stream, the recipient MUST respond with a connection
+error ({{errors}}) of type HTTP_WRONG_STREAM.
 
 ### PRIORITY {#frame-priority}
 


### PR DESCRIPTION
Receiving a HEADERS frame on a control stream should result in a connection error of type HTTP_WRONG_STREAM.

The correct error is documented for all other frame types except for HEADERS. This pr specifies the error for HEADERS frames as well.