### PR TITLE
Receiver's behavior on key update

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1167,13 +1167,12 @@ packet protection.
 
 An endpoint installs the new keys, possibly replacing the old keys, when it
 unprotects the header protection of a received packet and detects that the
-packet uses a new key phase.  The detection can be done by tracking the highest
-packet number of the packets being received, along with the KEY_PHASE bit of the
-packet that had the highest packet number.  If a newly received packet is likely
-to renew the recorded highest packet number and if it has a different KEY_PHASE
-value than the recorded bit, the endpoint install the new keys.  However, the
-highest packet number and the KEY_PHASE bit being tracked ought to be updated
-only after the packet is successfully unprotected.
+packet uses a new key phase.  The detection can be done by tracking the lowest
+packet number among the packets received with the currently active key phase.
+If a packet is received that has a different KEY_PHASE bit and a lower packet
+number than this value, the endpoint uses the old keys for unprotecting the
+packet, if these keys are still available.  If the packet has a higher packet
+number, the endpoint installs the updated keys.
 
 Updating keys multiple times rapidly can cause packets to be effectively lost if
 packets are significantly reordered.  Therefore, an endpoint SHOULD NOT initiate

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1171,21 +1171,21 @@ number among the packets received with the currently active key phase.  If a
 packet is received that has a different KEY_PHASE bit and a lower packet number
 than this value, the endpoint uses the old receive keys for unprotecting the
 packet, if these keys are still available.  If the packet has a higher packet
-number, the endpoint installs the new receive keys by calculating the next
-secret (see Section 7.2 of {{!TLS13}}), the corresponding read key and IV using
-the KDF function provided by TLS.  The header protection key is not updated.
+number, the endpoint derives the new receive keys by calculating the next secret
+(see Section 7.2 of {{!TLS13}}), the corresponding read key and IV using the KDF
+function provided by TLS.  The header protection key is not updated.
+
+If the packet can be decrypted and authenticated using the derived read key and
+IV, then those keys are installed and the keys the endpoint uses for packet
+protection are also updated.  The next packet sent by the endpoint MUST then use
+the new keys.  Once an endpoint has sent a packet encrypted with a given key
+phase, it MUST NOT send a packet encrypted with an older key phase.
 
 Updating keys multiple times rapidly can cause packets to be effectively lost if
 packets are significantly reordered.  Therefore, an endpoint SHOULD NOT initiate
 a key update for some time after it has last updated keys; the RECOMMENDED time
 period is three times the PTO.  This avoids valid reordered packets being
 dropped by the peer as a result of the peer discarding older keys.
-
-If the packet can be decrypted and authenticated using the updated key and IV,
-then the keys the endpoint uses for packet protection are also updated.  The
-next packet sent by the endpoint MUST then use the new keys.  Once an endpoint
-has sent a packet encrypted with a given key phase, it MUST NOT send a packet
-encrypted with an older key phase.
 
 An endpoint does not always need to send packets when it detects that its peer
 has updated keys.  The next packet that it sends will simply use the new keys.

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1162,9 +1162,9 @@ number sent with each KEY_PHASE, and the highest acknowledged packet number
 in the 1-RTT space: once the latter is higher than or equal to the former,
 another key update can be initiated.
 
-While only one send key is used at a time, an endpoint SHOULD retain at least
-two receive keys during a key update so that it can unprotect packets arriving
-out-of-order.
+While only one send key is used at a time, an endpoint MUST retain at least two
+receive keys during a key update so that it can unprotect packets arriving out-
+of-order.
 
 An endpoint determines which receive key to use by tracking the lowest packet
 number among the packets received with the currently active key phase.  If a

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1162,15 +1162,16 @@ number sent with each KEY_PHASE, and the highest acknowledged packet number
 in the 1-RTT space: once the latter is higher than or equal to the former,
 another key update can be initiated.
 
-Endpoints MAY limit the number of keys they retain to two sets for removing
-packet protection.
+While only one send key is used at a time, an endpoint SHOULD retain at least
+two receive keys during key update so that it can unprotect packets arriving
+out-of-order.
 
-An endpoint can detect which keys to use by tracking the lowest packet number
-among the packets received with the currently active key phase.  If a packet is
-received that has a different KEY_PHASE bit and a lower packet number than this
-value, the endpoint uses the old keys for unprotecting the packet, if these keys
-are still available.  If the packet has a higher packet number, the endpoint
-installs the updated keys.
+An endpoint can detect which receive key to use by tracking the lowest packet
+number among the packets received with the currently active key phase.  If a
+packet is received that has a different KEY_PHASE bit and a lower packet number
+than this value, the endpoint uses the old receive keys for unprotecting the
+packet, if these keys are still available.  If the packet has a higher packet
+number, the endpoint installs the updated recieve keys.
 
 Updating keys multiple times rapidly can cause packets to be effectively lost if
 packets are significantly reordered.  Therefore, an endpoint SHOULD NOT initiate

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1163,10 +1163,10 @@ in the 1-RTT space: once the latter is higher than or equal to the former,
 another key update can be initiated.
 
 While only one send key is used at a time, an endpoint SHOULD retain at least
-two receive keys during key update so that it can unprotect packets arriving
+two receive keys during a key update so that it can unprotect packets arriving
 out-of-order.
 
-An endpoint can detect which receive key to use by tracking the lowest packet
+An endpoint determines which receive key to use by tracking the lowest packet
 number among the packets received with the currently active key phase.  If a
 packet is received that has a different KEY_PHASE bit and a lower packet number
 than this value, the endpoint uses the old receive keys for unprotecting the

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1186,7 +1186,11 @@ key.
 If the packet can be unprotected using the next receive key and IV, then the
 endpoint switches to the next key phase.  Once an endpoint has sent a packet
 encrypted with a given key phase, it MUST NOT send a packet encrypted with an
-older key phase.
+older key phase.  An endpoint MAY close the connection with a PROTOCOL_VIOLATION
+error code if it successfully unprotects a packet and detects the peer violating
+this requirement; one way of detecting such misbehavior is to see if the packet
+number of a successfully unprotected packet using the previous key phase is no
+less than the tracked lowest of the current key phase.
 
 Updating keys multiple times rapidly can cause packets to be effectively lost if
 packets are significantly reordered.  Therefore, an endpoint SHOULD NOT initiate

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1171,18 +1171,15 @@ number among the packets received with the currently active key phase.  If a
 packet is received that has a different KEY_PHASE bit and a lower packet number
 than this value, the endpoint uses the old receive keys for unprotecting the
 packet, if these keys are still available.  If the packet has a higher packet
-number, the endpoint installs the updated recieve keys.
+number, the endpoint installs the new receive keys by calculating the next
+secret (see Section 7.2 of {{!TLS13}}), the corresponding read key and IV using
+the KDF function provided by TLS.  The header protection key is not updated.
 
 Updating keys multiple times rapidly can cause packets to be effectively lost if
 packets are significantly reordered.  Therefore, an endpoint SHOULD NOT initiate
 a key update for some time after it has last updated keys; the RECOMMENDED time
 period is three times the PTO.  This avoids valid reordered packets being
 dropped by the peer as a result of the peer discarding older keys.
-
-A receiving endpoint detects an update when the KEY_PHASE bit does not match
-what it is expecting.  It creates a new secret (see Section 7.2 of {{!TLS13}})
-and the corresponding read key and IV using the KDF function provided by TLS.
-The header protection key is not updated.
 
 If the packet can be decrypted and authenticated using the updated key and IV,
 then the keys the endpoint uses for packet protection are also updated.  The

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1165,14 +1165,12 @@ another key update can be initiated.
 Endpoints MAY limit the number of keys they retain to two sets for removing
 packet protection.
 
-An endpoint installs the new keys, possibly replacing the old keys, when it
-unprotects the header protection of a received packet and detects that the
-packet uses a new key phase.  The detection can be done by tracking the lowest
-packet number among the packets received with the currently active key phase.
-If a packet is received that has a different KEY_PHASE bit and a lower packet
-number than this value, the endpoint uses the old keys for unprotecting the
-packet, if these keys are still available.  If the packet has a higher packet
-number, the endpoint installs the updated keys.
+An endpoint can detect which keys to use by tracking the lowest packet number
+among the packets received with the currently active key phase.  If a packet is
+received that has a different KEY_PHASE bit and a lower packet number than this
+value, the endpoint uses the old keys for unprotecting the packet, if these keys
+are still available.  If the packet has a higher packet number, the endpoint
+installs the updated keys.
 
 Updating keys multiple times rapidly can cause packets to be effectively lost if
 packets are significantly reordered.  Therefore, an endpoint SHOULD NOT initiate

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1163,13 +1163,23 @@ in the 1-RTT space: once the latter is higher than or equal to the former,
 another key update can be initiated.
 
 Endpoints MAY limit the number of keys they retain to two sets for removing
-packet protection and one set for protecting packets.  Older keys can be
-discarded.  Updating keys multiple times rapidly can cause packets to be
-effectively lost if packets are significantly reordered.  Therefore, an
-endpoint SHOULD NOT initiate a key update for some time after it has last
-updated keys; the RECOMMENDED time period is three times the PTO. This avoids
-valid reordered packets being dropped by the peer as a result of the peer
-discarding older keys.
+packet protection.
+
+An endpoint installs the new keys, possibly replacing the old keys, when it
+unprotects the header protection of a received packet and detects that the
+packet uses a new key phase.  The detection can be done by tracking the highest
+packet number of the packets being received, along with the KEY_PHASE bit of the
+packet that had the highest packet number.  If a newly received packet is likely
+to renew the recorded highest packet number and if it has a different KEY_PHASE
+value than the recorded bit, the endpoint install the new keys.  However, the
+highest packet number and the KEY_PHASE bit being tracked ought to be updated
+only after the packet is successfully unprotected.
+
+Updating keys multiple times rapidly can cause packets to be effectively lost if
+packets are significantly reordered.  Therefore, an endpoint SHOULD NOT initiate
+a key update for some time after it has last updated keys; the RECOMMENDED time
+period is three times the PTO.  This avoids valid reordered packets being
+dropped by the peer as a result of the peer discarding older keys.
 
 A receiving endpoint detects an update when the KEY_PHASE bit does not match
 what it is expecting.  It creates a new secret (see Section 7.2 of {{!TLS13}})

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1183,10 +1183,10 @@ as an attack vector.  An endpoint that retains only two receive keys drops the
 receive key of the previous key phase in favor of retaining the next receive
 key.
 
-If the packet can be decrypted and authenticated using the next receive key and
-IV, then the endpoint switches to the next key phase.  Once an endpoint has sent
-a packet encrypted with a given key phase, it MUST NOT send a packet encrypted
-with an older key phase.
+If the packet can be unprotected using the next receive key and IV, then the
+endpoint switches to the next key phase.  Once an endpoint has sent a packet
+encrypted with a given key phase, it MUST NOT send a packet encrypted with an
+older key phase.
 
 Updating keys multiple times rapidly can cause packets to be effectively lost if
 packets are significantly reordered.  Therefore, an endpoint SHOULD NOT initiate

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1184,11 +1184,13 @@ receive key of the previous key phase in favor of retaining the next receive
 key.
 
 If the packet can be unprotected using the next receive key and IV, then the
-endpoint switches to the next key phase.  Once an endpoint has sent a packet
-encrypted with a given key phase, it MUST NOT send a packet encrypted with an
-older key phase.  An endpoint MAY close the connection with a PROTOCOL_VIOLATION
-error code if it successfully unprotects a packet and detects the peer violating
-this requirement; one way of detecting such misbehavior is to see if the packet
+endpoint switches to the next key phase: both send and receive keys associated
+with the next key phase become current. The next packet sent by the endpoint
+MUST then use the new send key.  Once an endpoint has sent a packet encrypted
+with a given key phase, it MUST NOT send a packet encrypted with an older key
+phase.  An endpoint MAY close the connection with a PROTOCOL_VIOLATION error
+code if it successfully unprotects a packet and detects the peer violating this
+requirement; one way of detecting such misbehavior is to see if the packet
 number of a successfully unprotected packet using the previous key phase is no
 less than the tracked lowest of the current key phase.
 


### PR DESCRIPTION
With help from @marten-seemann, I have composed a PR explains how a receiver should renew it's keys when seeing the KEY_PHASE bit changing.

This replaces #2788 (which I initially thought was correct, but was in fact incorrect as Marten has pointed out).

However, the question is if the approach being described in this PR is secure...