### PR TITLE
Fixed handshake key deadlock issue

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -384,13 +384,14 @@ perspective of the endpoint in question.
 ### Handshake Confirmed {#handshake-confirmed}
 
 In this document, the TLS handshake is considered confirmed at an endpoint when
-the following two conditions are met: the handshake is complete, and the
-endpoint has received an acknowledgment for a packet sent with 1-RTT keys.
-This second condition can be implemented by recording the lowest packet number
+the following three conditions are met: the handshake is complete, the
+endpoint has received an acknowledgment for a packet sent with 1-RTT keys, and
+the endpoint has received an ack-eliciting packet sent with 1-RTT keys.
+
+The second condition can be implemented by recording the lowest packet number
 sent with 1-RTT keys, and the highest value of the Largest Acknowledged field
 in any received 1-RTT ACK frame: once the latter is higher than or equal to the
 former, the handshake is confirmed.
-
 
 ### Sending and Receiving Handshake Messages
 


### PR DESCRIPTION
Along with some other PRs, I believe this fixes #2863.

Fundamentally, there are four ways to solve the problem of one endpoint throwing away the handshake keys while the other has no 1-RTT data.

1) Keep the handshake keys forever
2) Make the endpoint start a 1-RTT PTO timer whether or not it has data to send
3) Require each endpoint to send a retransmittable frame soon after the handshake is complete; or
4) Make the endpoint wait until it receives an ack-eliciting 1-RTT packet, in addition to a 1-RTT ack.

I believe that the discard keys group might have a plurality for #4. The added condition makes sure that the peer's PTO machinery has started and will have little effect on most applications, including HTTP3.

This PR is a concrete statement of the fourth option.