### PR TITLE
Clients can send GOAWAY too

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -696,8 +696,9 @@ requests or pushes were accepted prior to the connection shutdown.  Endpoints
 SHOULD abruptly terminate any requests or pushes that have identifiers greater
 than or equal to the smallest identifier sent in a GOAWAY frame.
 
-Endpoints MUST NOT initiate new requests or promise new pushes on the
-connection.  Clients MAY establish a new connection to send additional requests.
+Endpoints MUST NOT initiate new requests or promise new pushes on the connection
+after receipt of a GOAWAY from the peer.  Clients MAY establish a new connection
+to send additional requests.
 
 Some requests or pushes might already be in transit. If the endpoint has already
 sent requests or promised pushes with an identifier greater than or equal to

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -707,18 +707,24 @@ Endpoints MUST NOT initiate new requests or promise new pushes on the connection
 after receipt of a GOAWAY frame from the peer.  Clients MAY establish a new
 connection to send additional requests.
 
-Some requests or pushes might already be in transit.  Upon receipt of a GOAWAY
-frame, if the endpoint has already sent requests or promised pushes with an
-identifier greater than or equal to that received in a GOAWAY frame, those
-requests or pushes will not be processed.  The endpoint that initiated these
-requests or pushes MAY cancel them.  Clients MAY retry such requests on a
-different connection.
+Some requests or pushes might already be in transit:
 
-Requests on Stream IDs less than the Stream ID in a GOAWAY frame from the server
-might have been processed; their status cannot be known until a response is
-received, the stream is reset individually, or the connection terminates.
-Servers MAY reject individual requests on streams below the indicated ID if
-these requests were not processed.
+  - Upon receipt of a GOAWAY frame, if the client has already sent requests with
+    a Stream ID greater than or equal to the identifier received in a GOAWAY
+    frame, those requests will not be processed.  Clients can safely retry
+    unprocessed requests on a different connection.
+
+    Requests on Stream IDs less than the Stream ID in a GOAWAY frame from the
+    server might have been processed; their status cannot be known until a
+    response is received, the stream is reset individually, or the connection
+    terminates.
+
+    Servers MAY reject individual requests on streams below the indicated ID if
+    these requests were not processed.
+
+  - If a server receives a GOAWAY frame after having promised pushes with a Push
+    ID greater than or equal to the identifier received in a GOAWAY frame, those
+    pushes will not be accepted.
 
 Servers SHOULD send a GOAWAY frame when the closing of a connection is known
 in advance, even if the advance notice is small, so that the remote peer can
@@ -750,6 +756,11 @@ value indicates the client will reject pushes with Push IDs greater than or
 equal to this value.  Like the server, the client MAY send subsequent GOAWAY
 frames so long as the specified Push ID is strictly smaller than all previously
 sent values.
+
+Even when a GOAWAY indicates that a given request or push will not be processed
+or accepted upon receipt, the underlying transport resources still exist.  The
+endpoint that initiated these requests can cancel them to clean up transport
+state.
 
 Once all accepted requests and pushes have been processed, the endpoint can
 permit the connection to become idle, or MAY initiate an immediate closure of

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -709,10 +709,10 @@ sent requests or promised pushes with an identifier greater than or equal to
 that received in a GOAWAY frame, those requests or pushes will not be processed;
 requests MAY be retried by the client on a different connection.  The endpoint
 that initiated these requests or pushes MAY cancel them.  It is RECOMMENDED that
-the receiving endpoint explicitly reject such requests (see
-{{request-cancellation}}) or pushes (see {{frame-cancel-push}}) in order to
-clean up transport state for the affected streams.  Pushes which have been
-promised MAY still be fulfilled by the server.
+such requests be explicitly rejected (see {{request-cancellation}} and
+{{frame-cancel-push}}) upon receipt in order to clean up transport state for the
+affected streams.  Pushes which have been promised MAY still be fulfilled by the
+server.
 
 Requests on Stream IDs less than the Stream ID in a GOAWAY frame from the server
 might have been processed; their status cannot be known until a response is

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -716,8 +716,8 @@ Some requests or pushes might already be in transit:
 
     Requests on Stream IDs less than the Stream ID in a GOAWAY frame from the
     server might have been processed; their status cannot be known until a
-    response is received, the stream is reset individually, or the connection
-    terminates.
+    response is received, the stream is reset individually, another GOAWAY is
+    received, or the connection terminates.
 
     Servers MAY reject individual requests on streams below the indicated ID if
     these requests were not processed.

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -691,14 +691,14 @@ ID.  Requests or pushes with the indicated identifier or greater are rejected by
 the sender of the GOAWAY.  This identifier MAY be zero if no requests or pushes
 were processed.
 
-The information in the GOAWAY enables a client and server to agree on which
-requests or pushes were accepted prior to the connection shutdown.  Endpoints
-SHOULD abruptly terminate any requests or pushes that have identifiers greater
-than or equal to the smallest identifier sent in a GOAWAY frame.
+The information in the GOAWAY frame enables a client and server to agree on
+which requests or pushes were accepted prior to the connection shutdown.
+Endpoints SHOULD abruptly terminate any requests or pushes that have identifiers
+greater than or equal to the smallest identifier sent in a GOAWAY frame.
 
 Endpoints MUST NOT initiate new requests or promise new pushes on the connection
-after receipt of a GOAWAY from the peer.  Clients MAY establish a new connection
-to send additional requests.
+after receipt of a GOAWAY frame from the peer.  Clients MAY establish a new
+connection to send additional requests.
 
 Some requests or pushes might already be in transit. If the endpoint has already
 sent requests or promised pushes with an identifier greater than or equal to
@@ -762,8 +762,8 @@ This results in sending a QUIC CONNECTION_CLOSE frame to the peer; the error
 code in this frame indicates to the peer why the connection is being closed.
 See {{errors}} for error codes which can be used when closing a connection.
 
-Before closing the connection, a GOAWAY MAY be sent to allow the client to retry
-some requests.  Including the GOAWAY frame in the same packet as the QUIC
+Before closing the connection, a GOAWAY frame MAY be sent to allow the client to
+retry some requests.  Including the GOAWAY frame in the same packet as the QUIC
 CONNECTION_CLOSE frame improves the chances of the frame being received by
 clients.
 

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -739,8 +739,8 @@ GOAWAY frame with a value set to the maximum possible value (2^62-4 for servers,
 2^62-1 for clients). This ensures that the peer stops creating new requests or
 pushes. After allowing time for any in-flight requests or pushes to arrive, the
 endpoint can send another GOAWAY frame indicating which requests or pushes it
-will accept before the end of the connection. This ensures that a connection can
-be cleanly shut down without losing requests.
+might accept before the end of the connection. This ensures that a connection
+can be cleanly shut down without losing requests.
 
 A client has more flexibility in the value it chooses for the Push ID in a
 GOAWAY that it sends.  A value of 2^62 - 1 indicates that the server can

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -696,23 +696,23 @@ the sender of the GOAWAY.  This identifier MAY be zero if no requests or pushes
 were processed.
 
 The information in the GOAWAY frame enables a client and server to agree on
-which requests or pushes were accepted prior to the connection shutdown.
-Endpoints SHOULD abruptly terminate any requests or pushes that have identifiers
-greater than or equal to the smallest identifier sent in a GOAWAY frame.
+which requests or pushes were accepted prior to the connection shutdown. Upon
+sending a GOAWAY frame, the endpoint SHOULD explicitly cancel (see
+{{request-cancellation}} and {{frame-cancel-push}}) any requests or pushes that
+have identifiers greater than or equal to that indicated, in order to clean up
+transport state for the affected streams. The endpoint SHOULD continue to do so
+as more requests or pushes arrive.
 
 Endpoints MUST NOT initiate new requests or promise new pushes on the connection
 after receipt of a GOAWAY frame from the peer.  Clients MAY establish a new
 connection to send additional requests.
 
-Some requests or pushes might already be in transit. If the endpoint has already
-sent requests or promised pushes with an identifier greater than or equal to
-that received in a GOAWAY frame, those requests or pushes will not be processed;
-requests MAY be retried by the client on a different connection.  The endpoint
-that initiated these requests or pushes MAY cancel them.  It is RECOMMENDED that
-such requests be explicitly rejected (see {{request-cancellation}} and
-{{frame-cancel-push}}) upon receipt in order to clean up transport state for the
-affected streams.  Pushes which have been promised MAY still be fulfilled by the
-server.
+Some requests or pushes might already be in transit.  Upon receipt of a GOAWAY
+frame, if the endpoint has already sent requests or promised pushes with an
+identifier greater than or equal to that received in a GOAWAY frame, those
+requests or pushes will not be processed.  The endpoint that initiated these
+requests or pushes MAY cancel them.  Clients MAY retry such requests on a
+different connection.
 
 Requests on Stream IDs less than the Stream ID in a GOAWAY frame from the server
 might have been processed; their status cannot be known until a response is

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -739,7 +739,7 @@ ensures that a connection can be cleanly shut down without losing requests.
 
 A client has more flexibility in the value it chooses for the Push ID in a
 GOAWAY that it sends.  A value of 2^62 - 1 indicates that the server can
-continue fulfilling pushes promised while fulfilling outstanding requests, and
+continue fulfilling pushes promised while processing outstanding requests, and
 the client can continue granting push credit as needed (see
 {{frame-max-push-id}}). A smaller value indicates the client will reject pushes
 with Push IDs greater than or equal to this value.  Like the server, the client

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -696,18 +696,18 @@ requests or pushes were accepted prior to the connection shutdown.  Endpoints
 SHOULD abruptly terminate any requests or pushes that have identifiers greater
 than or equal to the smallest identifier sent in a GOAWAY frame.
 
-Endpoints MUST NOT initiate new requests or pushes on the connection with an
-identifier greater than or equal to the smallest identifier received in a GOAWAY
-frame.  Clients MAY establish a new connection to send additional requests.
+Endpoints MUST NOT initiate new requests or promise new pushes on the
+connection.  Clients MAY establish a new connection to send additional requests.
 
 Some requests or pushes might already be in transit. If the endpoint has already
-sent requests or pushes with an identifier greater than or equal to that
-received in a GOAWAY frame, those requests or pushes will not be processed;
+sent requests or promised pushes with an identifier greater than or equal to
+that received in a GOAWAY frame, those requests or pushes will not be processed;
 requests MAY be retried by the client on a different connection.  The endpoint
 that initiated these requests or pushes MAY cancel them.  It is RECOMMENDED that
 the receiving endpoint explicitly reject such requests (see
 {{request-cancellation}}) or pushes (see {{frame-cancel-push}}) in order to
-clean up transport state for the affected streams.
+clean up transport state for the affected streams.  Pushes which have been
+promised MAY still be fulfilled by the server.
 
 Requests on Stream IDs less than the Stream ID in a GOAWAY frame from the server
 might have been processed; their status cannot be known until a response is
@@ -738,12 +738,12 @@ ensures that a connection can be cleanly shut down without losing requests.
 
 A client has more flexibility in the value it chooses for the Push ID in a
 GOAWAY that it sends.  A value of 2^62 - 1 indicates that the server can
-continue initiating pushes to complete outstanding requests, and the client can
-continue granting push credit as needed (see {{frame-max-push-id}}).  A smaller
-value indicates the client will reject pushes with Push IDs greater than or
-equal to this value.  Like the server, the client MAY send subsequent GOAWAY
-frames so long as the specified Push ID is strictly smaller than all previously
-sent values.
+continue fulfilling pushes promised while fulfilling outstanding requests, and
+the client can continue granting push credit as needed (see
+{{frame-max-push-id}}). A smaller value indicates the client will reject pushes
+with Push IDs greater than or equal to this value.  Like the server, the client
+MAY send subsequent GOAWAY frames so long as the specified Push ID is strictly
+smaller than all previously sent values.
 
 Once all accepted requests and pushes have been processed, the endpoint can
 permit the connection to become idle, or MAY initiate an immediate closure of

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -734,16 +734,13 @@ frames indicating different identifiers, but MUST NOT increase the identifier
 value they send, since clients might already have retried unprocessed requests
 on another connection.
 
-A server that is attempting to gracefully shut down a connection can send an
-initial GOAWAY frame with the last Stream ID set to the maximum possible value
-for a client-initiated, bidirectional stream (i.e. 2^62-4 in case of QUIC
-version 1).  This GOAWAY frame signals to the client that a shutdown is imminent
-and that initiating further requests is prohibited. After allowing time for any
-in-flight requests to reach the server, the server can send another GOAWAY frame
-indicating which requests it will accept before the end of the connection. This
-ensures that a connection can be cleanly shut down without causing requests to
-fail.  This ensures that a connection can be cleanly shut down without losing
-requests.
+An endpoint that is attempting to gracefully shut down a connection can send a
+GOAWAY frame with a value set to the maximum possible value (2^62-4 for servers,
+2^62-1 for clients). This ensures that the peer stops creating new requests or
+pushes. After allowing time for any in-flight requests or pushes to arrive, the
+endpoint can send another GOAWAY frame indicating which requests or pushes it
+will accept before the end of the connection. This ensures that a connection can
+be cleanly shut down without losing requests.
 
 A client has more flexibility in the value it chooses for the Push ID in a
 GOAWAY that it sends.  A value of 2^62 - 1 indicates that the server can

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1905,7 +1905,7 @@ PING (0x6):
 
 GOAWAY (0x7):
 : GOAWAY does not contain an error code.  In the client to server direction,
-it carries a Push ID instead of a server initiated stream ID.
+  it carries a Push ID instead of a server initiated stream ID.
   See {{frame-goaway}}.
 
 WINDOW_UPDATE (0x8):

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -739,12 +739,12 @@ ensures that a connection can be cleanly shut down without losing requests.
 
 A client has more flexibility in the value it chooses for the Push ID in a
 GOAWAY that it sends.  A value of 2^62 - 1 indicates that the server can
-continue fulfilling pushes promised while processing outstanding requests, and
-the client can continue granting push credit as needed (see
-{{frame-max-push-id}}). A smaller value indicates the client will reject pushes
-with Push IDs greater than or equal to this value.  Like the server, the client
-MAY send subsequent GOAWAY frames so long as the specified Push ID is strictly
-smaller than all previously sent values.
+continue fulfilling pushes which have already been promised, and the client can
+continue granting push credit as needed (see {{frame-max-push-id}}). A smaller
+value indicates the client will reject pushes with Push IDs greater than or
+equal to this value.  Like the server, the client MAY send subsequent GOAWAY
+frames so long as the specified Push ID is strictly smaller than all previously
+sent values.
 
 Once all accepted requests and pushes have been processed, the endpoint can
 permit the connection to become idle, or MAY initiate an immediate closure of


### PR DESCRIPTION
A client initiated GOAWAY contains a Push ID.  The Push ID can be 2^62 - 1 if the client doesn't care how many more pushes the server wants to initiate before graceful shutdown.  It can be a smaller value if the client wishes to limit the pushes.

Fixes #2632