### PR TITLE
HTTP: Tweak wording about unknown error codes

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1384,7 +1384,7 @@ connection error.
 
 Because new error codes can be defined without negotiation (see {{extensions}}),
 receipt of an unknown error code or use of an error code in an unexpected
-context MUST NOT be treated as an error.  However, closing a stream can
+context MUST NOT be treated as a further error.  However, closing a stream can
 constitute an error regardless of the error code (see {{request-response}}).
 
 This section describes HTTP/3-specific error codes which can be used to express


### PR DESCRIPTION
It's not very clear what it means to not treat an error code as an error.

Maybe this is what's meant? (If not, please explain it better.)