### PR TITLE
Pseudo-header section reference

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -489,7 +489,9 @@ the status code for the response.  These pseudo-header fields are defined in
 Section 8.1.2.3 and 8.1.2.4 of {{!HTTP2}}. Pseudo-header fields are not HTTP
 header fields.  Endpoints MUST NOT generate pseudo-header fields other than
 those defined in {{!HTTP2}}.  The restrictions on the use of pseudo-header
-fields in Section 8.1.2 of {{!HTTP2}} also apply to HTTP/3.
+fields in Section 8.1.2 of {{!HTTP2}} also apply to HTTP/3.  Messages which
+are considered malformed under these restrictions are handled as described in
+{{malformed}}.
 
 HTTP/3 uses QPACK header compression as described in [QPACK], a variation of
 HPACK which allows the flexibility to avoid header-compression-induced

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -489,7 +489,7 @@ the status code for the response.  These pseudo-header fields are defined in
 Section 8.1.2.3 and 8.1.2.4 of {{!HTTP2}}. Pseudo-header fields are not HTTP
 header fields.  Endpoints MUST NOT generate pseudo-header fields other than
 those defined in {{!HTTP2}}.  The restrictions on the use of pseudo-header
-fields in Section 8.1.2.1 of {{!HTTP2}} also apply to HTTP/3.
+fields in Section 8.1.2 of {{!HTTP2}} also apply to HTTP/3.
 
 HTTP/3 uses QPACK header compression as described in [QPACK], a variation of
 HPACK which allows the flexibility to avoid header-compression-induced


### PR DESCRIPTION
Fixes #2966.  The constraints of 8.1.2.1 apply to all requests, but I missed that there are additional requirements in 8.1.2.3 for requests and 8.1.2.4 for responses.  I've broadened the statement to "the restrictions on the use of pseudo-headers in Section 8.1.2" to sweep them all up.  Does anyone think we need pointers to each specific subsection?

At Lucas's suggestion, I've also cross-referenced handling of malformed messages here, since those restrictions talk about what is malformed in a given context.