### PR TITLE
Forbid use of application-level close in Initial, Handshake packets

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -332,7 +332,7 @@ encryption levels:
   0x1c) MAY appear in packets of any encryption level except 0-RTT.
 
 - CONNECTION_CLOSE frames signaling application errors (type 0x1d) MUST only be
-  sent in 1-RTT level.
+  sent in packets at the 1-RTT encryption level.
 
 - ACK frames MAY appear in packets of any encryption level other than 0-RTT, but
   can only acknowledge packets which appeared in that packet number space.

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -328,8 +328,11 @@ encryption levels:
 
 - PADDING and PING frames MAY appear in packets of any encryption level.
 
-- CRYPTO and CONNECTION_CLOSE frames MAY appear in packets of any encryption
-  level except 0-RTT.
+- CRYPTO frames and CONNECTION_CLOSE frames signaling errors at QUIC layer (type
+  0x1c) MAY appear in packets of any encryption level except 0-RTT.
+
+- CONNECTION_CLOSE frames signaling application errors (type 0x1d) MUST only be
+  sent in 1-RTT level.
 
 - ACK frames MAY appear in packets of any encryption level other than 0-RTT, but
   can only acknowledge packets which appeared in that packet number space.

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -328,8 +328,8 @@ encryption levels:
 
 - PADDING and PING frames MAY appear in packets of any encryption level.
 
-- CRYPTO frames and CONNECTION_CLOSE frames signaling errors at QUIC layer (type
-  0x1c) MAY appear in packets of any encryption level except 0-RTT.
+- CRYPTO frames and CONNECTION_CLOSE frames signaling errors at the QUIC layer
+  (type 0x1c) MAY appear in packets of any encryption level except 0-RTT.
 
 - CONNECTION_CLOSE frames signaling application errors (type 0x1d) MUST only be
   sent in packets at the 1-RTT encryption level.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -5504,7 +5504,7 @@ Reason Phrase:
   This SHOULD be a UTF-8 encoded string {{!RFC3629}}.
 
 The application-specific variant of CONNECTION_CLOSE (type 0x1d) can only be
-sent using an 1-RTT packet ({{QUIC-TLS}}; section 4).  An application can close
+sent using an 1-RTT packet ({{QUIC-TLS}}, Section 4).  An application can close
 the connection during the handshake by sending a CONNECTION_CLOSE frame (type
 0x1c) with an error code of 0x15a ("user_canceled" alert; see {{?TLS13}}) in an
 Initial or a Handshake packet.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -5504,10 +5504,10 @@ Reason Phrase:
   This SHOULD be a UTF-8 encoded string {{!RFC3629}}.
 
 The application-specific variant of CONNECTION_CLOSE (type 0x1d) can only be
-sent using an 1-RTT packet ({{QUIC-TLS}}, Section 4).  An application can close
-the connection during the handshake by sending a CONNECTION_CLOSE frame (type
-0x1c) with an error code of 0x15a ("user_canceled" alert; see {{?TLS13}}) in an
-Initial or a Handshake packet.
+sent using an 1-RTT packet ({{QUIC-TLS}}, Section 4).  An application that
+wishes to abandon a connection during the handshake can send a CONNECTION_CLOSE
+frame (type 0x1c) with an error code of 0x15a ("user_canceled" alert; see
+{{?TLS13}}) in an Initial or a Handshake packet.
 
 
 ## Extension Frames

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -5504,10 +5504,10 @@ Reason Phrase:
   This SHOULD be a UTF-8 encoded string {{!RFC3629}}.
 
 The application-specific variant of CONNECTION_CLOSE (type 0x1d) can only be
-sent using an 1-RTT packet ({{QUIC-TLS}}, Section 4).  An application that
-wishes to abandon a connection during the handshake can send a CONNECTION_CLOSE
-frame (type 0x1c) with an error code of 0x15a ("user_canceled" alert; see
-{{?TLS13}}) in an Initial or a Handshake packet.
+sent using an 1-RTT packet ({{QUIC-TLS}}, Section 4).  When an application
+wishes to abandon a connection during the handshake, an endpoint can send a
+CONNECTION_CLOSE frame (type 0x1c) with an error code of 0x15a ("user_canceled"
+alert; see {{?TLS13}}) in an Initial or a Handshake packet.
 
 
 ## Extension Frames

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -5503,6 +5503,12 @@ Reason Phrase:
   zero length if the sender chooses to not give details beyond the Error Code.
   This SHOULD be a UTF-8 encoded string {{!RFC3629}}.
 
+The application-specific variant of CONNECTION_CLOSE (type 0x1d) can only be
+sent using an 1-RTT packet ({{QUIC-TLS}}; section 4).  An application can close
+the connection during the handshake by sending a CONNECTION_CLOSE frame (type
+0x1c) with an error code of 0x15a ("user_canceled" alert; see {{?TLS13}}) in an
+Initial or a Handshake packet.
+
 
 ## Extension Frames
 


### PR DESCRIPTION
As discussed in #3158, use of application-level close is problematic in Initial / Handshake packets.

This PR address the issue by limiting the use of that to 1-RTT packets, at the same time advising applications to use user_canceled TLS alert to abort the connection during the handshake.

Closes #3158.