### PR TITLE
Send after receiving an ACK

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1031,7 +1031,9 @@ OnAckReceived(ack, pn_space):
     OnPacketAcked(acked_packet.packet_number, pn_space)
 
   DetectLostPackets(pn_space)
-  SendPacketsAsCongestionControllerAllows()
+  // Immediately attempt to send, but never more than the
+  // initial window in a single burst.
+  SendUpToIWPacketsAsCongestionControllerAllows()
   pto_count = 0
   SetLossDetectionTimer()
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1007,8 +1007,8 @@ OnAckReceived(ack, pn_space):
     largest_acked_packet[pn_space] =
         max(largest_acked_packet[pn_space], ack.largest_acked)
 
-  // Nothing to do if there are no newly acked packets.
   newly_acked_packets = DetermineNewlyAckedPackets(ack, pn_space)
+  // Nothing to do if there are no newly acked packets.
   if (newly_acked_packets.empty()):
     return
 
@@ -1031,9 +1031,8 @@ OnAckReceived(ack, pn_space):
     OnPacketAcked(acked_packet.packet_number, pn_space)
 
   DetectLostPackets(pn_space)
-
+  SendPacketsAsCongestionControllerAllows()
   pto_count = 0
-
   SetLossDetectionTimer()
 
 


### PR DESCRIPTION
Fixes #2604

Clarifies that when you do send in response to an ACK, it should not be more than the initial window.