### PR TITLE
MUST limit bursts to the initial congestion window

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -744,9 +744,9 @@ their delivery to the peer.
 
 Sending multiple packets into the network without any delay between them
 creates a packet burst that might cause short-term congestion and losses.
-Implementations MUST either use pacing or limit such bursts to the minimum
-of 10 * kMaxDatagramSize and max(2* kMaxDatagramSize, 14720)), the same
-as the recommended initial congestion window.
+Implementations MUST either use pacing or limit such bursts to the initial
+congestion window, which in this document is recommended to be the min of
+10 * kMaxDatagramSize and max(2* kMaxDatagramSize, 14720)).
 
 As an example of a well-known and publicly available implementation of a flow
 pacer, implementers are referred to the Fair Queue packet scheduler (fq qdisc)

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -745,7 +745,7 @@ their delivery to the peer.
 Sending multiple packets into the network without any delay between them
 creates a packet burst that might cause short-term congestion and losses.
 Implementations MUST either use pacing or limit such bursts to the initial
-congestion window, which is recommended to be the min of
+congestion window, which is recommended to be the minimum of
 10 * kMaxDatagramSize and max(2* kMaxDatagramSize, 14720)).
 
 As an example of a well-known and publicly available implementation of a flow

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -745,7 +745,7 @@ their delivery to the peer.
 Sending multiple packets into the network without any delay between them
 creates a packet burst that might cause short-term congestion and losses.
 Implementations MUST either use pacing or limit such bursts to the initial
-congestion window, which in this document is recommended to be the min of
+congestion window, which is recommended to be the min of
 10 * kMaxDatagramSize and max(2* kMaxDatagramSize, 14720)).
 
 As an example of a well-known and publicly available implementation of a flow


### PR DESCRIPTION
From discussion on #3106 people prefer the normative text to apply to the initial congestion window, not the specific value recommended in the recovery document.
https://github.com/quicwg/base-drafts/pull/3106#discussion_r338921935