### PR TITLE
allow PRIORITY frames referring to placeholders exceeding `SETTING_NUM_PLACEHOLDERS`

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -613,7 +613,7 @@ tree could be discarded safely. Clients could potentially reference closed
 streams long after the server had discarded state, leading to disparate views of
 the prioritization the client had attempted to express.
 
-In HTTP/3, placeholders are given their own number space that spans between 0
+In HTTP/3, placeholders are given their own number space that spans between zero
 and 2^62-1.  By using the `SETTINGS_NUM_PLACEHOLDERS` setting, the server
 advertises the range of placeholder IDs it is committing to maintain state,
 which is between zero and one less than the value of this setting.  Clients can

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -641,6 +641,10 @@ client-controlled placeholders with an ID less than the value of this setting
 with the confidence that the server will not have discarded the state.  The
 orphan placeholder cannot be prioritized or referenced by the client.
 
+Servers are RECOMMENDED to support at least 32 placeholders.  Those do not
+SHOULD refrain from supporting placeholders at all, setting
+`SETTINGS_NUM_PLACEHOLDERS` to zero.
+
 Clients MUST NOT send the `SETTINGS_NUM_PLACEHOLDERS` setting; receipt of this
 setting by a server MUST be treated as a connection error of type
 `HTTP_WRONG_SETTING_DIRECTION`.
@@ -1343,8 +1347,7 @@ The following settings are defined in HTTP/3:
   : The default value is unlimited.  See {{header-formatting}} for usage.
 
   SETTINGS_NUM_PLACEHOLDERS (0x9):
-  : The default value is 0.  However, servers SHOULD set this value to 32 or
-    greater.  See {{placeholders}} for usage.
+  : The default value is 0.  See {{placeholders}} for usage.
 
 Setting identifiers of the format `0x1f * N + 0x21` for integer values of N are
 reserved to exercise the requirement that unknown identifiers be ignored.  Such

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1202,7 +1202,7 @@ The following situations are examples of invalid PRIORITY frames:
 A PRIORITY frame with Empty bits not set to zero MAY be treated as a connection
 error of type HTTP_MALFORMED_FRAME.
 
-A PRIORITY frame that references a non-existent Push ID, or a Stream ID the
+A PRIORITY frame that references a non-existent Push ID or a Stream ID the
 client is not yet permitted to open MUST be treated as a connection error of
 type HTTP_LIMIT_EXCEEDED.
 

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -638,8 +638,9 @@ advertises the number of client-controlled placeholders for which it is
 committing to maintain state.  Client-controlled placeholders are given their
 own number space that spans between zero and 2^62-1.  Clients can use the
 client-controlled placeholders with an ID less than the value of this setting
-with the confidence that the server will not have discarded the state.  The
-orphan placeholder cannot be prioritized or referenced by the client.
+with the confidence that the server will not have disposed of the priority of
+these placeholders.  The orphan placeholder cannot be prioritized or referenced
+by the client.
 
 Servers SHOULD support at least 32 placeholders.  Those that do not
 SHOULD refrain from supporting placeholders at all, setting

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1207,10 +1207,12 @@ client is not yet permitted to open MUST be treated as a connection error of
 type HTTP_LIMIT_EXCEEDED.
 
 A PRIORITY frame MAY reference a Placeholder ID that is equal to or greater than
-the server's advertised value of the `SETTINGS_NUM_PLACEHOLDERS` settings.  The
-server SHOULD ignore PRIORITY frames that specify such placeholders as the
-prioritized element.  The server SHOULD use the root of the tree as the
-dependency when such placeholders are specified as the depedencencies.
+the server's advertised value of the `SETTINGS_NUM_PLACEHOLDERS` settings.  When
+receiving a PRIORITY frame with its prioritized element set to such a
+placeholder, the server SHOULD discard the frame without making any change to
+the priority tree.  When receiving a PRIORITY frame with its element dependency
+set to such a placeholder, the server SHOULD update the priority tree with the
+root of the tree being the dependency instead.
 
 A PRIORITY frame received on any stream other than a request or control stream
 MUST be treated as a connection error of type HTTP_WRONG_STREAM.

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -641,7 +641,7 @@ client-controlled placeholders with an ID less than the value of this setting
 with the confidence that the server will not have discarded the state.  The
 orphan placeholder cannot be prioritized or referenced by the client.
 
-Servers are RECOMMENDED to support at least 32 placeholders.  Those that do not
+Servers SHOULD support at least 32 placeholders.  Those that do not
 SHOULD refrain from supporting placeholders at all, setting
 `SETTINGS_NUM_PLACEHOLDERS` to zero.
 

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -613,12 +613,11 @@ tree could be discarded safely. Clients could potentially reference closed
 streams long after the server had discarded state, leading to disparate views of
 the prioritization the client had attempted to express.
 
-In HTTP/3, placeholders are given their own number space that spans between zero
-and 2^62-1.  By using the `SETTINGS_NUM_PLACEHOLDERS` setting, the server
-advertises the range of placeholder IDs it is committing to maintain state,
-which is between zero and one less than the value of this setting.  Clients can
-use the placeholders within this range with the confidence that the server will
-not have discarded the state.
+In HTTP/3, by using the `SETTINGS_NUM_PLACEHOLDERS` setting, the server
+advertises the number of placeholders it is committing to maintain state.
+Placeholders are given their own number space that spans between zero and
+2^62-1.  Clients can use the placeholders with an ID less than the value of this
+setting with the confidence that the server will not have discarded the state.
 
 Clients MUST NOT send the `SETTINGS_NUM_PLACEHOLDERS` setting; receipt of this
 setting by a server MUST be treated as a connection error of type

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -641,7 +641,7 @@ client-controlled placeholders with an ID less than the value of this setting
 with the confidence that the server will not have discarded the state.  The
 orphan placeholder cannot be prioritized or referenced by the client.
 
-Servers are RECOMMENDED to support at least 32 placeholders.  Those do not
+Servers are RECOMMENDED to support at least 32 placeholders.  Those that do not
 SHOULD refrain from supporting placeholders at all, setting
 `SETTINGS_NUM_PLACEHOLDERS` to zero.
 

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -634,12 +634,12 @@ streams long after the server had discarded state, leading to disparate views of
 the prioritization the client had attempted to express.
 
 In HTTP/3, by using the `SETTINGS_NUM_PLACEHOLDERS` setting, the server
-advertises the number of client-controlled placeholders it is committing to
-maintain state.  Client-controlled placeholders are given their own number space
-that spans between zero and 2^62-1.  Clients can use the client-controlled
-placeholders with an ID less than the value of this setting with the confidence
-that the server will not have discarded the state.  The orphan placeholder
-cannot be prioritized or referenced by the client.
+advertises the number of client-controlled placeholders for which it is
+committing to maintain state.  Client-controlled placeholders are given their
+own number space that spans between zero and 2^62-1.  Clients can use the
+client-controlled placeholders with an ID less than the value of this setting
+with the confidence that the server will not have discarded the state.  The
+orphan placeholder cannot be prioritized or referenced by the client.
 
 Clients MUST NOT send the `SETTINGS_NUM_PLACEHOLDERS` setting; receipt of this
 setting by a server MUST be treated as a connection error of type

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1234,7 +1234,7 @@ receiving a PRIORITY frame with its prioritized element set to such a
 placeholder, the server SHOULD discard the frame without making any change to
 the priority tree.  When receiving a PRIORITY frame with its element dependency
 set to such a placeholder, the server SHOULD update the priority tree with the
-root of the tree being the dependency instead.
+orphan placeholder being the dependency instead.
 
 A PRIORITY frame received on any stream other than a request or control stream
 MUST be treated as a connection error of type HTTP_WRONG_STREAM.

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1321,8 +1321,8 @@ The following settings are defined in HTTP/3:
   : The default value is unlimited.  See {{header-formatting}} for usage.
 
   SETTINGS_NUM_PLACEHOLDERS (0x9):
-  : The default value is 0.  However, this value SHOULD be set to a non-zero
-    value by servers.  See {{placeholders}} for usage.
+  : The default value is 0.  However, servers SHOULD set this value to 32 or
+    greater.  See {{placeholders}} for usage.
 
 Setting identifiers of the format `0x1f * N + 0x21` for integer values of N are
 reserved to exercise the requirement that unknown identifiers be ignored.  Such


### PR DESCRIPTION
At the moment, it is the client's obligation to build a prioritization tree by respecting the server-advertised value of `SETTINGS_NUM_PLACEHOLDERS`.

That seems like an unnecessary complexity. We assume servers to provide sensible amount of space for placeholders (i.e., SHOULD). Then, why do the clients need to be _forced_ to implement complex logic to handle servers not complying to the recommendation?

This PR brings back the design we have in HTTP/2; i.e. give clients the freedom to express a prioritization tree that they need regardless of what the servers advertise using the `SETTINGS_NUM_PLACEHOLDERS` settings. The settings is changed to a purely advisory value; clients that do care are allowed to respect the value.

Maybe closes #2734, #2753.