### PR TITLE
Fix GOAWAY errors properly

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1395,7 +1395,7 @@ close a connection.
 The GOAWAY frame is always sent on the control stream. It carries a QUIC Stream
 ID for a client-initiated bidirectional stream encoded as a variable-length
 integer.  A client MUST treat receipt of a GOAWAY frame containing a Stream ID
-of any other type as a connection error of type HTTP_WRONG_STREAM.
+of any other type as a connection error of type HTTP_MALFORMED_FRAME.
 
 Clients do not need to send GOAWAY to initiate a graceful shutdown; they simply
 stop making new requests.  A server MUST treat receipt of a GOAWAY frame on any
@@ -1403,7 +1403,7 @@ stream as a connection error ({{errors}}) of type HTTP_UNEXPECTED_FRAME.
 
 The GOAWAY frame applies to the connection, not a specific stream.  A client
 MUST treat a GOAWAY frame on a stream other than the control stream as a
-connection error ({{errors}}) of type HTTP_UNEXPECTED_FRAME.
+connection error ({{errors}}) of type HTTP_WRONG_STREAM.
 
 See {{connection-shutdown}} for more information on the use of the GOAWAY frame.
 


### PR DESCRIPTION
In #2705, @DaanDeMeyer correctly observed that I messed up #2343, but he closed his PR and I'm not able to reopen it without more git wizardry than I'm interested in practicing today.  Easier just to fix it in my own branch.

So:
- GOAWAY properly sent by the server on the control stream, but *containing* the wrong stream ID can't be WRONG_STREAM, it should be MALFORMED_FRAME.
- GOAWAY sent by the server on something other than the control frame isn't UNEXPECTED_FRAME, it's WRONG_STREAM (see [aside with @kazuho](https://github.com/quicwg/base-drafts/issues/2551#issuecomment-492911408) about whether the distinction actually matters, but in the interest of keeping the document internally consistent....)
- GOAWAY sent by a client is UNEXPECTED_FRAME, and that's the only one I got right before.

Fixes #2714.