### PR TITLE
Retry MUST NOT -> cannot be treated as an acknowledgement

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -576,8 +576,8 @@ dictated by packet and time threshold mechanisms; see {{ack-loss-detection}}.
 A Retry packet causes a client to send another Initial packet, effectively
 restarting the connection process.  A Retry packet indicates that the Initial
 was received, but not processed.  A Retry packet cannot be treated as an
-acknowledgment, because it does not specify the packet number of the received
-packet.
+acknowledgment, because it does not indicate a packet was processed or
+specify the packet number of the packet.
 
 Clients that receive a Retry packet reset congestion control and loss recovery
 state, including resetting any pending timers.  Other connection state, in

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -576,7 +576,7 @@ dictated by packet and time threshold mechanisms; see {{ack-loss-detection}}.
 A Retry packet causes a client to send another Initial packet, effectively
 restarting the connection process.  A Retry packet indicates that the Initial
 was received, but not processed.  A Retry packet cannot be treated as an
-acknowledgment, because it does not indicate a packet was processed or
+acknowledgment, because it does not indicate that a packet was processed or
 specify the packet number.
 
 Clients that receive a Retry packet reset congestion control and loss recovery

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -575,8 +575,9 @@ dictated by packet and time threshold mechanisms; see {{ack-loss-detection}}.
 
 A Retry packet causes a client to send another Initial packet, effectively
 restarting the connection process.  A Retry packet indicates that the Initial
-was received, but not processed.  A Retry packet MUST NOT be treated as an
-acknowledgment.
+was received, but not processed.  A Retry packet cannot be treated as an
+acknowledgment, because it does not specify the packet number of the received
+packet.
 
 Clients that receive a Retry packet reset congestion control and loss recovery
 state, including resetting any pending timers.  Other connection state, in

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -577,7 +577,7 @@ A Retry packet causes a client to send another Initial packet, effectively
 restarting the connection process.  A Retry packet indicates that the Initial
 was received, but not processed.  A Retry packet cannot be treated as an
 acknowledgment, because it does not indicate a packet was processed or
-specify the packet number of the packet.
+specify the packet number.
 
 Clients that receive a Retry packet reset congestion control and loss recovery
 state, including resetting any pending timers.  Other connection state, in


### PR DESCRIPTION
I didn't notice this change in @martinthomson PR #3148, but I think the older text is more correct.  I added a bit more detail about why it cannot be treated as an acknowledgement.

https://github.com/quicwg/base-drafts/pull/3148/files/af478ca2727121b53a0c03c21965c39c961ab9b5..3a6f65f82156772609b98c180809db4230c06aac