### PR TITLE
[HTTP/3] [editorial] 421 and future connection reuse.

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -350,10 +350,9 @@ obtain a valid `http-opportunistic` response for the origin as described in
 {{!RFC8164}} prior to making any such requests.  Other schemes might define
 other mechanisms.
 
-A server that does not wish clients to reuse connections for a particular origin
-can indicate that it is not authoritative for a request by sending a 421
-(Misdirected Request) status code in response to the request (see Section 9.1.2
-of {{!HTTP2}}).
+A server can indicate that it is not authoritative for a request by sending a
+421 (Misdirected Request) status code in response to the request (see Section
+9.1.2 of {{!HTTP2}}).
 
 The considerations discussed in Section 9.1 of {{!HTTP2}} also apply to the
 management of HTTP/3 connections.


### PR DESCRIPTION
Status code 421 does not indicate to clients that the connection should
not be reused for subsequent requests for a particular origin.  It only
indicates that the server is not able to produce a reponse to one
particular request.  See
https://httpwg.org/specs/rfc7540.html#MisdirectedRequest.

In case it is desirable that clients do not reuse the connection for
subsequent requests for a particular origin, that it a deviation from
the original description of 421 and should be called out explicitly.