### PR TITLE
Don't use ECN if packets are discarded

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -5403,8 +5403,9 @@ their effects in more detail.
 An on-the-side attacker can duplicate and send packets with modified ECN
 codepoints to affect the sender's rate.  If duplicate packets are discarded by a
 receiver, an off-path attacker will need to race the duplicate packet against
-the original to be successful in this attack.  Therefore, QUIC receivers ignore
-ECN codepoints set in duplicate packets (see {{ecn}}).
+the original to be successful in this attack.  Therefore, QUIC endpoints ignore
+the ECN codepoint field on an IP packet unless a QUIC packet in that IP packet
+is successfully processed; see {{ecn}}.
 
 ## Stateless Reset Oracle {#reset-oracle}
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -5404,8 +5404,8 @@ An on-the-side attacker can duplicate and send packets with modified ECN
 codepoints to affect the sender's rate.  If duplicate packets are discarded by a
 receiver, an off-path attacker will need to race the duplicate packet against
 the original to be successful in this attack.  Therefore, QUIC endpoints ignore
-the ECN codepoint field on an IP packet unless a QUIC packet in that IP packet
-is successfully processed; see {{ecn}}.
+the ECN codepoint field on an IP packet unless at least one QUIC packet in that
+IP packet is successfully processed; see {{ecn}}.
 
 ## Stateless Reset Oracle {#reset-oracle}
 


### PR DESCRIPTION
@gorryfair made a good suggestion in #2163, which I have taken and
tweaked further.  It is not sufficient to discard ECN if one QUIC packet
is discared, you need to discard ALL QUIC packets in the IP packet.