### PR TITLE
Limit CWND increase in slow start

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -754,7 +754,10 @@ Implementations MUST either use pacing or limit such bursts to the initial
 congestion window, which is recommended to be the minimum of
 10 * max_datagram_size and max(2* max_datagram_size, 14720)), where
 max_datagram_size is the current maximum size of a datagram for the connection,
-not including UDP or IP overhead.
+not including UDP or IP overhead.  Implementations not using a pacer SHOULD
+limit the congestion window increase during slow start to
+2 * max_datagram_size per ACK frame received in order to limit bursts, as
+specified by {{?RFC3465}}.
 
 As an example of a well-known and publicly available implementation of a flow
 pacer, implementers are referred to the Fair Queue packet scheduler (fq qdisc)


### PR DESCRIPTION
When not pacing packets, limit the CWND increase to 2 packets per ACK frame received and cite RFC3465.

Fixes #3094