### PR TITLE
Http/complete settings

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1396,16 +1396,19 @@ servers, the initial value of each client setting is the default value.
 For clients using a 1-RTT QUIC connection, the initial value of each server
 setting is the default value. When a 0-RTT QUIC connection is being used, the
 initial value of each server setting is the value used in the previous session.
-Clients MUST store the settings the server provided in the session being resumed
-and MUST comply with stored settings until the current server settings are
-received.  A client can use these initial values to send requests before the
+Clients SHOULD store the settings the server provided in the session being
+resumed and MUST comply with stored settings until the current server settings
+are received.  If the client did not store, or did not receive, server settings
+from the previous session, the initial value of each setting is the default
+value.  A client can use these initial values to send requests before the
 server's SETTINGS frame has arrived.  This removes the need for a client to wait
 for the SETTINGS frame before sending requests.
 
 A server can remember the settings that it advertised, or store an
 integrity-protected copy of the values in the ticket and recover the information
 when accepting 0-RTT data. A server uses the HTTP/3 settings values in
-determining whether to accept 0-RTT data.
+determining whether to accept 0-RTT data.  If the server cannot recover the
+settings from a session being resumed, it MUST NOT accept 0-RTT data.
 
 A server MAY accept 0-RTT and subsequently provide different settings in its
 SETTINGS frame. If 0-RTT data is accepted by the server, its SETTINGS frame MUST

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1410,8 +1410,8 @@ determining whether to accept 0-RTT data.
 A server MAY accept 0-RTT and subsequently provide different settings in its
 SETTINGS frame. If 0-RTT data is accepted by the server, its SETTINGS frame MUST
 NOT reduce any limits or alter any values that might be violated by the client
-with its 0-RTT data.  The server MAY omit settings from its SETTINGS frame which
-are unchanged from the initial value.
+with its 0-RTT data.  The server MUST include all settings which differ from
+their default values, even if the value is unchanged from the previous session.
 
 
 ### PUSH_PROMISE {#frame-push-promise}


### PR DESCRIPTION
This is an alternative to #2958 that sticks closer to the current design / the pattern of HTTP/2.

It tightens constraints around SETTINGS in a couple of ways:
- Servers are now required to send complete SETTINGS frames -- they can still omit settings which match the default, but not settings which match the session being resumed.
- What happens if either side is uncertain which settings apply to a ticket?  Clients assume defaults; servers MUST NOT accept early data (though they could still accept a resumption).

Fixes #2790; fixes #2945; closes #2958.