### PR TITLE
Clarify resetting congestion control

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2015,7 +2015,7 @@ estimation for the new path.
 
 On confirming a peer's ownership of its new address, an endpoint SHOULD
 immediately reset the congestion controller and round-trip time estimator for
-the new path.
+the new path to initial values (see Sections A.3 and B.3 in {{QUIC-RECOVERY}}).
 
 An endpoint MUST NOT return to the send rate used for the previous path unless
 it is reasonably sure that the previous send rate is valid for the new path.


### PR DESCRIPTION
Closes #2685.

This doesn't address both editorial clarifications in #2685, but the second one is now getting covered in #2909.