### PR TITLE
Server sends a PING-only packet if it's limited

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -500,9 +500,9 @@ data.
 
 Until the server has validated the client's address on the path, the amount of
 data it can send is limited, as specified in Section 8.1 of {{QUIC-TRANSPORT}}.
-If the limit has been reached when the PTO expires, a PING with no PADDING MUST
-be sent.  This packet elicits a full-sized Initial packet from the client,
-allowing the server to send data again.
+If the limit has been reached when the PTO expires, a single packet containing
+a PING with no PADDING MUST be sent.  This packet elicits a full-sized Initial
+packet from the client, allowing the server to send data again.
 
 Prior to handshake completion, when few to none RTT samples have been
 generated, it is possible that the probe timer expiration is due to an

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -502,8 +502,7 @@ Until the server has validated the client's address on the path, the amount of
 data it can send is limited, as specified in Section 8.1 of {{QUIC-TRANSPORT}}.
 If the limit has been reached when the PTO expires, a PING with no PADDING MUST
 be sent.  This packet elicits a full-sized Initial packet from the client,
-allowing the server to send any data in need of transmission or
-re-transmission.
+allowing the server to send data again.
 
 Prior to handshake completion, when few to none RTT samples have been
 generated, it is possible that the probe timer expiration is due to an

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -558,6 +558,7 @@ payloads each time reduces the chances of spurious retransmission.
 
 ### Loss Detection {#pto-loss}
 
+
 Delivery or loss of packets in flight is established when an ACK frame is
 received that newly acknowledges one or more packets.
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -556,8 +556,8 @@ or sending different payloads.  Sending the same payload may be simpler
 and ensures the highest priority frames arrive first.  Sending different
 payloads each time reduces the chances of spurious retransmission.
 
-### Loss Detection {#pto-loss}
 
+### Loss Detection {#pto-loss}
 
 Delivery or loss of packets in flight is established when an ACK frame is
 received that newly acknowledges one or more packets.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1592,10 +1592,11 @@ server has successfully processed a Handshake packet from the client, it can
 consider the client address to have been validated.
 
 Prior to validating the client address, servers MUST NOT send more than three
-times as many bytes as the number of bytes they have received.  This limits the
-magnitude of any amplification attack that can be mounted using spoofed source
-addresses.  In determining this limit, servers only count the size of
-successfully processed packets.
+times as many bytes as the number of bytes they have received, except upon the
+probe timeout expiring, when servers can send a single PING-only packet.
+This limits the magnitude of any amplification attack that can be mounted
+using spoofed source addresses.  In determining this limit, servers only count
+the size of successfully processed packets.
 
 Clients MUST ensure that UDP datagrams containing Initial packets have UDP
 payloads of at least 1200 bytes, adding padding to packets in the datagram as


### PR DESCRIPTION
If a server is limited by the amplification factor when the PTO expires, send a PING-only packet instead of sending nothing.

This also removes the client complexity of continuing to arm the PTO and send even when there's nothing in flight and nothing to send.

Fixes #3161 and #3070 