### PR TITLE
Prohibit IP fragmentation

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3473,7 +3473,6 @@ it chooses.
 
 UDP datagrams MUST NOT be fragmented at the IP layer.  In IPv4
 {{!IPv4=RFC0791}}, the DF bit MUST be set to prevent fragmentation on the path.
-Endpoints SHOULD discard fragmented IP packets.
 
 A server MAY send a CONNECTION_CLOSE frame with error code PROTOCOL_VIOLATION in
 response to an Initial packet it receives from a client if the UDP datagram is

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3471,6 +3471,10 @@ Datagrams containing Initial packets MAY exceed 1200 bytes if the client
 believes that the Path Maximum Transmission Unit (PMTU) supports the size that
 it chooses.
 
+UDP datagrams MUST NOT be fragmented at the IP layer.  In IPv4
+{{!IPv4=RFC0791}}, the DF bit MUST be set to prevent fragmentation on the path.
+Endpoints SHOULD discard fragmented IP packets.
+
 A server MAY send a CONNECTION_CLOSE frame with error code PROTOCOL_VIOLATION in
 response to an Initial packet it receives from a client if the UDP datagram is
 smaller than 1200 bytes. It MUST NOT send any other frame type in response, or


### PR DESCRIPTION
This won't necessarily prevent fragmentation from happening, but it's
the best we can do.  I didn't REQUIRE dropping of fragments, because
some systems do that for you, but a SHOULD seems appropriate.

Closes #3243.