### PR TITLE
Require 8164 validation for non-https origins

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -381,6 +381,10 @@ certificate for the origin before considering it authoritative. Clients MUST NOT
 assume that an HTTP/3 endpoint is authoritative for other origins without an
 explicit signal.
 
+If the client intends to make requests for an origin containing a scheme other
+than "https", it MUST also obtain a valid `http-opportunistic` response for the
+origin as described in {{!RFC8164}} prior to making any such requests.
+
 A server that does not wish clients to reuse connections for a particular origin
 can indicate that it is not authoritative for a request by sending a 421
 (Misdirected Request) status code in response to the request (see Section 9.1.2


### PR DESCRIPTION
Fixes #2439 in what I believe is the simplest way possible -- point to 8164 and require that `http-opportunistic` be successfully retrieved prior to sending any scheme other than `https`.