### PR TITLE
Don't recommend 3 RTTs of credit (and other editorial)

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -833,6 +833,10 @@ implementations.  As an optimization, an endpoint could send frames related to
 flow control only when there are other frames to send or when a peer is blocked,
 ensuring that flow control does not cause extra packets to be sent.
 
+When a sender receives credit after being blocked, it can send a large amount of
+data in response resulting in short-term congestion; see Section 6.9 in
+{{QUIC-RECOVERY}} for a discussion of how a sender could avoid this congestion.
+
 
 ## Handling Stream Cancellation {#stream-cancellation}
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -812,12 +812,12 @@ not send STREAM_DATA_BLOCKED or DATA_BLOCKED frames. Even if the peer sent these
 frames, waiting for them means that a sender will be blocked for at least an
 entire round trip.
 
-If a sender runs out of flow control credit, it will be unable to send new data
-and is considered blocked, resulting in degraded performance. To avoid blocking
-a sender, and to reasonably account for the possibility of loss, a receiver can
-send a MAX_STREAM_DATA or MAX_DATA frame multiple times within a round trip or
-send it early enough to allow for recovery from potential loss before the sender
-becomes blocked.
+A sender that runs out of flow control credit will be unable to send new data
+and is considered blocked, resulting in degraded performance for the
+connection. To avoid blocking a sender and to reasonably account for the
+possibility of loss, a receiver can send a MAX_STREAM_DATA or MAX_DATA frame
+multiple times within a round trip or send it early enough to allow for recovery
+from potential loss.
 
 Control frames contribute to connection overhead. Therefore, frequently sending
 MAX_STREAM_DATA and MAX_DATA frames with small changes is undesirable.  At the
@@ -832,11 +832,6 @@ which the receiving application consumes data, similar to common TCP
 implementations.  As an optimization, an endpoint could send frames related to
 flow control only when there are other frames to send or when a peer is blocked,
 ensuring that flow control does not cause extra packets to be sent.
-
-When a sender receives credit after being blocked, it might send a large amount
-of data in response. As is recommended in {{QUIC-RECOVERY}}, implementations
-should pace this data to avoid sending it in a burst and causing short-term
-network congestion.
 
 
 ## Handling Stream Cancellation {#stream-cancellation}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -822,16 +822,17 @@ implementations.  As an optimization, an endpoint could send frames related to
 flow control only when there are other frames to send or when a peer is blocked,
 ensuring that flow control does not cause extra packets to be sent.
 
-A sender that is blocked could choose to not send STREAM_DATA_BLOCKED or
-DATA_BLOCKED frames. Therefore, a receiver MUST NOT wait for a
-STREAM_DATA_BLOCKED or DATA_BLOCKED frame before sending a MAX_STREAM_DATA or
-MAX_DATA frame; doing so could result in the sender being blocked for the rest
-of the connection. Even if the sender sent these frames, waiting for them will
-result in the sender being blocked for at least an entire round trip.
+A blocked sender is not required to send STREAM_DATA_BLOCKED or DATA_BLOCKED
+frames. Therefore, a receiver MUST NOT wait for a STREAM_DATA_BLOCKED or
+DATA_BLOCKED frame before sending a MAX_STREAM_DATA or MAX_DATA frame; doing so
+could result in the sender being blocked for the rest of the connection. Even if
+the sender sends these frames, waiting for them will result in the sender being
+blocked for at least an entire round trip.
 
-When a sender receives credit after being blocked, it can send a large amount of
-data in response, resulting in short-term congestion; see Section 6.9 in
-{{QUIC-RECOVERY}} for a discussion of how a sender can avoid this congestion.
+When a sender receives credit after being blocked, it might be able to send a
+large amount of data in response, resulting in short-term congestion; see
+Section 6.9 in {{QUIC-RECOVERY}} for a discussion of how a sender can avoid this
+congestion.
 
 
 ## Handling Stream Cancellation {#stream-cancellation}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -806,25 +806,24 @@ and MAX_DATA frames. This section describes one requirement and offers a few
 considerations.
 
 A receiver MUST NOT wait for a STREAM_DATA_BLOCKED or DATA_BLOCKED frame before
-sending a MAX_STREAM_DATA or MAX_DATA frame, since doing so will mean that a
-sender could be blocked for the rest of the connection if the peer chooses to
-not send STREAM_DATA_BLOCKED or DATA_BLOCKED frames. Even if the peer sent these
-frames, waiting for them means that a sender will be blocked for at least an
-entire round trip.
+sending a MAX_STREAM_DATA or MAX_DATA frame, since doing so means that a sender
+will be blocked for the rest of the connection if the peer chooses to not send
+STREAM_DATA_BLOCKED or DATA_BLOCKED frames. Even if the peer sent these frames,
+waiting for them means that a sender will be blocked for at least an entire
+round trip.
 
 A sender that runs out of flow control credit will be unable to send new data
 and is considered blocked, resulting in degraded performance for the
-connection. To avoid blocking a sender and to reasonably account for the
-possibility of loss, a receiver can send a MAX_STREAM_DATA or MAX_DATA frame
-multiple times within a round trip or send it early enough to allow for recovery
-from potential loss.
+connection. To avoid blocking a sender, a receiver can send a MAX_STREAM_DATA or
+MAX_DATA frame multiple times within a round trip or send it early enough to
+allow for recovery from loss of the frame.
 
 Control frames contribute to connection overhead. Therefore, frequently sending
-MAX_STREAM_DATA and MAX_DATA frames with small changes is undesirable.  At the
-same time, larger increments to limits are necessary to avoid blocking if
-updates are less frequent, requiring larger resource commitments at the
-receiver.  There is a trade-off between resource commitment and overhead when
-determining how large a limit is advertised.
+MAX_STREAM_DATA and MAX_DATA frames with small changes is undesirable.  On the
+other hand, if updates are less frequent, larger increments to limits are
+necessary to avoid blocking a sender, requiring larger resource commitments at
+the receiver.  There is a trade-off between resource commitment and overhead
+when determining how large a limit is advertised.
 
 A receiver can use an autotuning mechanism to tune the frequency and amount of
 advertised additional credit based on a round-trip time estimate and the rate at
@@ -834,8 +833,8 @@ flow control only when there are other frames to send or when a peer is blocked,
 ensuring that flow control does not cause extra packets to be sent.
 
 When a sender receives credit after being blocked, it can send a large amount of
-data in response resulting in short-term congestion; see Section 6.9 in
-{{QUIC-RECOVERY}} for a discussion of how a sender could avoid this congestion.
+data in response, resulting in short-term congestion; see Section 6.9 in
+{{QUIC-RECOVERY}} for a discussion of how a sender can avoid this congestion.
 
 
 ## Handling Stream Cancellation {#stream-cancellation}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -801,22 +801,12 @@ limit is increased.
 
 ## Flow Credit Increments {#fc-credit}
 
-Implementations decide when and how many bytes to advertise in MAX_STREAM_DATA
-and MAX_DATA frames. This section describes one requirement and offers a few
-considerations.
+Implementations decide when and how much credit to advertise in MAX_STREAM_DATA
+and MAX_DATA frames, but this section offers a few considerations.
 
-A receiver MUST NOT wait for a STREAM_DATA_BLOCKED or DATA_BLOCKED frame before
-sending a MAX_STREAM_DATA or MAX_DATA frame, since doing so means that a sender
-will be blocked for the rest of the connection if the peer chooses to not send
-STREAM_DATA_BLOCKED or DATA_BLOCKED frames. Even if the peer sent these frames,
-waiting for them means that a sender will be blocked for at least an entire
-round trip.
-
-A sender that runs out of flow control credit will be unable to send new data
-and is considered blocked, resulting in degraded performance for the
-connection. To avoid blocking a sender, a receiver can send a MAX_STREAM_DATA or
-MAX_DATA frame multiple times within a round trip or send it early enough to
-allow for recovery from loss of the frame.
+To avoid blocking a sender, a receiver can send a MAX_STREAM_DATA or MAX_DATA
+frame multiple times within a round trip or send it early enough to allow for
+recovery from loss of the frame.
 
 Control frames contribute to connection overhead. Therefore, frequently sending
 MAX_STREAM_DATA and MAX_DATA frames with small changes is undesirable.  On the
@@ -831,6 +821,13 @@ which the receiving application consumes data, similar to common TCP
 implementations.  As an optimization, an endpoint could send frames related to
 flow control only when there are other frames to send or when a peer is blocked,
 ensuring that flow control does not cause extra packets to be sent.
+
+A sender that is blocked could choose to not send STREAM_DATA_BLOCKED or
+DATA_BLOCKED frames. Therefore, a receiver MUST NOT wait for a
+STREAM_DATA_BLOCKED or DATA_BLOCKED frame before sending a MAX_STREAM_DATA or
+MAX_DATA frame; doing so could result in the sender being blocked for the rest
+of the connection. Even if the sender sent these frames, waiting for them will
+result in the sender being blocked for at least an entire round trip.
 
 When a sender receives credit after being blocked, it can send a large amount of
 data in response, resulting in short-term congestion; see Section 6.9 in


### PR DESCRIPTION
Addresses feedback from @gorryfair and @kazuho 
- to add a reference to the recovery doc on handling bursts resulting from flow control credit;
- that advice on when to send *_DATA frames (at least 2 RTTs before sender is blocked) is too specific.

I've also done some editorializing to fix flow.