### PR TITLE
Reference "Nonces are Noticed" in the header protection analysis section

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -74,8 +74,9 @@ informative:
     title: "Authenticated-Encryption with Associated-Data"
     author:
       - ins: P. Rogaway
-    date: 2002-09-20
-    target: "https://web.cs.ucdavis.edu/~rogaway/papers/ad.pdf"
+    date: 2002-11-22
+    target: "http://doi.acm.org/10.1145/586110.586125"
+    seriesinfo: Proceedings of the 9th ACM Conference on Computer and Communications Security, pages 98-107
 
   NAN:
     title: "Nonces are Noticed: AEAD Revisited"
@@ -84,7 +85,7 @@ informative:
       - ins: R. Ng
       - ins: B. Tackmann
     date: 2019-06-01
-    target: https://eprint.iacr.org/2019/624
+    target: "http://dx.doi.org/10.1007/978-3-030-26948-7_9"
     seriesinfo: Advances in Cryptology – CRYPTO 2019, pages 235-265
 
   QUIC-HTTP:
@@ -1441,11 +1442,12 @@ protected_field = field XOR PRF(hp_key, sample)
 ~~~
 
 As `hp_key` is distinct from the packet protection key, this construction
-(HN1) achieves AE2 security as defined in {{NAN}} and therefore guarantees privacy of `field`, the
-protected packet header. One important distinction between HN1 and the header
-protection construction in this document is that the latter uses an AEAD
-algorithm as the PRF. However, since the encrypted output of an AEAD is
-pseudorandom {{DefnAEAD}}, this achieves the properties desired from a PRF.
+(HN1) achieves AE2 security as defined in {{NAN}} and therefore guarantees
+privacy of `field`, the protected packet header. One important distinction
+between HN1 and the header protection construction in this document is that
+the latter uses an AEAD algorithm as the PRF. However, since the encrypted
+output of an AEAD is pseudorandom {{DefnAEAD}}, this achieves the properties
+desired from a PRF.
 
 Use of the same key and ciphertext sample more than once risks compromising
 header protection. Protecting two different headers with the same key and

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1440,7 +1440,7 @@ Header protection uses the output of the packet protection AEAD to derive
 protected_field = field XOR PRF(hp_key, sample)
 ~~~
 
-Assuming hp_key is distinct from the packet protection key, this construction
+As `hp_key` is distinct from the packet protection key, this construction
 (HN1) achieves AE2 security as defined in {{NAN}} and therefore guarantees privacy of `field`, the
 protected packet header. One important distinction between HN1 and the header
 protection construction in this document is that the latter uses an AEAD

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -70,14 +70,22 @@ informative:
     date: 2016-03-08
     target: "http://www.isg.rhul.ac.uk/~kp/TLS-AEbounds.pdf"
 
-  IMC:
-    title: "Introduction to Modern Cryptography, Second Edition"
+  DefnAEAD:
+    title: "Authenticated-Encryption with Associated-Data"
     author:
-      - ins: J. Katz
-      - ins: Y. Lindell
-    date: 2014-11-06
-    seriesinfo:
-      ISBN: 978-1466570269
+      - ins: P. Rogaway
+    date: 2002-09-20
+    target: "https://web.cs.ucdavis.edu/~rogaway/papers/ad.pdf"
+
+  NAN:
+    title: "Nonces are Noticed: AEAD Revisited"
+    author:
+      - ins: M. Bellare
+      - ins: R. Ng
+      - ins: B. Tackmann
+    date: 2019-06-01
+    target: https://eprint.iacr.org/2019/624
+    seriesinfo: Advances in Cryptology – CRYPTO 2019, pages 235-265
 
   QUIC-HTTP:
     title: "Hypertext Transfer Protocol (HTTP) over QUIC"
@@ -1421,19 +1429,23 @@ amplification.
 
 ## Header Protection Analysis {#header-protect-analysis}
 
-Header protection relies on the packet protection AEAD being a pseudorandom
-function (PRF), which is not a property that AEAD algorithms
-guarantee. Therefore, no strong assurances about the general security of this
-mechanism can be shown in the general case. The AEAD algorithms described in
-this document are assumed to be PRFs.
-
-The header protection algorithms defined in this document take the form:
+{{NAN}} analyzes authenticated encryption algorithms which provide nonce
+privacy, referred to as "Hide Nonce" (HN) transforms. The general header
+protection construction in this document is one of those algorithms (HN1).
+Header protection uses the output of the packet protection AEAD to derive
+`sample`, and then encrypts the header field using a pseudorandom function
+(PRF) as follows:
 
 ~~~
 protected_field = field XOR PRF(hp_key, sample)
 ~~~
 
-This construction is secure against chosen plaintext attacks (IND-CPA) {{IMC}}.
+Assuming hp_key is distinct from the packet protection key, this construction
+(HN1) achieves AE2 security and therefore guarantees privacy of `field`, the
+protected packet header. One important distinction between HN1 and the header
+protection construction in this document is that the latter uses an AEAD
+algorithm as the PRF. However, since the encrypted output of an AEAD is
+pseudorandom {{DefnAEAD}}, this achieves the properties desired from a PRF.
 
 Use of the same key and ciphertext sample more than once risks compromising
 header protection. Protecting two different headers with the same key and

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1441,7 +1441,7 @@ protected_field = field XOR PRF(hp_key, sample)
 ~~~
 
 Assuming hp_key is distinct from the packet protection key, this construction
-(HN1) achieves AE2 security and therefore guarantees privacy of `field`, the
+(HN1) achieves AE2 security as defined in {{NAN}} and therefore guarantees privacy of `field`, the
 protected packet header. One important distinction between HN1 and the header
 protection construction in this document is that the latter uses an AEAD
 algorithm as the PRF. However, since the encrypted output of an AEAD is

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -70,23 +70,14 @@ informative:
     date: 2016-03-08
     target: "http://www.isg.rhul.ac.uk/~kp/TLS-AEbounds.pdf"
 
-  DefnAEAD:
-    title: "Authenticated-Encryption with Associated-Data"
+  IMC:
+    title: "Introduction to Modern Cryptography, Second Edition"
     author:
-      - ins: P. Rogaway
-    date: 2002-11-22
-    target: "http://doi.acm.org/10.1145/586110.586125"
-    seriesinfo: Proceedings of the 9th ACM Conference on Computer and Communications Security, pages 98-107
-
-  NAN:
-    title: "Nonces are Noticed: AEAD Revisited"
-    author:
-      - ins: M. Bellare
-      - ins: R. Ng
-      - ins: B. Tackmann
-    date: 2019-06-01
-    target: "http://dx.doi.org/10.1007/978-3-030-26948-7_9"
-    seriesinfo: Advances in Cryptology – CRYPTO 2019, pages 235-265
+      - ins: J. Katz
+      - ins: Y. Lindell
+    date: 2014-11-06
+    seriesinfo:
+      ISBN: 978-1466570269
 
   QUIC-HTTP:
     title: "Hypertext Transfer Protocol (HTTP) over QUIC"
@@ -1430,24 +1421,26 @@ amplification.
 
 ## Header Protection Analysis {#header-protect-analysis}
 
-{{NAN}} analyzes authenticated encryption algorithms which provide nonce
-privacy, referred to as "Hide Nonce" (HN) transforms. The general header
-protection construction in this document is one of those algorithms (HN1).
-Header protection uses the output of the packet protection AEAD to derive
-`sample`, and then encrypts the header field using a pseudorandom function
-(PRF) as follows:
+{{?NAN=DOI.10.1007/978-3-030-26948-7_9}} analyzes authenticated encryption
+algorithms which provide nonce privacy, referred to as "Hide Nonce" (HN)
+transforms. The general header protection construction in this document is
+one of those algorithms (HN1). Header protection uses the output of the packet
+protection AEAD to derive `sample`, and then encrypts the header field using
+a pseudorandom function (PRF) as follows:
 
 ~~~
 protected_field = field XOR PRF(hp_key, sample)
 ~~~
 
-As `hp_key` is distinct from the packet protection key, this construction
-(HN1) achieves AE2 security as defined in {{NAN}} and therefore guarantees
-privacy of `field`, the protected packet header. One important distinction
-between HN1 and the header protection construction in this document is that
-the latter uses an AEAD algorithm as the PRF. However, since the encrypted
-output of an AEAD is pseudorandom {{DefnAEAD}}, this achieves the properties
-desired from a PRF.
+The header protection variants in this document use a pseudorandom permutation
+(PRP) in place of a generic PRF. However, since all PRPs are also PRFs {{IMC}},
+these variants do not deviate from the HN1 construction.
+
+As `hp_key` is distinct from the packet protection key, it follows that header
+protection achieves AE2 security as defined in {{NAN}} and therefore guarantees
+privacy of `field`, the protected packet header. Future header protection
+variants based on this construction MUST use a PRF to ensure equivalent
+security guarantees.
 
 Use of the same key and ciphertext sample more than once risks compromising
 header protection. Protecting two different headers with the same key and


### PR DESCRIPTION
This paper studies several "nonce hiding" transformations, of which the QUIC
header protection algorithm is one. This change replaces the old analysis
text with something a bit more crisp.