### PR TITLE
Editorial fix for #2479

### DIFF
--- a/draft-ietf-quic-invariants.md
+++ b/draft-ietf-quic-invariants.md
@@ -163,7 +163,7 @@ The next four bytes include a 32-bit Version field (see {{version}}).
 
 The byte contains the length in bytes of the Destination Connection ID (see
 {{connection-id}}) field that follows it.  This length is encoded as an 8-bit
-unsigned integer.  The Destination Connection ID field follows the DCI Len
+unsigned integer.  The Destination Connection ID field follows the DCID Len
 and is between 0 and 255 bytes in length.
 
 The byte following the Source Connection ID contains the length in bytes

--- a/draft-ietf-quic-invariants.md
+++ b/draft-ietf-quic-invariants.md
@@ -161,21 +161,18 @@ All other bits in that byte are version specific.
 
 The next four bytes include a 32-bit Version field (see {{version}}).
 
-The next byte contains the length in bytes of the two Connection IDs (see
-{{connection-id}}) that follow.  Each length is encoded as a 4-bit unsigned
-integer.  The length of the Destination Connection ID (DCIL) occupies the high
-bits of the byte and the length of the Source Connection ID (SCIL) occupies the
-low bits of the byte.  An encoded length of 0 indicates that the connection ID
-is also 0 bytes in length.  Non-zero encoded lengths are increased by 3 to get
-the full length of the connection ID; the final value is therefore either 0 or
-between 4 and 18 bytes in length (inclusive).  For example, a byte with the
-value 0xe0 describes a 17 byte Destination Connection ID and a zero byte Source
-Connection ID.
+The byte contains the length in bytes of the Destination Connection ID (see
+{{connection-id}}) field that follows it.  This length is encoded as an 8-bit
+unsigned integer.  The Destination Connection ID field follows the DCI Len
+and is between 0 and 255 bytes in length.
 
-The connection ID lengths are followed by two connection IDs.  The connection
-ID associated with the recipient of the packet (the Destination Connection ID)
-is followed by the connection ID associated with the sender of the packet (the
-Source Connection ID).
+The byte following the Source Connection ID contains the length in bytes
+of the Source Connection ID field that follows it.  This length is encoded as
+a 8-bit unsigned integer.  The Source Connection ID field follows the SCID Len
+and is between 0 and 255 bytes in length.
+
+{{negotiating-connection-ids}} describes the use of the source and destination
+connection ID fields in more detail.
 
 The remainder of the packet contains version-specific content.
 

--- a/draft-ietf-quic-invariants.md
+++ b/draft-ietf-quic-invariants.md
@@ -161,12 +161,12 @@ All other bits in that byte are version specific.
 
 The next four bytes include a 32-bit Version field (see {{version}}).
 
-The byte contains the length in bytes of the Destination Connection ID (see
+The next byte contains the length in bytes of the Destination Connection ID (see
 {{connection-id}}) field that follows it.  This length is encoded as an 8-bit
 unsigned integer.  The Destination Connection ID field follows the DCID Len
 field and is between 0 and 255 bytes in length.
 
-The byte following the Source Connection ID contains the length in bytes
+The next byte contains the length in bytes
 of the Source Connection ID field that follows it.  This length is encoded as
 a 8-bit unsigned integer.  The Source Connection ID field follows the SCID Len
 field and is between 0 and 255 bytes in length.

--- a/draft-ietf-quic-invariants.md
+++ b/draft-ietf-quic-invariants.md
@@ -164,7 +164,7 @@ The next four bytes include a 32-bit Version field (see {{version}}).
 The byte contains the length in bytes of the Destination Connection ID (see
 {{connection-id}}) field that follows it.  This length is encoded as an 8-bit
 unsigned integer.  The Destination Connection ID field follows the DCID Len
-and is between 0 and 255 bytes in length.
+field and is between 0 and 255 bytes in length.
 
 The byte following the Source Connection ID contains the length in bytes
 of the Source Connection ID field that follows it.  This length is encoded as

--- a/draft-ietf-quic-invariants.md
+++ b/draft-ietf-quic-invariants.md
@@ -169,7 +169,7 @@ field and is between 0 and 255 bytes in length.
 The byte following the Source Connection ID contains the length in bytes
 of the Source Connection ID field that follows it.  This length is encoded as
 a 8-bit unsigned integer.  The Source Connection ID field follows the SCID Len
-and is between 0 and 255 bytes in length.
+field and is between 0 and 255 bytes in length.
 
 {{negotiating-connection-ids}} describes the use of the source and destination
 connection ID fields in more detail.

--- a/draft-ietf-quic-invariants.md
+++ b/draft-ietf-quic-invariants.md
@@ -171,9 +171,6 @@ of the Source Connection ID field that follows it.  This length is encoded as
 a 8-bit unsigned integer.  The Source Connection ID field follows the SCID Len
 field and is between 0 and 255 bytes in length.
 
-{{negotiating-connection-ids}} describes the use of the source and destination
-connection ID fields in more detail.
-
 The remainder of the packet contains version-specific content.
 
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3503,16 +3503,13 @@ Version:
 
 DCID Len:
 
-: The byte following the version contains the lengths of the two connection ID
-  fields that follow it.  These lengths are encoded as two 4-bit unsigned
-  integers. The Destination Connection ID Length (DCIL) field occupies the 4
-  high bits of the byte and the Source Connection ID Length (SCIL) field
-  occupies the 4 low bits of the byte.  An encoded length of 0 indicates that
-  the connection ID is also 0 bytes in length.  Non-zero encoded lengths are
-  increased by 3 to get the full length of the connection ID, producing a length
-  between 4 and 18 bytes inclusive.  For example, a byte with the value 0x50
-  describes an 8-byte Destination Connection ID and a zero-length Source
-  Connection ID.
+: The byte following the version contains the length in bytes of the Destination
+  Connection ID field that follows it.  This length is encoded as an 8-bit
+  unsigned integer.  In QUIC version 1, this value MUST NOT exceed 20 bytes.
+  Endpoints that receive a version 1 long header with a value larger than
+  20 MUST drop the packet. Servers SHOULD be able to read longer connection IDs
+  from other QUIC versions in order to properly form a version negotiation
+  packet.
 
 Destination Connection ID:
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3505,7 +3505,7 @@ DCID Len:
 
 : The byte following the version contains the length in bytes of the Destination
   Connection ID field that follows it.  This length is encoded as an 8-bit
-  unsigned integer.  In QUIC version 1, this value MUST NOT exceed 20 bytes.
+  unsigned integer.  In QUIC version 1, this value MUST NOT exceed 20.
   Endpoints that receive a version 1 long header with a value larger than
   20 MUST drop the packet. Servers SHOULD be able to read longer connection IDs
   from other QUIC versions in order to properly form a version negotiation


### PR DESCRIPTION
I noticed this earlier today when trying to resolve conflicts relating to the connection ID change.