### PR TITLE
Update QPACK stream creation error

### DIFF
--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -624,7 +624,7 @@ QPACK defines two unidirectional stream types:
 HTTP/3 endpoints contain a QPACK encoder and decoder. Each endpoint MUST
 initiate at most one encoder stream and at most one decoder stream. Receipt of a
 second instance of either stream type MUST be treated as a connection error of
-type HTTP_WRONG_STREAM_COUNT. These streams MUST NOT be closed. Closure of
+type HTTP_STREAM_CREATION_ERROR. These streams MUST NOT be closed. Closure of
 either unidirectional stream type MUST be treated as a connection error of type
 HTTP_CLOSED_CRITICAL_STREAM.
 


### PR DESCRIPTION
On receiving duplicate QPACK streams, the error should be HTTP_STREAM_CREATION_ERROR which matches with control stream duplicates.