### PR TITLE
Disabling Spin bit for what percentage of connections?

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4331,11 +4331,10 @@ Each endpoint unilaterally decides if the spin bit is enabled or disabled for a
 connection. Implementations MUST allow administrators of clients and servers
 to disable the spin bit either globally or on a per-connection basis. Even when
 the spin bit is not disabled by the administrator, implementations MUST disable
-the spin bit for a given connection with a certain likelihood. The random
-selection process SHOULD be designed such that on average the spin bit is
-disabled for at least one eighth of network paths. The selection process
-performed at the beginning of the connection SHOULD be applied for all paths
-used by the connection.
+the spin bit for at least a sixteenth of connections with an expectation that
+the spin bit is disabled for at least one eighth of network paths. The selection
+process performed at the beginning of the connection SHOULD be applied for all
+paths used by the connection.
 
 When the spin bit is disabled, endpoints MAY set the spin bit to any value, and
 MUST ignore any incoming value. It is RECOMMENDED that endpoints set the spin


### PR DESCRIPTION
Clarify the fractions of connections an endpoint must disable spin bit for.
Fixes #3257.
Closes #2628.