### PR TITLE
Initial secrets change after Retry

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -767,8 +767,7 @@ TLS 1.3 (see {{initial-secrets}}).
 ## Initial Secrets {#initial-secrets}
 
 Initial packets are protected with a secret derived from the Destination
-Connection ID field from the client's first Initial packet of the
-connection. Specifically:
+Connection ID field from the client's Initial packet. Specifically:
 
 ~~~
 initial_salt = 0x7fbcdb0e7c66bbe9193a96cd21519ebd7a02644a
@@ -801,7 +800,9 @@ The HKDF-Expand-Label function defined in TLS 1.3 MUST be used for Initial
 packets even where the TLS versions offered do not include TLS 1.3.
 
 The secrets used for protecting Initial packets changes when a server sends a
-Retry packet to use the connection ID value selected by the server.
+Retry packet to use the connection ID value selected by the server.  The secrets
+do not change when a client changes the Destination Connection ID it uses in
+response to an Initial packet from the server.
 
 Note:
 

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -799,7 +799,7 @@ modifying the contents of packets from future versions.
 The HKDF-Expand-Label function defined in TLS 1.3 MUST be used for Initial
 packets even where the TLS versions offered do not include TLS 1.3.
 
-The secrets used for protecting Initial packets changes when a server sends a
+The secrets used for protecting Initial packets change when a server sends a
 Retry packet to use the connection ID value selected by the server.  The secrets
 do not change when a client changes the Destination Connection ID it uses in
 response to an Initial packet from the server.

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -800,8 +800,8 @@ modifying the contents of packets from future versions.
 The HKDF-Expand-Label function defined in TLS 1.3 MUST be used for Initial
 packets even where the TLS versions offered do not include TLS 1.3.
 
-{{test-vectors-initial}} contains test vectors for the initial packet
-encryption.
+The secrets used for protecting Initial packets changes when a server sends a
+Retry packet to use the connection ID value selected by the server.
 
 Note:
 
@@ -810,6 +810,9 @@ Note:
   ID field.  In this case, the Initial keys provide no assurance to the client
   that the server received its packet; the client has to rely on the exchange
   that included the Retry packet for that property.
+
+{{test-vectors-initial}} contains test vectors for the initial packet
+encryption.
 
 
 ## AEAD Usage {#aead}


### PR DESCRIPTION
This was implied, but not explicit previously.

Closes #2823.