### PR TITLE
QPACK [editorial] Post-base index is not relative index.

### DIFF
--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -131,8 +131,8 @@ Absolute Index:
 
 Base:
 
-: A reference point for relative indices.  Dynamic references are made relative
-  to a Base in header blocks.
+: A reference point for relative and post-base indices.  References to dynamic
+  table entries in header blocks are relative to a Base.
 
 Insert Count:
 
@@ -945,7 +945,7 @@ the Base; setting Delta Base to zero is the most efficient encoding.
 
 For example, with a Required Insert Count of 9, a decoder receives a S bit of 1
 and a Delta Base of 2.  This sets the Base to 6 and enables post-base indexing
-for three entries.  In this example, a regular index of 1 refers to the 5th
+for three entries.  In this example, a relative index of 1 refers to the 5th
 entry that was added to the table; a post-base index of 1 refers to the 8th
 entry.
 


### PR DESCRIPTION
Since post-base index has a section separate from relative index, I do not consider post-base index a type of relative index, but a distinct category.  Update text accordingly.

If the consensus is that this is not the case, relative index and post-base index sections should be reworded, and a new term should be introduced for non-post-base relative index.