### PR TITLE
Backoff on CONNECTION_CLOSE

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2391,12 +2391,12 @@ before sending additional packets or increase the time between packets.
 
 An endpoint is allowed to drop the packet protection keys when entering the
 closing period ({{draining}}) and send a packet containing a CONNECTION_CLOSE in
-response to any UDP datagram that is received.  However, an endpoint without the packet
-protection keys cannot identify and discard invalid packets.  To avoid creating
-an unwitting amplification attack, such endpoints MUST reduce the frequency with
-which it sends packets containing a CONNECTION_CLOSE frame.  To minimize the
-state that an endpoint maintains for a closing connection, endpoints MAY send
-the exact same packet.
+response to any UDP datagram that is received.  However, an endpoint without the
+packet protection keys cannot identify and discard invalid packets.  To avoid
+creating an unwitting amplification attack, such endpoints MUST reduce the
+frequency with which it sends packets containing a CONNECTION_CLOSE frame.  To
+minimize the state that an endpoint maintains for a closing connection,
+endpoints MAY send the exact same packet.
 
 Note:
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2393,10 +2393,9 @@ An endpoint is allowed to drop the packet protection keys when entering the
 closing period ({{draining}}).  However, an endpoint without the packet
 protection keys cannot identify and discard invalid packets.  To avoid creating
 an unwitting amplification attack, such endpoints MUST reduce the frequency with
-which it sends packets containing a CONNECTION_CLOSE frame.
-
-To minimize the state that an endpoint maintains for a closing connection,
-endpoints MAY send the exact same packet.
+which it sends packets containing a CONNECTION_CLOSE frame.  To minimize the
+state that an endpoint maintains for a closing connection, endpoints MAY send
+the exact same packet.
 
 Note:
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2381,17 +2381,17 @@ implicitly reset.
 
 After sending a CONNECTION_CLOSE frame, an endpoint immediately enters the
 closing state.  During the closing period, an endpoint that sends a
-CONNECTION_CLOSE frame SHOULD respond to any packet that it receives with
-another packet containing a CONNECTION_CLOSE frame, until it receives a packet
-that contains a CONNECTION_CLOSE frame.  However, such an endpoint SHOULD limit
-the number of packets it generates containing a CONNECTION_CLOSE frame.  For
-instance, an endpoint could progressively increase the number of packets that it
-receives before sending additional packets or increase the time between packets.
-An endpoint that drops the packet protection keys when entering the closing
-period and therefore being unable to decrypt the incoming packets MUST
-exponentially back off the frequency in which it sends packets containing
-CONNECTION_CLOSE frames.  To minimize the state that an endpoint maintains for a
-closing connection, endpoints MAY send the exact same packet.
+CONNECTION_CLOSE frame SHOULD respond to any incoming packet that can be
+decrypted with another packet containing a CONNECTION_CLOSE frame.  However,
+such an endpoint SHOULD limit the number of packets it generates containing a
+CONNECTION_CLOSE frame.  For instance, an endpoint could progressively increase
+the number of packets that it receives before sending additional packets or
+increase the time between packets.  An endpoint that drops the packet protection
+keys when entering the closing period and therefore being unable to decrypt the
+incoming packets MUST exponentially back off the frequency in which it sends
+packets containing CONNECTION_CLOSE frames.  To minimize the state that an
+endpoint maintains for a closing connection, endpoints MAY send the exact same
+packet.
 
 Note:
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2390,7 +2390,8 @@ endpoint could progressively increase the number of packets that it receives
 before sending additional packets or increase the time between packets.
 
 An endpoint is allowed to drop the packet protection keys when entering the
-closing period ({{draining}}).  However, an endpoint without the packet
+closing period ({{draining}}) and send a packet containing a CONNECTION_CLOSE in
+response to any UDP datagram that is received.  However, an endpoint without the packet
 protection keys cannot identify and discard invalid packets.  To avoid creating
 an unwitting amplification attack, such endpoints MUST reduce the frequency with
 which it sends packets containing a CONNECTION_CLOSE frame.  To minimize the

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2389,10 +2389,11 @@ of packets it generates containing a CONNECTION_CLOSE frame.  For instance, an
 endpoint could progressively increase the number of packets that it receives
 before sending additional packets or increase the time between packets.
 
-An endpoint that drops the packet protection keys when entering the closing
-period and therefore being unable to decrypt the incoming packets MUST
-exponentially back off the frequency in which it sends packets containing
-CONNECTION_CLOSE frames.
+An endpoint is allowed to drop the packet protection keys when entering the
+closing period ({{draining}}).  However, an endpoint without the packet
+protection keys cannot identify and discard invalid packets.  To avoid creating
+an unwitting amplification attack, such endpoints MUST reduce the frequency with
+which it sends packets containing a CONNECTION_CLOSE frame.
 
 To minimize the state that an endpoint maintains for a closing connection,
 endpoints MAY send the exact same packet.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2380,18 +2380,22 @@ streams to immediately become closed; open streams can be assumed to be
 implicitly reset.
 
 After sending a CONNECTION_CLOSE frame, an endpoint immediately enters the
-closing state.  During the closing period, an endpoint that sends a
-CONNECTION_CLOSE frame SHOULD respond to any incoming packet that can be
-decrypted with another packet containing a CONNECTION_CLOSE frame.  However,
-such an endpoint SHOULD limit the number of packets it generates containing a
-CONNECTION_CLOSE frame.  For instance, an endpoint could progressively increase
-the number of packets that it receives before sending additional packets or
-increase the time between packets.  An endpoint that drops the packet protection
-keys when entering the closing period and therefore being unable to decrypt the
-incoming packets MUST exponentially back off the frequency in which it sends
-packets containing CONNECTION_CLOSE frames.  To minimize the state that an
-endpoint maintains for a closing connection, endpoints MAY send the exact same
-packet.
+closing state.
+
+During the closing period, an endpoint that sends a CONNECTION_CLOSE frame
+SHOULD respond to any incoming packet that can be decrypted with another packet
+containing a CONNECTION_CLOSE frame.  Such an endpoint SHOULD limit the number
+of packets it generates containing a CONNECTION_CLOSE frame.  For instance, an
+endpoint could progressively increase the number of packets that it receives
+before sending additional packets or increase the time between packets.
+
+An endpoint that drops the packet protection keys when entering the closing
+period and therefore being unable to decrypt the incoming packets MUST
+exponentially back off the frequency in which it sends packets containing
+CONNECTION_CLOSE frames.
+
+To minimize the state that an endpoint maintains for a closing connection,
+endpoints MAY send the exact same packet.
 
 Note:
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2389,8 +2389,8 @@ instance, an endpoint could progressively increase the number of packets that it
 receives before sending additional packets or increase the time between packets.
 An endpoint that drops the packet protection keys when entering the closing
 period and therefore being unable to decrypt the incoming packets MUST
-exponentially back off the frequency in which it sends a packet containing a
-CONNECTION_CLOSE frame.  To minimize the state that an endpoint maintains for a
+exponentially back off the frequency in which it sends packets containing
+CONNECTION_CLOSE frames.  To minimize the state that an endpoint maintains for a
 closing connection, endpoints MAY send the exact same packet.
 
 Note:

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2379,15 +2379,19 @@ terminate the connection immediately.  A CONNECTION_CLOSE frame causes all
 streams to immediately become closed; open streams can be assumed to be
 implicitly reset.
 
-After sending a CONNECTION_CLOSE frame, endpoints immediately enter the closing
-state.  During the closing period, an endpoint that sends a CONNECTION_CLOSE
-frame SHOULD respond to any packet that it receives with another packet
-containing a CONNECTION_CLOSE frame.  To minimize the state that an endpoint
-maintains for a closing connection, endpoints MAY send the exact same packet.
-However, endpoints SHOULD limit the number of packets they generate containing a
-CONNECTION_CLOSE frame.  For instance, an endpoint could progressively increase
-the number of packets that it receives before sending additional packets or
-increase the time between packets.
+After sending a CONNECTION_CLOSE frame, an endpoint immediately enters the
+closing state.  During the closing period, an endpoint that sends a
+CONNECTION_CLOSE frame SHOULD respond to any packet that it receives with
+another packet containing a CONNECTION_CLOSE frame, until it receives a packet
+that contains a CONNECTION_CLOSE frame.  However, such an endpoint SHOULD limit
+the number of packets it generates containing a CONNECTION_CLOSE frame.  For
+instance, an endpoint could progressively increase the number of packets that it
+receives before sending additional packets or increase the time between packets.
+An endpoint that drops the packet protection keys when entering the closing
+period and therefore being unable to decrypt the incoming packets MUST
+exponentially back off the frequency in which it sends a packet containing a
+CONNECTION_CLOSE frame.  To minimize the state that an endpoint maintains for a
+closing connection, endpoints MAY send the exact same packet.
 
 Note:
 


### PR DESCRIPTION
The PR clarifies the following:

* An endpoint that drops the keys when entering closing state MUST back-off the frequency of CONNECTION_CLOSE packets that it sends.
* An endpoint that does not drop the keys stops sending CONNECTION_CLOSE packet once it receives a packet containing CONNECTION_CLOSE.

The first point is what we have discussed in #3095. The second point is an editorial clarification, which is explained far below in the original text ~~something we have not discussed, though I think it has been implied.~~

Closes #3095.