### PR TITLE
Clarify why post-handshake client auth is banned

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -615,9 +615,9 @@ and deployment.
 A server MUST NOT use post-handshake client authentication (as defined in
 Section 4.6.2 of {{!TLS13}}), because the multiplexing offered by QUIC prevents
 clients from correlating the certificate request with the application-level
-event which triggered it (see {{?HTTP2-TLS13=I-D.ietf-httpbis-http2-tls13}}).
+event that triggered it (see {{?HTTP2-TLS13=I-D.ietf-httpbis-http2-tls13}}).
 More specifically, servers MUST NOT send post-handshake TLS CertificateRequest
-messages, and clients MUST treat receipt of such messages as a connection error
+messages and clients MUST treat receipt of such messages as a connection error
 of type PROTOCOL_VIOLATION.
 
 

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -612,8 +612,13 @@ MAY refuse a connection if the client is unable to authenticate when requested.
 The requirements for client authentication vary based on application protocol
 and deployment.
 
-A server MUST NOT use post-handshake client authentication (see Section 4.6.2 of
-{{!TLS13}}).
+A server MUST NOT use post-handshake client authentication (as defined in
+Section 4.6.2 of {{!TLS13}}), because the multiplexing offered by QUIC prevents
+clients from correlating the certificate request with the application-level
+event which triggered it (see {{?HTTP2-TLS13=I-D.ietf-httpbis-http2-tls13}}).
+More specifically, servers MUST NOT send post-handshake TLS CertificateRequest
+messages, and clients MUST treat receipt of such messages as a connection error
+of type PROTOCOL_VIOLATION.
 
 
 ## Enabling 0-RTT {#enable-0rtt}


### PR DESCRIPTION
Add short explanation and reference to explain why QUIC-TLS bans the use of post-handshake client authentication.

Fixes #2367.