### PR TITLE
Add retry integrity tag

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1201,8 +1201,8 @@ anticipation of receiving a ClientHello.
 
 Retry packets (see the Retry Packet section of {{QUIC-TRANSPORT}}) carry a
 Retry Integrity Tag that provides two properties: it allows discarding
-packets that have accidentally been corrupted by the network, and it ensures
-that valid Retry packets cannot be sent by off-path attackers.
+packets that have accidentally been corrupted by the network, and it mitigates
+off-path attackers' ability to send valid Retry packets.
 
 The Retry Integrity Tag is a 128-bit field that is computed as the output of
 AEAD_AES_128_GCM used with the following inputs:
@@ -1252,7 +1252,7 @@ Original Destination Connection ID:
 : The Original Destination Connection ID contains the value of the Destination
   Connection ID from the Initial packet that this Retry is in response to. The
   length of this field is given in ODCID Len. The presence of this field
-  prevents an off-path attacker from injecting a Retry packet.
+  mitigates an off-path attacker's ability to inject a Retry packet.
 
 
 # Key Update

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1210,8 +1210,8 @@ AEAD_AES_128_GCM {{!AEAD=RFC5116}} used with the following inputs:
 - The secret key, K, is 128 bits all set to zero.
 - The nonce, N, is 96 bits all set to zero.
 - The plaintext, P, is empty.
-- The associated data, A, is the contents of the Retry Pseudo-Packet, as illustrated
-  in {{retry-pseudo}}:
+- The associated data, A, is the contents of the Retry Pseudo-Packet, as
+  illustrated in {{retry-pseudo}}:
 
 ~~~
  0                   1                   2                   3

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1205,10 +1205,10 @@ packets that have accidentally been corrupted by the network, and it mitigates
 off-path attackers' ability to send valid Retry packets.
 
 The Retry Integrity Tag is a 128-bit field that is computed as the output of
-AEAD_AES_128_GCM used with the following inputs:
+AEAD_AES_128_GCM {{!AEAD=RFC5116}} used with the following inputs:
 
-- The key is 128 bits all set to zero.
-- The nonce is 96 bits all set to zero.
+- The secret key, K, is 128 bits all set to zero.
+- The nonce, N, is 96 bits all set to zero.
 - The plaintext is empty.
 - The associated data is the contents of the Retry Pseudo-Packet, as described
   in {{retry-pseudo}}:

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1215,7 +1215,8 @@ off-path attackers' ability to send valid Retry packets.
 The Retry Integrity Tag is a 128-bit field that is computed as the output of
 AEAD_AES_128_GCM {{!AEAD=RFC5116}} used with the following inputs:
 
-- The secret key, K, is 128 bits all set to zero.
+- The secret key, K, is 128 bits equal to the initial_salt defined in
+  {{initial-secrets}}.
 - The nonce, N, is 96 bits all set to zero.
 - The plaintext, P, is empty.
 - The associated data, A, is the contents of the Retry Pseudo-Packet, as

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1215,8 +1215,7 @@ off-path attackers' ability to send valid Retry packets.
 The Retry Integrity Tag is a 128-bit field that is computed as the output of
 AEAD_AES_128_GCM {{!AEAD=RFC5116}} used with the following inputs:
 
-- The secret key, K, is 128 bits equal to the initial_salt defined in
-  {{initial-secrets}}.
+- The secret key, K, is 128 bits equal to 0xf5ed4642e0e4c8d878bbbc8a828821c9.
 - The nonce, N, is 96 bits all set to zero.
 - The plaintext, P, is empty.
 - The associated data, A, is the contents of the Retry Pseudo-Packet, as

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1209,7 +1209,7 @@ anticipation of receiving a ClientHello.
 
 Retry packets (see the Retry Packet section of {{QUIC-TRANSPORT}}) carry a
 Retry Integrity Tag that provides two properties: it allows discarding
-packets that have accidentally been corrupted by the network, and it mitigates
+packets that have accidentally been corrupted by the network, and it diminishes
 off-path attackers' ability to send valid Retry packets.
 
 The Retry Integrity Tag is a 128-bit field that is computed as the output of

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1209,8 +1209,8 @@ AEAD_AES_128_GCM {{!AEAD=RFC5116}} used with the following inputs:
 
 - The secret key, K, is 128 bits all set to zero.
 - The nonce, N, is 96 bits all set to zero.
-- The plaintext is empty.
-- The associated data is the contents of the Retry Pseudo-Packet, as described
+- The plaintext, P, is empty.
+- The associated data, A, is the contents of the Retry Pseudo-Packet, as illustrated
   in {{retry-pseudo}}:
 
 ~~~

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1216,7 +1216,11 @@ AEAD_AES_128_GCM used with the following inputs:
 ~~~
  0                   1                   2                   3
  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-+-+-+-+-+-+-+-+-+
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+| ODCID Len (8) |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|          Original Destination Connection ID (0..160)        ...
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |1|1| 3 | Unused|
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                         Version (32)                          |
@@ -1231,16 +1235,12 @@ AEAD_AES_128_GCM used with the following inputs:
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                        Retry Token (*)                      ...
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-| ODCID Len (8) |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|          Original Destination Connection ID (0..160)        ...
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 ~~~
 {: #retry-pseudo title="Retry Pseudo-Packet"}
 
 The Retry Pseudo-Packet is not sent over the wire. It is computed by taking
-the transmitted Retry packet and replacing the Retry Integrity Tag with the two
-following fields:
+the transmitted Retry packet, removing the Retry Integrity Tag and prepending
+the two following fields:
 
 ODCID Len:
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4158,8 +4158,8 @@ attempt.  After the client has received and processed an Initial or Retry packet
 from the server, it MUST discard any subsequent Retry packets that it receives.
 
 Clients MUST discard Retry packets whose Retry Integrity Tag cannot be
-validated, see the Retry Packet Integrity section of {{QUIC-TLS}}. This prevents
-an off-path attacker from injecting a Retry packet.
+validated, see the Retry Packet Integrity section of {{QUIC-TLS}}. This
+mitigates an off-path attacker's ability to inject a Retry packet.
 
 The client responds to a Retry packet with an Initial packet that includes the
 provided Retry Token to continue connection establishment.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4159,7 +4159,7 @@ from the server, it MUST discard any subsequent Retry packets that it receives.
 
 Clients MUST discard Retry packets whose Retry Integrity Tag cannot be
 validated, see the Retry Packet Integrity section of {{QUIC-TLS}}. This
-mitigates an off-path attacker's ability to inject a Retry packet, and protects
+mitigates an off-path attacker's ability to inject a Retry packet and protects
 against accidental corruption of Retry packets.
 
 The client responds to a Retry packet with an Initial packet that includes the

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4181,7 +4181,7 @@ from the server, it MUST discard any subsequent Retry packets that it receives.
 
 Clients MUST discard Retry packets that have a Retry Integrity Tag that cannot
 be validated, see the Retry Packet Integrity section of {{QUIC-TLS}}. This
-mitigates an off-path attacker's ability to inject a Retry packet and protects
+diminishes an off-path attacker's ability to inject a Retry packet and protects
 against accidental corruption of Retry packets.
 
 The client responds to a Retry packet with an Initial packet that includes the

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2738,9 +2738,9 @@ available.
 
 All QUIC packets except Version Negotiation packets use authenticated
 encryption with additional data (AEAD) {{!RFC5116}} to provide confidentiality
- and integrity protection. Retry packets use an AEAD to provide integrity 
-  protection.  Details of packet protection are found in
-{{QUIC-TLS}}; this section includes an overview of the process.
+and integrity protection.  Retry packets use an AEAD to provide integrity
+protection.  Details of packet protection are found in {{QUIC-TLS}}; this
+section includes an overview of the process.
 
 Initial packets are protected using keys that are statically derived. This
 packet protection is not effective confidentiality protection.  Initial
@@ -4158,8 +4158,8 @@ A client MUST accept and process at most one Retry packet for each connection
 attempt.  After the client has received and processed an Initial or Retry packet
 from the server, it MUST discard any subsequent Retry packets that it receives.
 
-Clients MUST discard Retry packets that have a Retry Integrity Tag that cannot be
-validated, see the Retry Packet Integrity section of {{QUIC-TLS}}. This
+Clients MUST discard Retry packets that have a Retry Integrity Tag that cannot
+be validated, see the Retry Packet Integrity section of {{QUIC-TLS}}. This
 mitigates an off-path attacker's ability to inject a Retry packet and protects
 against accidental corruption of Retry packets.
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2738,7 +2738,8 @@ available.
 
 All QUIC packets except Version Negotiation packets use authenticated
 encryption with additional data (AEAD) {{!RFC5116}} to provide confidentiality
-and integrity protection. Details of packet protection are found in
+ and integrity protection. Retry packets use an AEAD to provide integrity 
+  protection.  Details of packet protection are found in
 {{QUIC-TLS}}; this section includes an overview of the process.
 
 Initial packets are protected using keys that are statically derived. This
@@ -4157,7 +4158,7 @@ A client MUST accept and process at most one Retry packet for each connection
 attempt.  After the client has received and processed an Initial or Retry packet
 from the server, it MUST discard any subsequent Retry packets that it receives.
 
-Clients MUST discard Retry packets whose Retry Integrity Tag cannot be
+Clients MUST discard Retry packets that have a Retry Integrity Tag that cannot be
 validated, see the Retry Packet Integrity section of {{QUIC-TLS}}. This
 mitigates an off-path attacker's ability to inject a Retry packet and protects
 against accidental corruption of Retry packets.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4159,7 +4159,8 @@ from the server, it MUST discard any subsequent Retry packets that it receives.
 
 Clients MUST discard Retry packets whose Retry Integrity Tag cannot be
 validated, see the Retry Packet Integrity section of {{QUIC-TLS}}. This
-mitigates an off-path attacker's ability to inject a Retry packet.
+mitigates an off-path attacker's ability to inject a Retry packet, and protects
+against accidental corruption of Retry packets.
 
 The client responds to a Retry packet with an Initial packet that includes the
 provided Retry Token to continue connection establishment.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4189,7 +4189,9 @@ processing a Retry packet; {{packet-0rtt}} contains more information on this.
 
 A server acknowledges the use of a Retry packet for a connection using the
 original_connection_id transport parameter (see
-{{transport-parameter-definitions}}).
+{{transport-parameter-definitions}}).  If the server sends a Retry packet, it
+MUST include the Destination Connection ID field from the client's first
+Initial packet in the transport parameter.
 
 If the client received and processed a Retry packet, it MUST validate that the
 original_connection_id transport parameter is present and correct; otherwise, it


### PR DESCRIPTION
As discussed in Cupertino, this PR adds an integrity tag to retry packets to prevent on-network packet corruption from breaking QUIC handshakes.

Closes #3014.
Closes #3274.