### PR TITLE
Recommend replacing, not changing, protocol components

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1486,7 +1486,7 @@ Extensions that could change the semantics of existing protocol components MUST
 be negotiated before being used.  For example, an extension that changes the
 layout of the HEADERS frame cannot be used until the peer has given a positive
 signal that this is acceptable.  Coordinating when such a revised layout comes
-into effect could prove complex.  As such, allocating a new identifiers for
+into effect could prove complex.  As such, allocating new identifiers for
 alternate versions of existing protocol elements is likely to be more effective.
 
 This document doesn't mandate a specific method for negotiating the use of an

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1485,8 +1485,9 @@ requirement and SHOULD be treated as an error.
 Extensions that could change the semantics of existing protocol components MUST
 be negotiated before being used.  For example, an extension that changes the
 layout of the HEADERS frame cannot be used until the peer has given a positive
-signal that this is acceptable. In this case, it could also be necessary to
-coordinate when the revised layout comes into effect.
+signal that this is acceptable.  Coordinating when such a revised layout comes
+into effect could prove complex.  As such, allocating a new identifiers for
+alternate versions of existing protocol elements is likely to be more effective.
 
 This document doesn't mandate a specific method for negotiating the use of an
 extension but notes that a setting ({{settings-parameters}}) could be used for

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1487,7 +1487,7 @@ be negotiated before being used.  For example, an extension that changes the
 layout of the HEADERS frame cannot be used until the peer has given a positive
 signal that this is acceptable.  Coordinating when such a revised layout comes
 into effect could prove complex.  As such, allocating new identifiers for
-alternate versions of existing protocol elements is likely to be more effective.
+new definitions of existing protocol elements is likely to be more effective.
 
 This document doesn't mandate a specific method for negotiating the use of an
 extension but notes that a setting ({{settings-parameters}}) could be used for


### PR DESCRIPTION
Fixes #2985.  Simply notes that coordination is hard in the face of SETTINGS, so it's likely to be better to replace than modify.