### PR TITLE
Bad CONNECTION_CLOSE isn't special

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2709,9 +2709,6 @@ frame risks a peer missing the first such packet.  The only mechanism available
 to an endpoint that continues to receive data for a terminated connection is to
 use the stateless reset process ({{stateless-reset}}).
 
-An endpoint that receives an invalid CONNECTION_CLOSE frame MUST NOT signal the
-existence of the error to its peer.
-
 
 ## Stream Errors
 


### PR DESCRIPTION
If we get one, rely on the back-off that we require endpoints to
implement when they enter the closing state.  No need for any additional
special processing rules (as mentioned in #3230).

Closes #2475.
Closes #3230.