### PR TITLE
Stateless reset comparisons (constant time/any order/datagram)

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2572,11 +2572,11 @@ An endpoint MUST NOT check for any Stateless Reset Tokens associated with
 connection IDs it has not used or for connection IDs that have been retired.
 
 When comparing a packet to Stateless Reset Token values, endpoints MUST perform
-the comparison in constant time to avoid leaking information about valid values.
-Performing this comparison in constant time only protects the value of
+the comparison without leaking information about the value of the token.
+For example, performing this comparison in constant time protects the value of
 individual Stateless Reset Tokens from information leakage through timing side
-channels; it does not protect information about whether a packet was
-successfully decrypted, nor does it protect the number of valid Stateless Reset
+channels.  An endpoint is not expected to protect information about whether a
+packet was successfully decrypted, or the number of valid Stateless Reset
 Tokens.
 
 If the last 16 bytes of the packet values are identical to a Stateless Reset

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2559,7 +2559,7 @@ the packet other than the last 16 bytes for carrying data.
 ### Detecting a Stateless Reset
 
 An endpoint detects a potential stateless reset using the trailing 16 bytes of
-the UDP datagram.  The endpoint compare the last 16 bytes of the datagram with
+the UDP datagram.  The endpoint compares the last 16 bytes of the datagram with
 all Stateless Reset Tokens that are associated with connection IDs that the
 endpoint recently used to send packets from the IP address and port on which the
 datagram is received.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2575,9 +2575,12 @@ When comparing a packet to Stateless Reset Token values, endpoints MUST perform
 the comparison without leaking information about the value of the token.
 For example, performing this comparison in constant time protects the value of
 individual Stateless Reset Tokens from information leakage through timing side
-channels.  An endpoint is not expected to protect information about whether a
-packet was successfully decrypted, or the number of valid Stateless Reset
-Tokens.
+channels.  Another approach would be to store and compare the transformed values
+of Stateless Reset Tokens instead of the raw token values, where the
+transformation is defined as a cryptographically-secure pseudo-random function
+using a secret key (e.g., block cipher, HMAC {{?RFC2104}}). An endpoint is not
+expected to protect information about whether a packet was successfully
+decrypted, or the number of valid Stateless Reset Tokens.
 
 If the last 16 bytes of the packet values are identical to a Stateless Reset
 Token, the endpoint MUST enter the draining period and not send any further

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2558,21 +2558,25 @@ the packet other than the last 16 bytes for carrying data.
 
 ### Detecting a Stateless Reset
 
-An endpoint detects a potential stateless reset when an incoming packet either
-cannot be associated with a connection, cannot be decrypted, or is marked as a
-duplicate packet.  The endpoint MUST then compare the last 16 bytes of the
-packet with all Stateless Reset Tokens that are associated with connection IDs
-that the endpoint recently used to send packets from the IP address and port on
-which the datagram is received.
+An endpoint detects a potential stateless reset using the trailing 16 bytes of
+the UDP datagram.  The endpoint compare the last 16 bytes of the datagram with
+all Stateless Reset Tokens that are associated with connection IDs that the
+endpoint recently used to send packets from the IP address and port on which the
+datagram is received.
 This includes Stateless Reset Tokens from NEW_CONNECTION_ID frames and the
 server's transport parameters but excludes Stateless Reset Tokens associated
 with connection IDs that are either unused or retired.
 
+This comparison can be performed for every inbound datagram, but it MUST be
+performed when the first packet in an incoming datagram either cannot be
+associated with a connection, cannot be decrypted, or is identified as a
+duplicate.
+
 An endpoint MUST NOT check for any Stateless Reset Tokens associated with
 connection IDs it has not used or for connection IDs that have been retired.
 
-When comparing a packet to Stateless Reset Token values, endpoints MUST perform
-the comparison without leaking information about the value of the token.
+When comparing a datagram to Stateless Reset Token values, endpoints MUST
+perform the comparison without leaking information about the value of the token.
 For example, performing this comparison in constant time protects the value of
 individual Stateless Reset Tokens from information leakage through timing side
 channels.  Another approach would be to store and compare the transformed values
@@ -2582,10 +2586,9 @@ using a secret key (e.g., block cipher, HMAC {{?RFC2104}}). An endpoint is not
 expected to protect information about whether a packet was successfully
 decrypted, or the number of valid Stateless Reset Tokens.
 
-If the last 16 bytes of the packet values are identical to a Stateless Reset
+If the last 16 bytes of the datagram are identical in value to a Stateless Reset
 Token, the endpoint MUST enter the draining period and not send any further
-packets on this connection.  If the comparison fails, the packet can be
-discarded.
+packets on this connection.
 
 
 ### Calculating a Stateless Reset Token {#reset-token}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2571,8 +2571,7 @@ which the datagram was received.
 This comparison can be performed for every inbound datagram.  Endpoints MAY skip
 this check if any packet from a datagram is successfully processed.  However,
 the comparison MUST be performed when the first packet in an incoming datagram
-either cannot be associated with a connection, cannot be decrypted, or carries
-a duplicate packet number.
+either cannot be associated with a connection, or cannot be decrypted.
 
 An endpoint MUST NOT check for any Stateless Reset Tokens associated with
 connection IDs it has not used or for connection IDs that have been retired.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2559,13 +2559,14 @@ the packet other than the last 16 bytes for carrying data.
 ### Detecting a Stateless Reset
 
 An endpoint detects a potential stateless reset using the trailing 16 bytes of
-the UDP datagram.  The endpoint compares the last 16 bytes of the datagram with
-all Stateless Reset Tokens that are associated with connection IDs that the
-endpoint recently used to send packets from the IP address and port on which the
-datagram is received.
+the UDP datagram.  An endpoint remembers all Stateless Reset Tokens associated
+with the connection IDs and remote addresses for datagrams it has recently sent.
 This includes Stateless Reset Tokens from NEW_CONNECTION_ID frames and the
 server's transport parameters but excludes Stateless Reset Tokens associated
-with connection IDs that are either unused or retired.
+with connection IDs that are either unused or retired.  The endpoint identifies
+a received datagram as a stateless reset by comparing the last 16 bytes of the
+datagram with all Stateless Reset Tokens associated with the remote address on
+which the datagram was received.
 
 This comparison can be performed for every inbound datagram.  Endpoints MAY skip
 this check if any packet from a datagram is successfully processed.  However,

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2561,12 +2561,23 @@ the packet other than the last 16 bytes for carrying data.
 An endpoint detects a potential stateless reset when an incoming packet either
 cannot be associated with a connection, cannot be decrypted, or is marked as a
 duplicate packet.  The endpoint MUST then compare the last 16 bytes of the
-packet with all Stateless Reset Tokens corresponding to active connection IDs
-that the endpoint has used for sending packets to the IP address and port on
-which the datagram is received.  This includes Stateless Reset Tokens from
-NEW_CONNECTION_ID frames and the server's transport parameters.  An endpoint
-MUST NOT check for any Stateless Reset Tokens associated with connection IDs it
-has not used or for connection IDs that have been retired.
+packet with all Stateless Reset Tokens that are associated with connection IDs
+that the endpoint recently used to send packets from the IP address and port on
+which the datagram is received.
+This includes Stateless Reset Tokens from NEW_CONNECTION_ID frames and the
+server's transport parameters but excludes Stateless Reset Tokens associated
+with connection IDs that are either unused or retired.
+
+An endpoint MUST NOT check for any Stateless Reset Tokens associated with
+connection IDs it has not used or for connection IDs that have been retired.
+
+When comparing a packet to Stateless Reset Token values, endpoints MUST perform
+the comparison in constant time to avoid leaking information about valid values.
+Performing this comparison in constant time only protects the value of
+individual Stateless Reset Tokens from information leakage through timing side
+channels; it does not protect information about whether a packet was
+successfully decrypted, nor does it protect the number of valid Stateless Reset
+Tokens.
 
 If the last 16 bytes of the packet values are identical to a Stateless Reset
 Token, the endpoint MUST enter the draining period and not send any further

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2570,8 +2570,8 @@ with connection IDs that are either unused or retired.
 This comparison can be performed for every inbound datagram.  Endpoints MAY skip
 this check if packets from a datagram are successfully processed.  However, the
 comparison MUST be performed when the first packet in an incoming datagram
-either cannot be associated with a connection, cannot be decrypted, or is
-identified as a duplicate.
+either cannot be associated with a connection, cannot be decrypted, or carries
+a duplicate packet number.
 
 An endpoint MUST NOT check for any Stateless Reset Tokens associated with
 connection IDs it has not used or for connection IDs that have been retired.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2567,10 +2567,11 @@ This includes Stateless Reset Tokens from NEW_CONNECTION_ID frames and the
 server's transport parameters but excludes Stateless Reset Tokens associated
 with connection IDs that are either unused or retired.
 
-This comparison can be performed for every inbound datagram, but it MUST be
-performed when the first packet in an incoming datagram either cannot be
-associated with a connection, cannot be decrypted, or is identified as a
-duplicate.
+This comparison can be performed for every inbound datagram.  Endpoints MAY skip
+this check if packets from a datagram are successfully processed.  However, the
+comparison MUST be performed when the first packet in an incoming datagram
+either cannot be associated with a connection, cannot be decrypted, or is
+identified as a duplicate.
 
 An endpoint MUST NOT check for any Stateless Reset Tokens associated with
 connection IDs it has not used or for connection IDs that have been retired.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2568,8 +2568,8 @@ server's transport parameters but excludes Stateless Reset Tokens associated
 with connection IDs that are either unused or retired.
 
 This comparison can be performed for every inbound datagram.  Endpoints MAY skip
-this check if packets from a datagram are successfully processed.  However, the
-comparison MUST be performed when the first packet in an incoming datagram
+this check if any packet from a datagram is successfully processed.  However,
+the comparison MUST be performed when the first packet in an incoming datagram
 either cannot be associated with a connection, cannot be decrypted, or carries
 a duplicate packet number.
 


### PR DESCRIPTION
Otherwise information about the token might leak.

As @mikkelfj says, there is no strict need to compare across the entire
set of values.  That could leaks two things: that the inbound packet was
dropped and the total number of stateless reset tokens.  Both are things
that we might care about, but will probably find prohibitive to protect.

Closes #2152.