### PR TITLE
use key update for confirming the handshake

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -383,15 +383,26 @@ requirement that is based on the completion of the handshake depends on the
 perspective of the endpoint in question.
 
 
+### Handshake Acknowledged {#handshake-acknowledged}
+
+In this document, the TLS handshake is considered acknowledged at an endpoint
+when the handshake is complete and either of the following two conditions is
+met:
+
+- all the data sent using Handshake packets have been acknowledged
+- the peer initiates a key update ({{key-update}})
+
+When the handshake is acknowledged, the next 1-RTT packet that the endpoint
+sends MUST respond to the key update had it received a key update from peer as
+defined in {{key-update}}, else initiate a key update.
+
+
 ### Handshake Confirmed {#handshake-confirmed}
 
 In this document, the TLS handshake is considered confirmed at an endpoint when
-the following two conditions are met: the handshake is complete, and the
-endpoint has received an acknowledgment for a packet sent with 1-RTT keys.
-This second condition can be implemented by recording the lowest packet number
-sent with 1-RTT keys, and the highest value of the Largest Acknowledged field
-in any received 1-RTT ACK frame: once the latter is higher than or equal to the
-former, the handshake is confirmed.
+it receives a packet initiating a key update.  The transition from handshake
+acknowledged to handshake confirmed happens immediately when the endpoint
+receives a key update.
 
 
 ### Sending and Receiving Handshake Messages
@@ -1214,13 +1225,15 @@ TLS KeyUpdate message.  Endpoints MUST treat the receipt of a TLS KeyUpdate
 message as a connection error of type 0x10a, equivalent to a fatal TLS alert of
 unexpected_message (see {{tls-errors}}).
 
-An endpoint MUST NOT initiate the first key update until the handshake is
-confirmed ({{handshake-confirmed}}). An endpoint MUST NOT initiate a subsequent
-key update until it has received an acknowledgment for a packet sent at the
-current KEY_PHASE.  This can be implemented by tracking the lowest packet
-number sent with each KEY_PHASE, and the highest acknowledged packet number
-in the 1-RTT space: once the latter is higher than or equal to the former,
-another key update can be initiated.
+An endpoint MUST NOT initiate a key update until the handshake is acknowledged
+({{handshake-acknowledged}}).  Once the handshake is acknowledged, an endpoint
+initiates or responds to the first key update as defined in
+{{handshake-acknowledged}}.  An endpoint MUST NOT initiate a subsequent key
+update until it has received an acknowledgment for a packet sent at the current
+KEY_PHASE.  This can be implemented by tracking the lowest packet number sent
+with each KEY_PHASE, and the highest acknowledged packet number in the 1-RTT
+space: once the latter is higher than or equal to the former, another key update
+can be initiated.
 
 Endpoints MAY limit the number of keys they retain to two sets for removing
 packet protection and one set for protecting packets.  Older keys can be


### PR DESCRIPTION
As discussed in #2863, we need a signal that tells the peer that it can (or should) drop the Handshake keys.

That signal can be defined in two ways: a) drop Handshake keys, then signal the peer that the peer should also drop the Handshake keys, or b) retain the Handshake keys until the transmission of data ceases, then exchange a signal indicating that the transmission have ceased.

The problem with approach _a_ is that an endpoint would be mandated to retransmit 1-RTT packets carrying that signal until it receives an ACK. The solution that we have discussed when we considered adopting #3093 was to change the recovery draft to say that a PTO MUST elicit a new packet even if there's no data to be sent. But such a behavior is unnecessary from a recovery perspective, meaning that relying on recovery is prone to implementation errors.

Approach _b_ is simpler, and we have a guarantee that there would be no deadlocks, because we drop the keys only after both endpoints agree. Considering how late we are, I highly prefer having a safe design.

The other issue regarding handshake key discard is #3142. We need a mechanism that guarantees that the Handshake keys (and the original path used for exchanging Handshake packets) can be dropped before migration happens. As discussed in the issue, using a frame for signaling the completion of handshake does not work, unless we require the client to bundle frames (e.g., PATH_CHALLENGE and ACK) in certain ways.

This pull request adopts approach _b_, at the same time avoiding the frame bundling issue by using the KEY_PHASE bit as the signal. As the bit exists in every 1-RTT packet, using that bit to signal the confirmation of the handshake eliminates the delivery ordering problem.

The added bonus would be that we would be exercising key updates. In TLS 1.3 we've seen stacks ship without key updates because it is a feature seldomly used. That has caused interoperability issues. We can avoid that in QUIC.

Closes #2863
Closes #3142