### PR TITLE
clarify why clients can't send Handshake before receiving a server response

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1078,8 +1078,8 @@ Initial packet containing a CONNECTION_CLOSE frame with error code
 SERVER_BUSY.
 
 If the packet is a 0-RTT packet, the server MAY buffer a limited number of these
-packets in anticipation of a late-arriving Initial packet. Clients are forbidden
-from sending Handshake packets prior to receiving a server response, so servers
+packets in anticipation of a late-arriving Initial packet. Clients are not able
+to send Handshake packets prior to receiving a server response, so servers
 SHOULD ignore any such packets.
 
 Servers MUST drop incoming packets under all other circumstances.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1078,7 +1078,7 @@ Initial packet containing a CONNECTION_CLOSE frame with error code
 SERVER_BUSY.
 
 If the packet is a 0-RTT packet, the server MAY buffer a limited number of these
-packets in anticipation of a late-arriving Initial Packet. Clients are forbidden
+packets in anticipation of a late-arriving Initial packet. Clients are forbidden
 from sending Handshake packets prior to receiving a server response, so servers
 SHOULD ignore any such packets.
 


### PR DESCRIPTION
Clients aren't *forbidden* from sending a Handshake packet before receiving the ServerHello, they just don't have the keys to do so.