### PR TITLE
Forwarding status of errors on streams

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -536,10 +536,12 @@ not acting as a tunnel) MUST NOT forward a malformed request or response.
 Malformed requests or responses that are detected MUST be treated as a stream
 error ({{errors}}) of type H3_GENERAL_PROTOCOL_ERROR.
 
-An intermediary acting as a tunnel could carry HTTP messages from multiple endpoints on one side to a single endpoint on the other side within a single HTTP/3 connection. Such an intermediary might forward malformed HTTP messages as well. To limit the scope of damage to the offending endpoint, an endpoint that detects a malformed request or response MUST NOT escalate this error to a  connection-level error unless specified otherwise.
-malformed HTTP message from one of those endpoints on a coalesced connection.
-Therefore, an endpoint that detects a malformed request or response MUST NOT
-escalate the error to a connection-level error unless specified otherwise.
+An intermediary acting as a tunnel could carry HTTP messages from multiple
+endpoints on one side to a single endpoint on the other side within a single
+HTTP/3 connection.  Such an intermediary might forward malformed HTTP messages
+as well.  To limit the scope of damage to the offending endpoint, an endpoint
+that detects a malformed request or response MUST NOT escalate this error to a
+connection-level error unless specified otherwise.
 
 For malformed requests, a server MAY send an HTTP response prior to closing or
 resetting the stream.  Clients MUST NOT accept a malformed response.  Note that

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -536,16 +536,16 @@ not acting as a tunnel) MUST NOT forward a malformed request or response.
 Malformed requests or responses that are detected MUST be treated as a stream
 error ({{errors}}) of type H3_GENERAL_PROTOCOL_ERROR.
 
+A tunnel that dispatches HTTP messages to different endpoints might forward a
+malformed HTTP message from one of those endpoints on a coalesced connection.
+Therefore, an endpoint that detects a malformed request or response MUST NOT
+escalate the error to a connection-level error unless specified otherwise.
+
 For malformed requests, a server MAY send an HTTP response prior to closing or
 resetting the stream.  Clients MUST NOT accept a malformed response.  Note that
 these requirements are intended to protect against several types of common
 attacks against HTTP; they are deliberately strict because being permissive can
 expose implementations to these vulnerabilities.
-
-Unless specified otherwise, an endpoint MUST NOT handle the receipt of a
-malformed request or response as a connection-level error, because a tunnel that
-dispatches HTTP messages to different endpoints might forward a malformed
-message from one of those endpoints on a coalesced connection.
 
 
 ## The CONNECT Method

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -536,7 +536,7 @@ not acting as a tunnel) MUST NOT forward a malformed request or response.
 Malformed requests or responses that are detected MUST be treated as a stream
 error ({{errors}}) of type H3_GENERAL_PROTOCOL_ERROR.
 
-A tunnel that dispatches HTTP messages to different endpoints might forward a
+An intermediary acting as a tunnel could carry HTTP messages from multiple endpoints on one side to a single endpoint on the other side within a single HTTP/3 connection. Such an intermediary might forward malformed HTTP messages as well. To limit the scope of damage to the offending endpoint, an endpoint that detects a malformed request or response MUST NOT escalate this error to a  connection-level error unless specified otherwise.
 malformed HTTP message from one of those endpoints on a coalesced connection.
 Therefore, an endpoint that detects a malformed request or response MUST NOT
 escalate the error to a connection-level error unless specified otherwise.

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -542,6 +542,15 @@ these requirements are intended to protect against several types of common
 attacks against HTTP; they are deliberately strict because being permissive can
 expose implementations to these vulnerabilities.
 
+When receiving a malformed HTTP message from upstream, an HTTP/3 intermediary
+acting as a tunnel MUST either transmit a malformed HTTP message to downstream,
+or reset the stream.  Specifically, when an HTTP message received from upstream
+terminates abruptly, a tunnel MAY send an incomplete DATA frame and then close
+the stream normally.  Doing so guarantees the delivery of the partial response
+that the tunnel received to downstream, at the same time forwarding the fact
+that the HTTP message is malformed.  A client MUST NOT handle the receipt of an
+incomplete DATA frame at the end of the stream as a connection-level error.
+
 
 ## The CONNECT Method
 

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -542,14 +542,10 @@ these requirements are intended to protect against several types of common
 attacks against HTTP; they are deliberately strict because being permissive can
 expose implementations to these vulnerabilities.
 
-When receiving a malformed HTTP message from upstream, an HTTP/3 intermediary
-acting as a tunnel MUST either transmit a malformed HTTP message to downstream,
-or reset the stream.  Specifically, when an HTTP message received from upstream
-terminates abruptly, a tunnel MAY send an incomplete DATA frame and then close
-the stream normally.  Doing so guarantees the delivery of the partial response
-that the tunnel received to downstream, at the same time forwarding the fact
-that the HTTP message is malformed.  A client MUST NOT handle the receipt of an
-incomplete DATA frame at the end of the stream as a connection-level error.
+Unless specified otherwise, an endpoint MUST NOT handle the receipt of a
+malformed request or response as a connection-level error, because a tunnel that
+dispatches HTTP messages to different endpoints might forward a malformed
+message from one of those endpoints on a coalesced connection.
 
 
 ## The CONNECT Method


### PR DESCRIPTION
Clarifies that a tunnel might intentionally use an incomplete DATA frame to forward a malformed response, while preserving the partial response that has been transferred.

closes #3300.