### PR TITLE
Merge Crypto timeout and PTO

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -585,7 +585,7 @@ client.
 Because the server could be blocked until more packets are received, the client
 MUST ensure that the retransmission timer is set if there is
 unacknowledged crypto data or if the client does not yet have 1-RTT keys.
-If the retransmission timer expires before the client has 1-RTT keys,
+If the probe timer expires before the client has 1-RTT keys,
 it is possible that the client may not have any crypto data to retransmit.
 However, the client MUST send a new packet, containing only PADDING frames if
 necessary, to allow the server to continue sending data. If Handshake keys

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -165,7 +165,7 @@ of frames contained in a packet affect recovery and congestion control logic:
 
 * Long header packets that contain CRYPTO frames are critical to the
   performance of the QUIC handshake and use shorter timers for
-  acknowledgement and retransmission.
+  acknowledgement.
 
 * Packets that contain only ACK frames do not count toward congestion control
   limits and are not considered in-flight.

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1221,7 +1221,10 @@ OnLossDetectionTimeout():
   if (loss_time != 0):
     // Time threshold loss Detection
     DetectLostPackets(pn_space)
-  else if (endpoint is client without 1-RTT keys):
+    SetLossDetectionTimer()
+    return
+
+  if (endpoint is client without 1-RTT keys):
     // Client sends an anti-deadlock packet: Initial is padded
     // to earn more anti-amplification credit,
     // a Handshake packet proves address ownership.
@@ -1229,13 +1232,12 @@ OnLossDetectionTimeout():
       SendOneHandshakePacket()
     else:
       SendOnePaddedInitialPacket()
-    pto_count++
   else:
     // PTO. Send new data if available, else retransmit old data.
     // If neither is available, send a single PING frame.
     SendOneOrTwoPackets()
-    pto_count++
 
+  pto_count++
   SetLossDetectionTimer()
 ~~~
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -564,13 +564,11 @@ packet-threshold loss detection.
 ## Handshakes and new paths
 
 The initial probe timeout for a new connection or new path SHOULD be
-set to twice the initial RTT.
-
-Resumed connections over the same network SHOULD use the previous connection's
-final smoothed RTT value as the resumed connection's initial RTT.  If no
-previous RTT is available, or if the network changes, the initial RTT SHOULD
-be set to 500ms, resulting in a 1 second initial timeout as recommended in
-{{?RFC6298}}.
+set to twice the initial RTT.  Resumed connections over the same network 
+SHOULD use the previous connection's final smoothed RTT value as the resumed
+connection's initial RTT.  If no previous RTT is available, the initial RTT
+SHOULD be set to 500ms, resulting in a 1 second initial timeout as recommended
+in {{?RFC6298}}.
 
 A connection MAY use the delay between sending a PATH_CHALLENGE and receiving
 a PATH_RESPONSE to seed initial_rtt for a new path, but the delay SHOULD NOT
@@ -579,9 +577,9 @@ be considered an RTT sample.
 Until the server has validated the client's address on the path, the amount of
 data it can send is limited, as specified in Section 8.1 of {{QUIC-TRANSPORT}}.
 If not all data can be retransmitted, then data at Initial and Handshake
-encryption should be retransmitted before any ApplicationData. If no data can be
-sent, then the PTO alarm should not be armed until data has been received from
-the client.
+encryption should be retransmitted before any ApplicationData data. If no data
+can be sent, then the PTO alarm should not be armed until data has been
+received from the client.
 
 Because the server could be blocked until more packets are received, the client
 MUST ensure that the retransmission timer is set if the client does not yet

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -580,8 +580,8 @@ Until the server has validated the client's address on the path, the amount of
 data it can send is limited, as specified in Section 8.1 of {{QUIC-TRANSPORT}}.
 If not all data can be retransmitted, then data at Initial and Handshake
 encryption should be retransmitted before any ApplicationData. If no data can be
-sent, then no alarm should be armed until data has been received from the
-client.
+sent, then the PTO alarm should not be armed until data has been received from
+the client.
 
 Because the server could be blocked until more packets are received, the client
 MUST ensure that the retransmission timer is set if the client does not yet

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -553,8 +553,6 @@ sender might choose to optimize this by setting the timer fewer times if it
 knows that more ack-eliciting packets will be sent within a short period of
 time.
 
-
-
 The retransmission timer is not set if the time threshold
 {{time-threshold}} loss detection timer is set.  The time threshold loss
 detection timer is expected to both expire earlier than the crypto

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1188,7 +1188,7 @@ SetLossDetectionTimer():
 
   // Don't arm timer if there are no ack-eliciting packets
   // in flight and the handshake is complete.
-  if (endpoint is client with 1-RTT keys ||
+  if (endpoint is client with 1-RTT keys &&
       no ack-eliciting packets in flight):
     loss_detection_timer.cancel()
     return

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1234,9 +1234,9 @@ OnLossDetectionTimeout():
     // to earn more anti-amplification credit,
     // a Handshake packet proves address ownership.
     if (has Handshake keys):
-       SendOneHandshakePacket()
-     else:
-       SendOnePaddedInitialPacket()
+      SendOneHandshakePacket()
+    else:
+      SendOnePaddedInitialPacket()
     pto_count++
   else:
     // PTO. Send new data if available, else retransmit old data.

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -561,7 +561,7 @@ data. The Initial and Handshake packet number spaces will typically contain a
 small number of packets, so losses are less likely to be detected using
 packet-threshold loss detection.
 
-## Handshakes and new paths
+## Handshakes and New Paths
 
 The initial probe timeout for a new connection or new path SHOULD be
 set to twice the initial RTT.  Resumed connections over the same network 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -555,22 +555,21 @@ time.
 
 The retransmission timer is not set if the time threshold
 {{time-threshold}} loss detection timer is set.  The time threshold loss
-detection timer is expected to both expire earlier than the crypto
-retransmission timeout and be less likely to spuriously retransmit data.
-The Initial and Handshake packet number spaces will typically contain a small
-number of packets, so losses are less likely to be detected using
-packet-threshold loss detection.
+detection timer is expected to both expire earlier than the PTO and be less
+likely to spuriously retransmit data. The Initial and Handshake packet number
+spaces will typically contain a small number of packets, so losses are less
+likely to be detected using packet-threshold loss detection.
 
 ## Handshakes and new paths
 
 The initial probe timeout for a new connection or new path SHOULD be
 set to twice the initial RTT.
 
-Initially there are no prior RTT samples for a connection.  Resumed
-connections over the same network SHOULD use the previous connection's final
-smoothed RTT value as the resumed connection's initial RTT.  If no previous RTT
-is available, or if the network changes, the initial RTT SHOULD be set to 500ms,
-resulting in a 1 second initial timeout as recommended in {{?RFC6298}}.
+Resumed connections over the same network SHOULD use the previous connection's
+final smoothed RTT value as the resumed connection's initial RTT.  If no
+previous RTT is available, or if the network changes, the initial RTT SHOULD
+be set to 500ms, resulting in a 1 second initial timeout as recommended in
+{{?RFC6298}}.
 
 A connection MAY use the delay between sending a PATH_CHALLENGE and receiving
 a PATH_RESPONSE to seed initial_rtt for a new path, but the delay SHOULD NOT

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -589,7 +589,7 @@ necessary, to allow the server to continue sending data. If Handshake keys
 are available to the client, it MUST send a Handshake packet, and otherwise
 it MUST send an Initial packet in a UDP datagram of at least 1200 bytes.
 
-Because Initial packets only containing PADDING do not elicit an
+Because Initial packets containing only PADDING do not elicit an
 acknowledgement, they may never be acknowledged, but they are removed from
 bytes in flight when the client gets Handshake keys and the Initial keys are
 discarded.

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -557,9 +557,7 @@ time.
 The probe timer is not set if the time threshold {{time-threshold}} loss
 detection timer is set.  The time threshold loss detection timer is expected
 to both expire earlier than the PTO and be less likely to spuriously retransmit
-data. The Initial and Handshake packet number spaces will typically contain a
-small number of packets, so losses are less likely to be detected using
-packet-threshold loss detection.
+data.
 
 ## Handshakes and New Paths
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -553,7 +553,7 @@ sender might choose to optimize this by setting the timer fewer times if it
 knows that more ack-eliciting packets will be sent within a short period of
 time.
 
-The retransmission timer is not set if the time threshold
+The probe timer is not set if the time threshold
 {{time-threshold}} loss detection timer is set.  The time threshold loss
 detection timer is expected to both expire earlier than the PTO and be less
 likely to spuriously retransmit data. The Initial and Handshake packet number

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -564,7 +564,7 @@ packet-threshold loss detection.
 ## Handshakes and New Paths
 
 The initial probe timeout for a new connection or new path SHOULD be
-set to twice the initial RTT.  Resumed connections over the same network 
+set to twice the initial RTT.  Resumed connections over the same network
 SHOULD use the previous connection's final smoothed RTT value as the resumed
 connection's initial RTT.  If no previous RTT is available, the initial RTT
 SHOULD be set to 500ms, resulting in a 1 second initial timeout as recommended

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1221,12 +1221,6 @@ OnLossDetectionTimeout():
   if (loss_time != 0):
     // Time threshold loss Detection
     DetectLostPackets(pn_space)
-  // Retransmit crypto data if no packets were lost
-  // and there is crypto data to retransmit.
-  else if (has unacknowledged crypto data):
-    // Crypto retransmission timeout.
-    RetransmitUnackedCryptoData()
-    pto_count++
   else if (endpoint is client without 1-RTT keys):
     // Client sends an anti-deadlock packet: Initial is padded
     // to earn more anti-amplification credit,

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -576,10 +576,10 @@ be considered an RTT sample.
 
 Until the server has validated the client's address on the path, the amount of
 data it can send is limited, as specified in Section 8.1 of {{QUIC-TRANSPORT}}.
-If not all data can be retransmitted, then data at Initial and Handshake
-encryption should be retransmitted before any ApplicationData data. If no data
-can be sent, then the PTO alarm should not be armed until data has been
-received from the client.
+Data at Initial encryption MUST be retransmitted before Handshake data and
+data at Handshake encryption MUST be retransmitted before any ApplicationData
+data.  If no data can be sent, then the PTO alarm should not be armed until
+data has been received from the client.
 
 Because the server could be blocked until more packets are received, the client
 MUST ensure that the retransmission timer is set if the client does not yet

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -547,7 +547,8 @@ immediately.
 When a PTO timer expires, the PTO period MUST be set to twice its current
 value. This exponential reduction in the sender's rate is important because
 the PTOs might be caused by loss of packets or acknowledgements due to severe
-congestion.
+congestion.  The life of a connection that is experiencing consecutive PTOs is
+limited by the endpoint's idle timeout.
 
 A sender computes its PTO timer every time an ack-eliciting packet is sent. A
 sender might choose to optimize this by setting the timer fewer times if it

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -544,22 +544,22 @@ delay sending an acknowledgement.
 The PTO value MUST be set to at least kGranularity, to avoid the timer expiring
 immediately.
 
-When a PTO timer expires, the sender probes the network as described in the next
-section. The PTO period MUST be set to twice its current value. This exponential
-reduction in the sender's rate is important because the PTOs might be caused by
-loss of packets or acknowledgements due to severe congestion.
+When a PTO timer expires, the PTO period MUST be set to twice its current
+value. This exponential reduction in the sender's rate is important because
+the PTOs might be caused by loss of packets or acknowledgements due to severe
+congestion.
 
 A sender computes its PTO timer every time an ack-eliciting packet is sent. A
 sender might choose to optimize this by setting the timer fewer times if it
 knows that more ack-eliciting packets will be sent within a short period of
 time.
 
-The probe timer is not set if the time threshold
-{{time-threshold}} loss detection timer is set.  The time threshold loss
-detection timer is expected to both expire earlier than the PTO and be less
-likely to spuriously retransmit data. The Initial and Handshake packet number
-spaces will typically contain a small number of packets, so losses are less
-likely to be detected using packet-threshold loss detection.
+The probe timer is not set if the time threshold {{time-threshold}} loss
+detection timer is set.  The time threshold loss detection timer is expected
+to both expire earlier than the PTO and be less likely to spuriously retransmit
+data. The Initial and Handshake packet number spaces will typically contain a
+small number of packets, so losses are less likely to be detected using
+packet-threshold loss detection.
 
 ## Handshakes and new paths
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -514,11 +514,12 @@ and larger thresholds increase loss detection delay.
 
 ## Probe Timeout {#pto}
 
-A Probe Timeout (PTO) triggers a probe packet when ack-eliciting data is in
-flight but an acknowledgement is not received within the expected period of
-time.  A PTO enables a connection to recover from loss of tail packets or acks.
-The PTO algorithm used in QUIC implements the reliability functions of Tail Loss
-Probe {{?TLP=I-D.dukkipati-tcpm-tcp-loss-probe}} {{?RACK}}, RTO {{?RFC5681}} and
+A Probe Timeout (PTO) triggers sending one or two probe packets when
+ack-eliciting packets are not acknowledged within the expected period of
+time or the handshake has not been completed.  A PTO enables a connection to
+recover from loss of tail packets or acks. The PTO algorithm used in QUIC
+implements the reliability functions of Tail Loss Probe
+{{?TLP=I-D.dukkipati-tcpm-tcp-loss-probe}} {{?RACK}}, RTO {{?RFC5681}} and
 F-RTO algorithms for TCP {{?RFC5682}}, and the timeout computation is based on
 TCP's retransmission timeout period {{?RFC6298}}.
 
@@ -1191,14 +1192,14 @@ SetLossDetectionTimer():
 
   // Don't arm timer if there are no ack-eliciting packets
   // in flight and the handshake is complete.
-  if (!(endpoint is client without 1-RTT keys ||
-        has ack-eliciting packets in flight):
+  if (endpoint is client with 1-RTT keys ||
+      no ack-eliciting packets in flight):
     loss_detection_timer.cancel()
     return
-    
-  // Initialize the timeout if there are no RTT measurements
+
+  // Use a default timeout if ther are no RTT measurements
   if (smoothed_rtt == 0):
-    timeout = 1 second
+    timeout = 2 * kInitialRtt
     return
 
   // Calculate PTO duration

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -577,8 +577,8 @@ be considered an RTT sample.
 
 Until the server has validated the client's address on the path, the amount of
 data it can send is limited, as specified in Section 8.1 of {{QUIC-TRANSPORT}}.
-If not all unacknowledged CRYPTO data can be sent, then all unacknowledged
-CRYPTO data sent in Initial packets should be retransmitted.  If no data can be
+If not all data can be retransmitted, then data at Initial and Handshake
+encryption should be retransmitted before any ApplicationData. If no data can be
 sent, then no alarm should be armed until data has been received from the
 client.
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -576,7 +576,7 @@ Until the server has validated the client's address on the path, the amount of
 data it can send is limited, as specified in Section 8.1 of {{QUIC-TRANSPORT}}.
 Data at Initial encryption MUST be retransmitted before Handshake data and
 data at Handshake encryption MUST be retransmitted before any ApplicationData
-data.  If no data can be sent, then the PTO alarm should not be armed until
+data.  If no data can be sent, then the PTO alarm MUST NOT be armed until
 data has been received from the client.
 
 Because the server could be blocked until more packets are received, the client


### PR DESCRIPTION
This merges the crypto timeout into the PTO timeout.  Both have exponential backoff, so this is mostly a simplification, though this allows the crypto timeout to take RTT variance into account if possible(#2648) and I believe is simpler to understand.

A second attempt at PR #2655 

Fixes #2650, Fixes #2648
I believe this also fixes #2886 