### PR TITLE
s/up to/up to and including/ for clarity.

### DIFF
--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -588,7 +588,8 @@ The prefixed integer from Section 5.1 of [RFC7541] is used heavily throughout
 this document.  The format from [RFC7541] is used unmodified.  Note, however,
 that QPACK uses some prefix sizes not actually used in HPACK.
 
-QPACK implementations MUST be able to decode integers up to 62 bits long.
+QPACK implementations MUST be able to decode integers up to and including 62
+bits long.
 
 ### String Literals
 


### PR DESCRIPTION
This was suggested by dtikhonov at
https://github.com/quicwg/base-drafts/pull/2942/files/11edccf6ed3697ba785578712b54a42051bb090d#r337177688.