### PR TITLE
Skip a packet number when sending one PTO packet

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -569,8 +569,8 @@ To speed up handshake completion under these conditions, an endpoint MAY send
 a packet containing unacknowledged CRYPTO data earlier than the PTO expiry,
 subject to address validation limits; see Section 8.1 of {{QUIC-TRANSPORT}}.
 
-Peers can also use coalesced packets to ensure that each datagram elicits at least
-one acknowledgement.  For example, clients can coalesce an Initial packet
+Peers can also use coalesced packets to ensure that each datagram elicits at
+least one acknowledgement.  For example, clients can coalesce an Initial packet
 containing PING and PADDING frames with a 0-RTT data packet and a server can
 coalesce an Initial packet containing a PING frame with one or more packets in
 its first flight.

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -587,6 +587,9 @@ In addition to sending data in the packet number space for which the timer
 expired, the sender SHOULD send ack-eliciting packets from other packet
 number spaces with in-flight data, coalescing packets if possible.
 
+When only sending a single packet on PTO, senders can skip a packet number to
+elicit a faster acknowledgement.
+
 When the PTO timer expires, and there is new or previously sent unacknowledged
 data, it MUST be sent.
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -587,7 +587,7 @@ In addition to sending data in the packet number space for which the timer
 expired, the sender SHOULD send ack-eliciting packets from other packet
 number spaces with in-flight data, coalescing packets if possible.
 
-When only sending a single packet on PTO, senders can skip a packet number to
+If the sender sends a single packet on PTO, it can skip a packet number to
 elicit a faster acknowledgement.
 
 When the PTO timer expires, and there is new or previously sent unacknowledged

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -587,8 +587,8 @@ In addition to sending data in the packet number space for which the timer
 expired, the sender SHOULD send ack-eliciting packets from other packet
 number spaces with in-flight data, coalescing packets if possible.
 
-If the sender sends a single packet on PTO, it can skip a packet number to
-elicit a faster acknowledgement.
+If the sender wants to elicit a faster acknowledgement on PTO, it can skip a
+packet number to eliminate the ack delay.
 
 When the PTO timer expires, and there is new or previously sent unacknowledged
 data, it MUST be sent.


### PR DESCRIPTION
Indicates that peers can skip a packet number when sending a single PTO packet to elicit a faster ACK.