### PR TITLE
Immediately close with INVALID_TOKEN

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1646,7 +1646,8 @@ it knows the client will not accept another Retry token.  It can either
 proceed with the handshake without verifying the token or immediately close
 ({{immediate-close}}) the connection with an connection error of
 INVALID_TOKEN to cause the handshake to fail quickly instead of waiting
-for the client to timeout.
+for the client to timeout.  When a client receives a CONNECTION_CLOSE
+with an error of INVALID_TOKEN, it MAY create a new connection.
 
 A flow showing the use of a Retry packet is shown in {{fig-retry}}.
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1643,10 +1643,12 @@ more resources available for new connections.
 
 If a server receives a client Initial that can be unprotected but contains an
 invalid Retry token, it knows the client will not accept another Retry token.
-It can either proceed with the handshake without verifying the token or
-immediately close ({{immediate-close}}) the connection with an INVALID_TOKEN
-error to cause the handshake to fail quickly instead of
-waiting for the client to timeout.
+It can proceed with the handshake without verifying the token, drop the Initial
+packet, or immediately close ({{immediate-close}}) the connection with an
+INVALID_TOKEN error to cause the handshake to fail quickly instead of waiting
+for the client to timeout. The server MAY close the connection without creating
+connection state, including not adding the connection to those in the closing
+state.
 
 A flow showing the use of a Retry packet is shown in {{fig-retry}}.
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1644,7 +1644,7 @@ more resources available for new connections.
 If a server receives a client Initial that can be unprotected but contains an
 invalid Retry token, it knows the client will not accept another Retry token.
 It can either proceed with the handshake without verifying the token or
-immediately close ({{immediate-close}}) the connection with a connection
+immediately close ({{immediate-close}}) the connection with an INVALID_TOKEN
 error of INVALID_TOKEN to cause the handshake to fail quickly instead of
 waiting for the client to timeout.
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1641,13 +1641,12 @@ of connection establishment.  By giving the client a different connection ID to
 use, a server can cause the connection to be routed to a server instance with
 more resources available for new connections.
 
-If a server receives a client Initial with a unverifiable Retry token,
+If a server receives a client Initial with an invalid Retry token,
 it knows the client will not accept another Retry token.  It can either
 proceed with the handshake without verifying the token or immediately close
 ({{immediate-close}}) the connection with an connection error of
 INVALID_TOKEN to cause the handshake to fail quickly instead of waiting
-for the client to timeout.  When a client receives a CONNECTION_CLOSE
-with an error of INVALID_TOKEN, it MAY create a new connection.
+for the client to timeout.
 
 A flow showing the use of a Retry packet is shown in {{fig-retry}}.
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -5584,7 +5584,7 @@ PROTOCOL_VIOLATION (0xA):
 
 : An endpoint detected an error with protocol compliance that was not covered by
   more specific error codes.
-  
+
 INVALID_TOKEN (0xB):
 : A server received a Retry Token in a client Initial that is invalid.
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1643,12 +1643,14 @@ more resources available for new connections.
 
 If a server receives a client Initial that can be unprotected but contains an
 invalid Retry token, it knows the client will not accept another Retry token.
-The server can drop such a packet and allow the client to time out to detect
-handshake failure, but that is a significant latency penalty to the client.
-If possible, the server SHOULD either immediately close ({{immediate-close}})
-the connection with an INVALID_TOKEN error or proceed with the handshake
-without verifying the token. The server MAY close the connection without
-creating connection state, including skipping the closing state.
+The server can discard such a packet and allow the client to time out to
+detect handshake failure, but that is a significant latency penalty to the
+client.  A server MAY proceed with the connection without verifying the token,
+though the server MUST NOT consider the client address validated.  If a server
+chooses not to proceed with the handshake, it SHOULD immediately close
+({{immediate-close}}) the connection with an INVALID_TOKEN error.  Note that a
+server has not established any state for the connection at this point and so
+does not enter the closing period.
 
 A flow showing the use of a Retry packet is shown in {{fig-retry}}.
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1645,7 +1645,7 @@ If a server receives a client Initial that can be unprotected but contains an
 invalid Retry token, it knows the client will not accept another Retry token.
 It can either proceed with the handshake without verifying the token or
 immediately close ({{immediate-close}}) the connection with an INVALID_TOKEN
-error of INVALID_TOKEN to cause the handshake to fail quickly instead of
+error to cause the handshake to fail quickly instead of
 waiting for the client to timeout.
 
 A flow showing the use of a Retry packet is shown in {{fig-retry}}.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1644,10 +1644,10 @@ more resources available for new connections.
 If a server receives a client Initial that can be unprotected but contains an
 invalid Retry token, it knows the client will not accept another Retry token.
 The server can discard such a packet and allow the client to time out to
-detect handshake failure, but that could impose a significant latency penalty on the
-client.  A server MAY proceed with the connection without verifying the token,
-though the server MUST NOT consider the client address validated.  If a server
-chooses not to proceed with the handshake, it SHOULD immediately close
+detect handshake failure, but that could impose a significant latency penalty on
+the client.  A server MAY proceed with the connection without verifying the
+token, though the server MUST NOT consider the client address validated.  If a
+server chooses not to proceed with the handshake, it SHOULD immediately close
 ({{immediate-close}}) the connection with an INVALID_TOKEN error.  Note that a
 server has not established any state for the connection at this point and so
 does not enter the closing period.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1644,7 +1644,7 @@ more resources available for new connections.
 If a server receives a client Initial that can be unprotected but contains an
 invalid Retry token, it knows the client will not accept another Retry token.
 The server can discard such a packet and allow the client to time out to
-detect handshake failure, but that is a significant latency penalty to the
+detect handshake failure, but that could impose a significant latency penalty on the
 client.  A server MAY proceed with the connection without verifying the token,
 though the server MUST NOT consider the client address validated.  If a server
 chooses not to proceed with the handshake, it SHOULD immediately close

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1644,7 +1644,7 @@ more resources available for new connections.
 If a server receives a client Initial that can be unprotected but contains an
 invalid Retry token, it knows the client will not accept another Retry token.
 It can either proceed with the handshake without verifying the token or
-immediately close ({{immediate-close}}) the connection with an connection
+immediately close ({{immediate-close}}) the connection with a connection
 error of INVALID_TOKEN to cause the handshake to fail quickly instead of
 waiting for the client to timeout.
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1643,12 +1643,6 @@ more resources available for new connections.
 
 If a server receives a client Initial that can be unprotected but contains an
 invalid Retry token, it knows the client will not accept another Retry token.
-
-
-
-If a server receives a client Initial that can be unprotected but contains an
-invalid Retry token, it knows the client will not accept another Retry token.
-
 The server can drop such a packet and allow the client to time out to detect
 handshake failure, but that is a significant latency penalty to the client.
 If possible, the server SHOULD either immediately close ({{immediate-close}}) 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1641,6 +1641,13 @@ of connection establishment.  By giving the client a different connection ID to
 use, a server can cause the connection to be routed to a server instance with
 more resources available for new connections.
 
+If a server receives a client Initial with a unverifiable Retry token,
+it knows the client will not accept another Retry token.  It can either
+proceed with the handshake without verifying the token or immediately close
+({{immediate-close}}) the connection with an connection error of 
+INVALID_TOKEN to cause the handshake to fail quickly instead of waiting
+for the client to timeout.
+
 A flow showing the use of a Retry packet is shown in {{fig-retry}}.
 
 ~~~~

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1644,7 +1644,7 @@ more resources available for new connections.
 If a server receives a client Initial with a unverifiable Retry token,
 it knows the client will not accept another Retry token.  It can either
 proceed with the handshake without verifying the token or immediately close
-({{immediate-close}}) the connection with an connection error of 
+({{immediate-close}}) the connection with an connection error of
 INVALID_TOKEN to cause the handshake to fail quickly instead of waiting
 for the client to timeout.
 
@@ -5980,6 +5980,7 @@ The initial contents of this registry are shown in {{iana-error-table}}.
 | 0x7   | FRAME_ENCODING_ERROR      | Frame encoding error          | {{error-codes}} |
 | 0x8   | TRANSPORT_PARAMETER_ERROR | Error in transport parameters | {{error-codes}} |
 | 0xA   | PROTOCOL_VIOLATION        | Generic protocol violation    | {{error-codes}} |
+| 0xB   | INVALID_TOKEN             | Invalid Token Received        | {{error-codes}} |
 | 0xD   | CRYPTO_BUFFER_EXCEEDED    | CRYPTO data buffer overflowed | {{error-codes}} |
 {: #iana-error-table title="Initial QUIC Transport Error Codes Entries"}
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1645,7 +1645,7 @@ If a server receives a client Initial that can be unprotected but contains an
 invalid Retry token, it knows the client will not accept another Retry token.
 The server can drop such a packet and allow the client to time out to detect
 handshake failure, but that is a significant latency penalty to the client.
-If possible, the server SHOULD either immediately close ({{immediate-close}}) 
+If possible, the server SHOULD either immediately close ({{immediate-close}})
 the connection with an INVALID_TOKEN error or proceed with the handshake
 without verifying the token. The server MAY close the connection without
 creating connection state, including skipping the closing state.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1641,12 +1641,12 @@ of connection establishment.  By giving the client a different connection ID to
 use, a server can cause the connection to be routed to a server instance with
 more resources available for new connections.
 
-If a server receives a client Initial with an invalid Retry token,
-it knows the client will not accept another Retry token.  It can either
-proceed with the handshake without verifying the token or immediately close
-({{immediate-close}}) the connection with an connection error of
-INVALID_TOKEN to cause the handshake to fail quickly instead of waiting
-for the client to timeout.
+If a server receives a client Initial that can be unprotected but contains an
+invalid Retry token, it knows the client will not accept another Retry token.
+It can either proceed with the handshake without verifying the token or
+immediately close ({{immediate-close}}) the connection with an connection
+error of INVALID_TOKEN to cause the handshake to fail quickly instead of
+waiting for the client to timeout.
 
 A flow showing the use of a Retry packet is shown in {{fig-retry}}.
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1643,12 +1643,18 @@ more resources available for new connections.
 
 If a server receives a client Initial that can be unprotected but contains an
 invalid Retry token, it knows the client will not accept another Retry token.
-It can proceed with the handshake without verifying the token, drop the Initial
-packet, or immediately close ({{immediate-close}}) the connection with an
-INVALID_TOKEN error to cause the handshake to fail quickly instead of waiting
-for the client to timeout. The server MAY close the connection without creating
-connection state, including not adding the connection to those in the closing
-state.
+
+
+
+If a server receives a client Initial that can be unprotected but contains an
+invalid Retry token, it knows the client will not accept another Retry token.
+
+The server can drop such a packet and allow the client to time out to detect
+handshake failure, but that is a significant latency penalty to the client.
+If possible, the server SHOULD either immediately close ({{immediate-close}}) 
+the connection with an INVALID_TOKEN error or proceed with the handshake
+without verifying the token. The server MAY close the connection without
+creating connection state, including skipping the closing state.
 
 A flow showing the use of a Retry packet is shown in {{fig-retry}}.
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -5584,6 +5584,9 @@ PROTOCOL_VIOLATION (0xA):
 
 : An endpoint detected an error with protocol compliance that was not covered by
   more specific error codes.
+  
+INVALID_TOKEN (0xB):
+: A server received a Retry Token in a client Initial that is invalid.
 
 CRYPTO_BUFFER_EXCEEDED (0xD):
 


### PR DESCRIPTION
If the Retry token is known to be invalid by the server, then the server can close the connection with INVALID_TOKEN instead of waiting for a timeout.

Came out of discussion of Issue #3014
Fixes #3168 

Related to #3127 