### PR TITLE
rename HTTP_UNEXPECTED_FRAME to HTTP_FRAME_UNEXPECTED and fold HTTP_W…

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1415,7 +1415,7 @@ HTTP_CLOSED_CRITICAL_STREAM (0x104):
 : A stream required by the connection was closed or reset.
 
 HTTP_FRAME_UNEXPECTED (0x105):
-: A frame was received which was not permitted in the current state or stream.
+: A frame was received which was not permitted in the current state or on the current stream.
 
 HTTP_FRAME_ERROR (0x106):
 : A frame that fails to satisfy layout requirements or with an invalid size

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1415,7 +1415,8 @@ HTTP_CLOSED_CRITICAL_STREAM (0x104):
 : A stream required by the connection was closed or reset.
 
 HTTP_FRAME_UNEXPECTED (0x105):
-: A frame was received which was not permitted in the current state or on the current stream.
+: A frame was received which was not permitted in the current state or on the
+  current stream.
 
 HTTP_FRAME_ERROR (0x106):
 : A frame that fails to satisfy layout requirements or with an invalid size


### PR DESCRIPTION
…RONG_STREAM into it

Renaming the error to align with a suggestion from @MikeBishop made somewhere. This is a less drastic version of #2996. It too fixes #2809.

Closes #2996.