### PR TITLE
Allow reuse of stateless reset tokens

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2477,13 +2477,15 @@ that is reset by revealing the Stateless Reset Token MUST NOT be reused for new
 connections at nodes that share a static key.
 
 The same Stateless Reset Token MAY be used for multiple connection IDs on the
-same connection.  An endpoint that reuses a Stateless Reset Token MUST ensure
-that packets with Destination Connection ID field values that correspond to a
-reused Stateless Reset Token are attributed to the same connection, even when
-the connection ID has been retired.  Otherwise, an attacker might be able to
-send a packet with a retired connection ID and cause the endpoint to produce a
-Stateless Reset that it can use to disrupt the connection; just as with the
-attacks in {{reset-oracle}}.
+same connection.  However, reuse of a Stateless Reset Token might expose an
+endpoint to denial of service if associated connection IDs are forgotten while
+the associated token is still active at a peer.  An endpoint MUST ensure that
+packets with Destination Connection ID field values that correspond to a reused
+Stateless Reset Token are attributed to the same connection as long as the
+Stateless Reset Token is still usable, even when the connection ID has been
+retired.  Otherwise, an attacker might be able to send a packet with a retired
+connection ID and cause the endpoint to produce a Stateless Reset that it can
+use to disrupt the connection; just as with the attacks in {{reset-oracle}}.
 
 Note that Stateless Reset packets do not have any cryptographic protection.
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2485,7 +2485,7 @@ Stateless Reset Token are attributed to the same connection as long as the
 Stateless Reset Token is still usable, even when the connection ID has been
 retired.  Otherwise, an attacker might be able to send a packet with a retired
 connection ID and cause the endpoint to produce a Stateless Reset that it can
-use to disrupt the connection; just as with the attacks in {{reset-oracle}}.
+use to disrupt the connection, just as with the attacks in {{reset-oracle}}.
 
 Note that Stateless Reset packets do not have any cryptographic protection.
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2476,6 +2476,14 @@ the same static key (see {{reset-oracle}}).  A connection ID from a connection
 that is reset by revealing the Stateless Reset Token MUST NOT be reused for new
 connections at nodes that share a static key.
 
+The same Stateless Reset Token MAY be used for multiple connection IDs on the
+same connection.  An endpoint that reuses a Stateless Reset Token MUST ensure
+that any connection ID used on the connection is matched to the active
+connection, including any routing performed at load balancers, even when a
+connection ID has been retired.  Otherwise, an attacker might be able to send a
+packet with a retired connection ID and cause the endpoint to produce a
+Stateless Reset.
+
 Note that Stateless Reset packets do not have any cryptographic protection.
 
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2478,11 +2478,11 @@ connections at nodes that share a static key.
 
 The same Stateless Reset Token MAY be used for multiple connection IDs on the
 same connection.  An endpoint that reuses a Stateless Reset Token MUST ensure
-that any connection ID associated with the reused value is correlated with to
-the active connection, even when the connection ID has been retired.  Otherwise,
-an attacker might be able to send a packet with a retired connection ID and
-cause the endpoint to produce a Stateless Reset that it can use to disrupt the
-connection; just as with the attacks in {{reset-oracle}}.
+that packets that use connection IDs associated with the reused value are
+attributed to the active connection, even when the connection ID has been
+retired.  Otherwise, an attacker might be able to send a packet with a retired
+connection ID and cause the endpoint to produce a Stateless Reset that it can
+use to disrupt the connection; just as with the attacks in {{reset-oracle}}.
 
 Note that Stateless Reset packets do not have any cryptographic protection.
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2478,11 +2478,12 @@ connections at nodes that share a static key.
 
 The same Stateless Reset Token MAY be used for multiple connection IDs on the
 same connection.  An endpoint that reuses a Stateless Reset Token MUST ensure
-that packets that use connection IDs associated with the reused value are
-attributed to the active connection, even when the connection ID has been
-retired.  Otherwise, an attacker might be able to send a packet with a retired
-connection ID and cause the endpoint to produce a Stateless Reset that it can
-use to disrupt the connection; just as with the attacks in {{reset-oracle}}.
+that packets with Destination Connection ID field values that correspond to a
+reused Stateless Reset Token are attributed to the same connection, even when
+the connection ID has been retired.  Otherwise, an attacker might be able to
+send a packet with a retired connection ID and cause the endpoint to produce a
+Stateless Reset that it can use to disrupt the connection; just as with the
+attacks in {{reset-oracle}}.
 
 Note that Stateless Reset packets do not have any cryptographic protection.
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2472,17 +2472,17 @@ Stateless Reset Token means that the combination of connection ID and static key
 MUST NOT be used for another connection.  A denial of service attack is possible
 if the same connection ID is used by instances that share a static key, or if an
 attacker can cause a packet to be routed to an instance that has no state but
-the same static key (see {{reset-oracle}}).  A connection ID from a connection
+the same static key; see {{reset-oracle}}.  A connection ID from a connection
 that is reset by revealing the Stateless Reset Token MUST NOT be reused for new
 connections at nodes that share a static key.
 
 The same Stateless Reset Token MAY be used for multiple connection IDs on the
 same connection.  An endpoint that reuses a Stateless Reset Token MUST ensure
-that any connection ID used on the connection is matched to the active
-connection, including any routing performed at load balancers, even when a
-connection ID has been retired.  Otherwise, an attacker might be able to send a
-packet with a retired connection ID and cause the endpoint to produce a
-Stateless Reset.
+that any connection ID associated with the reused value is correlated with to
+the active connection, even when the connection ID has been retired.  Otherwise,
+an attacker might be able to send a packet with a retired connection ID and
+cause the endpoint to produce a Stateless Reset that it can use to disrupt the
+connection; just as with the attacks in {{reset-oracle}}.
 
 Note that Stateless Reset packets do not have any cryptographic protection.
 


### PR DESCRIPTION
This came up as the result of an incomplete implementation, but there
are - maybe - good reasons to have the same stateless reset token being
used for multiple connection IDs on the same connection.

There are drawbacks however.  Reuse of a stateless reset token means
that you have to remember (and consistently route) connection IDs, even
when they are retired.

This text makes a note of the possibility and explains the drawbacks.

Closes #2732.