### PR TITLE
use upper-case RECOMMENDED for text incorporated from RFC 7540

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -892,7 +892,7 @@ to permit these streams to open, an HTTP/3 client SHOULD send non-zero values
 for the QUIC transport parameters `initial_max_stream_data_bidi_local`. An
 HTTP/3 server SHOULD send non-zero values for the QUIC transport parameters
 `initial_max_stream_data_bidi_remote` and `initial_max_bidi_streams`. It is
-recommended that `initial_max_bidi_streams` be no smaller than 100, so as to not
+RECOMMENDED that `initial_max_bidi_streams` be no smaller than 100, so as to not
 unnecessarily limit parallelism.
 
 These streams carry frames related to the request/response (see


### PR DESCRIPTION
IIUC, RFC 2119 keywords used in RFC 7540 need to be converted to uppercase words in HTTP/3, because HTTP/3 invokes RFC 8174.