### PR TITLE
Remove stale text that forbids the use of TLS records carrying early data

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -613,10 +613,6 @@ by the "initial_max_data" transport parameter supplied by the server.  A client
 MUST treat receipt of a NewSessionTicket that contains an "early_data" extension
 with any other value as a connection error of type PROTOCOL_VIOLATION.
 
-Early data within the TLS connection MUST NOT be used.  As it is for other TLS
-application data, a server MUST treat receiving early data on the TLS connection
-as a connection error of type PROTOCOL_VIOLATION.
-
 
 ## Rejecting 0-RTT
 


### PR DESCRIPTION
As of -12, TLS records are not used in QUIC (TLS handshake messages are directly transmitted instead), and therefore it is impossible in QUIC to transmit early data using the machinery provided by TLS.