### PR TITLE
require peers to check if RETIRE_CONNECTION_ID sequence number is valid

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -5390,7 +5390,7 @@ Sequence Number:
   {{retiring-cids}}.
 
 Receipt of a RETIRE_CONNECTION_ID frame containing a sequence number greater
-than any previously sent to the peer MAY be treated as a connection error of
+than any previously sent to the peer MUST be treated as a connection error of
 type PROTOCOL_VIOLATION.
 
 The sequence number specified in a RETIRE_CONNECTION_ID frame MUST NOT refer


### PR DESCRIPTION
When it comes to error checks for protocol violations, our principle is that easy to implement error checks are REQUIRED. Only error checks that might require a lot of state to perform are optional.

The check that the sequence number retired in a RETIRE_CONNECTION_ID frame is smaller than the highest issued connection ID is a single trivial uint64 comparison. Furthermore, every implementation needs to track the highest issued sequence number anyway, since connection IDs are issued in order.

Fixes #3037 