### PR TITLE
Recommend only one packet per encryption level

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2632,7 +2632,8 @@ process coalesced packets.
 Coalescing packets in order of increasing encryption levels (Initial, 0-RTT,
 Handshake, 1-RTT) makes it more likely the receiver will be able to process all
 the packets in a single pass.  A packet with a short header does not include a
-length, so it can only be the last packet included in a UDP datagram.
+length, so it can only be the last packet included in a UDP datagram.  An
+endpoint SHOULD NOT coalesce multiple packets at the same encryption level.
 
 Senders MUST NOT coalesce QUIC packets for different connections into a single
 UDP datagram. Receivers SHOULD ignore any subsequent packets with a different


### PR DESCRIPTION
This is a SHOULD per agreement in London because a) we can't decide why
you might not, but b) we can't mandate any particular action on the part
of a receiver.

Closes #2308.