### PR TITLE
Make transport parameters varint

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1307,7 +1307,7 @@ protocol incompatible with the protocol version being used.
 ## QUIC Transport Parameters Extension {#quic_parameters}
 
 QUIC transport parameters are carried in a TLS extension. Different versions of
-QUIC might define a different format for this struct.
+QUIC might define a different format for them.
 
 Including transport parameters in the TLS handshake provides integrity
 protection for these values.
@@ -1319,9 +1319,7 @@ protection for these values.
 ~~~
 
 The `extension_data` field of the quic_transport_parameters extension contains a
-value that is defined by the version of QUIC that is in use.  The
-quic_transport_parameters extension carries a TransportParameters struct when
-the version of QUIC defined in {{QUIC-TRANSPORT}} is used.
+value that is defined by the version of QUIC that is in use.
 
 The quic_transport_parameters extension is carried in the ClientHello and the
 EncryptedExtensions messages during the handshake. Endpoints MUST send the


### PR DESCRIPTION
This PR moves transport parameters away from TLS presentation language to instead use QUIC notation. This allows us to encode small integer transport parameters as 3 bytes instead of 5, but the main goal is to make the identifiers a 62-bit space which will allow uncoordinated experiments without risking collisions.

This fixes #3020.