### PR TITLE
Change idle_timeout to max_idle_timeout

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2349,7 +2349,7 @@ and the state is discarded when it remains idle for longer than the max
 max_idle_timeout (see {{transport-parameter-definitions}}) and three times the
 current Probe Timeout (PTO).
 
-Each endpoint advertises a different max idle timeout, but the effective value
+Each endpoint advertises a different max_idle_timeout, but the effective value
 is determined by taking the minimum of the two advertised values. By announcing
 a max idle timeout, endpoints commit to initiating an immediate close
 ({{immediate-close}}) if it abandons a connection prior to the effective value.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2345,7 +2345,7 @@ source address.
 ## Idle Timeout {#idle-timeout}
 
 If the idle timeout is enabled by either peer, a connection is silently closed
-and the state is discarded when it remains idle for longer than the
+and its state is discarded when it remains idle for longer than the
 max_idle_timeout (see {{transport-parameter-definitions}}) and three times the
 current Probe Timeout (PTO).
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2349,16 +2349,17 @@ max_idle_timeout (see {{transport-parameter-definitions}}) and three times the
 current Probe Timeout (PTO).
 
 Each endpoint advertises a max_idle_timeout, but the effective value
-at an endpoint is computed as the minimum of the two advertised values. By announcing
-a max_idle_timeout, an endpoint commits to initiating an immediate close
-({{immediate-close}}) if it abandons the connection prior to the effective value.
+at an endpoint is computed as the minimum of the two advertised values. By
+announcing a max_idle_timeout, an endpoint commits to initiating an immediate
+close ({{immediate-close}}) if it abandons the connection prior to the effective
+value.
 
 An endpoint restarts any timer it maintains when a packet from its peer is
-received and processed successfully.  The timer is also restarted when sending an
-ack-eliciting packet (see {{QUIC-RECOVERY}}), but only if no other ack-eliciting
-packets have been sent since last receiving a packet.  Restarting when sending
-packets ensures that connections do not prematurely time out when initiating new
-activity.
+received and processed successfully.  The timer is also restarted when sending
+an ack-eliciting packet (see {{QUIC-RECOVERY}}), but only if no other
+ack-eliciting packets have been sent since last receiving a packet.  Restarting
+when sending packets ensures that connections do not prematurely time out when
+initiating new activity.
 
 An endpoint that sends packets near the end of the idle timeout period
 risks having those packets discarded if its peer enters the draining state
@@ -4444,8 +4445,8 @@ original_connection_id (0x0000):
 max_idle_timeout (0x0001):
 
 : The max idle timeout is a value in milliseconds that is encoded as an integer;
-  see ({{idle-timeout}}).  Idle timeout is disabled when both endpoints omit this
-  transport parameteter or specify a value of 0.
+  see ({{idle-timeout}}).  Idle timeout is disabled when both endpoints omit
+  this transport parameteter or specify a value of 0.
 
 stateless_reset_token (0x0002):
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2351,7 +2351,7 @@ current Probe Timeout (PTO).
 
 Each endpoint advertises a max_idle_timeout, but the effective value
 at an endpoint is computed as the minimum of the two advertised values. By announcing
-a max_idle_timeout, endpoints commit to initiating an immediate close
+a max_idle_timeout, an endpoint commits to initiating an immediate close
 ({{immediate-close}}) if it abandons a connection prior to the effective value.
 
 An endpoint restarts any timer it maintains when a packet from its peer is

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2344,9 +2344,9 @@ source address.
 ## Idle Timeout {#idle-timeout}
 
 If the idle timeout is enabled by either peer, a connection is silently closed
-and its state is discarded when it remains idle for longer than the
-max_idle_timeout (see {{transport-parameter-definitions}}) and three times the
-current Probe Timeout (PTO).
+and its state is discarded when it remains idle for longer than the minimum of
+the max_idle_timeouts (see {{transport-parameter-definitions}}) and three times
+the current Probe Timeout (PTO).
 
 Each endpoint advertises a max_idle_timeout, but the effective value
 at an endpoint is computed as the minimum of the two advertised values. By

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2361,7 +2361,7 @@ see {{QUIC-RECOVERY}}), but only if no other ack-eliciting packets have been
 sent since last receiving a packet.  Restarting when sending packets ensures
 that connections do not prematurely time out when initiating new activity.
 
-An endpoint that sends packets near the end of its peer's idle timeout period
+An endpoint that sends packets near the end of the idle timeout period
 risks having those packets discarded if its peer enters the draining state
 before the packets arrive.  If a peer could time out within an Probe Timeout
 (PTO; see Section 6.2.2 of {{QUIC-RECOVERY}}), it is advisable to test for

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2358,8 +2358,8 @@ An endpoint restarts any timer it maintains when a packet from its peer is
 received and processed successfully.  The timer is also restarted when sending
 a packet containing frames other than ACK or PADDING (an ack-eliciting packet;
 see {{QUIC-RECOVERY}}), but only if no other ack-eliciting packets have been
-sent since last receiving a packet.  Restarting when sending packets ensures that
-connections do not prematurely time out when initiating new activity.
+sent since last receiving a packet.  Restarting when sending packets ensures
+that connections do not prematurely time out when initiating new activity.
 
 An endpoint that sends packets near the end of its peer's idle timeout period
 risks having those packets discarded if its peer enters the draining state

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2349,7 +2349,7 @@ and its state is discarded when it remains idle for longer than the
 max_idle_timeout (see {{transport-parameter-definitions}}) and three times the
 current Probe Timeout (PTO).
 
-Each endpoint advertises a different max_idle_timeout, but the effective value
+Each endpoint advertises a max_idle_timeout, but the effective value
 is determined by taking the minimum of the two advertised values. By announcing
 a max_idle_timeout, endpoints commit to initiating an immediate close
 ({{immediate-close}}) if it abandons a connection prior to the effective value.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4419,8 +4419,8 @@ original_connection_id (0x0000):
 max_idle_timeout (0x0001):
 
 : The max idle timeout is a value in milliseconds that is encoded as an integer;
-  see ({{idle-timeout}}).  If this parameter is absent or zero then the idle
-  timeout is disabled unless the peer specifies a max idle timeout.
+  see ({{idle-timeout}}).  Idle timeout is disabled when this parameter is
+  absent or zero on both sides.
 
 stateless_reset_token (0x0002):
 
@@ -4595,7 +4595,7 @@ endpoints send PING frames without coordination can produce an excessive number
 of packets and poor performance.
 
 A connection will time out if no packets are sent or received for a period
-longer than the time specified in the max_idle_timeout transport parameter
+longer than the time negotiated using the max_idle_timeout transport parameter
 (see {{termination}}).  However, state in middleboxes might time out earlier
 than that.  Though REQ-5 in {{?RFC4787}} recommends a 2 minute timeout
 interval, experience shows that sending packets every 15 to 30 seconds is

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2346,7 +2346,7 @@ source address.
 
 If the idle timeout is enabled by either peer, a connection is silently closed
 and the state is discarded when it remains idle for longer than the max
-idle timeout (see {{transport-parameter-definitions}}) and three times the
+max_idle_timeout (see {{transport-parameter-definitions}}) and three times the
 current Probe Timeout (PTO).
 
 Each endpoint advertises a different max idle timeout, but the effective value

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4595,7 +4595,7 @@ endpoints send PING frames without coordination can produce an excessive number
 of packets and poor performance.
 
 A connection will time out if no packets are sent or received for a period
-longer than the time specified in the max)idle_timeout transport parameter
+longer than the time specified in the max_idle_timeout transport parameter
 (see {{termination}}).  However, state in middleboxes might time out earlier
 than that.  Though REQ-5 in {{?RFC4787}} recommends a 2 minute timeout
 interval, experience shows that sending packets every 15 to 30 seconds is

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2352,7 +2352,7 @@ current Probe Timeout (PTO).
 Each endpoint advertises a max_idle_timeout, but the effective value
 at an endpoint is computed as the minimum of the two advertised values. By announcing
 a max_idle_timeout, an endpoint commits to initiating an immediate close
-({{immediate-close}}) if it abandons a connection prior to the effective value.
+({{immediate-close}}) if it abandons the connection prior to the effective value.
 
 An endpoint restarts any timer it maintains when a packet from its peer is
 received and processed successfully.  The timer is also restarted when sending

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2345,7 +2345,7 @@ source address.
 ## Idle Timeout {#idle-timeout}
 
 If the idle timeout is enabled by either peer, a connection is silently closed
-and the state is discarded when it remains idle for longer than the max
+and the state is discarded when it remains idle for longer than the
 max_idle_timeout (see {{transport-parameter-definitions}}) and three times the
 current Probe Timeout (PTO).
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4444,8 +4444,8 @@ original_connection_id (0x0000):
 max_idle_timeout (0x0001):
 
 : The max idle timeout is a value in milliseconds that is encoded as an integer;
-  see ({{idle-timeout}}).  Idle timeout is disabled when this parameter is
-  absent or zero on both sides.
+  see ({{idle-timeout}}).  Idle timeout is disabled when both endpoints omit this
+  transport parameteter or specify a value of 0.
 
 stateless_reset_token (0x0002):
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2357,15 +2357,22 @@ containing frames other than ACK or PADDING (an ack-eliciting packet; see
 since last receiving a packet.  Restarting when sending packets ensures that
 connections do not prematurely time out when initiating new activity.
 
-The value for an idle timeout can be asymmetric.  The value advertised by an
-endpoint is only used to determine whether the connection is live at that
-endpoint.  An endpoint that sends packets near the end of the idle timeout
-period of a peer risks having those packets discarded if its peer enters the
-draining state before the packets arrive.  If a peer could timeout within a
-Probe Timeout (PTO; see Section 6.3 of {{QUIC-RECOVERY}}), it is advisable to
-test for liveness before sending any data that cannot be retried safely.  Note
-that it is likely that only applications or application protocols will
-know what information can be retried.
+Each endpoint can advertise a different idle timeout value. An idle timeout
+indicates the connection will be abandoned when the timer ends or soon
+afterwards.  If a peer advertises a smaller idle timeout value than the
+local endpoint, the local endpoint MAY choose to idle timeout after the
+shorter period advertised by the peer.  By announcing an idle timeout,
+an endpoint commits to initiating an immediate close ({{immediate-close}})
+if it abandons a connection prior to both its peers and its own idle timeout
+expiring.
+
+An endpoint that sends packets near the end of the idle timeout period of a peer
+risks having those packets discarded if its peer enters the draining state
+before the packets arrive.  If a peer could time out within an Probe Timeout
+(PTO; see Section 6.2.2 of {{QUIC-RECOVERY}}), it is advisable to test for
+liveness before sending any data that cannot be retried safely.  Note that it is
+likely that only applications or application protocols will know what
+information can be retried.
 
 
 ## Immediate Close

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2350,7 +2350,7 @@ max_idle_timeout (see {{transport-parameter-definitions}}) and three times the
 current Probe Timeout (PTO).
 
 Each endpoint advertises a max_idle_timeout, but the effective value
-is determined by taking the minimum of the two advertised values. By announcing
+at an endpoint is computed as the minimum of the two advertised values. By announcing
 a max_idle_timeout, endpoints commit to initiating an immediate close
 ({{immediate-close}}) if it abandons a connection prior to the effective value.
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2365,8 +2365,8 @@ An endpoint that sends packets near the end of the idle timeout period
 risks having those packets discarded if its peer enters the draining state
 before the packets arrive.  If a peer could time out within a Probe Timeout
 (PTO; see Section 6.2.2 of {{QUIC-RECOVERY}}), it is advisable to test for
-liveness before sending any data that cannot be retried safely.  Note that it is
-likely that only applications or application protocols will know what
+liveness before sending any data that cannot be retried safely.  Note that it
+is likely that only applications or application protocols will know what
 information can be retried.
 
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2351,7 +2351,7 @@ current Probe Timeout (PTO).
 
 Each endpoint advertises a different max_idle_timeout, but the effective value
 is determined by taking the minimum of the two advertised values. By announcing
-a max idle timeout, endpoints commit to initiating an immediate close
+a max_idle_timeout, endpoints commit to initiating an immediate close
 ({{immediate-close}}) if it abandons a connection prior to the effective value.
 
 An endpoint restarts any timer it maintains when a packet from its peer is

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2354,8 +2354,8 @@ announcing a max_idle_timeout, an endpoint commits to initiating an immediate
 close ({{immediate-close}}) if it abandons the connection prior to the effective
 value.
 
-An endpoint restarts any timer it maintains when a packet from its peer is
-received and processed successfully.  The timer is also restarted when sending
+An endpoint restarts its idle timer when a packet from its peer is
+received and processed successfully.  The idle timer is also restarted when sending
 an ack-eliciting packet (see {{QUIC-RECOVERY}}), but only if no other
 ack-eliciting packets have been sent since last receiving a packet.  Restarting
 when sending packets ensures that connections do not prematurely time out when

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2354,8 +2354,8 @@ announcing a max_idle_timeout, an endpoint commits to initiating an immediate
 close ({{immediate-close}}) if it abandons the connection prior to the effective
 value.
 
-An endpoint restarts its idle timer when a packet from its peer is
-received and processed successfully.  The idle timer is also restarted when sending
+An endpoint restarts its idle timer when a packet from its peer is received
+and processed successfully.  The idle timer is also restarted when sending
 an ack-eliciting packet (see {{QUIC-RECOVERY}}), but only if no other
 ack-eliciting packets have been sent since last receiving a packet.  Restarting
 when sending packets ensures that connections do not prematurely time out when

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2366,7 +2366,7 @@ an endpoint commits to initiating an immediate close ({{immediate-close}})
 if it abandons a connection prior to both its peers and its own idle timeout
 expiring.
 
-An endpoint that sends packets near the end of the idle timeout period of a peer
+An endpoint that sends packets near the end of its peer's idle timeout period
 risks having those packets discarded if its peer enters the draining state
 before the packets arrive.  If a peer could time out within an Probe Timeout
 (PTO; see Section 6.2.2 of {{QUIC-RECOVERY}}), it is advisable to test for


### PR DESCRIPTION
This makes idle timeout symmetric by stating that a peer will close the connection at or soon after the idle timeout expires, creating clear expectations of idle timeout behavior.  This also renames the transport parameter idle_timeout to max_idle_timeout for clarity.

Fixes #2602 
Takes some of the improved text from #2745