### PR TITLE
Change PTO to be per packet number space

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1176,7 +1176,7 @@ Pseudocode for OnLossDetectionTimeout follows:
 ~~~
 OnLossDetectionTimeout():
   earliest_loss_time, pn_space =
-    GetEarliestTimeAndSpace(loss_times)
+    GetEarliestTimeAndSpace(loss_time)
   if (earliest_loss_time != 0):
     // Time threshold loss Detection
     DetectLostPackets(pn_space)

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -524,10 +524,10 @@ removed from bytes in flight when the Initial and Handshake keys are discarded.
 ### Sending Probe Packets
 
 When a PTO timer expires, a sender MUST send at least one ack-eliciting packet
-in the packet number space as a probe, unless there is no data available to send.
-An endpoint MAY send up to two full-sized datagrams containing ack-eliciting
-packets, to avoid an expensive consecutive PTO expiration due to a single lost
-datagram.
+in the packet number space as a probe, unless there is no data available to
+send.  An endpoint MAY send up to two full-sized datagrams containing
+ack-eliciting packets, to avoid an expensive consecutive PTO expiration due
+to a single lost datagram.
 
 In addition to sending data in the packet number space for which the timer
 expired, the sender SHOULD coalesce ack-eliciting packets from all other packet

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -501,8 +501,8 @@ be considered an RTT sample.
 
 Until the server has validated the client's address on the path, the amount of
 data it can send is limited, as specified in Section 8.1 of {{QUIC-TRANSPORT}}.
-If no data can be sent, then the PTO alarm MUST NOT be armed for the corresponding packet number space until
-data has been received from the client.
+If no data can be sent, then the PTO alarm MUST NOT be armed until datagrams
+have been received from the client.
 
 Since the server could be blocked until more packets are received from the
 client, it is the client's responsibility to send packets to unblock the server

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -473,7 +473,7 @@ A sender computes its PTO timer every time an ack-eliciting packet is sent.
 When ack-eliciting packets are in-flight in multiple packet number spaces,
 the timer MUST be set for the packet number space with the earliest timeout,
 except for ApplicationData, which MUST be ignored until the handshake
-completes (See Section 4.1.1 of {{QUIC-TLS}}).  Not arming the PTO for
+completes; see Section 4.1.1 of {{QUIC-TLS}}.  Not arming the PTO for
 ApplicationData prioritizes completing the handshake and prevents the server
 from sending a 1-RTT PTO packet before it has the keys to process a 1-RTT
 packet.  When probe packets from two different packet number spaces are sent

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1160,8 +1160,8 @@ Pseudocode for OnLossDetectionTimeout follows:
 
 ~~~
 OnLossDetectionTimeout():
-  loss_time, pn_space = GetEarliestTimeAndSpace(loss_times)
-  if (loss_time != 0):
+  earliest_loss_time, pn_space = GetEarliestTimeAndSpace(loss_times)
+  if (earliest_loss_time != 0):
     // Time threshold loss Detection
     DetectLostPackets(pn_space)
     SetLossDetectionTimer()
@@ -1178,7 +1178,8 @@ OnLossDetectionTimeout():
   else:
     // PTO. Send new data if available, else retransmit old data.
     // If neither is available, send a single PING frame.
-    SendOneOrTwoAckElicitingPackets()
+    _, pn_space = GetEarliestTimeAndSpace(time_of_last_sent_ack_eliciting_packet)
+    SendOneOrTwoAckElicitingPackets(pn_space)
 
   pto_count++
   SetLossDetectionTimer()

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -443,7 +443,7 @@ recover from loss of tail packets or acknowledgements.
 
 As with loss detection, the probe timeout is per packet number space.
 The PTO algorithm used in QUIC implements the reliability functions of
-Tail Loss Probe {{?RACK}}, RTO {{?RFC5681}} and F-RTO algorithms for
+Tail Loss Probe {{?RACK}}, RTO {{?RFC5681}}, and F-RTO algorithms for
 TCP {{?RFC5682}}. The timeout computation is based on TCP's retransmission
 timeout period {{?RFC6298}}.
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -951,7 +951,7 @@ time_of_last_sent_ack_eliciting_packet\[kPacketNumberSpace]:
 largest_acked_packet\[kPacketNumberSpace]:
 : The largest packet number acknowledged in the packet number space so far.
 
-loss_time\[kPacketNumberSpace]:
+loss_times\[kPacketNumberSpace]:
 : The time at which the next packet in that packet number space will be
   considered lost based on exceeding the reordering window in time.
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -501,7 +501,7 @@ be considered an RTT sample.
 
 Until the server has validated the client's address on the path, the amount of
 data it can send is limited, as specified in Section 8.1 of {{QUIC-TRANSPORT}}.
-If no data can be sent, then the PTO alarm MUST NOT be armed until
+If no data can be sent, then the PTO alarm MUST NOT be armed for the corresponding packet number space until
 data has been received from the client.
 
 Since the server could be blocked until more packets are received from the

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -465,7 +465,8 @@ acknowledgement of a sent packet.  This time period includes the estimated
 network roundtrip-time (smoothed_rtt), the variance in the estimate (4*rttvar),
 and max_ack_delay, to account for the maximum time by which a receiver might
 delay sending an acknowledgement.  When the PTO is armed for Initial or
-Handshake packet number spaces, the max_ack_delay is 0.
+Handshake packet number spaces, the max_ack_delay is 0, as specified in
+13.2.5 of {{QUIC-TRANSPORT}}.
 
 The PTO value MUST be set to at least kGranularity, to avoid the timer expiring
 immediately.
@@ -477,9 +478,9 @@ except for ApplicationData, which MUST be ignored until the handshake
 completes; see Section 4.1.1 of {{QUIC-TLS}}.  Not arming the PTO for
 ApplicationData prioritizes completing the handshake and prevents the server
 from sending a 1-RTT PTO packet before it has the keys to process a 1-RTT
-packet.  When probe packets from two different packet number spaces are sent
-when the PTO fires and both spaces have in-flight packets, this simplifies to
-setting the PTO on the lowest active packet number space.
+packet.  This simplifies to setting the PTO on the lowest active packet number
+space if packets from two different packet number spaces are sent when the PTO
+fires.
 
 When a PTO timer expires, the PTO period MUST be set to twice its current
 value. This exponential reduction in the sender's rate is important because

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -476,15 +476,21 @@ except for ApplicationData, which MUST be ignored until the handshake
 completes (See Section 4.1.1 of {{QUIC-TLS}}).  Not arming the PTO for
 ApplicationData prioritizes completing the handshake and prevents the server
 from sending a 1-RTT PTO packet before it has the keys to process a 1-RTT
-packet.
+packet.  When probe packets from two different packet number spaces are sent when
+the PTO fires and both spaces have in-flight packets, this simplifies to
+setting the PTO on the lowest active packet number space.
 
 When a PTO timer expires, the PTO period MUST be set to twice its current
 value. This exponential reduction in the sender's rate is important because
 the PTOs might be caused by loss of packets or acknowledgements due to severe
 congestion.  Even when there are ack-eliciting packets in-flight in multiple
 packet number spaces, the exponential increase in probe timeout occurs across
-all spaces to prevent excess load on the network. The life of a connection that
-is experiencing consecutive PTOs is limited by the endpoint's idle timeout.
+all spaces to prevent excess load on the network.  For example, a timeout in
+the Initial packet number space doubles the length of the timeout in the
+Handshake packet number space.
+
+The life of a connection that is experiencing consecutive PTOs is limited by
+the endpoint's idle timeout.
 
 The probe timer is not set if the time threshold {{time-threshold}} loss
 detection timer is set.  The time threshold loss detection timer is expected

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -477,10 +477,8 @@ the timer MUST be set for the packet number space with the earliest timeout,
 except for ApplicationData, which MUST be ignored until the handshake
 completes; see Section 4.1.1 of {{QUIC-TLS}}.  Not arming the PTO for
 ApplicationData prioritizes completing the handshake and prevents the server
-from sending a 1-RTT PTO packet before it has the keys to process a 1-RTT
-packet.  This simplifies to setting the PTO on the lowest active packet number
-space if packets from two different packet number spaces are sent when the PTO
-fires.
+from sending a 1-RTT packet on a PTO before before it has the keys to process
+a 1-RTT packet.
 
 When a PTO timer expires, the PTO period MUST be set to twice its current
 value. This exponential reduction in the sender's rate is important because

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1150,7 +1150,6 @@ SetLossDetectionTimer():
       max_ack_delay
   timeout = timeout * (2 ^ pto_count)
 
-  // Set the 
   sent_time, _ = GetEarliestAckElicitingTime()
   loss_detection_timer.update(sent_time + timeout)
 ~~~

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -476,8 +476,8 @@ except for ApplicationData, which MUST be ignored until the handshake
 completes (See Section 4.1.1 of {{QUIC-TLS}}).  Not arming the PTO for
 ApplicationData prioritizes completing the handshake and prevents the server
 from sending a 1-RTT PTO packet before it has the keys to process a 1-RTT
-packet.  When probe packets from two different packet number spaces are sent when
-the PTO fires and both spaces have in-flight packets, this simplifies to
+packet.  When probe packets from two different packet number spaces are sent
+when the PTO fires and both spaces have in-flight packets, this simplifies to
 setting the PTO on the lowest active packet number space.
 
 When a PTO timer expires, the PTO period MUST be set to twice its current

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -976,7 +976,7 @@ follows:
    for pn_space in [ Initial, Handshake, ApplicationData ]:
      largest_acked_packet[pn_space] = infinite
      time_of_last_sent_ack_eliciting_packet[pn_space] = 0
-     loss_time[pn_space] = 0
+     loss_times[pn_space] = 0
 ~~~
 
 
@@ -1125,7 +1125,7 @@ PeerNotAwaitingAddressValidation():
          has received 1-RTT ACK
 
 SetLossDetectionTimer():
-  loss_time, _ = GetEarliestTimeAndSpace(loss_time)
+  loss_time, _ = GetEarliestTimeAndSpace(loss_times)
   if (loss_time != 0):
     // Time threshold loss detection.
     loss_detection_timer.update(loss_time)
@@ -1160,7 +1160,7 @@ Pseudocode for OnLossDetectionTimeout follows:
 
 ~~~
 OnLossDetectionTimeout():
-  loss_time, pn_space = GetEarliestLossTime()
+  loss_time, pn_space = GetEarliestTimeAndSpace(loss_times)
   if (loss_time != 0):
     // Time threshold loss Detection
     DetectLostPackets(pn_space)
@@ -1195,7 +1195,7 @@ Pseudocode for DetectLostPackets follows:
 ~~~
 DetectLostPackets(pn_space):
   assert(largest_acked_packet[pn_space] != infinite)
-  loss_time[pn_space] = 0
+  loss_times[pn_space] = 0
   lost_packets = {}
   loss_delay = kTimeThreshold * max(latest_rtt, smoothed_rtt)
 
@@ -1217,10 +1217,10 @@ DetectLostPackets(pn_space):
       if (unacked.in_flight):
         lost_packets.insert(unacked)
     else:
-      if (loss_time[pn_space] == 0):
-        loss_time[pn_space] = unacked.time_sent + loss_delay
+      if (loss_times[pn_space] == 0):
+        loss_times[pn_space] = unacked.time_sent + loss_delay
       else:
-        loss_time[pn_space] = min(loss_time[pn_space],
+        loss_times[pn_space] = min(loss_times[pn_space],
                                   unacked.time_sent + loss_delay)
 
   // Inform the congestion controller of lost packets and

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -463,7 +463,8 @@ The PTO period is the amount of time that a sender ought to wait for an
 acknowledgement of a sent packet.  This time period includes the estimated
 network roundtrip-time (smoothed_rtt), the variance in the estimate (4*rttvar),
 and max_ack_delay, to account for the maximum time by which a receiver might
-delay sending an acknowledgement.
+delay sending an acknowledgement.  When the PTO is armed for Initial or
+Handshake packet number spaces, the max_ack_delay is 0.
 
 The PTO value MUST be set to at least kGranularity, to avoid the timer expiring
 immediately.

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -476,7 +476,7 @@ limited by the endpoint's idle timeout.
 
 A sender computes its PTO timer every time an ack-eliciting packet is sent.
 When ack-eliciting packets are in-flight in multiple packet number spaces,
-the timer MUST be set from the packet number space with the earliest timeout.
+the timer MUST be set for the packet number space with the earliest timeout.
 A sender might choose to optimize this by setting the timer fewer times if it
 knows that more ack-eliciting packets will be sent within a short period of
 time.

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -528,7 +528,7 @@ When a PTO timer expires, a sender MUST send at least one ack-eliciting packet
 in the packet number space as a probe, unless there is no data available to
 send.  An endpoint MAY send up to two full-sized datagrams containing
 ack-eliciting packets, to avoid an expensive consecutive PTO expiration due
-to a single lost datagram.
+to a single lost datagram or transmit data from multiple packet number spaces.
 
 In addition to sending data in the packet number space for which the timer
 expired, the sender SHOULD send ack-eliciting packets from other packet

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -477,9 +477,6 @@ limited by the endpoint's idle timeout.
 A sender computes its PTO timer every time an ack-eliciting packet is sent.
 When ack-eliciting packets are in-flight in multiple packet number spaces,
 the timer MUST be set for the packet number space with the earliest timeout.
-A sender might choose to optimize this by setting the timer fewer times if it
-knows that more ack-eliciting packets will be sent within a short period of
-time.
 
 The probe timer is not set if the time threshold {{time-threshold}} loss
 detection timer is set.  The time threshold loss detection timer is expected
@@ -531,11 +528,11 @@ ack-eliciting packets, to avoid an expensive consecutive PTO expiration due
 to a single lost datagram.
 
 In addition to sending data in the packet number space for which the timer
-expired, the sender SHOULD coalesce ack-eliciting packets from all other packet
+expired, the sender SHOULD coalesce ack-eliciting packets from other packet
 number spaces with in-flight data if sending coalesced packets is supported.
-If implementations do not send coalesced packets upon timeout when multiple
-packet number spaces have in-flight data, then they MUST only send a single
-datagram per probe timeout.
+If an endpoint has data in multiple packet number spaces in-flight and is
+unable to send coalesced packets when a PTO expires, it MUST send only a
+single datagram.
 
 It is possible that the sender has no new or previously-sent data to send.  As
 an example, consider the following sequence of events: new application data is

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -473,7 +473,7 @@ A sender computes its PTO timer every time an ack-eliciting packet is sent.
 When ack-eliciting packets are in-flight in multiple packet number spaces,
 the timer MUST be set for the packet number space with the earliest timeout,
 except for ApplicationData, which MUST be ignored until the handshake
-completes(See Section 4.1.1 of {{QUIC-TLS}}).  Not arming the PTO for
+completes (See Section 4.1.1 of {{QUIC-TLS}}).  Not arming the PTO for
 ApplicationData prioritizes completing the handshake and prevents the server
 from sending a 1-RTT PTO packet before it has the keys to process a 1-RTT
 packet.

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1160,7 +1160,8 @@ Pseudocode for OnLossDetectionTimeout follows:
 
 ~~~
 OnLossDetectionTimeout():
-  earliest_loss_time, pn_space = GetEarliestTimeAndSpace(loss_times)
+  earliest_loss_time, pn_space =
+    GetEarliestTimeAndSpace(loss_times)
   if (earliest_loss_time != 0):
     // Time threshold loss Detection
     DetectLostPackets(pn_space)
@@ -1178,7 +1179,8 @@ OnLossDetectionTimeout():
   else:
     // PTO. Send new data if available, else retransmit old data.
     // If neither is available, send a single PING frame.
-    _, pn_space = GetEarliestTimeAndSpace(time_of_last_sent_ack_eliciting_packet)
+    _, pn_space = GetEarliestTimeAndSpace(
+      time_of_last_sent_ack_eliciting_packet)
     SendOneOrTwoAckElicitingPackets(pn_space)
 
   pto_count++

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -962,7 +962,7 @@ time_of_last_sent_ack_eliciting_packet\[kPacketNumberSpace]:
 largest_acked_packet\[kPacketNumberSpace]:
 : The largest packet number acknowledged in the packet number space so far.
 
-loss_times\[kPacketNumberSpace]:
+loss_time\[kPacketNumberSpace]:
 : The time at which the next packet in that packet number space will be
   considered lost based on exceeding the reordering window in time.
 
@@ -987,7 +987,7 @@ follows:
    for pn_space in [ Initial, Handshake, ApplicationData ]:
      largest_acked_packet[pn_space] = infinite
      time_of_last_sent_ack_eliciting_packet[pn_space] = 0
-     loss_times[pn_space] = 0
+     loss_time[pn_space] = 0
 ~~~
 
 
@@ -1139,10 +1139,10 @@ PeerNotAwaitingAddressValidation():
          has received 1-RTT ACK
 
 SetLossDetectionTimer():
-  loss_time, _ = GetEarliestTimeAndSpace(loss_times)
-  if (loss_time != 0):
+  earliest_loss_time, _ = GetEarliestTimeAndSpace(loss_time)
+  if (earliest_loss_time != 0):
     // Time threshold loss detection.
-    loss_detection_timer.update(loss_time)
+    loss_detection_timer.update(earliest_loss_time)
     return
 
   if (no ack-eliciting packets in flight &&
@@ -1212,7 +1212,7 @@ Pseudocode for DetectLostPackets follows:
 ~~~
 DetectLostPackets(pn_space):
   assert(largest_acked_packet[pn_space] != infinite)
-  loss_times[pn_space] = 0
+  loss_time[pn_space] = 0
   lost_packets = {}
   loss_delay = kTimeThreshold * max(latest_rtt, smoothed_rtt)
 
@@ -1234,10 +1234,10 @@ DetectLostPackets(pn_space):
       if (unacked.in_flight):
         lost_packets.insert(unacked)
     else:
-      if (loss_times[pn_space] == 0):
-        loss_times[pn_space] = unacked.time_sent + loss_delay
+      if (loss_time[pn_space] == 0):
+        loss_time[pn_space] = unacked.time_sent + loss_delay
       else:
-        loss_times[pn_space] = min(loss_times[pn_space],
+        loss_time[pn_space] = min(loss_time[pn_space],
                                   unacked.time_sent + loss_delay)
 
   // Inform the congestion controller of lost packets and

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -444,8 +444,8 @@ recover from loss of tail packets or acknowledgements.
 As with loss detection, the probe timeout is per packet number space.
 The PTO algorithm used in QUIC implements the reliability functions of
 Tail Loss Probe {{?RACK}}, RTO {{?RFC5681}} and F-RTO algorithms for
-TCP {{?RFC5682}}, and the timeout computation is based on TCP's
-retransmission timeout period {{?RFC6298}}.
+TCP {{?RFC5682}}. The timeout computation is based on TCP's retransmission
+timeout period {{?RFC6298}}.
 
 ### Computing PTO
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -477,6 +477,9 @@ limited by the endpoint's idle timeout.
 A sender computes its PTO timer every time an ack-eliciting packet is sent.
 When ack-eliciting packets are in-flight in multiple packet number spaces,
 the timer MUST be set for the packet number space with the earliest timeout.
+Even when there are ack-eliciting packets in-flight in multiple packet number
+spaces, the exponential increase in probe timeout occurs across all spaces to
+prevent causing excess load on the network.
 
 The probe timer is not set if the time threshold {{time-threshold}} loss
 detection timer is set.  The time threshold loss detection timer is expected
@@ -528,11 +531,8 @@ ack-eliciting packets, to avoid an expensive consecutive PTO expiration due
 to a single lost datagram.
 
 In addition to sending data in the packet number space for which the timer
-expired, the sender SHOULD coalesce ack-eliciting packets from other packet
-number spaces with in-flight data if sending coalesced packets is supported.
-If an endpoint has data in multiple packet number spaces in-flight and is
-unable to send coalesced packets when a PTO expires, it MUST send only a
-single datagram.
+expired, the sender SHOULD send ack-eliciting packets from other packet
+number spaces with in-flight data, coalescing packets if possible.
 
 It is possible that the sender has no new or previously-sent data to send.  As
 an example, consider the following sequence of events: new application data is


### PR DESCRIPTION
Makes PTO consistent with loss detection, which is per packet number space.  This keeps a unified exponential backoff to avoid excess network load and doesn't arm the PTO for ApplicationData until the handshake is complete.

Fixes #3067 and fixes #3074 
Necessary for fixing #2863 without an explicit signal

Also fixes an issue where PTO was always using max_ack_delay, but there is no longer a max_ack_delay in the Initial and Handshake packet number spaces, so those timeouts were longer than necessary.