### PR TITLE
remove RIC from Relative Index in Header Block figure; add Base value to two figures

### DIFF
--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -526,7 +526,7 @@ Insertion Point               Dropping Point
 n = count of entries inserted
 d = count of entries dropped
 ~~~~~
-{: title="Example Dynamic Table Indexing - Encoder Stream"}
+{: title="Example Dynamic Table Indexing on the Encoder Stream when Base = n-2"}
 
 Unlike encoder instructions, relative indices in header block representations
 are relative to the Base at the beginning of the header block (see
@@ -549,7 +549,7 @@ index equal to Base - 1.
 n = count of entries inserted
 d = count of entries dropped
 ~~~~~
-{: title="Example Dynamic Table Indexing - Relative Index in Header Block"}
+{: title="Example Dynamic Table Indexing in a Header Block when Base = n-2"}
 
 
 ### Post-Base Indexing {#post-base}

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -536,11 +536,9 @@ In a header block a relative index of "0" refers to the entry with absolute
 index equal to Base - 1.
 
 ~~~~~ drawing
- Required
-  Insert
-  Count        Base
-    |           |
-    V           V
+            Base
+             |
+             V
     +-----+-----+-----+-----+-------+
     | n-1 | n-2 | n-3 | ... |   d   |  Absolute Index
     +-----+-----+  -  +-----+   -   +
@@ -564,9 +562,9 @@ and include references to entries added while processing this (or other) header
 blocks.
 
 ~~~~~ drawing
-               Base
-                |
-                V
+            Base
+             |
+             V
     +-----+-----+-----+-----+-----+
     | n-1 | n-2 | n-3 | ... |  d  |  Absolute Index
     +-----+-----+-----+-----+-----+

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -526,7 +526,7 @@ Insertion Point               Dropping Point
 n = count of entries inserted
 d = count of entries dropped
 ~~~~~
-{: title="Example Dynamic Table Indexing on the Encoder Stream when Base = n-2"}
+{: title="Example Dynamic Table Indexing - Encoder Stream"}
 
 Unlike encoder instructions, relative indices in header block representations
 are relative to the Base at the beginning of the header block (see
@@ -549,7 +549,7 @@ index equal to Base - 1.
 n = count of entries inserted
 d = count of entries dropped
 ~~~~~
-{: title="Example Dynamic Table Indexing in a Header Block when Base = n-2"}
+{: title="Example Dynamic Table Indexing - Relative Index in Header Block"}
 
 
 ### Post-Base Indexing {#post-base}

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -537,9 +537,9 @@ In a header block a relative index of "0" refers to the entry with absolute
 index equal to Base - 1.
 
 ~~~~~ drawing
-            Base
-             |
-             V
+               Base
+                |
+                V
     +-----+-----+-----+-----+-------+
     | n-1 | n-2 | n-3 | ... |   d   |  Absolute Index
     +-----+-----+  -  +-----+   -   +
@@ -548,6 +548,7 @@ index equal to Base - 1.
 
 n = count of entries inserted
 d = count of entries dropped
+In this example, Base = n - 2
 ~~~~~
 {: title="Example Dynamic Table Indexing - Relative Index in Header Block"}
 
@@ -563,9 +564,9 @@ and include references to entries added while processing this (or other) header
 blocks.
 
 ~~~~~ drawing
-            Base
-             |
-             V
+               Base
+                |
+                V
     +-----+-----+-----+-----+-----+
     | n-1 | n-2 | n-3 | ... |  d  |  Absolute Index
     +-----+-----+-----+-----+-----+
@@ -574,6 +575,7 @@ blocks.
 
 n = count of entries inserted
 d = count of entries dropped
+In this example, Base = n - 2
 ~~~~~
 {: title="Example Dynamic Table Indexing - Post-Base Index in Header Block"}
 


### PR DESCRIPTION
In my mind Base is an index, so it should point to an entry (relative index 0 means the entry with absolute index one fewer than Base, post-base index 0 means the same entry as Base).  Required Insert Count is a counter, not an index, so it does not belong on figures.