### PR TITLE
Describe interaction between QUIC and TLS regarding saved 0-RTT state

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -364,8 +364,8 @@ As shown in {{schematic}}, the interface from QUIC to TLS consists of four
 primary functions:
 
 - Sending and receiving handshake messages
-- Processing stored transport and application state from a 0-RTT capable session
-  ticket and determining if it is valid to accept early data on the connection
+- Processing stored transport and application state from a resumed session
+  and determining if it is valid to accept early data
 - Rekeying (both transmit and receive)
 - Handshake state updates
 
@@ -647,7 +647,7 @@ A client MAY attempt to send 0-RTT again if it receives a Retry or Version
 Negotiation packet.  These packets do not signify rejection of 0-RTT.
 
 
-## Validating 0-RTT configuration
+## Validating 0-RTT Configuration
 
 When a server receives a ClientHello with the "early_data" extension, it has to
 decide whether to accept or reject early data from the client. Some of this
@@ -664,8 +664,8 @@ in the session ticket. Application protocols that use QUIC might have similar
 requirements regarding associating or storing state. This associated state is
 used for deciding whether early data must be rejected. For example, HTTP/3
 ({{QUIC-HTTP}}) settings determine how early data from the client is
-interpreted. Other applications using QUIC could have different requiremenets
-for determining whether ot accept or reject early data.
+interpreted. Other applications using QUIC could have different requirements
+for determining whether to accept or reject early data.
 
 
 ## HelloRetryRequest

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -659,13 +659,13 @@ configuration of the transport or application associated with the resumed
 session is not compatible with the server's current configuration.
 
 QUIC requires additional transport state to be associated with a 0-RTT session
-ticket. If stateless session tickets are used, this information must be stored
-in the session ticket. Application protocols that use QUIC might have similar
-requirements regarding associating or storing state. This associated state is
-used for deciding whether early data must be rejected. For example, HTTP/3
-({{QUIC-HTTP}}) settings determine how early data from the client is
-interpreted. Other applications using QUIC could have different requirements
-for determining whether to accept or reject early data.
+ticket. One common way to implement this is using stateless session tickets and
+storing this state in the session ticket. Application protocols that use QUIC
+might have similar requirements regarding associating or storing state. This
+associated state is used for deciding whether early data must be rejected. For
+example, HTTP/3 ({{QUIC-HTTP}}) settings determine how early data from the
+client is interpreted. Other applications using QUIC could have different
+requirements for determining whether to accept or reject early data.
 
 
 ## HelloRetryRequest


### PR DESCRIPTION
This PR describes how a TLS stack needs to cooperate with a QUIC stack
when making the decision whether or not to accept early data.

The purpose of this change is so that implementors working on the TLS
layer of QUIC are aware that other layers impact decisions traditionally
made at the TLS layer.