### PR TITLE
Fix lack of exponential backoff in pseudocode

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1194,7 +1194,7 @@ SetLossDetectionTimer():
     loss_detection_timer.cancel()
     return
 
-  // Use a default timeout if ther are no RTT measurements
+  // Use a default timeout if there are no RTT measurements
   if (smoothed_rtt == 0):
     timeout = 2 * kInitialRtt
   else:

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1199,8 +1199,8 @@ SetLossDetectionTimer():
     timeout = 2 * kInitialRtt
   else:
     // Calculate PTO duration
-    timeout =
-      smoothed_rtt + max(4 * rttvar, kGranularity) + max_ack_delay
+    timeout = smoothed_rtt + max(4 * rttvar, kGranularity) +
+      max_ack_delay
   timeout = timeout * (2 ^ pto_count)
 
   loss_detection_timer.update(

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1197,11 +1197,10 @@ SetLossDetectionTimer():
   // Use a default timeout if ther are no RTT measurements
   if (smoothed_rtt == 0):
     timeout = 2 * kInitialRtt
-    return
-
-  // Calculate PTO duration
-  timeout =
-    smoothed_rtt + max(4 * rttvar, kGranularity) + max_ack_delay
+  else:
+    // Calculate PTO duration
+    timeout =
+      smoothed_rtt + max(4 * rttvar, kGranularity) + max_ack_delay
   timeout = timeout * (2 ^ pto_count)
 
   loss_detection_timer.update(


### PR DESCRIPTION
When there is no smoothed_rtt, PR #2806 inadvertently removed the exponential backoff from the pseudocode.