### PR TITLE
Use contains() in recovery pseudocode

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1097,7 +1097,7 @@ OnAckReceived(ack, pn_space):
 
   // If the largest acknowledged is newly acked and
   // at least one ack-eliciting was newly acked, update the RTT.
-  if (sent_packets[pn_space][ack.largest_acked] &&
+  if (sent_packets[pn_space].contains(ack.largest_acked) &&
       IncludesAckEliciting(newly_acked_packets)):
     latest_rtt =
       now - sent_packets[pn_space][ack.largest_acked].time_sent


### PR DESCRIPTION
Per @martinthomson suggestion, use contains() instead of the implicit check.

Fixes #2569 
An alternative to #2987