### PR TITLE
Cache git repo, draft references in Circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ jobs:
           keys:
             - v1-cache-git-{{ .Branch }}-{{ .Revision }}
             - v1-cache-git-{{ .Branch }}
+            - v1-cache-git-master
             - v1-cache-git-
 
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
 
       - run:
           name: "Prepare for Caching"
-          command: "git gc"
+          command: "git gc --auto"
 
       - save_cache:
           name: "Saving Cache - Git"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,13 @@ jobs:
     working_directory: ~/draft
 
     steps:
+      - restore_cache:
+          name: "Restoring cache - Git"
+          keys:
+            - v1-cache-git-{{ .Branch }}-{{ .Revision }}
+            - v1-cache-git-{{ .Branch }}
+            - v1-cache-git-
+
       - checkout
 
       # Build txt and html versions of drafts
@@ -42,6 +49,15 @@ jobs:
       - store_artifacts:
           path: /tmp/artifacts
 
+      - run:
+          name: "Prepare for Caching"
+          command: "git gc"
+
+      - save_cache:
+          name: "Saving Cache - Git"
+          key: v1-cache-git-{{ .Branch }}-{{ .Revision }}
+          paths:
+            - ~/draft
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,12 @@ jobs:
             - v1-cache-git-{{ .Branch }}
             - v1-cache-git-
 
+      - restore_cache:
+          name: "Restoring cache - References"
+          keys:
+            - v1-cache-references-{{ epoch }}
+            - v1-cache-references-
+
       - checkout
 
       # Build txt and html versions of drafts
@@ -58,6 +64,12 @@ jobs:
           key: v1-cache-git-{{ .Branch }}-{{ .Revision }}
           paths:
             - ~/draft
+
+      - save_cache:
+          name: "Saving Cache - Drafts"
+          key: v1-cache-references-{{ epoch }}
+          paths:
+            - ~/.cache/xml2rfc
 
 workflows:
   version: 2


### PR DESCRIPTION
This appears to shave almost a minute off of build times.  See https://circleci.com/gh/quicwg/base-drafts/tree/circle_caching for the progression.