### PR TITLE
Retransmitting an ACK frame warning

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3181,10 +3181,10 @@ containing that information is acknowledged.
   unless the endpoint has sent a RESET_STREAM for that stream.  Once an endpoint
   sends a RESET_STREAM frame, no further STREAM frames are needed.
 
-* The most recent set of acknowledgments are sent in ACK frames.  An ACK frame
-  SHOULD contain all unacknowledged acknowledgments, as described in
-  {{sending-ack-frames}}.  Retransmitting an ACK frame can result in an
-  inflated RTT measurement.
+* ACK frames are sent containing the most recent set of acknowledgements and
+  Ack Delay, as described in {{sending-ack-frames}}. Retransmitting an old ACK
+  frame with stale Ack Delay can cause the peer to generate an inflated RTT
+  sample.
 
 * Cancellation of stream transmission, as carried in a RESET_STREAM frame, is
   sent until acknowledged or until all stream data is acknowledged by the peer

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3181,10 +3181,11 @@ containing that information is acknowledged.
   unless the endpoint has sent a RESET_STREAM for that stream.  Once an endpoint
   sends a RESET_STREAM frame, no further STREAM frames are needed.
 
-* ACK frames are sent containing the most recent set of acknowledgements and
-  Ack Delay, as described in {{sending-ack-frames}}. Delaying the transmission
-  of packets containing ACK frames or sending old ACK frames can cause the
-  peer to generate an inflated RTT sample or unnecessarily disable ECN.
+* ACK frames carry the most recent set of acknowledgements and the Ack Delay
+  from the largest acknowledge packet, as described in {{sending-ack-frames}}.
+  Delaying the transmission of packets containing ACK frames or sending old
+  ACK frames can cause the peer to generate an inflated RTT sample or
+  unnecessarily disable ECN.
 
 * Cancellation of stream transmission, as carried in a RESET_STREAM frame, is
   sent until acknowledged or until all stream data is acknowledged by the peer

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3183,7 +3183,8 @@ containing that information is acknowledged.
 
 * The most recent set of acknowledgments are sent in ACK frames.  An ACK frame
   SHOULD contain all unacknowledged acknowledgments, as described in
-  {{sending-ack-frames}}.
+  {{sending-ack-frames}}.  Retransmitting an ACK frame can result in an
+  inflated RTT measurement.
 
 * Cancellation of stream transmission, as carried in a RESET_STREAM frame, is
   sent until acknowledged or until all stream data is acknowledged by the peer

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3182,9 +3182,9 @@ containing that information is acknowledged.
   sends a RESET_STREAM frame, no further STREAM frames are needed.
 
 * ACK frames are sent containing the most recent set of acknowledgements and
-  Ack Delay, as described in {{sending-ack-frames}}. Retransmitting an old ACK
-  frame with stale Ack Delay can cause the peer to generate an inflated RTT
-  sample.
+  Ack Delay, as described in {{sending-ack-frames}}. Delaying the transmission
+  of packets containing ACK frames or sending old ACK frames can cause the
+  peer to generate an inflated RTT sample or unnecessarily disable ECN.
 
 * Cancellation of stream transmission, as carried in a RESET_STREAM frame, is
   sent until acknowledged or until all stream data is acknowledged by the peer


### PR DESCRIPTION
It can result in an inflated RTT, as well as being a waste of bytes.

Fixes #2748