### PR TITLE
Specify server error on receipt of a PUSH_PROMISE frame

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1370,8 +1370,11 @@ multiple PUSH_PROMISE frames.  A client MUST treat receipt of a PUSH_PROMISE
 that contains a larger Push ID than the client has advertised or a Push ID which
 has already been promised as a connection error of type HTTP_MALFORMED_FRAME.
 
-If a PUSH_PROMISE frame is received on either control stream, the recipient MUST
+If a PUSH_PROMISE frame is received on the control stream, the client MUST
 respond with a connection error ({{errors}}) of type HTTP_WRONG_STREAM.
+
+A client MUST NOT send a PUSH_PROMISE frame.  A server MUST treat the receipt
+of a PUSH_PROMISE frame as a connection error of type HTTP_UNEXPECTED_FRAME.
 
 See {{server-push}} for a description of the overall server push mechanism.
 


### PR DESCRIPTION
This pr changes the server's error on receipt of a PUSH_PROMISE frame. While the current draft implicitly suggests push promises can only be sent by the server, it doesn't explicitly disallow clients from sending PUSH_PROMISE frames. This pr explicitly disallows clients from sending PUSH_PROMISE frames and requires the server to treat each receipt of a PUSH_PROMISE frame as a connection error of type HTTP_UNEXPECTED_FRAME.
