### PR TITLE
Replace use of the TLS presentation language with QUIC encoding

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1336,7 +1336,7 @@ protocol incompatible with the protocol version being used.
 ## QUIC Transport Parameters Extension {#quic_parameters}
 
 QUIC transport parameters are carried in a TLS extension. Different versions of
-QUIC might define a different format for them.
+QUIC might define a different method for negotiating transport configuration.
 
 Including transport parameters in the TLS handshake provides integrity
 protection for these values.

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1307,7 +1307,7 @@ protocol incompatible with the protocol version being used.
 ## QUIC Transport Parameters Extension {#quic_parameters}
 
 QUIC transport parameters are carried in a TLS extension. Different versions of
-QUIC might define a different format for this struct.
+QUIC might define a different format for them.
 
 Including transport parameters in the TLS handshake provides integrity
 protection for these values.
@@ -1319,9 +1319,7 @@ protection for these values.
 ~~~
 
 The `extension_data` field of the quic_transport_parameters extension contains a
-value that is defined by the version of QUIC that is in use.  The
-quic_transport_parameters extension carries a TransportParameters struct when
-the version of QUIC defined in {{QUIC-TRANSPORT}} is used.
+value that is defined by the version of QUIC that is in use.
 
 The quic_transport_parameters extension is carried in the ClientHello and the
 EncryptedExtensions messages during the handshake. Endpoints MUST send the

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4379,7 +4379,7 @@ length, value) tuple, as shown in {{transport-parameter-encoding-fig}}:
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |  Transport Parameter ID (16)  |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|  Transport Param Length (16)  |
+|  Transport Parameter ID (16)  |  Transport Param Length (16)  |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                Transport Parameter Value (*)                ...
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4349,11 +4349,14 @@ connection.
 
 The `extension_data` field of the quic_transport_parameters extension defined in
 {{QUIC-TLS}} contains the QUIC transport parameters. They are encoded as a
-sequence of transport parameters, as shown in {{transport-parameter-sequence}}:
+length-prefixed sequence of transport parameters, as shown in
+{{transport-parameter-sequence}}:
 
 ~~~
  0                   1                   2                   3
  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|      Sequence Length (16)     |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                  Transport Parameter 1 (*)                  ...
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -4366,23 +4369,24 @@ sequence of transport parameters, as shown in {{transport-parameter-sequence}}:
 ~~~
 {: #transport-parameter-sequence title="Sequence of Transport Parameters"}
 
-Each transport parameter is encoded as an (identifier, length, value) tuple, as
-shown in {{transport-parameter-encoding-fig}}:
+The Sequence Length field contains the length of the sequence of transport
+parameters, in bytes. Each transport parameter is encoded as an (identifier,
+length, value) tuple, as shown in {{transport-parameter-encoding-fig}}:
 
 ~~~
  0                   1                   2                   3
  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|              Transport Parameter Identifier (i)             ...
+|  Transport Parameter ID (16)  |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                Transport Parameter Length (i)               ...
+|  Transport Param Length (16)  |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                Transport Parameter Value (*)                ...
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 ~~~
 {: #transport-parameter-encoding-fig title="Transport Parameter Encoding"}
 
-The Transport Parameter Length field contains the length of the Transport
+The Transport Param Length field contains the length of the Transport
 Parameter Value field.
 
 QUIC encodes transport parameters into a sequence of bytes, which are then
@@ -4408,20 +4412,20 @@ transport parameter is absent, unless otherwise stated.
 
 The following transport parameters are defined:
 
-original_connection_id (0x0):
+original_connection_id (0x0000):
 
 : The value of the Destination Connection ID field from the first Initial packet
   sent by the client.  This transport parameter is only sent by a server.  A
   server MUST include the original_connection_id transport parameter if it sent
   a Retry packet.
 
-idle_timeout (0x1):
+idle_timeout (0x0001):
 
 : The idle timeout is a value in milliseconds that is encoded as an integer; see
   ({{idle-timeout}}).  If this parameter is absent or zero then the idle
   timeout is disabled.
 
-stateless_reset_token (0x2):
+stateless_reset_token (0x0002):
 
 : A stateless reset token is used in verifying a stateless reset; see
   {{stateless-reset}}.  This parameter is a sequence of 16 bytes.  This
@@ -4430,7 +4434,7 @@ stateless_reset_token (0x2):
   reset ({{stateless-reset}}) for the connection ID negotiated during the
   handshake.
 
-max_packet_size (0x3):
+max_packet_size (0x0003):
 
 : The maximum packet size parameter is an integer value that limits the size of
   packets that the endpoint is willing to receive.  This indicates that packets
@@ -4438,14 +4442,14 @@ max_packet_size (0x3):
   maximum permitted UDP payload of 65527.  Values below 1200 are invalid.  This
   limit only applies to protected packets ({{packet-protected}}).
 
-initial_max_data (0x4):
+initial_max_data (0x0004):
 
 : The initial maximum data parameter is an integer value that contains the
   initial value for the maximum amount of data that can be sent on the
   connection.  This is equivalent to sending a MAX_DATA ({{frame-max-data}}) for
   the connection immediately after completing the handshake.
 
-initial_max_stream_data_bidi_local (0x5):
+initial_max_stream_data_bidi_local (0x0005):
 
 : This parameter is an integer value specifying the initial flow control limit
   for locally-initiated bidirectional streams.  This limit applies to newly
@@ -4455,7 +4459,7 @@ initial_max_stream_data_bidi_local (0x5):
   parameters, this applies to streams with the least significant two bits set to
   0x1.
 
-initial_max_stream_data_bidi_remote (0x6):
+initial_max_stream_data_bidi_remote (0x0006):
 
 : This parameter is an integer value specifying the initial flow control limit
   for peer-initiated bidirectional streams.  This limit applies to newly created
@@ -4465,7 +4469,7 @@ initial_max_stream_data_bidi_remote (0x6):
   parameters, this applies to streams with the least significant two bits set to
   0x0.
 
-initial_max_stream_data_uni (0x7):
+initial_max_stream_data_uni (0x0007):
 
 : This parameter is an integer value specifying the initial flow control limit
   for unidirectional streams.  This limit applies to newly created
@@ -4475,7 +4479,7 @@ initial_max_stream_data_uni (0x7):
   parameters, this applies to streams with the least significant two bits set to
   0x2.
 
-initial_max_streams_bidi (0x8):
+initial_max_streams_bidi (0x0008):
 
 : The initial maximum bidirectional streams parameter is an integer value that
   contains the initial maximum number of bidirectional streams the peer may
@@ -4484,7 +4488,7 @@ initial_max_streams_bidi (0x8):
   parameter is equivalent to sending a MAX_STREAMS ({{frame-max-streams}}) of
   the corresponding type with the same value.
 
-initial_max_streams_uni (0x9):
+initial_max_streams_uni (0x0009):
 
 : The initial maximum unidirectional streams parameter is an integer value that
   contains the initial maximum number of unidirectional streams the peer may
@@ -4493,14 +4497,14 @@ initial_max_streams_uni (0x9):
   parameter is equivalent to sending a MAX_STREAMS ({{frame-max-streams}}) of
   the corresponding type with the same value.
 
-ack_delay_exponent (0xA):
+ack_delay_exponent (0x000a):
 
 : The ACK delay exponent is an integer value indicating an
   exponent used to decode the ACK Delay field in the ACK frame ({{frame-ack}}).
   If this value is absent, a default value of 3 is assumed (indicating a
   multiplier of 8). Values above 20 are invalid.
 
-max_ack_delay (0xB):
+max_ack_delay (0x000b):
 
 : The maximum ACK delay is an integer value indicating the
   maximum amount of time in milliseconds by which the endpoint will delay
@@ -4510,7 +4514,7 @@ max_ack_delay (0xB):
   of 6ms.  If this value is absent, a default of 25 milliseconds is assumed.
   Values of 2^14 or greater are invalid.
 
-disable_active_migration (0xC):
+disable_active_migration (0x000c):
 
 : The disable active migration transport parameter is included if the endpoint
   does not support active connection migration ({{migration}}). Peers of an
@@ -4519,7 +4523,7 @@ disable_active_migration (0xC):
   than that used to perform the handshake.  This parameter is a zero-length
   value.
 
-preferred_address (0xD):
+preferred_address (0x000d):
 
 : The server's preferred address is used to effect a change in server address at
   the end of the handshake, as described in {{preferred-address}}.  The format
@@ -4538,7 +4542,13 @@ preferred_address (0xD):
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |         IPv4 Port (16)        |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                     IPv6 Address (128)                      ...
+|                                                               |
++                                                               +
+|                                                               |
++                      IPv6 Address (128)                       +
+|                                                               |
++                                                               +
+|                                                               |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |         IPv6 Port (16)        |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -4546,7 +4556,13 @@ preferred_address (0xD):
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                      Connection ID (*)                      ...
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                 Stateless Reset Token (128)                 ...
+|                                                               |
++                                                               +
+|                                                               |
++                   Stateless Reset Token (128)                 +
+|                                                               |
++                                                               +
+|                                                               |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 ~~~
 {: #fig-preferred-address title="Preferred Address format"}
@@ -5840,19 +5856,18 @@ ID can be selected to route later packets to the same server.
 IANA \[SHALL add/has added] a registry for "QUIC Transport Parameters" under a
 "QUIC Protocol" heading.
 
-The "QUIC Transport Parameters" registry governs a 62-bit space.  This space is
-split into three spaces that are governed by different policies.  Values between
-0x0 and 0x3f (in hexadecimal) are assigned via the Standards Action or IESG
-Review policies {{!RFC8126}}.  Values from 0x40 to 0x3fff operate on the
-Specification Required policy {{!RFC8126}}.  All other values are assigned to
-Private Use {{!RFC8126}}.
+The "QUIC Transport Parameters" registry governs a 16-bit space.  This space is
+split into two spaces that are governed by different policies.  Values with the
+first byte in the range 0x00 to 0xfe (in hexadecimal) are assigned via the
+Specification Required policy {{!RFC8126}}.  Values with the first byte 0xff are
+reserved for Private Use {{!RFC8126}}.
 
 Registrations MUST include the following fields:
 
 Value:
 
-: The numeric value of the assignment (registrations will be between 0x0 and
-  0x3fff).
+: The numeric value of the assignment (registrations will be between 0x0000 and
+  0xfeff).
 
 Parameter Name:
 
@@ -5869,23 +5884,23 @@ merely aesthetically displeasing, or architecturally dubious).
 
 The initial contents of this registry are shown in {{iana-tp-table}}.
 
-| Value | Parameter Name              | Specification                       |
-|:------|:----------------------------|:------------------------------------|
-|  0x0  | original_connection_id      | {{transport-parameter-definitions}} |
-|  0x1  | idle_timeout                | {{transport-parameter-definitions}} |
-|  0x2  | stateless_reset_token       | {{transport-parameter-definitions}} |
-|  0x3  | max_packet_size             | {{transport-parameter-definitions}} |
-|  0x4  | initial_max_data            | {{transport-parameter-definitions}} |
-|  0x5  | initial_max_stream_data_bidi_local | {{transport-parameter-definitions}} |
-|  0x6  | initial_max_stream_data_bidi_remote | {{transport-parameter-definitions}} |
-|  0x7  | initial_max_stream_data_uni | {{transport-parameter-definitions}} |
-|  0x8  | initial_max_streams_bidi    | {{transport-parameter-definitions}} |
-|  0x9  | initial_max_streams_uni     | {{transport-parameter-definitions}} |
-|  0xA  | ack_delay_exponent          | {{transport-parameter-definitions}} |
-|  0xB  | max_ack_delay               | {{transport-parameter-definitions}} |
-|  0xC  | disable_active_migration    | {{transport-parameter-definitions}} |
-|  0xD  | preferred_address           | {{transport-parameter-definitions}} |
-|  0xE  | active_connection_id_limit  | {{transport-parameter-definitions}} |
+| Value  | Parameter Name              | Specification                       |
+|:-------|:----------------------------|:------------------------------------|
+| 0x0000 | original_connection_id      | {{transport-parameter-definitions}} |
+| 0x0001 | idle_timeout                | {{transport-parameter-definitions}} |
+| 0x0002 | stateless_reset_token       | {{transport-parameter-definitions}} |
+| 0x0003 | max_packet_size             | {{transport-parameter-definitions}} |
+| 0x0004 | initial_max_data            | {{transport-parameter-definitions}} |
+| 0x0005 | initial_max_stream_data_bidi_local | {{transport-parameter-definitions}} |
+| 0x0006 | initial_max_stream_data_bidi_remote | {{transport-parameter-definitions}} |
+| 0x0007 | initial_max_stream_data_uni | {{transport-parameter-definitions}} |
+| 0x0008 | initial_max_streams_bidi    | {{transport-parameter-definitions}} |
+| 0x0009 | initial_max_streams_uni     | {{transport-parameter-definitions}} |
+| 0x000a | ack_delay_exponent          | {{transport-parameter-definitions}} |
+| 0x000b | max_ack_delay               | {{transport-parameter-definitions}} |
+| 0x000c | disable_active_migration    | {{transport-parameter-definitions}} |
+| 0x000d | preferred_address           | {{transport-parameter-definitions}} |
+| 0x000e | active_connection_id_limit  | {{transport-parameter-definitions}} |
 {: #iana-tp-table title="Initial QUIC Transport Parameters Entries"}
 
 Additionally, each value of the format `31 * N + 27` for integer values of N

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4567,7 +4567,7 @@ preferred_address (0x000d):
 ~~~
 {: #fig-preferred-address title="Preferred Address format"}
 
-active_connection_id_limit (0xE):
+active_connection_id_limit (0x000e):
 
 : The maximum number of connection IDs from the peer that an endpoint is willing
   to store. This value includes only connection IDs sent in NEW_CONNECTION_ID

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4377,8 +4377,6 @@ length, value) tuple, as shown in {{transport-parameter-encoding-fig}}:
  0                   1                   2                   3
  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|  Transport Parameter ID (16)  |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |  Transport Parameter ID (16)  |  Transport Param Length (16)  |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                Transport Parameter Value (*)                ...


### PR DESCRIPTION
This PR is purely editorial and does not change the protocol in any way.

When we discussed #3020 in Cupertino, it emerged that there was consensus for this editorial change but not for all topics in that issue, so I split this out to its own PR.