### PR TITLE
token-based greasing / initial packet protection

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2736,7 +2736,7 @@ which is comprised of:
 
 * Packet type modifier; a two-bit value that obfuscates the Long Packet Type of
   a long header packet ({{long-header}}).  The long packet type bits of a long
-  header packet is encoded as an bti-wise exclusive or (XOR) of the packet type
+  header packet is encoded as an bit-wise exclusive or (XOR) of the packet type
   modifier and the type numbers defined in {{long-packet-types}}.
 
 * Initial salt; a 16-byte binary blob that is to be used in place of the initial

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2744,8 +2744,8 @@ which is comprised of:
 
 A server advertises these values using a NEW_TOKEN frame {{frame-new-token}}.
 The token MUST permit the server to recover this alternative initial set.  This
-property can be achieved for example by embedding the alternative version number
-in the encrypted token.
+property can be achieved for example by embedding the alternative initial set in
+the encrypted token.
 
 For the alternative initial set to work, all the servers within the scope of a
 NEW_TOKEN token are required to have a shared knowledge of the alternative

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -5691,12 +5691,6 @@ TRANSPORT_PARAMETER_ERROR (0x8):
   an invalid value, was absent even though it is mandatory, was present though
   it is forbidden, or is otherwise in error.
 
-VERSION_NEGOTIATION_ERROR (0x9):
-
-: An endpoint received a packet with an unexpected version.  This error code
-  indicates a potential version downgrade attack.
-
-
 PROTOCOL_VIOLATION (0xA):
 
 : An endpoint detected an error with protocol compliance that was not covered by

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2768,8 +2768,8 @@ specified in this document as its alternative initial set.
 
 When the server receives an Initial packet containing a valid NEW_TOKEN token,
 and the value of the version number field of that Initial packet does not match
-the version number expected for that token, the server MUST close the connection
-with an VERSION_NEGOTIATION_ERROR.
+the alternative version number embedded to or associated with that token, the
+server MUST close the connection with an VERSION_NEGOTIATION_ERROR.
 
 When a client uses a token supplied by a NEW_TOKEN frame, it MUST use the
 provided alternative initial set instead of using the default values defined in

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2740,8 +2740,10 @@ which is comprised of:
   the initial salt defined in section 5.2 of {{QUIC-TLS}}.
 
 A server advertises these values using a NEW_TOKEN frame {{frame-new-token}}.
-The token MUST include or associated with the alternative version number with
-which it can be used.
+The token MUST permit the server to recover at least the alternative version
+number being associated to the token.  This property can be achieved for example
+by embedding the alternative version number in the encrypted token.  Other
+elements of the alternative initial set MAY also be associated with the token.
 
 Typically, a server would act in the following steps:
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2727,7 +2727,7 @@ streams that are prematurely cancelled by either endpoint.
 # Alternative Initial Set {#alternative-initial}
 
 In order to avoid ossification of the cleartext and obfuscated fields of QUIC
-packets, a server can announce an alternative set of initial values to be used,
+packets, a server announces an alternative set of initial values to be used,
 which is comprised of:
 
 * Alternative version number; a 32-bit unsigned number that is to be presented

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2764,9 +2764,16 @@ version.  A server that is incapable of issuing a different version number,
 packet type modifier, or initial salt MAY advertise the original values
 specified in this document as its alternative initial set.
 
+When the server receives an Initial packet containing a valid NEW_TOKEN token,
+and the value of the version number field of that Initial packet does not match
+the version number expected for that token, the server MUST close the connection
+with an VERSION_NEGOTIATION_ERROR.
+
 When a client uses a token supplied by a NEW_TOKEN frame, it MUST use the
 provided alternative initial set instead of using the default values defined in
-this document.
+this document.  When the client downgrades to the original version defined in
+this document due to receipt of a Version Negotiation packet, it MUST continue
+sending the same token.
 
 Other specifications MAY define other methods for distributing or deducing the
 alternative initial set.
@@ -5662,6 +5669,12 @@ TRANSPORT_PARAMETER_ERROR (0x8):
 : An endpoint received transport parameters that were badly formatted, included
   an invalid value, was absent even though it is mandatory, was present though
   it is forbidden, or is otherwise in error.
+
+VERSION_NEGOTIATION_ERROR (0x9):
+
+: An endpoint received a packet with an unexpected version.  This error code
+  indicates a potential version downgrade attack.
+
 
 PROTOCOL_VIOLATION (0xA):
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2751,12 +2751,12 @@ the alternative initial set.
 
 When the client reconnects to the server by using the provided token and the
 alternative initial set, the server first checks if the version number field of
-the incoming packet is within the set of the alternative version numbers it
-advertises, then if that is the case, applies the packet type modifier to
-recover the correct packet type.  If the recovered packet type is an Initial
-packet and it contains a NEW_TOKEN token, the server decrypts that token and
-recovers the alternative initial salt, uses that to decrypt the payload of the
-Initial packet.
+the incoming packet contains one of the alternative version numbers it
+advertises, then if that is the case, applies the corresponding packet type
+modifier to recover the correct packet type.  If the recovered packet type is an
+Initial packet and that packet contains a NEW_TOKEN token, the server decrypts
+the embedded token and recovers the alternative initial salt, uses that to
+decrypt the payload of the Initial packet.
 
 When the server is incapable of determining the alternative initial salt, it can
 send a Version Negotiation packet that instructs the client to use the default

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2764,7 +2764,7 @@ values as their alternative initial sets.
 
 ## Server Behavior
 
-A server that advertises alternative initial sets would typcially act in the
+Typically, a server that advertises alternative initial sets would act in the
 following steps:
 
 * The server pre-allocates a set of unused version numbers as the alternative

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2794,7 +2794,7 @@ following steps:
   alternative initial salt that is to be used for unprotecting the packet
   payload.
 
-Instead of associating a new alternative initial salt to every NEW_TOKEN token,
+Instead of associating a new alternative initial salt with every NEW_TOKEN token,
 a server might map a fixed salt to each of the alternative version numbers it
 issues.  Such design is not recommended, as an active attacker might build a
 list of known alternative version numbers and their initial salts and use that

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2790,7 +2790,7 @@ following steps:
   version number, the server embeds the NEW_TOKEN token found in the Initial
   packet within the retry token it issues.  Once the server receives a response
   from the client carrying that retry token and the path is validated, it
-  decrypts the NEW_TOKEN token embedded in the retry token to recover the
+  decrypts the NEW_TOKEN token embedded within the retry token to recover the
   alternative initial salt that is to be used for unprotecting the packet
   payload.
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -5083,7 +5083,7 @@ NEW_TOKEN frames contain the following fields:
 Lifetime:
 
 : Indicates the lifetime of the values contained in this frame in milliseconds.
-  An endpoint MUST NOT use the values provided by this frame, once the time that
+  An endpoint MUST NOT use the values provided by this frame once the time that
   has elapsed since receipt becomes greater than the value of this field.
 
 Alternative Version Number:

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2743,10 +2743,9 @@ which is comprised of:
   the initial salt defined in section 5.2 of {{QUIC-TLS}}.
 
 A server advertises these values using a NEW_TOKEN frame {{frame-new-token}}.
-The token MUST permit the server to recover at least the alternative version
-number being associated to the token.  This property can be achieved for example
-by embedding the alternative version number in the encrypted token.  Other
-elements of the alternative initial set MAY also be associated with the token.
+The token MUST permit the server to recover this alternative initial set.  This
+property can be achieved for example by embedding the alternative version number
+in the encrypted token.
 
 For the alternative initial set to work, all the servers within the scope of a
 NEW_TOKEN token are required to have a shared knowledge of the alternative

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2740,6 +2740,8 @@ which is comprised of:
   the initial salt defined in section 5.2 of {{QUIC-TLS}}.
 
 A server advertises these values using a NEW_TOKEN frame {{frame-new-token}}.
+The token MUST include or associated with the alternative version number with
+which it can be used.
 
 Typically, a server would pre-allocate a set of unused version numbers as the
 alternative version numbers, associating each of those version numbers with a

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -5053,7 +5053,7 @@ The NEW_TOKEN frame is as follows:
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                Alternative Version Number (32)                |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|PTM|R R R R R R|
+|R R R R R R|PTM|
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                                                               |
 +                                                               +
@@ -5075,15 +5075,15 @@ Alternative Version Number:
 
 : The alternative version number to be used (see {{alternative-initial}}).
 
-Packet Type Modifier (PTM):
-
-: The packet type modifier to be used.
-
 Reserved (R):
 
 : Reserved bits.  These bits MUST be set to zero.  An endpoint MUST treat
   the receipt of a NEW_TOKEN frame carrying a non-zero reserved bit as a
   connection error of type FRAME_ENCODING_ERROR.
+
+Packet Type Modifier (PTM):
+
+: The packet type modifier to be used.
 
 Alternative Initial Salt:
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2789,6 +2789,23 @@ following steps:
   decrypts the embedded token and recovers the alternative initial salt, uses
   that to decrypt the payload of the Initial packet.
 
+* When sending a Retry in response to an Initial packet carrying an alternative
+  version number, the server embeds the NEW_TOKEN token found in the Initial
+  packet within the retry token it issues.  Once the server receives a response
+  from the client carrying that retry token and the path is validated, it
+  decrypts the NEW_TOKEN token embedded in the retry token to recover the
+  alternative initial salt that is to be used for unprotecting the packet
+  payload.
+
+Instead of associating a new alternative initial salt to every NEW_TOKEN token,
+a server might map a fixed salt to each of the alternative version numbers it
+issues.  Such design is not recommended, as an active attacker might build a
+list of known alternative version numbers and their initial salts and use that
+list to decrypt the payload of Initial packets using those alternative version
+numbers.  But still, having a set of version numbers and initial salts used
+concurrently is considered better than just using the default values of QUIC in
+terms of preventing ossification.
+
 A server MUST NOT send a Version Negotitation packet in response to a long
 header packet with an alternative version number it has advertised.
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2794,14 +2794,14 @@ following steps:
   alternative initial salt that is to be used for unprotecting the packet
   payload.
 
-Instead of associating a new alternative initial salt with every NEW_TOKEN token,
-a server might map a fixed salt to each of the alternative version numbers it
-issues.  Such design is not recommended, as an active attacker might build a
-list of known alternative version numbers and their initial salts and use that
-list to decrypt the payload of Initial packets using those alternative version
-numbers.  But still, having a set of version numbers and initial salts used
-concurrently is considered better than just using the default values of QUIC in
-terms of preventing ossification.
+Instead of associating a new alternative initial salt with every NEW_TOKEN
+token, a server might map a fixed salt to each of the alternative version
+numbers it issues.  Such design is not recommended, as an active attacker might
+build a list of known alternative version numbers and their initial salts and
+use that list to decrypt the payload of Initial packets using those alternative
+version numbers.  But still, having a set of version numbers and initial salts
+used concurrently is considered better than just using the default values of
+QUIC in terms of preventing ossification.
 
 A server MUST NOT send a Version Negotitation packet in response to a long
 header packet with an alternative version number it has advertised.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2756,8 +2756,8 @@ Typically, a server would act in the following steps:
   embeds the alternative initial set including the alternative initial salt
   being generated.  The token will be encrypted using a key known only to the
   server, thereby conforming to the requirements in {{validate-future}}. After
-  that, the server sends a NEW_TOKEN frame that comprises of the generated token
-  and the alternative initial set that has been embedded to that token.
+  that, the server sends a NEW_TOKEN frame that contains the generated token and
+  the alternative initial set that has been embedded to that token.
 
 * When the client reconnects to the server by using the provided token and the
   alternative initial set, the server first checks if the version number field

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2770,12 +2770,12 @@ following steps:
   modifier chosen at random.
 
 * When issuing a NEW_TOKEN token, the server generates the alternative initial
-  salt by calling a pseudo-random function.  Then it builds a token that
-  embeds the alternative seeds including the initial salt being generated.  The
-  token will be encrypted using a key known only to the server, thereby
-  conforming to the requirements in {{validate-future}}. After that, the server
-  sends a NEW_TOKEN frame that contains the generated token and the seeds that
-  have been embedded into that token.
+  salt using a cryptographically secure pseudo-random number generator.  Then it
+  builds a token that embeds the alternative seeds including the initial salt
+  being generated.  The  token will be encrypted using a key known only to the
+  server, thereby conforming to the requirements in {{validate-future}}.  After
+  that, the server sends a NEW_TOKEN frame that contains the generated token and
+  the seeds that have been embedded into that token.
 
 * When the client reconnects to the server by using the provided token and the
   seeds, the server first checks if the version number field of the incoming

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -5058,6 +5058,8 @@ The NEW_TOKEN frame is as follows:
  0                   1                   2                   3
  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                          Lifetime (i)                       ...
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                Alternative Version Number (32)                |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |R R R R R R|PTM|
@@ -5077,6 +5079,12 @@ The NEW_TOKEN frame is as follows:
 ~~~
 
 NEW_TOKEN frames contain the following fields:
+
+Lifetime:
+
+: Indicates the lifetime of the values contained in this frame in milliseconds.
+  An endpoint MUST NOT use the values provided by this frame, once the time that
+  has elapsed since receipt becomes greater than the value of this field.
 
 Alternative Version Number:
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2745,7 +2745,25 @@ number being associated to the token.  This property can be achieved for example
 by embedding the alternative version number in the encrypted token.  Other
 elements of the alternative initial set MAY also be associated with the token.
 
-Typically, a server would act in the following steps:
+For the alternative initial set to work, all the servers within the scope of a
+NEW_TOKEN token are required to have a shared knowledge of the alternative
+initial sets being issued and / or how that can be recovered from the tokens.
+Certain server deployments might have difficulty in meeting such a requirement.
+
+A server (or a set of servers) that cannot satisfy this requirement can
+effectively opt-out from using alternative initial sets by fixing the
+alternative version number and the alternative initial salt to the defaults of
+QUIC for any NEW_TOKEN tokens it issues, and by setting the packet type modifier
+to zero.
+
+The rest of this section applies to the servers that advertise non-default
+values as their alternative initial sets.
+
+
+## Server Behavior
+
+A server that advertises alternative initial sets would typcially act in the
+following steps:
 
 * The server pre-allocates a set of unused version numbers as the alternative
   version numbers, associating each of those version numbers with a packet type
@@ -2771,9 +2789,7 @@ Typically, a server would act in the following steps:
 When the server receives an Initial packet using an alernative version number
 but is incapable of determining the alternative initial salt from the token
 being associated, it MAY send a Version Negotiation packet that instructs the
-client to use the default version.  A server that is incapable of issuing a
-different version number, packet type modifier, or initial salt MAY advertise
-the original values specified in this document as its alternative initial set.
+client to use the default version.
 
 When the server receives an Initial packet containing a valid NEW_TOKEN token,
 and the value of the version number field of that Initial packet does not match
@@ -2786,8 +2802,12 @@ this document.  When the client downgrades to the original version defined in
 this document due to receipt of a Version Negotiation packet, it MUST continue
 sending the same token.
 
-Other specifications MAY define other methods for distributing or deducing the
-alternative initial set.
+
+## Distributing the Alternative Initial Set
+
+This specification defines how the alternative initial set is used as well as
+how it is advertised using a NEW_TOKEN frame.  Other specifications MAY define
+other methods for distributing or deducing the alternative initial set.
 
 
 # Packets and Frames {#packets-frames}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3992,8 +3992,6 @@ carries ACKs in either direction.
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                            Token (*)                        ...
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                     [Token Checksum (128)]                    |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                           Length (i)                        ...
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                    Packet Number (8/16/24/32)               ...
@@ -4021,11 +4019,6 @@ Token:
 : The value of the token that was previously provided in a Retry packet or
   NEW_TOKEN frame.
 
-Token Checksum:
-
-: The checksum of the token.  The field is omitted when the value of the Token
-  Length field is zero.
-
 Payload:
 
 : The payload of the packet.
@@ -4035,19 +4028,6 @@ are protected with connection- and version-specific keys (Initial keys) as
 described in {{QUIC-TLS}}.  This protection does not provide confidentiality or
 integrity against on-path attackers, but provides some level of protection
 against off-path attackers.
-
-Additionally, the token is accompanied by a checksum.  This is because when a
-token is used, its integrity is a prerequisite of unprotecting the Initial
-packet (see {{alternative-initial}}).  An endpoint MUST discard a packet that
-contains a corrupt token checksum.
-
-The checksum is calculated as the output of AEAD_AES_128_GCM {{!AEAD=RFC5116}}
-using the following inputs:
-
-- The secret key, K, is 128 bits all set to zero.
-- The nonce, N, is 96 bits all set to zero.
-- The plaintext, P, is empty.
-- The associated data, A, is the token.
 
 The client and server use the Initial packet type for any packet that contains
 an initial cryptographic handshake message. This includes all cases where a new

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2732,9 +2732,9 @@ which is comprised of:
   MUST NOT be a reserved version ({{versions}}).
 
 * Packet type modifier; a two-bit value that is to be applied as a bit-wise
-  exclusive or (XOR) to the most significant bits of the Initial, Handshake,
-  0-RTT, and Retry packets. This XOR is applied after the packets are encrypted
-  and before they are decrypted.
+  exclusive or (XOR) to the Long Packet Type of the long header packet
+  ({{long-header}}).  This XOR is applied after the packets are encrypted and
+  before they are decrypted.
 
 * Alternative initial salt; a 16-byte binary blob that is to be used in place of
   the initial salt defined in section 5.2 of {{QUIC-TLS}}.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1701,7 +1701,10 @@ connections; validating the port is therefore unlikely to be successful.
 If the client has a token received in a NEW_TOKEN frame on a previous connection
 to what it believes to be the same server, it SHOULD include that value in the
 Token field of its Initial packet.  Including a token might allow the server to
-validate the client address without an additional round trip.
+validate the client address without an additional round trip.  When using a
+NEW_TOKEN token for establishing a new connection, the client MUST construct its
+long header packets by using the values of the alternative initial set that it
+received alongside that token ({{alternative-initial}}).
 
 A token allows a server to correlate activity between the connection where the
 token was issued and any connection where it is used.  Clients that want to
@@ -2786,21 +2789,8 @@ following steps:
   decrypts the embedded token and recovers the alternative initial salt, uses
   that to decrypt the payload of the Initial packet.
 
-When the server receives an Initial packet using an alernative version number
-but is incapable of determining the alternative initial salt from the token
-being associated, it MAY send a Version Negotiation packet that instructs the
-client to use the default version.
-
-When the server receives an Initial packet containing a valid NEW_TOKEN token,
-and the value of the version number field of that Initial packet does not match
-the alternative version number embedded to or associated with that token, the
-server MUST close the connection with an VERSION_NEGOTIATION_ERROR.
-
-When a client uses a token supplied by a NEW_TOKEN frame, it MUST use the
-provided alternative initial set instead of using the default values defined in
-this document.  When the client downgrades to the original version defined in
-this document due to receipt of a Version Negotiation packet, it MUST continue
-sending the same token.
+A server MUST NOT send a Version Negotitation packet in response to a long
+header packet with an alternative version number it has advertised.
 
 
 ## Distributing the Alternative Initial Set

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2743,28 +2743,35 @@ A server advertises these values using a NEW_TOKEN frame {{frame-new-token}}.
 The token MUST include or associated with the alternative version number with
 which it can be used.
 
-Typically, a server would pre-allocate a set of unused version numbers as the
-alternative version numbers, associating each of those version numbers with a
-packet type modifier chosen at random.  Then, when issuing a token using a
-NEW_TOKEN frame, the server generates the alternative initial salt by calling a
-pseudo-random function, embeds that initial salt into the token which is then
-encrypted, and sends a NEW_TOKEN frame that comprises of the generated token and
-the alternative initial set.
+Typically, a server would act in the following steps:
 
-When the client reconnects to the server by using the provided token and the
-alternative initial set, the server first checks if the version number field of
-the incoming packet contains one of the alternative version numbers it
-advertises, then if that is the case, applies the corresponding packet type
-modifier to recover the correct packet type.  If the recovered packet type is an
-Initial packet and that packet contains a NEW_TOKEN token, the server decrypts
-the embedded token and recovers the alternative initial salt, uses that to
-decrypt the payload of the Initial packet.
+* The server pre-allocates a set of unused version numbers as the alternative
+  version numbers, associating each of those version numbers with a packet type
+  modifier chosen at random.
 
-When the server is incapable of determining the alternative initial salt, it can
-send a Version Negotiation packet that instructs the client to use the default
-version.  A server that is incapable of issuing a different version number,
-packet type modifier, or initial salt MAY advertise the original values
-specified in this document as its alternative initial set.
+* When issuing a NEW_TOKEN token, the server generates the alternative initial
+  salt by calling a pseudo-random function.  Then it builds a token that
+  embeds the alternative initial set including the alternative initial salt
+  being generated.  The token will be encrypted using a key known only to the
+  server, thereby conforming to the requirements in {{validate-future}}. After
+  that, the server sends a NEW_TOKEN frame that comprises of the generated token
+  and the alternative initial set that has been embedded to that token.
+
+* When the client reconnects to the server by using the provided token and the
+  alternative initial set, the server first checks if the version number field
+  of the incoming packet contains one of the alternative version numbers it
+  advertises, then if that is the case, applies the corresponding packet type
+  modifier to recover the correct packet type.  If the recovered packet type is
+  an Initial packet and that packet contains a NEW_TOKEN token, the server
+  decrypts the embedded token and recovers the alternative initial salt, uses
+  that to decrypt the payload of the Initial packet.
+
+When the server receives an Initial packet using an alernative version number
+but is incapable of determining the alternative initial salt from the token
+being associated, it MAY send a Version Negotiation packet that instructs the
+client to use the default version.  A server that is incapable of issuing a
+different version number, packet type modifier, or initial salt MAY advertise
+the original values specified in this document as its alternative initial set.
 
 When the server receives an Initial packet containing a valid NEW_TOKEN token,
 and the value of the version number field of that Initial packet does not match

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2775,7 +2775,7 @@ following steps:
   token will be encrypted using a key known only to the server, thereby
   conforming to the requirements in {{validate-future}}. After that, the server
   sends a NEW_TOKEN frame that contains the generated token and the seeds that
-  have been embedded to that token.
+  have been embedded into that token.
 
 * When the client reconnects to the server by using the provided token and the
   seeds, the server first checks if the version number field of the incoming

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2731,10 +2731,10 @@ which is comprised of:
   on wire in place of the version number specified in this document.  This value
   MUST NOT be a reserved version ({{versions}}).
 
-* Packet type modifier; a two-bit value that is to be applied as a bit-wise
-  exclusive or (XOR) to the Long Packet Type of the long header packet
-  ({{long-header}}).  This XOR is applied after the packets are encrypted and
-  before they are decrypted.
+* Packet type modifier; a two-bit value that obfuscates the Long Packet Type of
+  a long header packet ({{long-header}}).  The long packet type bits of a long
+  header packet is encoded as an bti-wise exclusive or (XOR) of the packet type
+  modifier and the type numbers defined in {{long-packet-types}}.
 
 * Alternative initial salt; a 16-byte binary blob that is to be used in place of
   the initial salt defined in section 5.2 of {{QUIC-TLS}}.


### PR DESCRIPTION
Based on the discussion in #3111, this PR implements greasing using the NEW_TOKEN frame as the conveyor.

It defines defines three properties: Alternative Version Number, Packet Type Modifier, Initial Salt, for obfuscating the version number field and the long header packet type, as well as encrypting the Initial packet payload.

Those three properties are carried by a NEW_TOKEN frame, and a client uses those "alternative initial sets" when resuming a connection using a NEW_TOKEN token. A server that is not interested in greasing or encrypting the Initial packets can advertise the values defined in the specification as the "alternative initial sets," and the client behavior would be the same as it is now (with the only difference being that the format of NEW_TOKEN frame has changed).

The text discusses separately about the properties and how they are distributed. Therefore it would be straightforward to define other methods of distributing the "alternative initial set" (e.g., by using the alt-svc header field).

Closes #2496, closes #3111, an alternative to #2573.