### PR TITLE
Improve language on evictable entries.

### DIFF
--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -205,9 +205,9 @@ If the dynamic table does not contain enough room for a new entry without
 evicting other entries, and the entries which would be evicted are not
 evictable, the encoder MUST NOT insert that entry into the dynamic table
 (including duplicates of existing entries). In order to avoid this, an encoder
-that uses the dynamic table has to keep track of each dynamic table referenced
-by each header block until that header block is acknowledged by the decoder (see
-{{header-acknowledgement}}).
+that uses the dynamic table has to keep track of each dynamic table entry
+referenced by each header block until that header block is acknowledged by the
+decoder (see {{header-acknowledgement}}).
 
 #### Avoiding Prohibited Insertions
 

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -188,28 +188,25 @@ input header list.
 QPACK is designed to contain the more complex state tracking to the encoder,
 while the decoder is relatively simple.
 
-### Reference Tracking
-
-An encoder MUST ensure that a header block which references a dynamic table
-entry is not processed by the decoder after the referenced entry has been
-evicted.  Hence the encoder needs to retain information about each compressed
-header block that references the dynamic table until that header block is
-acknowledged by the decoder (see {{header-acknowledgement}}).
-
 ### Blocked Dynamic Table Insertions {#blocked-insertion}
 
-A dynamic table entry is considered blocking and cannot be evicted until its
-insertion has been acknowledged and there are no outstanding unacknowledged
-references to the entry.  In particular, a dynamic table entry that has never
-been referenced can still be blocking.
+A dynamic table entry is blocking if its absolute index is larger than or equal
+to the Known Received Count, or if it is referenced by an unacknowledged header
+block.  In particular, a dynamic table entry that has never been referenced can
+still be blocking.
+
+Note that references on the encoder stream do not make an entry blocking,
+because those are guaranteed to be processed before the instruction that evicts
+the entry.
 
 An encoder MUST NOT insert an entry into the dynamic table (or duplicate an
 existing entry) if doing so would evict a blocking entry.  In order to avoid
-this, an encoder that uses the dynamic table has to keep track of blocking
-entries.
+this, the encoder needs to retain information about each header block that
+references the dynamic table until that header block is acknowledged by the
+decoder (see {{header-acknowledgement}}).
 
-Note:
-: A blocking entry is unrelated to a blocked stream, see {{blocked-streams}}.
+Note that a blocking entry is unrelated to a blocked stream, see
+{{blocked-streams}}.
 
 #### Avoiding Blocked Insertions
 

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -196,10 +196,10 @@ contains entries which cannot be evicted.
 A dynamic table entry cannot be evicted immediately after insertion, even if it
 has never been referenced. Once the insertion of a dynamic table entry has been
 acknowledged and there are no outstanding references to the entry in
-unacknowledged header blocks, the entry becomes evictable.  Note that references
-on the encoder stream do not prevent an entry from being evictable, because
-those references are guaranteed to be processed before the instruction that
-evicts the entry.
+unacknowledged header blocks, the entry becomes evictable.  Note that
+unacknowledged references on the encoder stream do not preclude the eviction of
+an entry, because those references are guaranteed to be processed before the
+instruction evicting the entry.
 
 If the dynamic table does not contain enough room for a new entry without
 evicting other entries, and the entries which would be evicted are not

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -190,10 +190,10 @@ while the decoder is relatively simple.
 
 ### Blocked Dynamic Table Insertions {#blocked-insertion}
 
-A dynamic table entry is blocking if its absolute index is larger than or equal
-to the Known Received Count, or if it is referenced by an unacknowledged header
-block.  In particular, a dynamic table entry that has never been referenced can
-still be blocking.
+A dynamic table entry is blocking if its insertion has not been acknowledged by
+the decoder, or if it is referenced by an unacknowledged header block.  In
+particular, a dynamic table entry that has never been referenced can still be
+blocking.
 
 Note that references on the encoder stream do not make an entry blocking,
 because those are guaranteed to be processed before the instruction that evicts

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -190,10 +190,10 @@ while the decoder is relatively simple.
 
 ### Blocked Dynamic Table Insertions {#blocked-insertion}
 
-A dynamic table entry is blocking if its insertion has not been acknowledged by
-the decoder, or if it is referenced by an unacknowledged header block.  In
-particular, a dynamic table entry that has never been referenced can still be
-blocking.
+A dynamic table entry is considered blocking and cannot be evicted until its
+insertion has been acknowledged and there are no outstanding unacknowledged
+references to the entry.  In particular, a dynamic table entry that has never
+been referenced can still be blocking.
 
 Note that references on the encoder stream do not make an entry blocking,
 because those are guaranteed to be processed before the instruction that evicts

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -197,9 +197,9 @@ A dynamic table entry cannot be evicted immediately after insertion, even if it
 has never been referenced. Once the insertion of a dynamic table entry has been
 acknowledged and there are no outstanding references to the entry in
 unacknowledged header blocks, the entry becomes evictable.  Note that
-unacknowledged references on the encoder stream do not preclude the eviction of
-an entry, because those references are guaranteed to be processed before the
-instruction evicting the entry.
+references on the encoder stream never preclude the eviction of an entry,
+because those references are guaranteed to be processed before the instruction
+evicting the entry.
 
 If the dynamic table does not contain enough room for a new entry without
 evicting other entries, and the entries which would be evicted are not


### PR DESCRIPTION
Add a note that references on the encoder stream do not block an entry
from eviction.  Trivial as it is, I overlooked this at first, and added quite
some unnecessary complexity that was eventually removed at
https://quiche.googlesource.com/quiche/+/b09d44167c543b80b2c27408dd1f9df3b07c9741.
My motivation here is to help future implementers to avoid this pitfall.

Merge redundant Reference Tracking section into Limits on Dynamic Table
Insertions section without relaxing requirements on the encoder.