### PR TITLE
Rationalize HTTP_WRONG_SETTING_DIRECTION

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1663,9 +1663,9 @@ HTTP_REQUEST_REJECTED (0x0014):
 : A server rejected a request without performing any application processing.
 
 HTTP_SETTINGS_ERROR (0x00FF):
-: An endpoint detected an error with a SETTINGS frame: a duplicate setting was
-  detected, a client-only setting was sent by a server, or a server-only setting
-  by a client.
+: An endpoint detected an error in the payload of a SETTINGS frame: a duplicate
+  setting was detected, a client-only setting was sent by a server, or a
+  server-only setting by a client.
 
 HTTP_MALFORMED_FRAME (0x01XX):
 : An error in a specific frame type.  If the frame type is `0xfe` or less, the

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -679,7 +679,7 @@ maintaining these placeholders in the prioritization tree, clients can use them
 with confidence that the server will not have discarded the state. Clients MUST
 NOT send the `SETTINGS_NUM_PLACEHOLDERS` setting; receipt of this setting by a
 server MUST be treated as a connection error of type
-`HTTP_WRONG_SETTING_DIRECTION`.
+`HTTP_SETTINGS_ERROR`.
 
 Client-controlled placeholders are identified by an ID between zero and one less
 than the number of placeholders the server has permitted.  The orphan
@@ -1338,7 +1338,7 @@ while servers are more cautious about request size.
 
 Parameters MUST NOT occur more than once in the SETTINGS frame.  A receiver MAY
 treat the presence of the same parameter more than once as a connection error of
-type HTTP_MALFORMED_FRAME.
+type HTTP_SETTINGS_ERROR.
 
 The payload of a SETTINGS frame consists of zero or more parameters.  Each
 parameter consists of a setting identifier and a value, both encoded as QUIC
@@ -1594,9 +1594,10 @@ HTTP_NO_ERROR (0x00):
 : No error.  This is used when the connection or stream needs to be closed, but
   there is no error to signal.
 
-HTTP_WRONG_SETTING_DIRECTION (0x01):
-: A client-only setting was sent by a server, or a server-only setting by a
-  client.
+HTTP_SETTINGS_ERROR (0x01):
+: An endpoint detected an error with a SETTINGS frame: a duplicate setting was
+  detected, a client-only setting was sent by a server, or a server-only setting
+  by a client.
 
 Reserved (0x02):
 : This code is reserved and has no meaning.
@@ -1900,7 +1901,7 @@ The entries in the following table are registered by this document.
 | Name                                | Code       | Description                              | Specification          |
 | ----------------------------------- | ---------- | ---------------------------------------- | ---------------------- |
 | HTTP_NO_ERROR                       | 0x0000     | No error                                 | {{http-error-codes}}   |
-| HTTP_WRONG_SETTING_DIRECTION        | 0x0001     | Setting sent in wrong direction          | {{http-error-codes}}   |
+| HTTP_SETTINGS_ERROR                 | 0x0001     | Setting duplication or wrong direction   | {{http-error-codes}}   |
 | Reserved                            | 0x0002     | N/A                                      | N/A                    |
 | HTTP_INTERNAL_ERROR                 | 0x0003     | Internal error                           | {{http-error-codes}}   |
 | Reserved                            | 0x0004     | N/A                                      | N/A                    |

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1594,10 +1594,9 @@ HTTP_NO_ERROR (0x00):
 : No error.  This is used when the connection or stream needs to be closed, but
   there is no error to signal.
 
-HTTP_SETTINGS_ERROR (0x01):
-: An endpoint detected an error with a SETTINGS frame: a duplicate setting was
-  detected, a client-only setting was sent by a server, or a server-only setting
-  by a client.
+HTTP_GENERAL_PROTOCOL_ERROR (0x01):
+: Peer violated protocol requirements in a way which doesn't match a more
+  specific error code, or endpoint declines to use the more specific error code.
 
 Reserved (0x02):
 : This code is reserved and has no meaning.
@@ -1663,9 +1662,10 @@ HTTP_UNEXPECTED_FRAME (0x0013):
 HTTP_REQUEST_REJECTED (0x0014):
 : A server rejected a request without performing any application processing.
 
-HTTP_GENERAL_PROTOCOL_ERROR (0x00FF):
-: Peer violated protocol requirements in a way which doesn't match a more
-  specific error code, or endpoint declines to use the more specific error code.
+HTTP_SETTINGS_ERROR (0x00FF):
+: An endpoint detected an error with a SETTINGS frame: a duplicate setting was
+  detected, a client-only setting was sent by a server, or a server-only setting
+  by a client.
 
 HTTP_MALFORMED_FRAME (0x01XX):
 : An error in a specific frame type.  If the frame type is `0xfe` or less, the
@@ -1901,7 +1901,7 @@ The entries in the following table are registered by this document.
 | Name                                | Code       | Description                              | Specification          |
 | ----------------------------------- | ---------- | ---------------------------------------- | ---------------------- |
 | HTTP_NO_ERROR                       | 0x0000     | No error                                 | {{http-error-codes}}   |
-| HTTP_SETTINGS_ERROR                 | 0x0001     | Setting duplication or wrong direction   | {{http-error-codes}}   |
+| HTTP_GENERAL_PROTOCOL_ERROR         | 0x0001     | General protocol error                   | {{http-error-codes}}   |
 | Reserved                            | 0x0002     | N/A                                      | N/A                    |
 | HTTP_INTERNAL_ERROR                 | 0x0003     | Internal error                           | {{http-error-codes}}   |
 | Reserved                            | 0x0004     | N/A                                      | N/A                    |
@@ -1922,6 +1922,7 @@ The entries in the following table are registered by this document.
 | HTTP_UNEXPECTED_FRAME               | 0x0013     | Frame not permitted in the current state | {{http-error-codes}}   |
 | HTTP_REQUEST_REJECTED               | 0x0014     | Request not processed                    | {{http-error-codes}}   |
 | HTTP_MALFORMED_FRAME                | 0x01XX     | Error in frame formatting                | {{http-error-codes}}   |
+| HTTP_SETTINGS_ERROR                 | 0x00FF     | SETTINGS frame contained invalid values  | {{http-error-codes}}   |
 | ----------------------------------- | ---------- | ---------------------------------------- | ---------------------- |
 
 ## Stream Types {#iana-stream-types}


### PR DESCRIPTION
This fixes #2810 in a different way by subtituting the error code and not changing the requirements related to NUM_PLACEHOLDERS.

Closes #2811.