### PR TITLE
QPACK editorial revision

### DIFF
--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -167,15 +167,8 @@ fields (some of them with an empty value).  The dynamic table (see
 {{table-dynamic}}) is built up over the course of the connection and can be used
 by the encoder to index header fields in the encoded header lists.
 
-QPACK instructions appear in three different types of streams:
-
-- The encoder uses a unidirectional stream to modify the state of the dynamic
-table without emitting header fields associated with any particular request.
-
-- Header blocks reference the table state without modifying it.
-
-- The decoder sends feedback to the encoder on a unidirectional stream.  This
-feedback enables the encoder to manage dynamic table state.
+QPACK defines unidirectional streams for sending instructions from encoder to
+decoder and vice-versa.
 
 ## Encoder
 
@@ -344,7 +337,7 @@ MUST treat this as a connection error of type HTTP_QPACK_DECOMPRESSION_FAILED.
 
 ### State Synchronization
 
-The decoder signals key events by emitting decoder instructions
+The decoder signals the following key events by emitting decoder instructions
 ({{decoder-instructions}}) on the decoder stream.
 
 #### Completed Processing of a Header Block
@@ -619,20 +612,7 @@ prefix integer.  The remainder of the string literal is unmodified.
 A string literal without a prefix length noted is an 8-bit prefix string literal
 and follows the definitions in [RFC7541] without modification.
 
-## Instructions
-
-There are three separate QPACK instruction spaces. Encoder instructions
-({{encoder-instructions}}) carry table updates, decoder instructions
-({{decoder-instructions}}) carry acknowledgments of table modifications and
-header processing, and header block instructions ({{header-block-instructions}})
-convey an encoded representation of a header list by referring to the QPACK
-table state.
-
-Encoder and decoder instructions appear on the unidirectional stream types
-described in this section. Header block instructions are contained in header
-blocks, which are conveyed in frames as described in {{HTTP3}}.
-
-### Encoder and Decoder Streams {#enc-dec-stream-def}
+## Encoder and Decoder Streams {#enc-dec-stream-def}
 
 QPACK defines two unidirectional stream types:
 
@@ -663,12 +643,13 @@ even if the connection's settings prevent their use.
 
 ## Encoder Instructions {#encoder-instructions}
 
-An encoder uses encoder instructions to set the capacity of the dynamic table
-and add dynamic table entries.  Instructions adding table entries can use
-existing entries to avoid transmitting redundant information.  The name can be
-transmitted as a reference to an existing entry in the static or the dynamic
-table or as a string literal.  For entries which already exist in the dynamic
-table, the full entry can also be used by reference, creating a duplicate entry.
+An encoder sends encoder instructions on the encoder stream to set the capacity
+of the dynamic table and add dynamic table entries.  Instructions adding table
+entries can use existing entries to avoid transmitting redundant information.
+The name can be transmitted as a reference to an existing entry in the static or
+the dynamic table or as a string literal.  For entries which already exist in
+the dynamic table, the full entry can also be used by reference, creating a
+duplicate entry.
 
 This section specifies the following encoder instructions.
 

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -320,11 +320,11 @@ greater than or equal to the Required Insert Count for all header blocks the
 decoder has started reading from the stream.
 <!-- doesn't the stream become unblocked when the encoder receives the acks? -->
 
-When processing header blocks, the decoder expects the Required Insert Count
-value to exactly match the value defined in {{blocked-streams}. If it encounters
-a smaller value, it MUST treat this as a connection error of type
+When processing header blocks, the decoder expects the Required Insert Count to
+exactly match the value defined in {{blocked-streams}. If it encounters a
+smaller value than expected, it MUST treat this as a connection error of type
 HTTP_QPACK_DECOMPRESSION_FAILED (see {{invalid-references}}). If it encounters a
-larger value, it MAY treat this as a connection error of type
+larger value than expected, it MAY treat this as a connection error of type
 HTTP_QPACK_DECOMPRESSION_FAILED.
 
 If the decoder encounters more blocked streams than it promised to support, it
@@ -970,8 +970,8 @@ index less than the Base, this representation starts with the '1' 1-bit pattern,
 followed by the `S` bit indicating whether the reference is into the static or
 dynamic table.  The 6-bit prefix integer (see Section 5.1 of [RFC7541]) that
 follows is used to locate the table entry for the header name.  When S=1, the
-number represents the static table index; when S=0, the number is the index of
-the entry in the dynamic table relative to Base.
+number represents the static table index; when S=0, the number is the relative
+index of the entry in the dynamic table.
 
 
 ### Indexed Header Field With Post-Base Index
@@ -1028,8 +1028,8 @@ values that are not to be put at risk by compressing them (see Section 7.1 of
 The fourth (`S`) bit indicates whether the reference is to the static or dynamic
 table.  The 4-bit prefix integer (see Section 5.1 of [RFC7541]) that follows is
 used to locate the table entry for the header name.  When S=1, the number
-represents the static table index; when S=0, the number is the index of the
-entry in the dynamic table relative to Base.
+represents the static table index; when S=0, the number is the relative index of
+the entry in the dynamic table.
 
 
 ### Literal Header Field With Post-Base Name Reference

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -174,7 +174,7 @@ decoder and vice-versa.
 
 An encoder compresses a header list into a header block by emitting either an
 indexed or a literal representation for each header field in the list (see
-{{header-block-instructions}}).  Indexed representations achieve high
+{{header-block-representations}}).  Indexed representations achieve high
 compression by replacing the literal name and possibly the value with an index
 to either the static or dynamic table.  References to the static table and
 literal representations do not require any dynamic state and never risk
@@ -383,9 +383,9 @@ acknowledged before using it.
 
 ### Invalid References
 
-If the decoder encounters a reference in a header block instruction to a dynamic
-table entry which has already been evicted or which has an absolute index
-greater than or equal to the declared Required Insert Count (see
+If the decoder encounters a reference in a header block representation to a
+dynamic table entry which has already been evicted or which has an absolute
+index greater than or equal to the declared Required Insert Count (see
 {{header-prefix}}), it MUST treat this as a connection error of type
 `HTTP_QPACK_DECOMPRESSION_FAILED`.
 
@@ -412,7 +412,7 @@ Note the QPACK static table is indexed from 0, whereas the HPACK static table
 is indexed from 1.
 
 When the decoder encounters an invalid static table index in a header block
-instruction it MUST treat this as a connection error of type
+representation it MUST treat this as a connection error of type
 `HTTP_QPACK_DECOMPRESSION_FAILED`.  If this index is received on the encoder
 stream, this MUST be treated as a connection error of type
 `HTTP_QPACK_ENCODER_STREAM_ERROR`.
@@ -531,8 +531,8 @@ d = count of entries dropped
 ~~~~~
 {: title="Example Dynamic Table Indexing - Encoder Stream"}
 
-Unlike encoder instructions, relative indices in header block instructions are
-relative to the Base at the beginning of the header block (see
+Unlike encoder instructions, relative indices in header block representations
+are relative to the Base at the beginning of the header block (see
 {{header-prefix}}). This ensures that references are stable even if header
 blocks and dynamic table updates are processed out of order.
 
@@ -823,10 +823,10 @@ the Known Received Count beyond what the encoder has sent MUST treat this as a
 connection error of type `HTTP_QPACK_DECODER_STREAM_ERROR`.
 
 
-## Header Block Instructions
+## Header Block Representations
 
 Header blocks contain compressed representations of header lists and are carried
-in frames on streams defined by the enclosing protocol.  These instructions
+in frames on streams defined by the enclosing protocol.  These representations
 reference the static table, or dynamic table in a particular state without
 modifying it.
 
@@ -837,7 +837,7 @@ encoded as an integer with an 8-bit prefix after the encoding described in
 {{ric}}).  The Base is encoded as sign-and-modulus integer, using a single sign
 bit and a value with a 7-bit prefix (see {{base}}).
 
-These two values are followed by instructions for compressed headers.
+These two values are followed by representations for compressed headers.
 
 ~~~~~~~~~~  drawing
   0   1   2   3   4   5   6   7
@@ -1106,8 +1106,8 @@ The following error codes are defined for HTTP/3 to indicate failures of
 QPACK which prevent the connection from continuing:
 
 HTTP_QPACK_DECOMPRESSION_FAILED (0x200):
-: The decoder failed to interpret a header block instruction and is not
-  able to continue decoding that header block.
+: The decoder failed to interpret a header block and is not able to continue
+  decoding that header block.
 
 HTTP_QPACK_ENCODER_STREAM_ERROR (0x201):
 : The decoder failed to interpret an encoder instruction received on the

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -172,8 +172,7 @@ QPACK instructions appear in three different types of streams:
 - The encoder uses a unidirectional stream to modify the state of the dynamic
 table without emitting header fields associated with any particular request.
 
-- HEADERS and PUSH_PROMISE frames on request and push streams reference the
-table state without modifying it.
+- Header blocks reference the table state without modifying it.
 
 - The decoder sends feedback to the encoder on a unidirectional stream.  This
 feedback enables the encoder to manage dynamic table state.
@@ -607,9 +606,8 @@ convey an encoded representation of a header list by referring to the QPACK
 table state.
 
 Encoder and decoder instructions appear on the unidirectional stream types
-described in this section. Header block instructions are contained in HEADERS
-and PUSH_PROMISE frames, which are conveyed on request or push streams as
-described in {{HTTP3}}.
+described in this section. Header block instructions are contained in header
+blocks, which are conveyed in frames as described in {{HTTP3}}.
 
 ### Encoder and Decoder Streams {#enc-dec-stream-def}
 
@@ -799,7 +797,7 @@ possibly update the Known Received Count.
 
 The same Stream ID can be identified multiple times, as multiple header blocks
 can be sent on a single stream in the case of intermediate responses, trailers,
-and pushed requests.  Since HEADERS and PUSH_PROMISE frames on each stream are
+and pushed requests.  Since frames carrying header blocks on each stream are
 received and processed in order, this gives the encoder precise feedback on
 which header blocks within a stream have been fully processed.
 
@@ -820,8 +818,7 @@ Known Received Count.
 ### Stream Cancellation
 
 The instruction begins with the '01' two-bit pattern. The instruction includes
-the stream ID of the affected stream - a request or push stream - encoded as a
-6-bit prefix integer.
+the stream ID of the affected stream encoded as a 6-bit prefix integer.
 
 ~~~~~~~~~~ drawing
   0   1   2   3   4   5   6   7
@@ -847,12 +844,10 @@ table have been received.
 
 ## Header Block Instructions
 
-HTTP/3 endpoints convert header lists to headers blocks and exchange them inside
-HEADERS and PUSH_PROMISE frames. A decoder interprets header block instructions
-in order to construct a header list. These instructions reference the static
-table, or dynamic table in a particular state without modifying it.
-
-This section specifies the following header block instructions.
+Header blocks contain compressed representations of header lists and are carried
+in frames on streams defined by the enclosing protocol.  These instructions
+reference the static table, or dynamic table in a particular state without
+modifying it.
 
 ### Header Block Prefix {#header-prefix}
 
@@ -861,8 +856,7 @@ encoded as an integer with an 8-bit prefix after the encoding described in
 {{ric}}).  The Base is encoded as sign-and-modulus integer, using a single sign
 bit and a value with a 7-bit prefix (see {{base}}).
 
-These two values are followed by instructions for compressed headers.  The
-entire block is expected to be framed by the enclosing protocol.
+These two values are followed by instructions for compressed headers.
 
 ~~~~~~~~~~  drawing
   0   1   2   3   4   5   6   7

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -82,24 +82,21 @@ code and issues list for this draft can be found at
 
 # Introduction
 
-The QUIC transport protocol was designed from the outset to support HTTP
-semantics, and its design subsumes many of the features of HTTP/2.  HTTP/2 uses
-HPACK ({{!RFC7541}}) for header compression, but QUIC's stream multiplexing
-comes into some conflict with HPACK.  A key goal of the design of QUIC is to
-improve stream multiplexing relative to HTTP/2 by reducing head-of-line
-blocking.  If HPACK were used for HTTP/3, it would induce head-of-line
-blocking due to built-in assumptions of a total ordering across frames on all
-streams.
-
-QUIC is described in {{QUIC-TRANSPORT}}.  The HTTP/3 mapping is described in
-{{HTTP3}}. For a full description of HTTP/2, see {{?RFC7540}}. The
-description of HPACK is {{!RFC7541}}.
+The QUIC transport protocol is designed to support HTTP semantics, and its
+design subsumes many of the features of HTTP/2.  HTTP/2 uses HPACK
+({{!RFC7541}}) for header compression.  If HPACK were used for HTTP/3, it would
+induce head-of-line blocking due to built-in assumptions of a total ordering
+across frames on all streams.
 
 QPACK reuses core concepts from HPACK, but is redesigned to allow correctness in
 the presence of out-of-order delivery, with flexibility for implementations to
 balance between resilience against head-of-line blocking and optimal compression
 ratio.  The design goals are to closely approach the compression ratio of HPACK
 with substantially less head-of-line blocking under the same loss conditions.
+
+QUIC is described in {{QUIC-TRANSPORT}}.  The HTTP/3 mapping is described in
+{{HTTP3}}. For a full description of HTTP/2, see {{?RFC7540}}. The
+description of HPACK is {{!RFC7541}}.
 
 ## Conventions and Definitions
 


### PR DESCRIPTION
I made a major editorial pass on the QPACK spec, hoping to address some of the issues mentioned in #2339, and others.

I separated logical changes into individual commits in this PR, which should (hopefully) make it a bit easier to review the changes.  For example, some sections were reordered and updated, so there's a commit that just moves the text without changes.  

The "Editorial Clarifications" commit should not impact design at all, but does add new text explaining the handling of certain cases.

In addition to looking at the individual changes, giving the final product a read from start to finish would also be appreciated.