### PR TITLE
remove misleading sentence about incompatible QUIC versions and ALPN

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1279,8 +1279,7 @@ An application-layer protocol MAY restrict the QUIC versions that it can operate
 over.  Servers MUST select an application protocol compatible with the QUIC
 version that the client has selected.  If the server cannot select a compatible
 combination of application protocol and QUIC version, it MUST abort the
-connection. A client MUST abort a connection if the server picks an incompatible
-combination of QUIC version and ALPN identifier.
+connection.
 
 
 ## QUIC Transport Parameters Extension {#quic_parameters}

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1279,7 +1279,8 @@ An application-layer protocol MAY restrict the QUIC versions that it can operate
 over.  Servers MUST select an application protocol compatible with the QUIC
 version that the client has selected.  If the server cannot select a compatible
 combination of application protocol and QUIC version, it MUST abort the
-connection.
+connection.  A client MUST abort a connection if the server picks an application
+protocol incompatible with the protocol version being used.
 
 
 ## QUIC Transport Parameters Extension {#quic_parameters}


### PR DESCRIPTION
The server doesn't pick a version. The server only picks the application protocol from what the client offered, and it might do that based on the QUIC version that the client picked.