### PR TITLE
Forbid duplicate setting identifiers.

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1340,9 +1340,9 @@ Different values for the same parameter can be advertised by each peer. For
 example, a client might be willing to consume a very large response header,
 while servers are more cautious about request size.
 
-Parameters MUST NOT occur more than once in the SETTINGS frame.  A receiver MAY
-treat the presence of the same parameter more than once as a connection error of
-type HTTP_SETTINGS_ERROR.
+Setting identifiers MUST NOT occur more than once in the SETTINGS frame.  A
+receiver MAY treat the presence of the same setting identifier more than once as
+a connection error of type HTTP_SETTINGS_ERROR.
 
 The payload of a SETTINGS frame consists of zero or more parameters.  Each
 parameter consists of a setting identifier and a value, both encoded as QUIC


### PR DESCRIPTION
I assume the intention was to forbid the same setting identifier
occurring multiple times in a SETTINGS frame, regardless of the values.
However, since a parameter is defined as an identifier-value pair, the
current text does not forbid duplicate identifiers if the values are
different.