### PR TITLE
Packets on one path must not adjust values for a different path

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2096,7 +2096,7 @@ more likely to indicate an intentional migration rather than an attack.
 ## Loss Detection and Congestion Control {#migration-cc}
 
 The capacity available on the new path might not be the same as the old path.
-Packets sent on the old path SHOULD NOT contribute to congestion control or RTT
+Packets sent on the old path MUST NOT contribute to congestion control or RTT
 estimation for the new path.
 
 On confirming a peer's ownership of its new address, an endpoint MUST


### PR DESCRIPTION
The intent here was that either (a) you only ever have a singe CC context and you reset it for each path, or (b) you have a CC context for each path, in which case each context is strongly tied to a path and you don't need to reset anything (except when it's been a while and the previous values may no longer be valid, etc.). We require that everyone does at least (a), while not preventing folks who want to do extra work for a potential performance gain from doing (b).

Packets *can* contribute to the CC/RTT estimation for the old path if it's still around and you're willing to maintain that state, which is why this (mistakenly) was a SHOULD.

Closes #2909.