### PR TITLE
Fix nit in protocol overview in TLS draft

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -299,7 +299,7 @@ protection being called out specially.
 
 Unlike TLS over TCP, QUIC applications which want to send data do not send it
 through TLS "application_data" records. Rather, they send it as QUIC STREAM
-frames which are then carried in QUIC packets.
+frames or other frame types which are then carried in QUIC packets.
 
 # Carrying TLS Messages {#carrying-tls}
 


### PR DESCRIPTION
Mention that application data could be conveyed in other frame types
than STREAM frames. (E.g. the proposed DATAGRAM draft sends application
data in DATAGRAM frames.)