### PR TITLE
Update Stream Commitment Attack example

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -5509,7 +5509,7 @@ However, when several streams are initiated at short intervals, transmission
 error may cause STREAM DATA frames opening streams to be received out of
 sequence.  A receiver is obligated to open intervening streams if a
 higher-numbered stream ID is received.  Thus, on a new connection, opening
-stream 2000001 opens 1 million streams, as required by the specification.
+stream 4000000 opens 1 million streams, as required by the specification.
 
 The number of active streams is limited by the initial_max_streams_bidi and
 initial_max_streams_uni transport parameters, as explained in

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -5509,7 +5509,7 @@ However, when several streams are initiated at short intervals, transmission
 error may cause STREAM frames opening streams to be received out of
 sequence.  A receiver is obligated to open intervening streams if a
 higher-numbered stream ID is received.  Thus, on a new connection, opening
-stream 4000000 opens 1 million streams, as required by the specification.
+stream 4000000 opens 1 million and 1 streams, as required by the specification.
 
 The number of active streams is limited by the initial_max_streams_bidi and
 initial_max_streams_uni transport parameters, as explained in

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -5506,7 +5506,7 @@ of connections, in a manner similar to SYN flooding attacks in TCP.
 
 Normally, clients will open streams sequentially, as explained in {{stream-id}}.
 However, when several streams are initiated at short intervals, transmission
-error may cause STREAM DATA frames opening streams to be received out of
+error may cause STREAM frames opening streams to be received out of
 sequence.  A receiver is obligated to open intervening streams if a
 higher-numbered stream ID is received.  Thus, on a new connection, opening
 stream 4000000 opens 1 million streams, as required by the specification.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -5505,11 +5505,12 @@ endpoint.  The adversarial endpoint could repeat the process on a large number
 of connections, in a manner similar to SYN flooding attacks in TCP.
 
 Normally, clients will open streams sequentially, as explained in {{stream-id}}.
-However, when several streams are initiated at short intervals, transmission
-error may cause STREAM frames opening streams to be received out of
-sequence.  A receiver is obligated to open intervening streams if a
-higher-numbered stream ID is received.  Thus, on a new connection, opening
-stream 4000000 opens 1 million and 1 streams, as required by the specification.
+However, when several streams are initiated at short intervals, loss or
+reordering may cause STREAM frames that open streams to be received out of
+sequence.  On receiving a higher-numbered stream ID, a receiver is required to
+open all intervening streams of the same type (see {{stream-recv-states}}).
+Thus, on a new connection, opening stream 4000000 opens 1 million and 1
+client-initiated bidirectional streams.
 
 The number of active streams is limited by the initial_max_streams_bidi and
 initial_max_streams_uni transport parameters, as explained in


### PR DESCRIPTION
The Stream Commitment Attack part was added in draft-ietf-quic-transport-03, when unidirectional streams were not used.

In draft-ietf-quic-transport-08, streams were split into unidirectional and bidirectional, but this example of stream commitment attack was missed.