### PR TITLE
Clarify ACK of ACKs and bundling a PING

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2885,7 +2885,7 @@ An endpoint that is only sending ACK frames will not receive
 acknowledgments from its peer unless those acknowledgements are included in
 packets with ACK-eliciting frames.  A sender SHOULD bundle ACK frames with
 other frames when there are new ACK-eliciting packets to acknowledge.
-When only non-ACK-eliciting packets need to be acknowledged, the sender MAY
+When only non-ACK-eliciting packets need to be acknowledged, an endpoint MAY
 wait until an ACK-eliciting packet has been received to bundle an ACK frame
 with outgoing frames.
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2868,7 +2868,7 @@ one ACK-frame-only packet in response to receiving an ACK-eliciting packet
 (one containing frames other than ACK and/or PADDING).  An endpoint MUST NOT
 send a packet containing only an ACK frame in response to a non-ACK-eliciting
 packet (one containing only ACK and/or PADDING frames), even if there are
-packet gaps which precede the received packet. Limiting the sending of ACK
+packet gaps which precede the received packet. Limiting ACK
 frames avoids an infinite feedback loop of acknowledgements,
 which could prevent the connection from ever becoming idle. The endpoint MUST
 however acknowledge non-ACK-eliciting packets when sending ACK frames in

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2863,10 +2863,10 @@ An endpoint MUST NOT send more than one packet containing only an ACK frame per
 received non-ACK-eliciting packet(ie: one containing only ACK and/or PADDING
 frames).  An endpoint MUST NOT send a packet containing only an ACK frame in
 response to a non-ACK-eliciting packet, even if there are packet gaps which
-precede the received packet. This prevents an indefinite feedback loop of ACKs,
-which may prevent the connection from ever becoming idle. The endpoint MUST
-however acknowledge non-ACK-eliciting packets when sending ACK frames in
-response to other packets.
+precede the received packet. This prevents an indefinite feedback loop of
+acknowledgements, which may prevent the connection from ever becoming idle.
+The endpoint MUST however acknowledge non-ACK-eliciting packets when sending
+ACK frames in response to other packets.
 
 Packets containing PADDING frames are considered to be in flight for congestion
 control purposes {{QUIC-RECOVERY}}. Sending only PADDING frames might cause the

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2886,8 +2886,8 @@ discussed in more detail in {{QUIC-RECOVERY}}.
 
 ACK-only packets are only sent in response to ACK-eliciting packets, so a
 receiver that is only sending ACK frames will only receive acknowledgements
-for its packets if the sender includes them in packets with ACK-eliciting frames.
-A sender SHOULD bundle ACK frames with other frames when possible.
+for its packets if the sender includes them in packets with ACK-eliciting
+frames.  A sender SHOULD bundle ACK frames with other frames when possible.
 
 To limit ACK Ranges (see {{ack-ranges}}) to those that have not yet been
 received by the sender, the receiver SHOULD track which ACK frames have been

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2896,7 +2896,9 @@ packets from future ACK frames whenever these packets would unnecessarily
 contribute to the ACK frame size.  When the receiver is only sending ACK-only
 packets, it can bundle a PING with a fraction of them, such as one per round
 trip, to drop unnecessary ACK ranges and any tracking state associated with the
-previously sent ACK-only packets.
+previously sent ACK-only packets.  The receiver MUST NOT bundle a PING with all
+packets that would otherwise be ACK-only, in order to avoid an indefinite
+feedback loop of ACKs.
 
 To limit receiver state or the size of ACK frames, a receiver MAY limit the
 number of ACK Ranges it sends.  A receiver can do this even without receiving

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2859,11 +2859,13 @@ valid frames? -->
 
 ### Sending ACK Frames
 
-An endpoint MUST NOT send more than one packet containing only an ACK frame per
-received ACK-eliciting packet(one containing frames other than ACK and/or
-PADDING).  An endpoint MUST NOT send a packet containing only an ACK frame in
-response to a non-ACK-eliciting packet(one containing only ACK and/or PADDING
-frames), even if there are packet gaps which precede the received packet. This
+Packets containing only ACK frames are not congestion controlled, so there are
+limits on how frequently the can be sent.  An endpoint MUST NOT send more than
+one packet containing only an ACK frame per received ACK-eliciting
+packet(one containing frames other than ACK and/or PADDING).  An endpoint
+MUST NOT send a packet containing only an ACK frame in response to a
+non-ACK-eliciting packet(one containing only ACK and/or PADDING frames),
+even if there are packet gaps which precede the received packet. This
 prevents an indefinite feedback loop of acknowledgements, which may prevent the
 connection from ever becoming idle. The endpoint MUST however acknowledge
 non-ACK-eliciting packets when sending ACK frames in response to other packets.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2883,7 +2883,7 @@ addition to PADDING frames to elicit acknowledgments from the receiver.
 
 An endpoint that is only sending ACK frames will not receive
 acknowledgments from its peer unless those acknowledgements are included in
-packets with ACK-eliciting frames.  A sender SHOULD bundle ACK frames with
+packets with ACK-eliciting frames.  An endpoint SHOULD bundle ACK frames with
 other frames when there are new ACK-eliciting packets to acknowledge.
 When only non-ACK-eliciting packets need to be acknowledged, an endpoint MAY
 wait until an ACK-eliciting packet has been received to bundle an ACK frame

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2881,7 +2881,7 @@ sender to become limited by the congestion controller (as described in
 receiver. Therefore, a sender SHOULD ensure that other frames are sent in
 addition to PADDING frames to elicit acknowledgments from the receiver.
 
-An endpoint that is only sending acknowledgements will not receive
+An endpoint that is only sending ACK frames will not receive
 acknowledgments from its peer unless those acknowledgements are included in
 packets with ACK-eliciting frames.  A sender SHOULD bundle ACK frames with
 other frames when there are new ACK-eliciting packets to acknowledge.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2885,10 +2885,10 @@ addition to PADDING frames to elicit acknowledgments from the receiver.
 An endpoint that is only sending acknowledgements will not receive
 acknowledgments from its peer unless those acknowledgements are included in
 packets with ACK-eliciting frames.  A sender SHOULD bundle ACK frames with
-other frames when possible and there are new ACK-eliciting packets to
-acknowledge.  When only non-ACK-eliciting packets need to be acknowledged,
-the sender MAY wait until an ACK-eliciting packet has been received to bundle
-an ACK frame with outgoing frames.
+other frames when there are new ACK-eliciting packets to acknowledge.
+When only non-ACK-eliciting packets need to be acknowledged, the sender MAY
+wait until an ACK-eliciting packet has been received to bundle an ACK frame
+with outgoing frames.
 
 An endpoint SHOULD treat receipt of an acknowledgment for a packet it did not
 send as a connection error of type PROTOCOL_VIOLATION, if it is able to detect

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2898,7 +2898,7 @@ non-ACK-eliciting packets, it can bundle a PING with a fraction of them, such
 as one per round trip, to enable dropping unnecessary ACK ranges and any state
 for previously sent packets.  The receiver MUST NOT bundle a PING with all
 packets that would otherwise not be ACK-eliciting, in order to avoid an
-indefinite feedback loop of ACKs.
+indefinite feedback loop of acknowledgements.
 
 To limit receiver state or the size of ACK frames, a receiver MAY limit the
 number of ACK Ranges it sends.  A receiver can do this even without receiving

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2860,7 +2860,7 @@ valid frames? -->
 ### Sending ACK Frames
 
 Packets containing only ACK frames are not congestion controlled, so there are
-limits on how frequently the can be sent.  An endpoint MUST NOT send more than
+limits on how frequently they can be sent.  An endpoint MUST NOT send more than
 one packet containing only an ACK frame per received ACK-eliciting
 packet(one containing frames other than ACK and/or PADDING).  An endpoint
 MUST NOT send a packet containing only an ACK frame in response to a

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2864,7 +2864,7 @@ limits on how frequently they can be sent.  An endpoint MUST NOT send more than
 one packet containing only an ACK frame per received ACK-eliciting
 packet (one containing frames other than ACK and/or PADDING).  An endpoint
 MUST NOT send a packet containing only an ACK frame in response to a
-non-ACK-eliciting packet(one containing only ACK and/or PADDING frames),
+non-ACK-eliciting packet (one containing only ACK and/or PADDING frames),
 even if there are packet gaps which precede the received packet. This
 prevents an indefinite feedback loop of acknowledgements, which may prevent the
 connection from ever becoming idle. The endpoint MUST however acknowledge

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2864,8 +2864,9 @@ received packet that contains frames other than ACK and PADDING frames.
 An endpoint MUST NOT send a packet containing only an ACK frame in response
 to a packet containing only ACK or PADDING frames, even if there are packet
 gaps which precede the received packet. This prevents an indefinite feedback
-loop of ACKs. The endpoint MUST however acknowledge packets containing only
-ACK or PADDING frames when sending ACK frames in response to other packets.
+loop of ACKs, which may prevent the connection from ever becoming idle.
+The endpoint MUST however acknowledge packets containing only ACK or PADDING
+frames when sending ACK frames in response to other packets.
 
 Packets containing PADDING frames are considered to be in flight for congestion
 control purposes {{QUIC-RECOVERY}}. Sending only PADDING frames might cause the
@@ -2883,16 +2884,19 @@ needing acknowledgement are received.  The sender can use the receiver's
 Strategies and implications of the frequency of generating acknowledgments are
 discussed in more detail in {{QUIC-RECOVERY}}.
 
-To limit ACK Ranges (see {{ack-ranges}}) to those that have not yet been
-received by the sender, the receiver SHOULD track which ACK frames have been
-acknowledged by its peer. The receiver SHOULD exclude already acknowledged
-packets from future ACK frames whenever these packets would unnecessarily
-contribute to the ACK frame size.
-
 Because ACK frames are not sent in response to ACK-only packets, a receiver that
 is only sending ACK frames will only receive acknowledgements for its packets if
 the sender includes them in packets with non-ACK frames.  A sender SHOULD bundle
 ACK frames with other frames when possible.
+
+To limit ACK Ranges (see {{ack-ranges}}) to those that have not yet been
+received by the sender, the receiver SHOULD track which ACK frames have been
+acknowledged by its peer. The receiver SHOULD exclude already acknowledged
+packets from future ACK frames whenever these packets would unnecessarily
+contribute to the ACK frame size.  When the receiver is only sending ACK-only
+packets, it can bundle a PING with a fraction of them, such as one per round
+trip, to drop unnecessary ACK ranges and any tracking state associated with the
+send ACK-only packets.
 
 To limit receiver state or the size of ACK frames, a receiver MAY limit the
 number of ACK Ranges it sends.  A receiver can do this even without receiving

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2860,13 +2860,12 @@ valid frames? -->
 ### Sending ACK Frames
 
 An endpoint MUST NOT send more than one packet containing only an ACK frame per
-received packet that contains frames other than ACK and PADDING frames.
-An endpoint MUST NOT send a packet containing only an ACK frame in response
-to a packet containing only ACK or PADDING frames, even if there are packet
-gaps which precede the received packet. This prevents an indefinite feedback
-loop of ACKs, which may prevent the connection from ever becoming idle.
-The endpoint MUST however acknowledge non ACK-eliciting packets(ie: those
-containing only ACK or PADDING frames) when sending ACK frames in response to
+received non ACK-eliciting packet(ie: one containing only ACK or PADDING frames).
+An endpoint MUST NOT send a packet containing only an ACK frame in response to a
+non ACK-eliciting packet, even if there are packet gaps which precede the
+received packet. This prevents an indefinite feedback loop of ACKs, which may
+prevent the connection from ever becoming idle. The endpoint MUST however
+acknowledge non ACK-eliciting packets when sending ACK frames in response to
 other packets.
 
 Packets containing PADDING frames are considered to be in flight for congestion

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2886,7 +2886,7 @@ discussed in more detail in {{QUIC-RECOVERY}}.
 
 ACK-only packets are only sent in response to ACK-eliciting packets, so a
 receiver that is only sending ACK frames will only receive acknowledgements
-for its packets if the sender includes them in packets with non-ACK frames.
+for its packets if the sender includes them in packets with ACK-eliciting frames.
 A sender SHOULD bundle ACK frames with other frames when possible.
 
 To limit ACK Ranges (see {{ack-ranges}}) to those that have not yet been

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2868,11 +2868,10 @@ one ACK-frame-only packet in response to receiving an ACK-eliciting packet
 (one containing frames other than ACK and/or PADDING).  An endpoint MUST NOT
 send a packet containing only an ACK frame in response to a non-ACK-eliciting
 packet (one containing only ACK and/or PADDING frames), even if there are
-packet gaps which precede the received packet. Limiting ACK
-frames avoids an infinite feedback loop of acknowledgements,
-which could prevent the connection from ever becoming idle. The endpoint MUST
-however acknowledge non-ACK-eliciting packets when sending ACK frames in
-response to ACK-eliciting packets.
+packet gaps which precede the received packet. Limiting ACK frames avoids an
+infinite feedback loop of acknowledgements, which could prevent the connection
+from ever becoming idle. However, the endpoint acknowledges non-ACK-eliciting
+packets when it sends an ACK frame.
 
 Packets containing PADDING frames are considered to be in flight for congestion
 control purposes {{QUIC-RECOVERY}}. Sending only PADDING frames might cause the

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2893,10 +2893,10 @@ To limit ACK Ranges (see {{ack-ranges}}) to those that have not yet been
 received by the sender, the receiver SHOULD track which ACK frames have been
 acknowledged by its peer. The receiver SHOULD exclude already acknowledged
 packets from future ACK frames whenever these packets would unnecessarily
-contribute to the ACK frame size.  When the receiver is only sending non
-ACK-eliciting packets, it can bundle a PING with a fraction of them, such as one
-per round trip, to enable dropping unnecessary ACK ranges and any state for
-previously sent packets.  The receiver MUST NOT bundle a PING with all
+contribute to the ACK frame size.  When the receiver is only sending
+non-ACK-eliciting packets, it can bundle a PING with a fraction of them, such
+as one per round trip, to enable dropping unnecessary ACK ranges and any state
+for previously sent packets.  The receiver MUST NOT bundle a PING with all
 packets that would otherwise not be ACK-eliciting, in order to avoid an
 indefinite feedback loop of ACKs.
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2897,7 +2897,7 @@ contribute to the ACK frame size.  When the receiver is only sending ACK-only
 packets, it can bundle a PING with a fraction of them, such as one per round
 trip, to drop unnecessary ACK ranges and any tracking state associated with the
 previously sent ACK-only packets.  The receiver MUST NOT bundle a PING with all
-packets that would otherwise be ACK-only, in order to avoid an indefinite
+packets that would otherwise not be ACK-eliciting, in order to avoid an indefinite
 feedback loop of ACKs.
 
 To limit receiver state or the size of ACK frames, a receiver MAY limit the

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2870,7 +2870,7 @@ one packet containing only an ACK frame per received ACK-eliciting packet
 send a packet containing only an ACK frame in response to a non-ACK-eliciting
 packet (one containing only ACK and/or PADDING frames), even if there are
 packet gaps which precede the received packet. Limiting the sending of ACK
-frames avoids creating an indefinite feedback loop of acknowledgements,
+frames avoids an infinite feedback loop of acknowledgements,
 which could prevent the connection from ever becoming idle. The endpoint MUST
 however acknowledge non-ACK-eliciting packets when sending ACK frames in
 response to ACK-eliciting packets.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2902,7 +2902,7 @@ Strategies and implications of the frequency of generating acknowledgments are
 discussed in more detail in {{QUIC-RECOVERY}}.
 
 
-### Limiting ACK ranges
+### Limiting ACK Ranges
 
 To limit ACK Ranges (see {{ack-ranges}}) to those that have not yet been
 received by the sender, the receiver SHOULD track which ACK frames have been

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -985,9 +985,9 @@ response to a migrating peer; see {{migration-linkability}} for more.
 An endpoint maintains a set of connection IDs received from its peer, any of
 which it can use when sending packets.  When the endpoint wishes to remove a
 connection ID from use, it sends a RETIRE_CONNECTION_ID frame to its peer.
-Sending a RETIRE_CONNECTION_ID frame indicates that the connection ID won't be
-used again and requests that the peer replace it with a new connection ID using
-a NEW_CONNECTION_ID frame.
+Sending a RETIRE_CONNECTION_ID frame indicates that the connection ID will not
+be used again and requests that the peer replace it with a new connection ID
+using a NEW_CONNECTION_ID frame.
 
 As discussed in {{migration-linkability}}, each connection ID MUST be used on
 packets sent from only one local address.  An endpoint that migrates away from a
@@ -2884,8 +2884,8 @@ needing acknowledgement are received.  The sender can use the receiver's
 Strategies and implications of the frequency of generating acknowledgments are
 discussed in more detail in {{QUIC-RECOVERY}}.
 
-An endpoint that is only sending ACK frames won't receive acknowledgments from
-its peer unless those acknowledgements are included in packets with
+An endpoint that is only sending ACK frames will not receive acknowledgments
+from its peer unless those acknowledgements are included in packets with
 ACK-eliciting frames.  A sender SHOULD bundle ACK frames with other frames
 when possible.
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2911,7 +2911,7 @@ acknowledged by its peer. The receiver SHOULD exclude already acknowledged
 packets from future ACK frames whenever these packets would unnecessarily
 contribute to the ACK frame size.  When the receiver is only sending
 non-ACK-eliciting packets, it can bundle a PING with a fraction of them, such
-as one per round trip, to enable dropping unnecessary ACK ranges and any state
+as once per round trip, to enable dropping unnecessary ACK ranges and any state
 for previously sent packets.  The receiver MUST NOT bundle a PING with all
 packets that would otherwise not be ACK-eliciting, in order to avoid an
 infinite feedback loop of acknowledgements.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2873,7 +2873,7 @@ packet gaps which precede the received packet. Limiting the sending of ACK
 frames avoids creating an indefinite feedback loop of acknowledgements,
 which could prevent the connection from ever becoming idle. The endpoint MUST
 however acknowledge non-ACK-eliciting packets when sending ACK frames in
-response to Ack-eliciting packets.
+response to ACK-eliciting packets.
 
 Packets containing PADDING frames are considered to be in flight for congestion
 control purposes {{QUIC-RECOVERY}}. Sending only PADDING frames might cause the

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2860,12 +2860,12 @@ valid frames? -->
 ### Sending ACK Frames
 
 An endpoint MUST NOT send more than one packet containing only an ACK frame per
-received non ACK-eliciting packet(ie: one containing only ACK and/or PADDING
+received non-ACK-eliciting packet(ie: one containing only ACK and/or PADDING
 frames).  An endpoint MUST NOT send a packet containing only an ACK frame in
-response to a non ACK-eliciting packet, even if there are packet gaps which
+response to a non-ACK-eliciting packet, even if there are packet gaps which
 precede the received packet. This prevents an indefinite feedback loop of ACKs,
 which may prevent the connection from ever becoming idle. The endpoint MUST
-however acknowledge non ACK-eliciting packets when sending ACK frames in
+however acknowledge non-ACK-eliciting packets when sending ACK frames in
 response to other packets.
 
 Packets containing PADDING frames are considered to be in flight for congestion

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2885,10 +2885,10 @@ needing acknowledgement are received.  The sender can use the receiver's
 Strategies and implications of the frequency of generating acknowledgments are
 discussed in more detail in {{QUIC-RECOVERY}}.
 
-Because ACK frames are only sent in response to ACK-eliciting packets, a receiver
-that is only sending ACK frames will only receive acknowledgements for its packets
-if the sender includes them in packets with non-ACK frames.  A sender SHOULD
-bundle ACK frames with other frames when possible.
+Because ACK frames are only sent in response to ACK-eliciting packets, a
+receiver that is only sending ACK frames will only receive acknowledgements
+for its packets if the sender includes them in packets with non-ACK frames.
+A sender SHOULD bundle ACK frames with other frames when possible.
 
 To limit ACK Ranges (see {{ack-ranges}}) to those that have not yet been
 received by the sender, the receiver SHOULD track which ACK frames have been
@@ -2898,8 +2898,8 @@ contribute to the ACK frame size.  When the receiver is only sending non
 ACK-eliciting packets, it can bundle a PING with a fraction of them, such as one
 per round trip, to enable dropping unnecessary ACK ranges and any state for
 previously sent packets.  The receiver MUST NOT bundle a PING with all
-packets that would otherwise not be ACK-eliciting, in order to avoid an indefinite
-feedback loop of ACKs.
+packets that would otherwise not be ACK-eliciting, in order to avoid an
+indefinite feedback loop of ACKs.
 
 To limit receiver state or the size of ACK frames, a receiver MAY limit the
 number of ACK Ranges it sends.  A receiver can do this even without receiving

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2884,10 +2884,10 @@ needing acknowledgement are received.  The sender can use the receiver's
 Strategies and implications of the frequency of generating acknowledgments are
 discussed in more detail in {{QUIC-RECOVERY}}.
 
-ACK-only packets are only sent in response to ACK-eliciting packets, so a
-receiver that is only sending ACK frames will only receive acknowledgements
-for its packets if the sender includes them in packets with ACK-eliciting
-frames.  A sender SHOULD bundle ACK frames with other frames when possible.
+An endpoint that is only sending ACK frames won't receive acknowledgments from
+its peer unless those acknowledgements are included in packets with
+ACK-eliciting frames.  A sender SHOULD bundle ACK frames with other frames
+when possible.
 
 To limit ACK Ranges (see {{ack-ranges}}) to those that have not yet been
 received by the sender, the receiver SHOULD track which ACK frames have been

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2884,7 +2884,7 @@ needing acknowledgement are received.  The sender can use the receiver's
 Strategies and implications of the frequency of generating acknowledgments are
 discussed in more detail in {{QUIC-RECOVERY}}.
 
-Because ACK frames are only sent in response to ACK-eliciting packets, a
+ACK-only packets are only sent in response to ACK-eliciting packets, so a
 receiver that is only sending ACK frames will only receive acknowledgements
 for its packets if the sender includes them in packets with non-ACK frames.
 A sender SHOULD bundle ACK frames with other frames when possible.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2860,13 +2860,13 @@ valid frames? -->
 ### Sending ACK Frames
 
 An endpoint MUST NOT send more than one packet containing only an ACK frame per
-received non ACK-eliciting packet(ie: one containing only ACK or PADDING frames).
-An endpoint MUST NOT send a packet containing only an ACK frame in response to a
-non ACK-eliciting packet, even if there are packet gaps which precede the
-received packet. This prevents an indefinite feedback loop of ACKs, which may
-prevent the connection from ever becoming idle. The endpoint MUST however
-acknowledge non ACK-eliciting packets when sending ACK frames in response to
-other packets.
+received non ACK-eliciting packet(ie: one containing only ACK and/or PADDING
+frames).  An endpoint MUST NOT send a packet containing only an ACK frame in
+response to a non ACK-eliciting packet, even if there are packet gaps which
+precede the received packet. This prevents an indefinite feedback loop of ACKs,
+which may prevent the connection from ever becoming idle. The endpoint MUST
+however acknowledge non ACK-eliciting packets when sending ACK frames in
+response to other packets.
 
 Packets containing PADDING frames are considered to be in flight for congestion
 control purposes {{QUIC-RECOVERY}}. Sending only PADDING frames might cause the

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2860,13 +2860,13 @@ valid frames? -->
 ### Sending ACK Frames
 
 An endpoint MUST NOT send more than one packet containing only an ACK frame per
-received non-ACK-eliciting packet(ie: one containing only ACK and/or PADDING
-frames).  An endpoint MUST NOT send a packet containing only an ACK frame in
-response to a non-ACK-eliciting packet, even if there are packet gaps which
-precede the received packet. This prevents an indefinite feedback loop of
-acknowledgements, which may prevent the connection from ever becoming idle.
-The endpoint MUST however acknowledge non-ACK-eliciting packets when sending
-ACK frames in response to other packets.
+received ACK-eliciting packet(ie: one containing frames other than ACK and/or
+PADDING).  An endpoint MUST NOT send a packet containing only an ACK frame in
+response to a non-ACK-eliciting packet(one containing only ACK and/or PADDING
+frames), even if there are packet gaps which precede the received packet. This
+prevents an indefinite feedback loop of acknowledgements, which may prevent the
+connection from ever becoming idle. The endpoint MUST however acknowledge
+non-ACK-eliciting packets when sending ACK frames in response to other packets.
 
 Packets containing PADDING frames are considered to be in flight for congestion
 control purposes {{QUIC-RECOVERY}}. Sending only PADDING frames might cause the
@@ -2884,10 +2884,10 @@ needing acknowledgement are received.  The sender can use the receiver's
 Strategies and implications of the frequency of generating acknowledgments are
 discussed in more detail in {{QUIC-RECOVERY}}.
 
-An endpoint that is only sending ACK frames will not receive acknowledgments
-from its peer unless those acknowledgements are included in packets with
-ACK-eliciting frames.  A sender SHOULD bundle ACK frames with other frames
-when possible.
+An endpoint that is only sending acknowledgements will not receive
+acknowledgments from its peer unless those acknowledgements are included in
+packets with ACK-eliciting frames.  A sender SHOULD bundle ACK frames with
+other frames when possible.
 
 To limit ACK Ranges (see {{ack-ranges}}) to those that have not yet been
 received by the sender, the receiver SHOULD track which ACK frames have been

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2865,8 +2865,9 @@ An endpoint MUST NOT send a packet containing only an ACK frame in response
 to a packet containing only ACK or PADDING frames, even if there are packet
 gaps which precede the received packet. This prevents an indefinite feedback
 loop of ACKs, which may prevent the connection from ever becoming idle.
-The endpoint MUST however acknowledge packets containing only ACK or PADDING
-frames when sending ACK frames in response to other packets.
+The endpoint MUST however acknowledge non ACK-eliciting packets(ie: those
+containing only ACK or PADDING frames) when sending ACK frames in response to
+other packets.
 
 Packets containing PADDING frames are considered to be in flight for congestion
 control purposes {{QUIC-RECOVERY}}. Sending only PADDING frames might cause the

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2860,8 +2860,7 @@ valid frames? -->
 ### Sending ACK Frames
 
 An endpoint sends ACK frames to acknowledge packets it has received and
-processed. Sending ACK frames is the primary mechanism for advancing the state
-of a connection.
+processed.
 
 Packets containing only ACK frames are not congestion controlled, so there are
 limits on how frequently they can be sent.  An endpoint MUST NOT send more than

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2864,7 +2864,7 @@ processed.
 
 Packets containing only ACK frames are not congestion controlled, so there are
 limits on how frequently they can be sent.  An endpoint MUST NOT send more than
-one packet containing only an ACK frame per received ACK-eliciting packet
+one ACK-frame-only packet in response to receiving an ACK-eliciting packet
 (one containing frames other than ACK and/or PADDING).  An endpoint MUST NOT
 send a packet containing only an ACK frame in response to a non-ACK-eliciting
 packet (one containing only ACK and/or PADDING frames), even if there are

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2860,7 +2860,7 @@ valid frames? -->
 ### Sending ACK Frames
 
 An endpoint MUST NOT send more than one packet containing only an ACK frame per
-received ACK-eliciting packet(ie: one containing frames other than ACK and/or
+received ACK-eliciting packet(one containing frames other than ACK and/or
 PADDING).  An endpoint MUST NOT send a packet containing only an ACK frame in
 response to a non-ACK-eliciting packet(one containing only ACK and/or PADDING
 frames), even if there are packet gaps which precede the received packet. This

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2862,7 +2862,7 @@ valid frames? -->
 Packets containing only ACK frames are not congestion controlled, so there are
 limits on how frequently they can be sent.  An endpoint MUST NOT send more than
 one packet containing only an ACK frame per received ACK-eliciting
-packet(one containing frames other than ACK and/or PADDING).  An endpoint
+packet (one containing frames other than ACK and/or PADDING).  An endpoint
 MUST NOT send a packet containing only an ACK frame in response to a
 non-ACK-eliciting packet(one containing only ACK and/or PADDING frames),
 even if there are packet gaps which precede the received packet. This

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2861,14 +2861,14 @@ valid frames? -->
 
 Packets containing only ACK frames are not congestion controlled, so there are
 limits on how frequently they can be sent.  An endpoint MUST NOT send more than
-one packet containing only an ACK frame per received ACK-eliciting
-packet (one containing frames other than ACK and/or PADDING).  An endpoint
-MUST NOT send a packet containing only an ACK frame in response to a
-non-ACK-eliciting packet (one containing only ACK and/or PADDING frames),
-even if there are packet gaps which precede the received packet. This
-prevents an indefinite feedback loop of acknowledgements, which may prevent the
-connection from ever becoming idle. The endpoint MUST however acknowledge
-non-ACK-eliciting packets when sending ACK frames in response to other packets.
+one packet containing only an ACK frame per received ACK-eliciting packet
+(one containing frames other than ACK and/or PADDING).  An endpoint MUST NOT
+send a packet containing only an ACK frame in response to a non-ACK-eliciting
+packet (one containing only ACK and/or PADDING frames), even if there are
+packet gaps which precede the received packet. This prevents an indefinite
+feedback loop of acknowledgements, which may prevent the connection from ever
+becoming idle. The endpoint MUST however acknowledge non-ACK-eliciting packets
+when sending ACK frames in response to other packets.
 
 Packets containing PADDING frames are considered to be in flight for congestion
 control purposes {{QUIC-RECOVERY}}. Sending only PADDING frames might cause the

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2896,7 +2896,7 @@ packets from future ACK frames whenever these packets would unnecessarily
 contribute to the ACK frame size.  When the receiver is only sending ACK-only
 packets, it can bundle a PING with a fraction of them, such as one per round
 trip, to drop unnecessary ACK ranges and any tracking state associated with the
-send ACK-only packets.
+previously sent ACK-only packets.
 
 To limit receiver state or the size of ACK frames, a receiver MAY limit the
 number of ACK Ranges it sends.  A receiver can do this even without receiving

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2914,7 +2914,7 @@ non-ACK-eliciting packets, it can bundle a PING with a fraction of them, such
 as one per round trip, to enable dropping unnecessary ACK ranges and any state
 for previously sent packets.  The receiver MUST NOT bundle a PING with all
 packets that would otherwise not be ACK-eliciting, in order to avoid an
-indefinite feedback loop of acknowledgements.
+infinite feedback loop of acknowledgements.
 
 To limit receiver state or the size of ACK frames, a receiver MAY limit the
 number of ACK Ranges it sends.  A receiver can do this even without receiving

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2884,18 +2884,18 @@ needing acknowledgement are received.  The sender can use the receiver's
 Strategies and implications of the frequency of generating acknowledgments are
 discussed in more detail in {{QUIC-RECOVERY}}.
 
-Because ACK frames are not sent in response to ACK-only packets, a receiver that
-is only sending ACK frames will only receive acknowledgements for its packets if
-the sender includes them in packets with non-ACK frames.  A sender SHOULD bundle
-ACK frames with other frames when possible.
+Because ACK frames are only sent in response to ACK-eliciting packets, a receiver
+that is only sending ACK frames will only receive acknowledgements for its packets
+if the sender includes them in packets with non-ACK frames.  A sender SHOULD
+bundle ACK frames with other frames when possible.
 
 To limit ACK Ranges (see {{ack-ranges}}) to those that have not yet been
 received by the sender, the receiver SHOULD track which ACK frames have been
 acknowledged by its peer. The receiver SHOULD exclude already acknowledged
 packets from future ACK frames whenever these packets would unnecessarily
-contribute to the ACK frame size.  When the receiver is only sending ACK-only
-packets, it can bundle a PING with a fraction of them, such as one per round
-trip, to drop unnecessary ACK ranges and any tracking state associated with the
+contribute to the ACK frame size.  When the receiver is only sending non
+ACK-eliciting packets, it can bundle a PING with a fraction of them, such as one
+per round trip, to enabel dropping unnecessary ACK ranges and any state for the
 previously sent ACK-only packets.  The receiver MUST NOT bundle a PING with all
 packets that would otherwise not be ACK-eliciting, in order to avoid an indefinite
 feedback loop of ACKs.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2909,10 +2909,11 @@ received by the sender, the receiver SHOULD track which ACK frames have been
 acknowledged by its peer. The receiver SHOULD exclude already acknowledged
 packets from future ACK frames whenever these packets would unnecessarily
 contribute to the ACK frame size.  When the receiver is only sending
-non-ACK-eliciting packets, it can bundle a PING with a fraction of them, such
-as once per round trip, to enable dropping unnecessary ACK ranges and any state
-for previously sent packets.  The receiver MUST NOT bundle a PING with all
-packets that would otherwise not be ACK-eliciting, in order to avoid an
+non-ACK-eliciting packets, it can bundle a PING or other small ACK-eliciting
+frame with a fraction of them, such as once per round trip, to enable
+dropping unnecessary ACK ranges and any state for previously sent packets.
+The receiver MUST NOT bundle an ACK-elicing frame, such as a PING, with all
+packets that would otherwise be non-ACK-eliciting, in order to avoid an
 infinite feedback loop of acknowledgements.
 
 To limit receiver state or the size of ACK frames, a receiver MAY limit the

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2895,8 +2895,8 @@ acknowledged by its peer. The receiver SHOULD exclude already acknowledged
 packets from future ACK frames whenever these packets would unnecessarily
 contribute to the ACK frame size.  When the receiver is only sending non
 ACK-eliciting packets, it can bundle a PING with a fraction of them, such as one
-per round trip, to enabel dropping unnecessary ACK ranges and any state for the
-previously sent ACK-only packets.  The receiver MUST NOT bundle a PING with all
+per round trip, to enable dropping unnecessary ACK ranges and any state for
+previously sent packets.  The receiver MUST NOT bundle a PING with all
 packets that would otherwise not be ACK-eliciting, in order to avoid an indefinite
 feedback loop of ACKs.
 


### PR DESCRIPTION
Fixes #2546 

MUST NOT bundle a PING with all packets that would otherwise be ACK-only.

If there's anything else discussed in London that I missed, please tell me.