### PR TITLE
Drop maximum value restrictions on QPACK settings

### DIFF
--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -1104,13 +1104,11 @@ represented as an 8-bit prefix string literal.
 QPACK defines two settings which are included in the HTTP/3 SETTINGS frame.
 
   SETTINGS_QPACK_MAX_TABLE_CAPACITY (0x1):
-  : An integer with a maximum value of 2^30 - 1.  The default value is zero
-    bytes.  See {{table-dynamic}} for usage.  This is the equivalent of the
-    SETTINGS_HEADER_TABLE_SIZE from HTTP/2.
+  : The default value is zero.  See {{table-dynamic}} for usage.  This is
+    the equivalent of the SETTINGS_HEADER_TABLE_SIZE from HTTP/2.
 
   SETTINGS_QPACK_BLOCKED_STREAMS (0x7):
-  : An integer with a maximum value of 2^16 - 1.  The default value is zero.
-    See {{overview-hol-avoidance}}.
+  : The default value is zero.  See {{overview-hol-avoidance}}.
 
 
 # Error Handling {#error-handling}


### PR DESCRIPTION
In addition, remove verbiage stating that the settings values are integers, as the are integers by the definition of the _SETTINGS_ frame.

Closes #2766.