### PR TITLE
Prevent Idle Timeout while Blocked

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -785,13 +785,12 @@ flow control limits.
 If a sender runs out of flow control credit, it will be unable to send new data
 and is considered blocked.  A sender SHOULD send a STREAM_DATA_BLOCKED or
 DATA_BLOCKED frame to indicate it has data to write but is blocked by flow
-control limits.  These frames are expected to be sent infrequently in common
-cases, but they are considered useful for debugging and monitoring purposes.
-
-A sender SHOULD NOT send multiple STREAM_DATA_BLOCKED or DATA_BLOCKED frames
-for the same data limit, unless the original frame is determined to be lost.
-Another STREAM_DATA_BLOCKED or DATA_BLOCKED frame can be sent after the data
-limit is increased.
+control limits.  If a sender is blocked for long enough it is possible for the
+connection to idle timeout, even though the data is actively queued to be sent.
+To prevent this idle timeout from occurring, the sender SHOULD continue to
+periodically send the STREAM_DATA_BLOCKED or DATA_BLOCKED frame.  One method is
+to immediately resend the frame on acknowledgment of the previous one if the
+sender is still blocked.
 
 
 ## Flow Credit Increments {#fc-credit}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -786,7 +786,7 @@ If a sender runs out of flow control credit, it will be unable to send new data
 and is considered blocked.  A sender SHOULD send a STREAM_DATA_BLOCKED or
 DATA_BLOCKED frame to indicate it has data to write but is blocked by flow
 control limits.  If a sender is blocked for a period longer than the idle
-timeout ({{idle-timeout}}), the connection might get closed even when data is
+timeout ({{idle-timeout}}), the connection might be closed even when data is
 available for transmission.  To keep the connection from closing, a sender that
 is flow control limited SHOULD periodically send a STREAM_DATA_BLOCKED or
 DATA_BLOCKED frame when it has no ack-eliciting packets in flight.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2351,8 +2351,9 @@ processed successfully.  The timer is also restarted when sending an
 ack-eliciting packet (see {{QUIC-RECOVERY}}), but only if no other ack-eliciting
 packets have been sent since last receiving a packet.  Restarting when sending
 packets ensures that connections do not prematurely time out when initiating new
-activity.  An endpoint should be careful to avoid an idle timeout if it is idle
-because of flow control (see {{data-flow-control}}).
+activity.  An endpoint might need to send packets to avoid an idle timeout if it
+is unable to send application data due to being blocked on flow control limits;
+see {{flow-control}}.
 
 The value for an idle timeout can be asymmetric.  The value advertised by an
 endpoint is only used to determine whether the connection is live at that

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -785,12 +785,11 @@ flow control limits.
 If a sender runs out of flow control credit, it will be unable to send new data
 and is considered blocked.  A sender SHOULD send a STREAM_DATA_BLOCKED or
 DATA_BLOCKED frame to indicate it has data to write but is blocked by flow
-control limits.  If a sender is blocked for long enough it is possible for the
-connection to idle timeout, even though the data is actively queued to be sent.
-To prevent this idle timeout from occurring, the sender SHOULD continue to
-periodically send the STREAM_DATA_BLOCKED or DATA_BLOCKED frame.  One method is
-to resend a DATA_BLOCKED or STREAM_DATA_BLOCKED frame when there are no
-ack-eliciting packets in flight.
+control limits.  If a sender is blocked for a period longer than the idle
+timeout ({{idle-timeout}}), the connection might get closed even when data is
+available for transmission.  To keep the connection from closing, a sender
+SHOULD periodically send a STREAM_DATA_BLOCKED or DATA_BLOCKED frame when there
+are no ack-eliciting packets in flight.
 
 
 ## Flow Credit Increments {#fc-credit}
@@ -2352,7 +2351,8 @@ processed successfully.  The timer is also restarted when sending an
 ack-eliciting packet (see {{QUIC-RECOVERY}}), but only if no other ack-eliciting
 packets have been sent since last receiving a packet.  Restarting when sending
 packets ensures that connections do not prematurely time out when initiating new
-activity.
+activity.  An endpoint should be careful to avoid an idle timeout if it is idle
+because of flow control (see {{data-flow-control}}).
 
 The value for an idle timeout can be asymmetric.  The value advertised by an
 endpoint is only used to determine whether the connection is live at that

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -789,8 +789,8 @@ control limits.  If a sender is blocked for long enough it is possible for the
 connection to idle timeout, even though the data is actively queued to be sent.
 To prevent this idle timeout from occurring, the sender SHOULD continue to
 periodically send the STREAM_DATA_BLOCKED or DATA_BLOCKED frame.  One method is
-to immediately resend the frame on acknowledgment of the previous one if the
-sender is still blocked.
+to resend a DATA_BLOCKED or STREAM_DATA_BLOCKED frame when there are no
+ack-eliciting packets in flight.
 
 
 ## Flow Credit Increments {#fc-credit}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -787,9 +787,9 @@ and is considered blocked.  A sender SHOULD send a STREAM_DATA_BLOCKED or
 DATA_BLOCKED frame to indicate it has data to write but is blocked by flow
 control limits.  If a sender is blocked for a period longer than the idle
 timeout ({{idle-timeout}}), the connection might get closed even when data is
-available for transmission.  To keep the connection from closing, a sender
-SHOULD periodically send a STREAM_DATA_BLOCKED or DATA_BLOCKED frame when there
-are no ack-eliciting packets in flight.
+available for transmission.  To keep the connection from closing, a sender that
+is flow control limited SHOULD periodically send a STREAM_DATA_BLOCKED or
+DATA_BLOCKED frame when it has no ack-eliciting packets in flight.
 
 
 ## Flow Credit Increments {#fc-credit}


### PR DESCRIPTION
Fixes #2744 

To prevent a connection from going idle while it has application data to send, this PR recommends periodically sending the blocked frame as a keep alive.