### PR TITLE
[HTTP/3] [editorial] Remove mention of redefining setting format.

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1940,8 +1940,7 @@ SETTINGS_MAX_HEADER_LIST_SIZE:
 In HTTP/3, setting values are variable-length integers (6, 14, 30, or 62 bits
 long) rather than fixed-length 32-bit fields as in HTTP/2.  This will often
 produce a shorter encoding, but can produce a longer encoding for settings which
-use the full 32-bit space.  Settings ported from HTTP/2 might choose to redefine
-the format of their settings to avoid using the 62-bit encoding.
+use the full 32-bit space.
 
 Settings need to be defined separately for HTTP/2 and HTTP/3. The IDs of
 settings defined in {{!HTTP2}} have been reserved for simplicity.  Note that

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1942,8 +1942,7 @@ long) rather than fixed-length 32-bit fields as in HTTP/2.  This will often
 produce a shorter encoding, but can produce a longer encoding for settings which
 use the full 32-bit space.  Settings ported from HTTP/2 might choose to redefine
 their value to limit it to 30 bits for more efficient encoding, or to make use
-of the 62-bit space (for example, if encoding the original value often requires
-eight bytes anyway).
+of the 62-bit space if more than 30 bits are required.
 
 Settings need to be defined separately for HTTP/2 and HTTP/3. The IDs of
 settings defined in {{!HTTP2}} have been reserved for simplicity.  Note that

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1940,7 +1940,10 @@ SETTINGS_MAX_HEADER_LIST_SIZE:
 In HTTP/3, setting values are variable-length integers (6, 14, 30, or 62 bits
 long) rather than fixed-length 32-bit fields as in HTTP/2.  This will often
 produce a shorter encoding, but can produce a longer encoding for settings which
-use the full 32-bit space.
+use the full 32-bit space.  Settings ported from HTTP/2 might choose to redefine
+their value to limit it to 30 bits for more efficient encoding, or to make use
+of the 62-bit space (for example, if encoding the original value often requires
+eight bytes anyway).
 
 Settings need to be defined separately for HTTP/2 and HTTP/3. The IDs of
 settings defined in {{!HTTP2}} have been reserved for simplicity.  Note that


### PR DESCRIPTION
Each SETTINGS parameter consists of an identifier and a value, each
encoded as QUIC variable-length integer.  The sentence being removed is
a remnant from the time when setting values were encoded as
length-prefixed binary blobs.