### PR TITLE
Request to Retire Locally Issued CIDs

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1001,13 +1001,11 @@ corresponding RETIRE_CONNECTION_ID frames in a timely manner.  Failing to do so
 can cause packets to be delayed, lost, or cause the original endpoint to send a
 stateless reset in response to a connection ID it can no longer route correctly.
 
-The sender of the Retire Prior To field MUST keep track of the connection IDs it
-wishes to retire until it has received a corresponding RETIRE_CONNECTION_ID
-frame, with one exception: if the sender of the Retire Prior To field has used
-distinct stateless reset tokens for all of their issued connection IDs, and 3
-times the PTO has elapsed since it received an acknowledgment for its Retire
-Prior To field, then it MAY drop state for that connection ID, and respond to
-packets with that connection ID with the corresponding stateless reset token.
+An endpoint MAY discard a connection ID for which retirement has been requested
+once an interval of no less than 3 PTO has elapsed since an acknowledgement is
+received for the NEW_CONNECTION_ID frame requesting that retirement.  Subsequent
+incoming packets using that connection ID will elicit a response with the
+corresponding stateless reset token.
 
 
 ## Matching Packets to Connections {#packet-handling}
@@ -5003,7 +5001,7 @@ Sequence Number:
 
 Retire Prior To:
 
-: A variable-length integer specifying the limit, for which all connection IDs
+: A variable-length integer specifying the limit for which all connection IDs
   assigned to the receiver that have a sequence number less than this value
   should be retired.  See {{retiring-cids}}.
 
@@ -5057,11 +5055,10 @@ The Retire Prior To field MUST be less than or equal to the Sequence Number
 field.  Values greater than the Sequence Number MUST be treated as a connection
 error of type PROTOCOL_VIOLATION.
 
-The sender cannot reduce the value of the Retire Prior To field in subsequent
-NEW_CONNECTION_ID frames.  That is, once a sender indicates a Retire Prior To
-value, it MAY indicate a smaller value, but it has no effect.  A receiver MUST
-ignore any Retire Prior To fields that do not increase.
-
+Once a sender indicates a Retire Prior To value, smaller values sent in
+subsequent NEW_CONNECTION_ID frames have no effect. A receiver MUST ignore any
+Retire Prior To fields that do not increase the largest received Retire Prior To
+value.
 
 
 ## RETIRE_CONNECTION_ID Frame {#frame-retire-connection-id}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -994,12 +994,11 @@ packets sent from only one local address.  An endpoint that migrates away from a
 local address SHOULD retire all connection IDs used on that address once it no
 longer plans to use that address.
 
-The endpoint can explicitly request its peer to retire connection IDs by sending
+The endpoint can explicitly require its peer to retire connection IDs by sending
 a NEW_CONNECTION_ID frame with an increased Retire Prior To field.  The peer is
-required to retire these connection IDs in a timely manner.  On receipt of the
-acknowledgement for the packet that contained the NEW_CONNECTION_ID frame, the
-endpoint MAY start a 3 PTO timer.  If the timer expires before all the requested
-connection IDs are retired, the endpoint MAY close the connection with a
+required to retire these connection IDs in a timely manner.  If the peer does
+not retire the connection IDs within 3 PTO of acknowledging the packet with the
+NEW_CONNECTION_ID frame, the endpoint MAY close the connection with a
 PROTOCOL_VIOLATION.
 
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -5040,7 +5040,7 @@ initial and preferred_address transport parameter connection IDs.  The peer
 SHOULD immediately retire all the connection IDs.
 
 The sender of the NEW_CONNECTION_ID frame MAY remove the connection IDs after 3
-PTO, even if the peer has not retired them yet.  The 3 PTO timer starts on
+PTO, even if the peer has not retired them yet.  The 3-PTO timer starts on
 acknowledgement of the packet containing the NEW_CONNECTION_ID frame.  Continued
 use of the retired connection IDs after this point will likely result in a
 stateless reset being sent.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -5037,7 +5037,7 @@ PROTOCOL_VIOLATION.
 The Retire Prior To field is a request for the peer to immediately retire all
 connection IDs with a sequence number less than the specified value.  The Retire
 Prior To field MUST be less than the Sequence Number field.  Values greater than
-or equal to the Sequence Number MUST be treated as a connection error of type
+the Sequence Number MUST be treated as a connection error of type
 PROTOCOL_VIOLATION.
 
 The sender cannot reduce the value of the Retire Prior To field in subsequent

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -5035,9 +5035,10 @@ IDs, the endpoint MAY treat that receipt as a connection error of type
 PROTOCOL_VIOLATION.
 
 The Retire Prior To field is a request for the peer to immediately retire all
-connection IDs with a sequence number less than the specified value.  The Retire
-Prior To field MUST be less than the Sequence Number field.  Values greater than
-the Sequence Number MUST be treated as a connection error of type
+connection IDs with a sequence number less than the specified value.  This
+includes the initial and preferred_address transport parameter connection IDs.
+The Retire Prior To field MUST be less than the Sequence Number field.  Values
+greater than the Sequence Number MUST be treated as a connection error of type
 PROTOCOL_VIOLATION.
 
 The sender cannot reduce the value of the Retire Prior To field in subsequent

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -5040,14 +5040,18 @@ initial and preferred_address transport parameter connection IDs.  The peer
 SHOULD immediately retire all the connection IDs.
 
 The sender of the NEW_CONNECTION_ID frame MAY remove the connection IDs after 3
-PTO, even if the peer has not retired them yet.  The 3-PTO timer starts on
-acknowledgement of the packet containing the NEW_CONNECTION_ID frame.  Continued
-use of the retired connection IDs after this point will likely result in a
-stateless reset being sent.
+PTO, even if the peer has not retired them with RETIRE_CONNECTION_ID yet.  The
+3-PTO timer starts on acknowledgement of the packet containing the
+NEW_CONNECTION_ID frame.  Continued use of the retired connection IDs after this
+point will likely result in a stateless reset being sent.
 
-In order to prevent a stateless reset sent in response to a heavily delayed
-packet using a retired connection ID from closing the connection, the
-stateless reset token of the retired connection IDs SHOULD NOT be reused.
+If a stateless reset is received in response to a retired connection ID, the
+reset SHOULD be ignored and the receiver SHOULD immediately switch to a
+connection ID that has not been retired if it has not done so already.
+
+In order to prevent a heavily delayed packet with a retired connection ID from
+eliciting a stateless reset that closes the connection, the stateless reset
+token of the retired connection IDs SHOULD NOT be reused.
 
 The Retire Prior To field MUST be less than or equal to the Sequence Number
 field.  Values greater than the Sequence Number MUST be treated as a connection

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -5046,7 +5046,7 @@ use of the retired connection IDs after this point will likely result in a
 stateless reset being sent.
 
 In order to prevent a stateless reset sent in response to a heavily delayed
-packet using a retired connection ID, from closing the connection, the
+packet using a retired connection ID from closing the connection, the
 stateless reset token of the retired connection IDs SHOULD NOT be reused.
 
 The Retire Prior To field MUST be less than or equal to the Sequence Number

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -5043,13 +5043,7 @@ The Retire Prior To field is a request for the peer to retire all connection IDs
 with a sequence number less than the specified value.  This includes the initial
 and preferred_address transport parameter connection IDs.  The peer SHOULD
 retire the corresponding connection IDs and send the corresponding
-RETIRE_CONNECTION_ID frames in a timely manner
-
-The sender of the NEW_CONNECTION_ID frame MAY remove the connection IDs after 3
-PTO, even if the peer has not retired them with RETIRE_CONNECTION_ID yet.  The
-3-PTO timer starts on acknowledgement of the packet containing the
-NEW_CONNECTION_ID frame.  Continued use of the retired connection IDs after this
-point will likely result in a stateless reset being sent.
+RETIRE_CONNECTION_ID frames in a timely manner.
 
 The Retire Prior To field MUST be less than or equal to the Sequence Number
 field.  Values greater than the Sequence Number MUST be treated as a connection

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -5034,9 +5034,14 @@ sequence number, or if a sequence number is used for different connection
 IDs, the endpoint MAY treat that receipt as a connection error of type
 PROTOCOL_VIOLATION.
 
-The Retire Prior To field is a request for the peer to immediately retire all
-connection IDs with a sequence number less than the specified value.  This
-includes the initial and preferred_address transport parameter connection IDs.
+The Retire Prior To field is a requirement for the peer to retire all connection
+IDs with a sequence number less than the specified value.  This includes the
+initial and preferred_address transport parameter connection IDs.  The peer
+SHOULD immediately retire all the connection IDs.  The sender of the
+NEW_CONNECTION_ID frame MAY close the connection with an error of type
+PROTOCOL_VIOLATION if the peer does not retire the connection IDs within 3 PTO
+of the packet containing the NEW_CONNECTION_ID frame being acknowledged.
+
 The Retire Prior To field MUST be less than or equal to the Sequence Number
 field.  Values greater than the Sequence Number MUST be treated as a connection
 error of type PROTOCOL_VIOLATION.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1004,7 +1004,7 @@ stateless reset in response to a connection ID it can no longer route correctly.
 An endpoint MAY discard a connection ID for which retirement has been requested
 once an interval of no less than 3 PTO has elapsed since an acknowledgement is
 received for the NEW_CONNECTION_ID frame requesting that retirement.  Subsequent
-incoming packets using that connection ID will elicit a response with the
+incoming packets using that connection ID could elicit a response with the
 corresponding stateless reset token.
 
 
@@ -5045,8 +5045,8 @@ retire the corresponding connection IDs and send the corresponding
 RETIRE_CONNECTION_ID frames in a timely manner.
 
 The Retire Prior To field MUST be less than or equal to the Sequence Number
-field.  Values greater than the Sequence Number MUST be treated as a connection
-error of type PROTOCOL_VIOLATION.
+field.  Receiving a value greater than the Sequence Number MUST be treated as a
+connection error of type PROTOCOL_VIOLATION.
 
 Once a sender indicates a Retire Prior To value, smaller values sent in
 subsequent NEW_CONNECTION_ID frames have no effect. A receiver MUST ignore any

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -995,7 +995,7 @@ local address SHOULD retire all connection IDs used on that address once it no
 longer plans to use that address.
 
 An endpoint can request that its peer retire connection IDs by sending a
-NEW_CONNECTION_ID frames with an increased Retire Prior To field.  Upon receipt,
+NEW_CONNECTION_ID frame with an increased Retire Prior To field.  Upon receipt,
 the peer SHOULD retire the corresponding connection IDs and send the
 corresponding RETIRE_CONNECTION_ID frames in a timely manner.  Failing to do so
 can cause packets to be delayed, lost, or cause the original endpoint to send a

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -5001,9 +5001,8 @@ Sequence Number:
 
 Retire Prior To:
 
-: A variable-length integer specifying the limit for which all connection IDs
-  assigned to the receiver that have a sequence number less than this value
-  should be retired.  See {{retiring-cids}}.
+: A variable-length integer indicating which connection IDs should be retired.
+  See {{retiring-cids}}.
 
 Length:
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -5045,21 +5045,14 @@ PROTOCOL_VIOLATION.
 The Retire Prior To field is a request for the peer to retire all connection IDs
 with a sequence number less than the specified value.  This includes the initial
 and preferred_address transport parameter connection IDs.  The peer SHOULD
-immediately retire all the connection IDs.
+retire the corresponding connection IDs and send the corresponding
+RETIRE_CONNECTION_ID frame in a timely manner
 
 The sender of the NEW_CONNECTION_ID frame MAY remove the connection IDs after 3
 PTO, even if the peer has not retired them with RETIRE_CONNECTION_ID yet.  The
 3-PTO timer starts on acknowledgement of the packet containing the
 NEW_CONNECTION_ID frame.  Continued use of the retired connection IDs after this
 point will likely result in a stateless reset being sent.
-
-If a stateless reset is received in response to a retired connection ID, the
-reset SHOULD be ignored and the receiver SHOULD immediately switch to a
-connection ID that has not been retired if it has not done so already.
-
-In order to prevent a heavily delayed packet with a retired connection ID from
-eliciting a stateless reset that closes the connection, the stateless reset
-token of the retired connection IDs SHOULD NOT be reused.
 
 The Retire Prior To field MUST be less than or equal to the Sequence Number
 field.  Values greater than the Sequence Number MUST be treated as a connection

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -995,12 +995,12 @@ local address SHOULD retire all connection IDs used on that address once it no
 longer plans to use that address.
 
 The endpoint can explicitly request its peer to retire connection IDs by sending
-a NEW_CONNECTION_ID frame that contains a Retire Prior To field.  The peer is
+a NEW_CONNECTION_ID frame with an increased Retire Prior To field.  The peer is
 required to retire these connection IDs in a timely manner.  On receipt of the
 acknowledgement for the packet that contained the NEW_CONNECTION_ID frame, the
-endpoint may start a 3 PTO timer, which on expiring may close the connection
-with a PROTOCOL_VIOLATION error if all the connection IDs were not retired as
-requested.
+endpoint MAY start a 3 PTO timer.  If the timer expires before all the requested
+connection IDs are retired, the endpoint MAY close the connection with a
+PROTOCOL_VIOLATION.
 
 
 ## Matching Packets to Connections {#packet-handling}
@@ -2784,11 +2784,11 @@ frames are explained in more detail in {{frame-formats}}.
 | 0x14        | DATA_BLOCKED         | {{frame-data-blocked}}         |
 | 0x15        | STREAM_DATA_BLOCKED  | {{frame-stream-data-blocked}}  |
 | 0x16 - 0x17 | STREAMS_BLOCKED      | {{frame-streams-blocked}}      |
-| 0x18 - 0x19 | NEW_CONNECTION_ID    | {{frame-new-connection-id}}    |
-| 0x1a        | RETIRE_CONNECTION_ID | {{frame-retire-connection-id}} |
-| 0x1b        | PATH_CHALLENGE       | {{frame-path-challenge}}       |
-| 0x1c        | PATH_RESPONSE        | {{frame-path-response}}        |
-| 0x1d - 0x1e | CONNECTION_CLOSE     | {{frame-connection-close}}     |
+| 0x18        | NEW_CONNECTION_ID    | {{frame-new-connection-id}}    |
+| 0x19        | RETIRE_CONNECTION_ID | {{frame-retire-connection-id}} |
+| 0x1a        | PATH_CHALLENGE       | {{frame-path-challenge}}       |
+| 0x1b        | PATH_RESPONSE        | {{frame-path-response}}        |
+| 0x1c - 0x1d | CONNECTION_CLOSE     | {{frame-connection-close}}     |
 {: #frame-types title="Frame Types"}
 
 An endpoint MUST treat the receipt of a frame of unknown type as a connection
@@ -4959,9 +4959,9 @@ Stream Limit:
 
 ## NEW_CONNECTION_ID Frame {#frame-new-connection-id}
 
-An endpoint sends a NEW_CONNECTION_ID frame (type=0x18 or 0x19) to provide its
-peer with alternative connection IDs that can be used to break linkability when
-migrating connections (see {{migration-linkability}}).
+An endpoint sends a NEW_CONNECTION_ID frame (type=0x18) to provide its peer with
+alternative connection IDs that can be used to break linkability when migrating
+connections (see {{migration-linkability}}).
 
 The NEW_CONNECTION_ID frame is as follows:
 
@@ -4971,7 +4971,7 @@ The NEW_CONNECTION_ID frame is as follows:
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                      Sequence Number (i)                    ...
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                    [Retire Prior To (i)]                    ...
+|                      Retire Prior To (i)                    ...
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |   Length (8)  |                                               |
 +-+-+-+-+-+-+-+-+       Connection ID (32..144)                 +
@@ -4998,7 +4998,7 @@ Retire Prior To:
 
 : A variable-length integer specifying the limit, for which all connection IDs
   assigned to the receiver that have a sequence number less this value should be
-  retired.  See {{retiring-cids}}.  This field is only present for type=0x19.
+  retired.  See {{retiring-cids}}.
 
 Length:
 
@@ -5034,16 +5034,22 @@ sequence number, or if a sequence number is used for different connection
 IDs, the endpoint MAY treat that receipt as a connection error of type
 PROTOCOL_VIOLATION.
 
-If the Retire Prior To field is present it is a request for the peer to
-immediately retire all connection IDs with a sequence number less than the
-specified value.  For more information see {{retiring-cids}}.  This field
-should only ever increase, though reordering and retransmission of older packets
-may make it seem to decrease.  So any decrease in this field should be ignored.
+The Retire Prior To field is a request for the peer to immediately retire all
+connection IDs with a sequence number less than the specified value.  The Retire
+Prior To field MUST be less than the Sequence Number field.  Values greater than
+or equal to the Sequence Number MUST be treated as a connection error of type
+PROTOCOL_VIOLATION.
+
+The sender cannot reduce the value of the Retire Prior To field in subsequent
+NEW_CONNECTION_ID frames.  That is, once a sender indicates a Retire Prior To
+value, it MAY indicate a smaller value, but it has no effect.  A receiver MUST
+ignore any Retire Prior To fields that do not increase.
+
 
 
 ## RETIRE_CONNECTION_ID Frame {#frame-retire-connection-id}
 
-An endpoint sends a RETIRE_CONNECTION_ID frame (type=0x1b) to indicate that it
+An endpoint sends a RETIRE_CONNECTION_ID frame (type=0x19) to indicate that it
 will no longer use a connection ID that was issued by its peer. This may include
 the connection ID provided during the handshake.  Sending a RETIRE_CONNECTION_ID
 frame also serves as a request to the peer to send additional connection IDs for
@@ -5087,7 +5093,7 @@ type PROTOCOL_VIOLATION.
 
 ## PATH_CHALLENGE Frame {#frame-path-challenge}
 
-Endpoints can use PATH_CHALLENGE frames (type=0x1b) to check reachability to the
+Endpoints can use PATH_CHALLENGE frames (type=0x1a) to check reachability to the
 peer and for path validation during connection migration.
 
 The PATH_CHALLENGE frames are as follows:
@@ -5118,7 +5124,7 @@ The recipient of this frame MUST generate a PATH_RESPONSE frame
 
 ## PATH_RESPONSE Frame {#frame-path-response}
 
-The PATH_RESPONSE frame (type=0x1c) is sent in response to a PATH_CHALLENGE
+The PATH_RESPONSE frame (type=0x1b) is sent in response to a PATH_CHALLENGE
 frame.  Its format is identical to the PATH_CHALLENGE frame
 ({{frame-path-challenge}}).
 
@@ -5129,7 +5135,7 @@ a connection error of type PROTOCOL_VIOLATION.
 
 ## CONNECTION_CLOSE Frames {#frame-connection-close}
 
-An endpoint sends a CONNECTION_CLOSE frame (type=0x1d or 0x1e) to notify its
+An endpoint sends a CONNECTION_CLOSE frame (type=0x1c or 0x1d) to notify its
 peer that the connection is being closed.  The CONNECTION_CLOSE with a frame
 type of 0x1d is used to signal errors at only the QUIC layer, or the absence of
 errors (with the NO_ERROR code).  The CONNECTION_CLOSE frame with a type of 0x1e

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -5037,9 +5037,9 @@ PROTOCOL_VIOLATION.
 The Retire Prior To field is a request for the peer to immediately retire all
 connection IDs with a sequence number less than the specified value.  This
 includes the initial and preferred_address transport parameter connection IDs.
-The Retire Prior To field MUST be less than the Sequence Number field.  Values
-greater than the Sequence Number MUST be treated as a connection error of type
-PROTOCOL_VIOLATION.
+The Retire Prior To field MUST be less than or equal to the Sequence Number
+field.  Values greater than the Sequence Number MUST be treated as a connection
+error of type PROTOCOL_VIOLATION.
 
 The sender cannot reduce the value of the Retire Prior To field in subsequent
 NEW_CONNECTION_ID frames.  That is, once a sender indicates a Retire Prior To

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4997,8 +4997,8 @@ Sequence Number:
 Retire Prior To:
 
 : A variable-length integer specifying the limit, for which all connection IDs
-  assigned to the receiver that have a sequence number less this value should be
-  retired.  See {{retiring-cids}}.
+  assigned to the receiver that have a sequence number less than this value
+  should be retired.  See {{retiring-cids}}.
 
 Length:
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -5137,8 +5137,8 @@ a connection error of type PROTOCOL_VIOLATION.
 
 An endpoint sends a CONNECTION_CLOSE frame (type=0x1c or 0x1d) to notify its
 peer that the connection is being closed.  The CONNECTION_CLOSE with a frame
-type of 0x1d is used to signal errors at only the QUIC layer, or the absence of
-errors (with the NO_ERROR code).  The CONNECTION_CLOSE frame with a type of 0x1e
+type of 0x1c is used to signal errors at only the QUIC layer, or the absence of
+errors (with the NO_ERROR code).  The CONNECTION_CLOSE frame with a type of 0x1d
 is used to signal an error with the application that uses QUIC.
 
 If there are open streams that haven't been explicitly closed, they are

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -995,12 +995,11 @@ local address SHOULD retire all connection IDs used on that address once it no
 longer plans to use that address.
 
 An endpoint can request that its peer retire connection IDs by sending a
-NEW_CONNECTION_ID frame with an increased Retire Prior To field.  Upon receipt,
+NEW_CONNECTION_ID frames with an increased Retire Prior To field.  Upon receipt,
 the peer SHOULD retire the corresponding connection IDs and send the
-corresponding RETIRE_CONNECTION_ID frame in a timely manner.  Failing to do so
-can cause packets to be delayed or lost and harm connection performance as the
-original endpoint might not route those connection IDs optimally after some
-delay.
+corresponding RETIRE_CONNECTION_ID frames in a timely manner.  Failing to do so
+can cause packets to be delayed, lost, or cause the original endpoint to send a
+stateless reset in response to a connection ID it can no longer route correctly.
 
 The sender of the Retire Prior To field MUST keep track of the connection IDs it
 wishes to retire until it has received a corresponding RETIRE_CONNECTION_ID
@@ -5046,7 +5045,7 @@ The Retire Prior To field is a request for the peer to retire all connection IDs
 with a sequence number less than the specified value.  This includes the initial
 and preferred_address transport parameter connection IDs.  The peer SHOULD
 retire the corresponding connection IDs and send the corresponding
-RETIRE_CONNECTION_ID frame in a timely manner
+RETIRE_CONNECTION_ID frames in a timely manner
 
 The sender of the NEW_CONNECTION_ID frame MAY remove the connection IDs after 3
 PTO, even if the peer has not retired them with RETIRE_CONNECTION_ID yet.  The

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1007,7 +1007,7 @@ wishes to retire until it has received a corresponding RETIRE_CONNECTION_ID
 frame, with one exception: if the sender of the Retire Prior To field has used
 distinct stateless reset tokens for all of their issued connection IDs, and 3
 times the PTO has elapsed since it received an acknowledgment for its Retire
-Prior To field, then it MAY lose track of that connection ID, and respond to
+Prior To field, then it MAY drop state for that connection ID, and respond to
 packets with that connection ID with the corresponding stateless reset token.
 
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -5045,7 +5045,7 @@ acknowledgement of the packet containing the NEW_CONNECTION_ID frame.  Continued
 use of the retired connection IDs after this point will likely result in a
 stateless reset being sent.
 
-In order to prevent a stateless reset, sent in response to a heavily delayed
+In order to prevent a stateless reset sent in response to a heavily delayed
 packet using a retired connection ID, from closing the connection, the
 stateless reset token of the retired connection IDs SHOULD NOT be reused.
 


### PR DESCRIPTION
Adds a new (optional) field, 'Retire Prior To' (placeholder name), to the NEW_CONNECTION_ID frame, which allows a sender to request that its peer immediately retire all connection IDs up to a certain sequence number. Once the peer acknowledges this packet, it has at most 3 PTO to follow through or risk the sender closing the connection.

Fixes #2645.