### PR TITLE
Error codes can't cause errors

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1396,9 +1396,8 @@ connection error.
 
 Because new error codes can be defined without negotiation (see {{extensions}}),
 receipt of an unknown error code or use of an error code in an unexpected
-context MUST NOT be treated as an error.  However, the fact that a stream closed
-might itself constitute an error regardless of the error code provided -- see
-{{request-response}}.
+context MUST NOT be treated as an error.  However, closing a stream can
+constitute an error regardless of the error code -- see {{request-response}}.
 
 This section describes HTTP/3-specific error codes which can be used to express
 the cause of a connection or stream error.

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1397,7 +1397,7 @@ connection error.
 Because new error codes can be defined without negotiation (see {{extensions}}),
 receipt of an unknown error code or use of an error code in an unexpected
 context MUST NOT be treated as an error.  However, closing a stream can
-constitute an error regardless of the error code -- see {{request-response}}.
+constitute an error regardless of the error code (see {{request-response}}).
 
 This section describes HTTP/3-specific error codes which can be used to express
 the cause of a connection or stream error.

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1394,6 +1394,12 @@ the entire connection when an error is encountered.  These are referred to as
 {{QUIC-TRANSPORT}}.  An endpoint MAY choose to treat a stream error as a
 connection error.
 
+Because new error codes can be defined without negotiation (see {{extensions}}),
+receipt of an unknown error code or use of an error code in an unexpected
+context MUST NOT be treated as an error.  However, the fact that a stream closed
+might itself constitute an error regardless of the error code provided -- see
+{{request-response}}.
+
 This section describes HTTP/3-specific error codes which can be used to express
 the cause of a connection or stream error.
 


### PR DESCRIPTION
Fixes #2816 by saying that, since error codes are extensible, you can't treat the receipt of an error code you don't understand or don't think you should have gotten as an error itself.  (Though it can still be an error that the stream closed, regardless of the error code.)

(Which leads to the question, should we be greasing the error code space?)