### PR TITLE
fix incorrect error code name

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1388,7 +1388,7 @@ implementation chooses.
 
 Frame types which were used in HTTP/2 where there is no corresponding HTTP/3
 frame have also been reserved ({{iana-frames}}).  These frame types MUST NOT be
-sent, and receipt MAY be treated as an error of type HTTP_UNEXPECTED_FRAME.
+sent, and receipt MAY be treated as an error of type HTTP_FRAME_UNEXPECTED.
 
 
 # Error Handling {#errors}


### PR DESCRIPTION
This changes HTTP_UNEXPECTED_FRAME, which is used only once, to HTTP_FRAME_UNEXPECTED that is used multiple times.