### PR TITLE
forbid empty NEW_TOKEN frames

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4843,7 +4843,8 @@ Token Length:
 
 Token:
 
-: An opaque blob that the client may use with a future Initial packet.
+: An opaque blob that the client may use with a future Initial packet. The token
+  MUST NOT be empty.
 
 
 ## STREAM Frames {#frame-stream}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4844,7 +4844,8 @@ Token Length:
 Token:
 
 : An opaque blob that the client may use with a future Initial packet. The token
-  MUST NOT be empty.
+  MUST NOT be empty.  An endpoint MUST treat receipt of a NEW_TOKEN frame with
+  an empty Token field as a connection error of type FRAME_ENCODING_ERROR.
 
 
 ## STREAM Frames {#frame-stream}


### PR DESCRIPTION
Closes #2978.

If we allow empty NEW_TOKEN frames, the receiver would have to check that the token is not empty before saving and reusing it, so it seems slightly easier to forbid this nonsensical edge case.