### PR TITLE
Clarify conditions for disabling spin bit

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4382,8 +4382,9 @@ connection. Implementations MUST allow administrators of clients and servers
 to disable the spin bit either globally or on a per-connection basis. Even when
 the spin bit is not disabled by the administrator, endpoints MUST disable their
 use of the spin bit for a random selection of at least one in every 16 network
-paths, or for one in every 16 connection IDs. This ensures that the spin bit
-signal is disabled on approximately one in eight network paths.
+paths, or for one in every 16 connection IDs.  As each endpoint disables the
+spin bit independently, this ensures that the spin bit signal is disabled on
+approximately one in eight network paths.
 
 When the spin bit is disabled, endpoints MAY set the spin bit to any value, and
 MUST ignore any incoming value. It is RECOMMENDED that endpoints set the spin

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4381,11 +4381,10 @@ Each endpoint unilaterally decides if the spin bit is enabled or disabled for a
 connection. Implementations MUST allow administrators of clients and servers
 to disable the spin bit either globally or on a per-connection basis. Even when
 the spin bit is not disabled by the administrator, implementations MUST disable
-the spin bit for a given connection with a certain likelihood. The random
-selection process SHOULD be designed such that on average the spin bit is
-disabled for at least one eighth of network paths. The selection process
-performed at the beginning of the connection SHOULD be applied for all paths
-used by the connection.
+the spin bit for at least a sixteenth of connections with an expectation that
+the spin bit is disabled for at least one eighth of network paths. The selection
+process performed at the beginning of the connection SHOULD be applied for all
+paths used by the connection.
 
 When the spin bit is disabled, endpoints MAY set the spin bit to any value, and
 MUST ignore any incoming value. It is RECOMMENDED that endpoints set the spin

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4380,11 +4380,10 @@ support the spin bit MUST implement it as specified in this section.
 Each endpoint unilaterally decides if the spin bit is enabled or disabled for a
 connection. Implementations MUST allow administrators of clients and servers
 to disable the spin bit either globally or on a per-connection basis. Even when
-the spin bit is not disabled by the administrator, implementations MUST disable
-the spin bit for at least a sixteenth of connections with an expectation that
-the spin bit is disabled for at least one eighth of network paths. The selection
-process performed at the beginning of the connection SHOULD be applied for all
-paths used by the connection.
+the spin bit is not disabled by the administrator, endpoints MUST disable their
+use of the spin bit for a random selection of at least one in every 16 network
+paths, or for one in every 16 connection IDs. This ensures that the spin bit
+signal is disabled on approximately one in eight network paths.
 
 When the spin bit is disabled, endpoints MAY set the spin bit to any value, and
 MUST ignore any incoming value. It is RECOMMENDED that endpoints set the spin


### PR DESCRIPTION
This builds on #3270 to address the linkability issues that it added.  It recommends 1/16 of *network paths* are disabled *randomly* as suggested by @kazuho.  It also allows the determination to be made per connection ID rather than per-path (which is more granular, but I expect it will have a nearly identical effect).  The net effect is that 1/8 paths will not spin as originally intended.

Closes #3270.
Closes #3257.
Closes #2628.