### PR TITLE
Define terms for application actions

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -453,11 +453,11 @@ HTTP_INCOMPLETE_REQUEST.
 A server can send a complete response prior to the client sending an entire
 request if the response does not depend on any portion of the request that has
 not been sent and received. When this is true, a server MAY abort reading the
-receiving part of the request stream with error code HTTP_EARLY_RESPONSE, send a
-complete response, and cleanly close the sending part of the stream. Clients
-MUST NOT discard complete responses as a result of having their request
-terminated abruptly, though clients can always discard responses at their
-discretion for other reasons.
+request stream with error code HTTP_EARLY_RESPONSE, send a complete response,
+and cleanly close the sending part of the stream. Clients MUST NOT discard
+complete responses as a result of having their request terminated abruptly,
+though clients can always discard responses at their discretion for other
+reasons.
 
 
 ### Header Formatting and Compression {#header-formatting}
@@ -505,11 +505,11 @@ this limit are not guaranteed to be accepted.
 
 ### Request Cancellation and Rejection {#request-cancellation}
 
-Clients can cancel requests by abruptly terminating the sending part of the
-request stream with an error code of HTTP_REQUEST_CANCELLED
-({{http-error-codes}}).  When the client aborts reading a response, it indicates
-that this response is no longer of interest. Implementations SHOULD cancel
-requests by terminating both directions of a stream.
+Clients can cancel requests by resetting the request stream with an error code
+of HTTP_REQUEST_CANCELLED ({{http-error-codes}}).  When the client aborts
+reading a response, it indicates that this response is no longer of interest.
+Implementations SHOULD cancel requests by terminating both directions of a
+stream.
 
 When the server rejects a request without performing any application processing,
 it SHOULD abort its response stream with the error code HTTP_REQUEST_REJECTED.
@@ -522,11 +522,11 @@ were partially or fully processed.  When a server abandons a response after
 partial processing, it SHOULD abort its response stream with the error code
 HTTP_REQUEST_CANCELLED.
 
-When a client abruptly terminates a request with the error code
-HTTP_REQUEST_CANCELLED, a server MAY abruptly terminate the response using the
-error code HTTP_REQUEST_REJECTED if no processing was performed.  Clients MUST
-NOT use the HTTP_REQUEST_REJECTED error code, except when a server has requested
-closure of the request stream with this error code.
+When a client resets a request with the error code HTTP_REQUEST_CANCELLED, a
+server MAY abruptly terminate the response using the error code
+HTTP_REQUEST_REJECTED if no processing was performed.  Clients MUST NOT use the
+HTTP_REQUEST_REJECTED error code, except when a server has requested closure of
+the request stream with this error code.
 
 If a stream is cancelled after receiving a complete response, the client MAY
 ignore the cancellation and use the response.  However, if a stream is cancelled
@@ -1584,9 +1584,8 @@ the cause of a connection or stream error.
 
 ## HTTP/3 Error Codes {#http-error-codes}
 
-The following error codes are defined for use when abruptly terminating the
-sending part of streams, aborting reading of the receiving part of streams, or
-immediately closing connections.
+The following error codes are defined for use when abruptly terminating streams,
+aborting reading of streams, or immediately closing connections.
 
 HTTP_NO_ERROR (0x00):
 : No error.  This is used when the connection or stream needs to be closed, but

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -453,9 +453,9 @@ HTTP_INCOMPLETE_REQUEST.
 A server can send a complete response prior to the client sending an entire
 request if the response does not depend on any portion of the request that has
 not been sent and received. When this is true, a server MAY abort reading the
-receiving part of the request stream with error code HTTP_EARLY_RESPONSE,
-sending a complete response, and cleanly closing the sending part of the stream.
-Clients MUST NOT discard complete responses as a result of having their request
+receiving part of the request stream with error code HTTP_EARLY_RESPONSE, send a
+complete response, and cleanly close the sending part of the stream. Clients
+MUST NOT discard complete responses as a result of having their request
 terminated abruptly, though clients can always discard responses at their
 discretion for other reasons.
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -345,6 +345,29 @@ the relative priority of streams.  When deciding which streams to dedicate
 resources to, the implementation SHOULD use the information provided by the
 application.
 
+## Required Operations on Streams
+
+There are certain operations which an application MUST be able to perform when
+interacting with QUIC streams.  This document does not specify an API, but
+any implementation of this version of QUIC MUST expose the ability to perform
+the operations described in this section on a QUIC stream.
+
+On the sending part of a stream:
+- Attempt to write data, understanding when stream flow control credit
+  ({{data-flow-control}}) has successfully been reserved to send the written
+  data or possibly discovering that the stream has been closed because the peer
+  sent a STOP_SENDING frame ({{frame-stop-sending}})
+- Cleanly terminate the stream, resulting in a STREAM frame ({{frame-stream}})
+  with the FIN bit set
+- Abruptly terminate the stream, resulting in a RESET_STREAM frame
+  ({{frame-reset-stream}}), even if the stream was cleanly terminated previously
+
+On the receiving part of a stream:
+- Attempt to read data, possibly discovering that the peer has terminated the
+  stream either cleanly or abruptly
+- Abort reading of the stream and request closure, resulting in a STOP_SENDING
+  frame ({{frame-stop-sending}})
+
 
 # Stream States {#stream-states}
 
@@ -876,29 +899,6 @@ considered useful for debugging. An endpoint MUST NOT wait to receive this
 signal before advertising additional credit, since doing so will mean that the
 peer will be blocked for at least an entire round trip, and potentially for
 longer if the peer chooses to not send STREAMS_BLOCKED frames.
-
-## Required Operations on Streams
-
-There are certain operations which an application MUST be able to perform when
-interacting with QUIC streams.  This document does not specify an API, but
-any implementation of this version of QUIC MUST expose the ability to perform
-the operations described in this section on a QUIC stream.
-
-On the sending part of a stream:
-- Attempt to write data, understanding when stream flow control credit
-  ({{data-flow-control}}) has successfully been reserved to send the written
-  data or possibly discovering that the stream has been closed because the peer
-  sent a STOP_SENDING frame ({{frame-stop-sending}})
-- Cleanly terminate the stream, resulting in a STREAM frame ({{frame-stream}})
-  with the FIN bit set
-- Abruptly terminate the stream, resulting in a RESET_STREAM frame
-  ({{frame-reset-stream}}), even if the stream was cleanly terminated previously
-
-On the receiving part of a stream:
-- Attempt to read data, possibly discovering that the peer has terminated the
-  stream either cleanly or abruptly
-- Abort reading of the stream and request closure, resulting in a STOP_SENDING
-  frame ({{frame-stop-sending}})
 
 
 # Connections {#connections}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -352,24 +352,27 @@ interacting with QUIC streams.  This document does not specify an API, but
 any implementation of this version of QUIC MUST expose the ability to perform
 the operations described in this section on a QUIC stream.
 
-On the sending part of a stream:
+On the sending part of a stream, application protocols need to be able to:
 
-- Attempt to write data, understanding when stream flow control credit
+- write data, understanding when stream flow control credit
   ({{data-flow-control}}) has successfully been reserved to send the written
   data or possibly discovering that the stream has been closed because the peer
-  sent a STOP_SENDING frame ({{frame-stop-sending}})
-- Cleanly terminate the stream, resulting in a STREAM frame ({{frame-stream}})
-  with the FIN bit set
-- Abruptly terminate the stream, resulting in a RESET_STREAM frame
-  ({{frame-reset-stream}}), even if the stream was cleanly terminated previously
+  sent a STOP_SENDING frame ({{frame-stop-sending}});
+- end the stream (clean termination), resulting in a STREAM frame
+  ({{frame-stream}}) with the FIN bit set; and
+- reset the stream (abrupt termination), resulting in a RESET_STREAM frame
+  ({{frame-reset-stream}}), even if the stream was already ended.
 
-On the receiving part of a stream:
+On the receiving part of a stream, application protocols need to be able to:
 
-- Attempt to read data, possibly discovering that the peer has terminated the
-  stream either cleanly or abruptly
-- Abort reading of the stream and request closure, resulting in a STOP_SENDING
-  frame ({{frame-stop-sending}})
+- read data
+- abort reading of the stream and request closure, possibly resulting in a
+  STOP_SENDING frame ({{frame-stop-sending}})
 
+Applications also need to be informed of state changes on streams, including
+when the peer has initiated, reset, or aborted reading on a stream; when new
+data is available; and when data on the stream is blocked due to flow
+control.
 
 # Stream States {#stream-states}
 
@@ -1133,29 +1136,32 @@ interacting with the QUIC transport.  This document does not specify an API, but
 any implementation of this version of QUIC MUST expose the ability to perform
 the operations described in this section on a QUIC connection.
 
-When implementing the client role:
+When implementing the client role, applications need to be able to:
 
-- Open a connection, which begins the exchange described in {{handshake}}
+- open a connection, which begins the exchange described in {{handshake}};
+- enable 0-RTT; and
+- be informed when 0-RTT has been accepted or rejected by a server.
 
-When implementing the server role:
+When implementing the server role, applications need to be able to:
 
-- Listen for incoming connections, which prepares for the exchange described in
-  {{handshake}}
-- If Early Data is supported, embed application-controlled data in the TLS
-  resumption ticket sent to the client
-- If Early Data is supported, retrieve application-controlled data from the
-  client's resumption ticket and approve/veto accepting Early Data
+- listen for incoming connections, which prepares for the exchange described in
+  {{handshake}};
+- if Early Data is supported, embed application-controlled data in the TLS
+  resumption ticket sent to the client; and
+- if Early Data is supported, retrieve application-controlled data from the
+  client's resumption ticket and enable rejecting Early Data based on that
+  information.
 
-In either role:
+In either role, applications need to be able to:
 
-- Configure minimum values for the initial number of permitted streams of each
-  type, as communicated in the transport parameters ({{transport-parameters}})
-- Keep a connection from silently closing, either by generating PING frames
+- configure minimum values for the initial number of permitted streams of each
+  type, as communicated in the transport parameters ({{transport-parameters}});
+- control resource allocation of various types, including flow control and the
+  number of permitted streams of each type;
+- keep a connection from silently closing, either by generating PING frames
   ({{frame-ping}}) or by requesting that the transport send additional frames
-  before the idle timeout expires ({{idle-timeout}})
-- Cease issuing credit for new streams via MAX_STREAMS frames
-  ({{frame-max-streams}})
-- Immediately close ({{immediate-close}}) the connection
+  before the idle timeout expires ({{idle-timeout}}); and
+- immediately close ({{immediate-close}}) the connection.
 
 
 # Version Negotiation {#version-negotiation}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -353,6 +353,7 @@ any implementation of this version of QUIC MUST expose the ability to perform
 the operations described in this section on a QUIC stream.
 
 On the sending part of a stream:
+
 - Attempt to write data, understanding when stream flow control credit
   ({{data-flow-control}}) has successfully been reserved to send the written
   data or possibly discovering that the stream has been closed because the peer
@@ -363,6 +364,7 @@ On the sending part of a stream:
   ({{frame-reset-stream}}), even if the stream was cleanly terminated previously
 
 On the receiving part of a stream:
+
 - Attempt to read data, possibly discovering that the peer has terminated the
   stream either cleanly or abruptly
 - Abort reading of the stream and request closure, resulting in a STOP_SENDING
@@ -1132,9 +1134,11 @@ any implementation of this version of QUIC MUST expose the ability to perform
 the operations described in this section on a QUIC connection.
 
 When implementing the client role:
+
 - Open a connection, which begins the exchange described in {{handshake}}
 
 When implementing the server role:
+
 - Listen for incoming connections, which prepares for the exchange described in
   {{handshake}}
 - If Early Data is supported, embed application-controlled data in the TLS
@@ -1143,6 +1147,7 @@ When implementing the server role:
   client's resumption ticket and approve/veto accepting Early Data
 
 In either role:
+
 - Configure minimum values for the initial number of permitted streams of each
   type, as communicated in the transport parameters ({{transport-parameters}})
 - Keep a connection from silently closing, either by generating PING frames

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -666,11 +666,14 @@ Note (*1):
 
 ## Solicited State Transitions
 
-If an endpoint is no longer interested in the data it is receiving on a stream,
-it MAY send a STOP_SENDING frame identifying that stream to prompt closure of
-the stream in the opposite direction.  This typically indicates that the
-receiving application is no longer reading data it receives from the stream, but
-it is not a guarantee that incoming data will be ignored.
+If an application is no longer interested in the data it is receiving on a
+stream, it can abort reading the stream and specify an application error code.
+
+If the stream is in the "Recv or "Size Known" states, the transport SHOULD
+signal this by sending a STOP_SENDING frame identifying that stream to prompt
+closure of the stream in the opposite direction.  This typically indicates that
+the receiving application is no longer reading data it receives from the stream,
+but it is not a guarantee that incoming data will be ignored.
 
 STREAM frames received after sending STOP_SENDING are still counted toward
 connection and stream flow control, even though these frames can be discarded

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -369,9 +369,9 @@ On the receiving part of a stream, application protocols need to be able to:
   STOP_SENDING frame ({{frame-stop-sending}})
 
 Applications also need to be informed of state changes on streams, including
-when the peer has initiated, reset, or aborted reading on a stream; when new
-data is available; and when data can or cannot be written to the stream due to
-flow control.
+when the peer has opened or reset a stream, when a peer aborts reading on a
+stream, when new data is available, and when data can or cannot be written to
+the stream due to flow control.
 
 # Stream States {#stream-states}
 
@@ -669,10 +669,10 @@ If an application is no longer interested in the data it is receiving on a
 stream, it can abort reading the stream and specify an application error code.
 
 If the stream is in the "Recv or "Size Known" states, the transport SHOULD
-signal this by sending a STOP_SENDING frame identifying that stream to prompt
-closure of the stream in the opposite direction.  This typically indicates that
-the receiving application is no longer reading data it receives from the stream,
-but it is not a guarantee that incoming data will be ignored.
+signal this by sending a STOP_SENDING frame to prompt closure of the stream in
+the opposite direction.  This typically indicates that the receiving application
+is no longer reading data it receives from the stream, but it is not a guarantee
+that incoming data will be ignored.
 
 STREAM frames received after sending STOP_SENDING are still counted toward
 connection and stream flow control, even though these frames can be discarded

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -356,8 +356,7 @@ On the sending part of a stream, application protocols need to be able to:
 
 - write data, understanding when stream flow control credit
   ({{data-flow-control}}) has successfully been reserved to send the written
-  data or possibly discovering that the stream has been closed because the peer
-  sent a STOP_SENDING frame ({{frame-stop-sending}});
+  data
 - end the stream (clean termination), resulting in a STREAM frame
   ({{frame-stream}}) with the FIN bit set; and
 - reset the stream (abrupt termination), resulting in a RESET_STREAM frame
@@ -368,11 +367,12 @@ On the receiving part of a stream, application protocols need to be able to:
 - read data
 - abort reading of the stream and request closure, possibly resulting in a
   STOP_SENDING frame ({{frame-stop-sending}})
+- identify whether any stream data was carried in Early Data
 
 Applications also need to be informed of state changes on streams, including
 when the peer has initiated, reset, or aborted reading on a stream; when new
-data is available; and when data on the stream is blocked due to flow
-control.
+data is available; and when data can or cannot be written to the stream due to
+flow control.
 
 # Stream States {#stream-states}
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -367,7 +367,6 @@ On the receiving part of a stream, application protocols need to be able to:
 - read data
 - abort reading of the stream and request closure, possibly resulting in a
   STOP_SENDING frame ({{frame-stop-sending}})
-- identify whether any stream data was carried in Early Data
 
 Applications also need to be informed of state changes on streams, including
 when the peer has initiated, reset, or aborted reading on a stream; when new
@@ -1161,6 +1160,7 @@ In either role, applications need to be able to:
   type, as communicated in the transport parameters ({{transport-parameters}});
 - control resource allocation of various types, including flow control and the
   number of permitted streams of each type;
+- identify whether the handshake has completed successfully or is still ongoing
 - keep a connection from silently closing, either by generating PING frames
   ({{frame-ping}}) or by requesting that the transport send additional frames
   before the idle timeout expires ({{idle-timeout}}); and


### PR DESCRIPTION
This consists of two related commits:

- Defines the minimal set of operations which a QUIC implementation MUST expose to the application, introducing terms for them which don't rely on the specific wire formatting
- Changes HTTP/3 to use these terms instead of referring to specific QUIC frames

Note that this doesn't remove all references to QUIC frames, but the remaining references are explanatory -- they describe what will happen at the transport layer after taking a particular action, rather than being part of the normative text.  (But if you find one of these you think needs to go, please include that in this review.)

This is a design, because exposing this functionality is mandatory.  I'm not sure how you would previously have created a usable QUIC implementation without these operations, but you weren't previously required to have them all.

Fixes #2805, closes #2677.