### PR TITLE
Suggest sending empty CRYPTO frames in Initial/Handshake packets

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -533,8 +533,10 @@ then the original transmission is acknowledged.  In the absence of any new
 application data, a PTO timer expiration now would find the sender with no new
 or previously-sent data to send.
 
-When there is no data to send, the sender SHOULD send a PING or other
-ack-eliciting frame in a single packet, re-arming the PTO timer.
+When there is no data to send, the sender SHOULD send an ack-eliciting frame in
+a single packet, re-arming the PTO timer.  PING frames can be used for 0/1-RTT
+packets, while empty CRYPTO frames can be used for Initial/Handshake packets
+where PING frames are not allowed.
 
 Alternatively, instead of sending an ack-eliciting packet, the sender MAY mark
 any packets still in flight as lost.  Doing so avoids sending an additional


### PR DESCRIPTION
As per @tatsuhiro-t, since PING frames are not allowed in
Initial/Handshake packets, one can use an empty CRYPTO frame when
sending a probe when there is no other ack-eliciting frame to send.

It seems to me like this is something that is fairly easy to miss, so
worth expanding the existing suggestion I think.

The alternative would be to allow PING frames in Initial/Handshake, but
I figured we are maybe too late in the process for that kind of design
change.