### PR TITLE
clarify the scope of a NEW_TOKEN token

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1700,12 +1700,11 @@ connections; validating the port is therefore unlikely to be successful.
 
 A token received in a NEW_TOKEN frame is applicable to any server that the
 connection is considered authoritative for (e.g., server names included in the
-certificate).  A client MUST only use a token that is applicable to the server
-that the client is connecting to to.  If the client has a token received in a
-NEW_TOKEN frame that is applicable to a new connection attempt, it SHOULD
-include that value in the Token field of its Initial packet.  Including a token
-might allow the server to validate the client address without an additional
-round trip.
+certificate).  When connecting to a server for which the client retains an
+applicable and unused token, it SHOULD include that token in the Token field of
+its Initial packet.  Including a token might allow the server to validate the
+client address without an additional round trip.  A client MUST NOT include a
+token that is unapplicable to the server that it is connecting to.
 
 A token allows a server to correlate activity between the connection where the
 token was issued and any connection where it is used.  Clients that want to

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1704,7 +1704,7 @@ certificate).  When connecting to a server for which the client retains an
 applicable and unused token, it SHOULD include that token in the Token field of
 its Initial packet.  Including a token might allow the server to validate the
 client address without an additional round trip.  A client MUST NOT include a
-token that is unapplicable to the server that it is connecting to.
+token that is not applicable to the server that it is connecting to.
 
 A token allows a server to correlate activity between the connection where the
 token was issued and any connection where it is used.  Clients that want to

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1704,7 +1704,9 @@ certificate).  When connecting to a server for which the client retains an
 applicable and unused token, it SHOULD include that token in the Token field of
 its Initial packet.  Including a token might allow the server to validate the
 client address without an additional round trip.  A client MUST NOT include a
-token that is not applicable to the server that it is connecting to.
+token that is not applicable to the server that it is connecting to, unless the
+client has the knowledge that the server that issued the token and the server
+the client is connecting to are jointly managing the tokens.
 
 A token allows a server to correlate activity between the connection where the
 token was issued and any connection where it is used.  Clients that want to

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1698,10 +1698,14 @@ encrypted form in the token.
 It is unlikely that the client port number is the same on two different
 connections; validating the port is therefore unlikely to be successful.
 
-If the client has a token received in a NEW_TOKEN frame on a previous connection
-to what it believes to be the same server, it SHOULD include that value in the
-Token field of its Initial packet.  Including a token might allow the server to
-validate the client address without an additional round trip.
+A token received in a NEW_TOKEN frame is applicable against the servers that the
+connection is considered authoritative for (e.g., server names included in the
+certificate).  A client MUST only use a token that is applicable to the server
+that the client is connecting to to.  If the client has a token received in a
+NEW_TOKEN frame that is applicable to a new connection attempt, it SHOULD
+include that value in the Token field of its Initial packet.  Including a token
+might allow the server to validate the client address without an additional
+round trip.
 
 A token allows a server to correlate activity between the connection where the
 token was issued and any connection where it is used.  Clients that want to

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1698,7 +1698,7 @@ encrypted form in the token.
 It is unlikely that the client port number is the same on two different
 connections; validating the port is therefore unlikely to be successful.
 
-A token received in a NEW_TOKEN frame is applicable against the servers that the
+A token received in a NEW_TOKEN frame is applicable to any server that the
 connection is considered authoritative for (e.g., server names included in the
 certificate).  A client MUST only use a token that is applicable to the server
 that the client is connecting to to.  If the client has a token received in a


### PR DESCRIPTION
This PR clarifies that the scope of a NEW_TOKEN is equivalent to that of the TLS connection (i.e., the scope of the server certificate), in a minimalistic way.

Closes #3155.