### PR TITLE
Mandatory distinction between token types

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1630,12 +1630,6 @@ that allows the server to identity how it was provided to a client.  These
 tokens are carried in the same field, but require different handling from
 servers.
 
-A token MUST NOT include information that would allow values to be linked by an
-on-path observer to the connection on which it was issued.  For example, it
-cannot include the connection ID or addressing information unless the values are
-encrypted.  Information that allows the server to distinguish between tokens
-from Retry and NEW_TOKEN MAY be accessible to entities other than the server.
-
 
 ### Address Validation using Retry Packets {#validate-retry}
 
@@ -1695,6 +1689,13 @@ Thus, a token SHOULD have an expiration time, which could be either an explicit
 expiration time or an issued timestamp that can be used to dynamically calculate
 the expiration time.  A server can store the expiration time or include it in an
 encrypted form in the token.
+
+A token issued with NEW_TOKEN MUST NOT include information that would allow
+values to be linked by an on-path observer to the connection on which it was
+issued.  For example, it cannot include the connection ID or addressing
+information unless the values are encrypted.  Information that allows the server
+to distinguish between tokens from Retry and NEW_TOKEN MAY be accessible to
+entities other than the server.
 
 It is unlikely that the client port number is the same on two different
 connections; validating the port is therefore unlikely to be successful.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1625,8 +1625,8 @@ controller.  Clients are only constrained by the congestion controller.
 
 ### Token Construction
 
-Tokens sent in NEW_TOKEN frames or Retry packets MUST be constructed in a way
-that allows the server to identity how it was provided to a client.  These
+A token sent in a NEW_TOKEN frames or a Retry packet MUST be constructed in a
+way that allows the server to identity how it was provided to a client.  These
 tokens are carried in the same field, but require different handling from
 servers.
 
@@ -1692,10 +1692,10 @@ encrypted form in the token.
 
 A token issued with NEW_TOKEN MUST NOT include information that would allow
 values to be linked by an on-path observer to the connection on which it was
-issued.  For example, it cannot include the previous connection ID or addressing
-information unless the values are encrypted.  Information that allows the server
-to distinguish between tokens from Retry and NEW_TOKEN MAY be accessible to
-entities other than the server.
+issued, unless the values are encrypted.  For example, it cannot include the
+previous connection ID or addressing information.  Information that allows the
+server to distinguish between tokens from Retry and NEW_TOKEN MAY be accessible
+to entities other than the server.
 
 It is unlikely that the client port number is the same on two different
 connections; validating the port is therefore unlikely to be successful.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1623,6 +1623,20 @@ also constrained in what they can send by the limits set by the congestion
 controller.  Clients are only constrained by the congestion controller.
 
 
+### Token Construction
+
+Tokens sent in NEW_TOKEN frames or Retry packets MUST be constructed in a way
+that allows the server to identity how it was provided to a client.  These
+tokens are carried in the same field, but require different handling from
+servers.
+
+A token MUST NOT include information that would allow values to be linked by an
+on-path observer to the connection on which it was issued.  For example, it
+cannot include the connection ID or addressing information unless the values are
+encrypted.  Information that allows the server to distinguish between tokens
+from Retry and NEW_TOKEN MAY be accessible to entities other than the server.
+
+
 ### Address Validation using Retry Packets {#validate-retry}
 
 Upon receiving the client's Initial packet, the server can request address
@@ -1675,16 +1689,6 @@ one.  The client MUST NOT use the token provided in a Retry for future
 connections. Servers MAY discard any Initial packet that does not carry the
 expected token.
 
-A token send in NEW_TOKEN frames MUST be constructed in a way that allows the
-server to distinguish it from tokens that are sent in Retry packets.  These
-tokens are carried in the same field, but require different handling from
-servers.
-
-The token MUST NOT include information that would allow it to be linked by an
-on-path observer to the connection on which it was issued.  For example, it
-cannot include the connection ID or addressing information unless the values are
-encrypted.
-
 Unlike the token that is created for a Retry packet, there might be some time
 between when the token is created and when the token is subsequently used.
 Thus, a token SHOULD have an expiration time, which could be either an explicit
@@ -1703,12 +1707,12 @@ validate the client address without an additional round trip.
 A token allows a server to correlate activity between the connection where the
 token was issued and any connection where it is used.  Clients that want to
 break continuity of identity with a server MAY discard tokens provided using the
-NEW_TOKEN frame.  A token obtained in a Retry packet MUST be used immediately
-during the connection attempt and cannot be used in subsequent connection
-attempts.
+NEW_TOKEN frame.  In comparison, a token obtained in a Retry packet MUST be used
+immediately during the connection attempt and cannot be used in subsequent
+connection attempts.
 
-A client SHOULD NOT reuse a token in different connections.  Reusing a token
-allows connections to be linked by entities on the network path; see
+A client SHOULD NOT reuse a token for different connection attempts.  Reusing a
+token allows connections to be linked by entities on the network path; see
 {{migration-linkability}}.  A client MUST NOT reuse a token if it believes that
 its point of network attachment has changed since the token was last used; that
 is, if there is a change in its local IP address or network interface.  A client

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1675,9 +1675,10 @@ one.  The client MUST NOT use the token provided in a Retry for future
 connections. Servers MAY discard any Initial packet that does not carry the
 expected token.
 
-A token SHOULD be constructed in a way that allows the server to distinguish it
-from tokens that are sent in Retry packets as they are carried in the same
-field.
+A token send in NEW_TOKEN frames MUST be constructed in a way that allows the
+server to distinguish it from tokens that are sent in Retry packets.  These
+tokens are carried in the same field, but require different handling from
+servers.
 
 The token MUST NOT include information that would allow it to be linked by an
 on-path observer to the connection on which it was issued.  For example, it

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1692,7 +1692,7 @@ encrypted form in the token.
 
 A token issued with NEW_TOKEN MUST NOT include information that would allow
 values to be linked by an on-path observer to the connection on which it was
-issued.  For example, it cannot include the connection ID or addressing
+issued.  For example, it cannot include the previous connection ID or addressing
 information unless the values are encrypted.  Information that allows the server
 to distinguish between tokens from Retry and NEW_TOKEN MAY be accessible to
 entities other than the server.
@@ -1712,13 +1712,13 @@ NEW_TOKEN frame.  In comparison, a token obtained in a Retry packet MUST be used
 immediately during the connection attempt and cannot be used in subsequent
 connection attempts.
 
-A client SHOULD NOT reuse a token for different connection attempts.  Reusing a
-token allows connections to be linked by entities on the network path; see
-{{migration-linkability}}.  A client MUST NOT reuse a token if it believes that
-its point of network attachment has changed since the token was last used; that
-is, if there is a change in its local IP address or network interface.  A client
-needs to start the connection process over if there is any change in its local
-address prior to completing the handshake.
+A client SHOULD NOT reuse a NEW_TOKEN token for different connection attempts.
+Reusing a token allows connections to be linked by entities on the network path;
+see {{migration-linkability}}.  A client MUST NOT reuse a token if it believes
+that its point of network attachment has changed since the token was last used;
+that is, if there is a change in its local IP address or network interface.  A
+client needs to start the connection process over if there is any change in its
+local address prior to completing the handshake.
 
 Clients might receive multiple tokens on a single connection.  Aside from
 preventing linkability, any token can be used in any connection attempt.


### PR DESCRIPTION
Closes #3127.

Question for reviewers: do you think it necessary to point out that this distinction doesn't need to be hidden from other entities?  That's almost obvious based on the way that this results in different behaviour from servers, but should it be written down?