### PR TITLE
Allow ClientHello to span multiple QUIC packets

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -579,10 +579,7 @@ ClientHello spans multiple Initial packets, such servers would need to buffer
 the first received fragments, which could consume excessive resources if the
 client's address has not yet been validated.  To avoid this, servers MAY use
 the Retry feature (see Section 8.1 of {{QUIC-TRANSPORT}}) to only buffer
-partial ClientHello messages from clients with a validated address.  Though a
-packet larger than 1200 bytes might be supported by the path, a client improves
-the likelihood that a packet is accepted if it ensures that the first
-ClientHello message is small enough to stay within this limit.
+partial ClientHello messages from clients with a validated address.
 
 QUIC packet and framing add at least 36 bytes of overhead to the ClientHello
 message.  That overhead increases if the client chooses a connection ID without

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -570,15 +570,15 @@ older than 1.3 is negotiated.
 
 ## ClientHello Size {#clienthello-size}
 
-The first Initial packet from a client starts with its first cryptographic
-handshake message, which for TLS is the ClientHello.  Servers might need to
-parse the entire ClientHello (e.g., to access extensions such as Server Name
-Identification (SNI) or Application Layer Protocol Negotiation (ALPN)) in order
-to decide whether to accept the new incoming QUIC connection.  If the
-ClientHello spans multiple Initial packets, such servers would need to buffer
-the first received fragments, which could consume excessive resources if the
-client's address has not yet been validated.  To avoid this, servers MAY use
-the Retry feature (see Section 8.1 of {{QUIC-TRANSPORT}}) to only buffer
+The first Initial packet from a client contains the start or all of its first
+cryptographic handshake message, which for TLS is the ClientHello.  Servers
+might need to parse the entire ClientHello (e.g., to access extensions such as
+Server Name Identification (SNI) or Application Layer Protocol Negotiation
+(ALPN)) in order to decide whether to accept the new incoming QUIC connection.
+If the ClientHello spans multiple Initial packets, such servers would need to
+buffer the first received fragments, which could consume excessive resources if
+the client's address has not yet been validated.  To avoid this, servers MAY
+use the Retry feature (see Section 8.1 of {{QUIC-TRANSPORT}}) to only buffer
 partial ClientHello messages from clients with a validated address.
 
 QUIC packet and framing add at least 36 bytes of overhead to the ClientHello
@@ -595,8 +595,8 @@ cause this message to grow.
 
 For servers, in addition to connection IDs and tokens, the size of TLS session
 tickets can have an effect on a client's ability to connect efficiently.
-Minimizing the size of these values increases the probability that they can be
-successfully used by a client.
+Minimizing the size of these values increases the probability that clients can
+use them and still fit their ClientHello message in their first Initial packet.
 
 The TLS implementation does not need to ensure that the ClientHello is
 sufficiently large.  QUIC PADDING frames are added to increase the size of the

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -579,10 +579,10 @@ ClientHello spans multiple Initial packets, such servers would need to buffer
 the first received fragments, which could consume excessive resources if the
 client's address has not yet been validated.  To avoid this, servers MAY use
 the Retry feature (see Section 8.1 of {{QUIC-TRANSPORT}}) to only buffer
-partial ClientHello messages from clients with a validated address.  Though a packet
-larger than 1200 bytes might be supported by the path, a client improves the
-likelihood that a packet is accepted if it ensures that the first ClientHello
-message is small enough to stay within this limit.
+partial ClientHello messages from clients with a validated address.  Though a
+packet larger than 1200 bytes might be supported by the path, a client improves
+the likelihood that a packet is accepted if it ensures that the first
+ClientHello message is small enough to stay within this limit.
 
 QUIC packet and framing add at least 36 bytes of overhead to the ClientHello
 message.  That overhead increases if the client chooses a connection ID without

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -574,7 +574,7 @@ ClientHello spans multiple Initial packets, such servers would need to buffer
 the first received fragments, which could consume excessive resources if the
 client's address has not yet been validated.  To avoid this, servers MAY use
 the Retry feature (see Section 8.1 of {{QUIC-TRANSPORT}}) to only buffer
-partial ClientHellos from clients with a validated address.  Though a packet
+partial ClientHello messages from clients with a validated address.  Though a packet
 larger than 1200 bytes might be supported by the path, a client improves the
 likelihood that a packet is accepted if it ensures that the first ClientHello
 message is small enough to stay within this limit.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3954,9 +3954,11 @@ the start of the first cryptographic handshake message.  The first CRYPTO frame
 sent always begins at an offset of 0 (see {{handshake}}).
 
 Note that if the server sends a HelloRetryRequest, the client will send another
-series of Initial packets.  These Initial packets will continue the cryptographic handshake
-and will contain CRYPTO frames starting at an offset matching the size of the CRYPTO
-frames sent in the first flight of Initial packets.
+series of Initial packets.  These Initial packets will continue the
+cryptographic handshake and will contain CRYPTO frames starting at an offset
+matching the size of the CRYPTO frames sent in the first flight of Initial
+packets.
+
 
 #### Abandoning Initial Packets {#discard-initial}
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3954,9 +3954,9 @@ the start of the first cryptographic handshake message.  The first CRYPTO frame
 sent always begins at an offset of 0 (see {{handshake}}).
 
 Note that if the server sends a HelloRetryRequest, the client will send another
-Initial packet.  This Initial packet will continue the cryptographic handshake
-and will contain a CRYPTO frame with an offset matching the size of the CRYPTO
-frame sent in the first Initial packet.
+series of Initial packets.  These Initial packets will continue the cryptographic handshake
+and will contain CRYPTO frames starting at an offset matching the size of the CRYPTO
+frames sent in the first flight of Initial packets.
 
 #### Abandoning Initial Packets {#discard-initial}
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3950,8 +3950,8 @@ Initial packet containing other frames can either discard the packet as spurious
 or treat it as a connection error.
 
 The first packet sent by a client always includes a CRYPTO frame that contains
-the start of the first cryptographic handshake message.  The first CRYPTO frame
-sent always begins at an offset of 0 (see {{handshake}}).
+the start or all of the first cryptographic handshake message.  The first
+CRYPTO frame sent always begins at an offset of 0 (see {{handshake}}).
 
 Note that if the server sends a HelloRetryRequest, the client will send another
 series of Initial packets.  These Initial packets will continue the

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1298,15 +1298,6 @@ properties:
 * authenticated negotiation of an application protocol (TLS uses ALPN
   {{?RFC7301}} for this purpose)
 
-The first CRYPTO frame from a client MUST be sent in a single packet.  Any
-second attempt that is triggered by address validation (see
-{{validate-handshake}}) MUST also be sent within a single packet. This avoids
-having to reassemble a message from multiple packets.
-
-The first client packet of the cryptographic handshake protocol MUST fit within
-a 1232 byte QUIC packet payload.  This includes overheads that reduce the space
-available to the cryptographic handshake protocol.
-
 An endpoint can verify support for Explicit Congestion Notification (ECN) in the
 first packets it sends, as described in {{ecn-validation}}.
 
@@ -3959,16 +3950,13 @@ Initial packet containing other frames can either discard the packet as spurious
 or treat it as a connection error.
 
 The first packet sent by a client always includes a CRYPTO frame that contains
-the entirety of the first cryptographic handshake message.  This packet, and the
-cryptographic handshake message, MUST fit in a single UDP datagram (see
-{{handshake}}).  The first CRYPTO frame sent always begins at an offset of 0
-(see {{handshake}}).
+the start of the first cryptographic handshake message.  The first CRYPTO frame
+sent always begins at an offset of 0 (see {{handshake}}).
 
-Note that if the server sends a HelloRetryRequest, the client will send a second
+Note that if the server sends a HelloRetryRequest, the client will send another
 Initial packet.  This Initial packet will continue the cryptographic handshake
 and will contain a CRYPTO frame with an offset matching the size of the CRYPTO
-frame sent in the first Initial packet.  Cryptographic handshake messages
-subsequent to the first do not need to fit within a single UDP datagram.
+frame sent in the first Initial packet.
 
 #### Abandoning Initial Packets {#discard-initial}
 


### PR DESCRIPTION
The restriction for ClientHello to fit in a single UDP datagram was added back when the retry mechanism was more tightly coupled to the TLS crypto. At this point, the restriction doesn't get us much, and is preventing us from running some post-quantum experiments.

Fixes #2928.