### PR TITLE
Fix grammar in 3.2. Receiving Stream States

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -526,7 +526,7 @@ an unopened stream indicates that the remote peer no longer wishes to receive
 data on this stream.  Either frame might arrive before a STREAM or
 STREAM_DATA_BLOCKED frame if packets are lost or reordered.
 
-Before creating a stream, all streams of the same type with lower-numbered
+Before a stream is created, all streams of the same type with lower-numbered
 stream IDs MUST be created.  This ensures that the creation order for streams is
 consistent on both endpoints.
 


### PR DESCRIPTION
The phrase, `Before creating a stream, all streams of the same type with lower-numbered stream IDs MUST be created.`, is semantically equal to `Before all streams (of the same type with lower-numbered stream IDs) create a stream, all streams of the same type with lower-numbered stream IDs MUST be created.`

This is not correct since all streams don't create a (new) stream. Moreover, by definition, a stream is created by sending data[1] or STREAM frames implicitly create a stream[2]. This indicates a stream itself doesn't create another stream.

[1] https://tools.ietf.org/html/draft-ietf-quic-transport-20#section-2
[2] https://tools.ietf.org/html/draft-ietf-quic-transport-20#section-19.8