### PR TITLE
Retransmit server initial upon second Initial

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -529,7 +529,7 @@ it may assume some or all of the server's Initial packets were lost.
 
 To speed up handshake completion under these conditions, an endpoint MAY send
 a packet containing unacknowledged CRYPTO data earlier than the PTO expiry,
-subject to address validation limits. (see Section 8.1 of {{QUIC-TRANSPORT}})
+subject to address validation limits; see Section 8.1 of {{QUIC-TRANSPORT}}.
 
 Peers can also use coalesced packets to ensure that each datagram elicits at least
 one acknowledgement.  For example, clients can coalesce an Initial packet

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -527,7 +527,7 @@ small. When a client receives Handshake or 1-RTT packets prior to obtaining
 Handshake keys it may assume some or all of the server's Initial packets were
 lost.
 
-To speed handshake completion, either peer MAY send a packet containing
+To speed up handshake completion under these conditions, an endpoint MAY send a packet containing
 unacknowledged Initial CRYPTO data subject to the path validation limits, as
 though the PTO expired. The PTO MUST only be shortened once in this way.
 Subsequently, the PTO uses the normal calculation with exponential backoff.

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -509,7 +509,7 @@ probe timer if the client has not received an acknowledgement for one of its
 Handshake or 1-RTT packets.
 
 When a server receives duplicate Initial CRYPTO data when there
-is unacknoweledged Initial CRYPTO data, it can assume the client did not
+is unacknowledged Initial CRYPTO data, it can assume the client did not
 receive all Initial CRYPTO data or the client's estimated RTT is too short.
 To speed handshake completion, it MAY retransmit unacknowledged Initial
 CRYPTO data subject to the path validation limits, as though the PTO expired.

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -511,7 +511,7 @@ Handshake or 1-RTT packets.
 When a server receives duplicate CRYPTO data in an Initial packet after sending
 its Initial flight, it can assume the client did not receive all Initial CRYPTO
 data. To speed handshake completion, it SHOULD retransmit all unacknowledged
-Initial data subject to the path validation limits.  After doing so,
+Initial CRYPTO data subject to the path validation limits.  After doing so,
 the PTO is re-armed.
 
 Prior to handshake completion, when few to none RTT samples have been

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -537,7 +537,7 @@ Peers can also use coalesced packets to ensure each datagram elicits at least
 one acknowledgement.  For example, clients can coalesce an Initial packet
 containing a PING and PADDING with 0-RTT data packets and a server can
 coalesce an Initial packet containing a PING with one or more packets in
-it's first flight.
+its first flight.
 
 ### Sending Probe Packets
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -523,15 +523,14 @@ removed from bytes in flight when the Initial and Handshake keys are discarded.
 
 When a server receives duplicate Initial CRYPTO data, it can assume the client
 did not receive all Initial CRYPTO data or the client's estimated RTT is too
-small. When a client receives Handshake packets prior to obtaining Handshake
-keys it may assume some or all of the server's Initial packets were lost.
+small. When a client receives Handshake or 1-RTT packets prior to obtaining
+Handshake keys it may assume some or all of the server's Initial packets were
+lost.
 
 To speed handshake completion, either peer MAY send a packet containing
 unacknowledged Initial CRYPTO data subject to the path validation limits, as
-though the PTO expired. A client MAY send an ack-eliciting packet with no
-CRYPTO data if all Initial data has been acknowledged.  The PTO can only be
-shortened once in this way. Subsequently, the PTO uses the normal calculation
-with exponential backoff.
+though the PTO expired. The PTO MUST only be shortened once in this way.
+Subsequently, the PTO uses the normal calculation with exponential backoff.
 
 Peers can also use coalesced packets to ensure each datagram elicits at least
 one acknowledgement.  For example, clients can coalesce an Initial packet

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -519,7 +519,7 @@ bytes.
 Initial packets and Handshake packets may never be acknowledged, but they are
 removed from bytes in flight when the Initial and Handshake keys are discarded.
 
-### Speeding Handshake Completion
+### Speeding Up Handshake Completion
 
 When a server receives duplicate Initial CRYPTO data, it can assume the client
 did not receive all Initial CRYPTO data or the client's estimated RTT is too

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -508,6 +508,11 @@ until it is certain that the server has finished its address validation
 probe timer if the client has not received an acknowledgement for one of its
 Handshake or 1-RTT packets.
 
+When a server receives a second Initial packet after sending its first Initial
+packet, it can assume the client did not receive it's Initial packet. To speed
+handshake completion, it SHOULD retransmit the contents of its Initial packet.
+After doing so, the PTO is re-armed.
+
 Prior to handshake completion, when few to none RTT samples have been
 generated, it is possible that the probe timer expiration is due to an
 incorrect RTT estimate at the client. To allow the client to improve its RTT

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -508,10 +508,11 @@ until it is certain that the server has finished its address validation
 probe timer if the client has not received an acknowledgement for one of its
 Handshake or 1-RTT packets.
 
-When a server receives a second Initial packet after sending its first Initial
-packet, it can assume the client did not receive it's Initial packet. To speed
-handshake completion, it SHOULD retransmit the contents of its Initial packet.
-After doing so, the PTO is re-armed.
+When a server receives duplicate CRYPTO data in an Initial packet after sending
+its Initial flight, it can assume the client did not receive all Initial CRYPTO
+data. To speed handshake completion, it SHOULD retransmit all unacknowledged
+Initial data subject to the path validation limits.  After doing so,
+the PTO is re-armed.
 
 Prior to handshake completion, when few to none RTT samples have been
 generated, it is possible that the probe timer expiration is due to an

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -508,11 +508,11 @@ until it is certain that the server has finished its address validation
 probe timer if the client has not received an acknowledgement for one of its
 Handshake or 1-RTT packets.
 
-When a server receives duplicate CRYPTO data in an Initial packet after sending
-its Initial flight, it can assume the client did not receive all Initial CRYPTO
-data. To speed handshake completion, it SHOULD retransmit all unacknowledged
-Initial CRYPTO data subject to the path validation limits.  After doing so,
-the PTO is re-armed.
+When a server receives duplicate Initial CRYPTO data when there
+is unacknoweledged Initial CRYPTO data, it can assume the client did not
+receive all Initial CRYPTO data or the client's estimated RTT is too short.
+To speed handshake completion, it MAY retransmit unacknowledged Initial
+CRYPTO data subject to the path validation limits, as though the PTO expired.
 
 Prior to handshake completion, when few to none RTT samples have been
 generated, it is possible that the probe timer expiration is due to an

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -526,14 +526,15 @@ did not receive all Initial CRYPTO data or the client's estimated RTT is too
 small. When a client receives undecryptable packets it may assume the server's
 Initial was lost.
 
-To speed handshake completion, either peer MAY send a packet containing unacknowledged
-Initial CRYPTO data subject to the path validation limits, as though the PTO
-expired. A client may send an ack-eliciting packet with no CRYPTO data if all Initial
-data has been acknowledged.  The PTO may only be shortened once in this way.
-Subsequently the PTO uses the normal calculation with exponential backoff.
+To speed handshake completion, either peer MAY send a packet containing
+unacknowledged Initial CRYPTO data subject to the path validation limits, as
+though the PTO expired. A client may send an ack-eliciting packet with no
+CRYPTO data if all Initial data has been acknowledged.  The PTO may only be
+shortened once in this way. Subsequently the PTO uses the normal calculation
+with exponential backoff.
 
-Peers can also use coalesced packets to ensure each datagram elicits at least one
-acknowledgement.
+Peers can also use coalesced packets to ensure each datagram elicits at least
+one acknowledgement.
 
 ### Sending Probe Packets
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -523,14 +523,14 @@ removed from bytes in flight when the Initial and Handshake keys are discarded.
 
 When a server receives duplicate Initial CRYPTO data, it can assume the client
 did not receive all Initial CRYPTO data or the client's estimated RTT is too
-small. When a client receives undecryptable Handshake packets it may assume
-some or all of the server's Initial was lost.
+small. When a client receives Handshake packets prior to obtaining Handshake
+keys it may assume some or all of the server's Initial packets were lost.
 
 To speed handshake completion, either peer MAY send a packet containing
 unacknowledged Initial CRYPTO data subject to the path validation limits, as
-though the PTO expired. A client may send an ack-eliciting packet with no
-CRYPTO data if all Initial data has been acknowledged.  The PTO may only be
-shortened once in this way. Subsequently the PTO uses the normal calculation
+though the PTO expired. A client MAY send an ack-eliciting packet with no
+CRYPTO data if all Initial data has been acknowledged.  The PTO can only be
+shortened once in this way. Subsequently, the PTO uses the normal calculation
 with exponential backoff.
 
 Peers can also use coalesced packets to ensure each datagram elicits at least

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -528,9 +528,9 @@ Initial was lost.
 
 To speed handshake completion, either peer MAY send a packet containing unacknowledged
 Initial CRYPTO data subject to the path validation limits, as though the PTO
-expired. A client may send a retransmittable packet if all Initial data has been
-acknowledged.  The PTO may only be shortened once in this way.  Subsequently the PTO
-uses the normal calculation with exponential backoff.
+expired. A client may send an ack-eliciting packet with no CRYPTO data if all Initial
+data has been acknowledged.  The PTO may only be shortened once in this way.
+Subsequently the PTO uses the normal calculation with exponential backoff.
 
 Peers can also use coalesced packets to ensure each datagram elicits at least one
 acknowledgement.

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -523,8 +523,8 @@ removed from bytes in flight when the Initial and Handshake keys are discarded.
 
 When a server receives duplicate Initial CRYPTO data, it can assume the client
 did not receive all Initial CRYPTO data or the client's estimated RTT is too
-small. When a client receives undecryptable packets it may assume the server's
-Initial was lost.
+small. When a client receives undecryptable Handshake packets it may assume
+some or all of the server's Initial was lost.
 
 To speed handshake completion, either peer MAY send a packet containing
 unacknowledged Initial CRYPTO data subject to the path validation limits, as

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -522,7 +522,7 @@ removed from bytes in flight when the Initial and Handshake keys are discarded.
 ### Speeding Up Handshake Completion
 
 When a server receives duplicate Initial CRYPTO data, it can assume the client
-did not receive all Initial CRYPTO data or the client's estimated RTT is too
+did not receive all of the server's CRYPTO data sent in Initial packets, or the client's estimated RTT is too
 small. When a client receives Handshake or 1-RTT packets prior to obtaining
 Handshake keys it may assume some or all of the server's Initial packets were
 lost.

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -521,14 +521,15 @@ removed from bytes in flight when the Initial and Handshake keys are discarded.
 
 ### Speeding Up Handshake Completion
 
-When a server receives an Initial packet containing duplicate data in a CRYPTO frame, it can assume the client
-did not receive all of the server's CRYPTO data sent in Initial packets, or the client's estimated RTT is too
-small. When a client receives Handshake or 1-RTT packets prior to obtaining
-Handshake keys it may assume some or all of the server's Initial packets were
-lost.
+When a server receives an Initial packet containing duplicate CRYPTO data,
+it can assume the client did not receive all of the server's Initially
+encrypted CRYPTO data, or the client's estimated RTT is too small. When a
+client receives Handshake or 1-RTT packets prior to obtaining Handshake keys,
+it may assume some or all of the server's Initial packets were lost.
 
-To speed up handshake completion under these conditions, an endpoint MAY send a packet containing
-unacknowledged CRYPTO data, subject to path validation limits, earlier than the PTO period.
+To speed up handshake completion under these conditions, an endpoint MAY send
+a packet containing unacknowledged CRYPTO data earlier than the PTO expiry,
+subject to address validation limits. (see Section 8.1 of {{QUIC-TRANSPORT}})
 
 Peers can also use coalesced packets to ensure that each datagram elicits at least
 one acknowledgement.  For example, clients can coalesce an Initial packet

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -522,8 +522,8 @@ removed from bytes in flight when the Initial and Handshake keys are discarded.
 ### Speeding Up Handshake Completion
 
 When a server receives an Initial packet containing duplicate CRYPTO data,
-it can assume the client did not receive all of the server's Initially
-encrypted CRYPTO data, or the client's estimated RTT is too small. When a
+it can assume the client did not receive all of the server's CRYPTO data sent
+in Initial packets, or the client's estimated RTT is too small. When a
 client receives Handshake or 1-RTT packets prior to obtaining Handshake keys,
 it may assume some or all of the server's Initial packets were lost.
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -528,14 +528,12 @@ Handshake keys it may assume some or all of the server's Initial packets were
 lost.
 
 To speed up handshake completion under these conditions, an endpoint MAY send a packet containing
-unacknowledged Initial CRYPTO data subject to the path validation limits, as
-though the PTO expired. The PTO MUST only be shortened once in this way.
-Subsequently, the PTO uses the normal calculation with exponential backoff.
+unacknowledged CRYPTO data, subject to path validation limits, earlier than the PTO period.
 
-Peers can also use coalesced packets to ensure each datagram elicits at least
+Peers can also use coalesced packets to ensure that each datagram elicits at least
 one acknowledgement.  For example, clients can coalesce an Initial packet
-containing a PING and PADDING with 0-RTT data packets and a server can
-coalesce an Initial packet containing a PING with one or more packets in
+containing PING and PADDING frames with a 0-RTT data packet and a server can
+coalesce an Initial packet containing a PING frame with one or more packets in
 its first flight.
 
 ### Sending Probe Packets

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -534,7 +534,10 @@ shortened once in this way. Subsequently the PTO uses the normal calculation
 with exponential backoff.
 
 Peers can also use coalesced packets to ensure each datagram elicits at least
-one acknowledgement.
+one acknowledgement.  For example, clients can coalesce an Initial packet
+containing a PING and PADDING with 0-RTT data packets and a server can
+coalesce an Initial packet containing a PING with one or more packets in
+it's first flight.
 
 ### Sending Probe Packets
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -521,7 +521,7 @@ removed from bytes in flight when the Initial and Handshake keys are discarded.
 
 ### Speeding Up Handshake Completion
 
-When a server receives duplicate Initial CRYPTO data, it can assume the client
+When a server receives an Initial packet containing duplicate data in a CRYPTO frame, it can assume the client
 did not receive all of the server's CRYPTO data sent in Initial packets, or the client's estimated RTT is too
 small. When a client receives Handshake or 1-RTT packets prior to obtaining
 Handshake keys it may assume some or all of the server's Initial packets were

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -508,12 +508,6 @@ until it is certain that the server has finished its address validation
 probe timer if the client has not received an acknowledgement for one of its
 Handshake or 1-RTT packets.
 
-When a server receives duplicate Initial CRYPTO data when there
-is unacknowledged Initial CRYPTO data, it can assume the client did not
-receive all Initial CRYPTO data or the client's estimated RTT is too short.
-To speed handshake completion, it MAY retransmit unacknowledged Initial
-CRYPTO data subject to the path validation limits, as though the PTO expired.
-
 Prior to handshake completion, when few to none RTT samples have been
 generated, it is possible that the probe timer expiration is due to an
 incorrect RTT estimate at the client. To allow the client to improve its RTT
@@ -524,6 +518,22 @@ bytes.
 
 Initial packets and Handshake packets may never be acknowledged, but they are
 removed from bytes in flight when the Initial and Handshake keys are discarded.
+
+### Speeding Handshake Completion
+
+When a server receives duplicate Initial CRYPTO data, it can assume the client
+did not receive all Initial CRYPTO data or the client's estimated RTT is too
+small. When a client receives undecryptable packets it may assume the server's
+Initial was lost.
+
+To speed handshake completion, either peer MAY send a packet containing unacknowledged
+Initial CRYPTO data subject to the path validation limits, as though the PTO
+expired. A client may send a retransmittable packet if all Initial data has been
+acknowledged.  The PTO may only be shortened once in this way.  Subsequently the PTO
+uses the normal calculation with exponential backoff.
+
+Peers can also use coalesced packets to ensure each datagram elicits at least one
+acknowledgement.
 
 ### Sending Probe Packets
 


### PR DESCRIPTION
When the second duplicate client Initial is received, the server MAY retransmit the contents of it's Initial to speed up the handshake.

I'm not sure we want to document only this case, or have a larger section about optimizations to speed recovery during the handshake.

Fixes #3078