### PR TITLE
Use the right connection ID

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4158,8 +4158,9 @@ The server includes a connection ID of its choice in the Source Connection ID
 field.  This value MUST not be equal to the Destination Connection ID field of
 the packet sent by the client.  A client MUST discard a Retry packet that
 contains a Source Connection ID field that is identical to the Destination
-Connection ID field of its Initial packet.  The client MUST use this connection
-ID in the Destination Connection ID field of subsequent packets that it sends.
+Connection ID field of its Initial packet.  The client MUST use the value from
+the Source Connection ID field of the Retry packet in the Destination Connection
+ID field of subsequent packets that it sends.
 
 A server MAY send Retry packets in response to Initial and 0-RTT packets.  A
 server can either discard or buffer 0-RTT packets that it receives.  A server


### PR DESCRIPTION
The use of "this" here was a bit ambiguous