### PR TITLE
Remove DUPLICATE_PUSH and allow duplicate PUSH_PROMISE

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -636,7 +636,7 @@ is associated with the request stream on which the PUSH_PROMISE frame was
 received.  The same server push can be associated with additional client
 requests using a PUSH_PROMISE frame with the same Push ID on multiple request
 streams.  These associations do not affect the operation of the protocol, but
-MAY be used by user agents when deciding how to use pushed resources.
+MAY be considered by user agents when deciding how to use pushed resources.
 
 Ordering of a PUSH_PROMISE in relation to certain parts of the response is
 important. The server SHOULD send PUSH_PROMISE frames prior to sending HEADERS

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -387,7 +387,7 @@ An HTTP message (request or response) consists of:
 3. optionally, trailing headers, if present (see Section 4.1.2 of {{!RFC7230}}),
    sent as a single HEADERS frame.
 
-A server MAY send one or more PUSH_PROMISE (see {{frame-push-promise}}) frames
+A server MAY send one or more PUSH_PROMISE frames (see {{frame-push-promise}})
 before, after, or interleaved with the frames of a response message.
 These PUSH_PROMISE frames are not part of the response; see {{server-push}} for
 more details.
@@ -615,8 +615,8 @@ Each server push is identified by a unique Push ID. This Push ID is used in one
 or more PUSH_PROMISE frames (see {{frame-push-promise}}) that carry the request
 headers, then included with the push stream which ultimately fulfills those
 promises. When the same Push ID is promised on multiple request streams, the
-decompressed request header set MUST contain the same set of fields in the
-same order, and in each field both the name and value MUST be byte-for-byte
+decompressed request header sets MUST contain the same fields in the
+same order, and both the name and the value in each field MUST be exact
 matches.
 
 Server push is only enabled on a connection when a client sends a MAX_PUSH_ID
@@ -1250,12 +1250,12 @@ PUSH_PROMISE frame that contains a larger Push ID than the client has advertised
 as a connection error of H3_ID_ERROR.
 
 A server MAY use the same Push ID in multiple PUSH_PROMISE frames. If so, the
-decompressed request header set MUST contain the same set of fields in the same
-order, and in each field both the name and and value MUST be byte-for-byte
-matches. When a client receives a Push ID which has alread been promised, if the
-client detects a mismatch, it MUST response with a connection error of type
-H3_GENERAL_PROTOCOL_ERROR. Otherwise it MUST ignore the PUSH_PROMISE frame if no
-mismatch is detected.
+decompressed request header sets MUST contain the same fields in the same
+order, and both the name and and value in each field MUST be exact
+matches. If a client receives a Push ID that has already been promised
+and detects a mismatch, it MUST respond with a connection error of type
+H3_GENERAL_PROTOCOL_ERROR. If the decompressed header sets match exactly, the
+client MUST ignore the duplicate PUSH_PROMISE frame.
 
 If a PUSH_PROMISE frame is received on the control stream, the client MUST
 respond with a connection error ({{errors}}) of type H3_FRAME_UNEXPECTED.

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -647,11 +647,11 @@ using the same format described for responses in {{request-response}}.
 
 Due to reordering, push stream data can arrive before the corresponding
 PUSH_PROMISE frame.  When a client receives a new push stream with an
-as-yet-unknown Push ID, both the associated client request and the pushed request
-headers are unknown.  The client can buffer the stream data in expectation of the
-matching PUSH_PROMISE. The client can use stream flow control (see section 4.1 of
-{{QUIC-TRANSPORT}}) to limit the amount of data a server may commit to the pushed
-stream.
+as-yet-unknown Push ID, both the associated client request and the pushed
+request headers are unknown.  The client can buffer the stream data in
+expectation of the matching PUSH_PROMISE. The client can use stream flow control
+(see section 4.1 of {{QUIC-TRANSPORT}}) to limit the amount of data a server may
+commit to the pushed stream.
 
 If the same Push ID is promised on multiple request streams, the decompressed
 request headers MUST be byte-for-byte idential.

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -615,7 +615,9 @@ Each server push is identified by a unique Push ID. This Push ID is used in one
 or more PUSH_PROMISE frames (see {{frame-push-promise}}) that carry the request
 headers, then included with the push stream which ultimately fulfills those
 promises. When the same Push ID is promised on multiple request streams, the
-decompressed request header fields MUST be byte-for-byte identical.
+decompressed request header set MUST contains the same set of fields in the
+same order, and in each field both the name and and value MUST be byte-for-byte
+matches.
 
 Server push is only enabled on a connection when a client sends a MAX_PUSH_ID
 frame (see {{frame-max-push-id}}). A server cannot use server push until it
@@ -653,9 +655,6 @@ request headers are unknown.  The client can buffer the stream data in
 expectation of the matching PUSH_PROMISE. The client can use stream flow control
 (see section 4.1 of {{QUIC-TRANSPORT}}) to limit the amount of data a server may
 commit to the pushed stream.
-
-If the same Push ID is promised on multiple request streams, the decompressed
-request headers MUST be byte-for-byte idential.
 
 If a promised server push is not needed by the client, the client SHOULD send a
 CANCEL_PUSH frame. If the push stream is already open or opens after sending the
@@ -1251,9 +1250,12 @@ PUSH_PROMISE frame that contains a larger Push ID than the client has advertised
 as a connection error of H3_ID_ERROR.
 
 A server MAY use the same Push ID in multiple PUSH_PROMISE frames. If so, the
-decompressed request headers MUST be idential.  A client MUST treat receipt of a
-Push ID which has already been promised with different headers than the previous
-promise as a connection error of type H3_ID_ERROR.
+decompressed request header set MUST contain the same set of fields in the same
+order, and in each field both the name and and value MUST be byte-for-byte
+matches. When a client receives a Push ID which has alread been promised, if the
+client detects a mismatch, it MUST response with a connection error of type
+H3_GENERAL_PROTOCOL_ERROR. Otherwise it MUST ignore the PUSH_PROMISE frame if no
+mismatch is detected.
 
 If a PUSH_PROMISE frame is received on the control stream, the client MUST
 respond with a connection error ({{errors}}) of type H3_FRAME_UNEXPECTED.

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -635,8 +635,8 @@ Each pushed response is associated with one or more client requests.  The push
 is associated with the request stream on which the PUSH_PROMISE frame was
 received.  The same server push can be associated with additional client
 requests using a PUSH_PROMISE frame with the same Push ID on multiple request
-stream.  These associations do not affect the operation of the protocol, but MAY
-be used by user agents when deciding how to use pushed resources.
+streams.  These associations do not affect the operation of the protocol, but
+MAY be used by user agents when deciding how to use pushed resources.
 
 Ordering of a PUSH_PROMISE in relation to certain parts of the response is
 important. The server SHOULD send PUSH_PROMISE frames prior to sending HEADERS
@@ -1252,7 +1252,8 @@ as a connection error of H3_ID_ERROR.
 A server MAY use the same Push ID in multiple PUSH_PROMISE frames. If so, the
 decompressed request header sets MUST contain the same fields in the same
 order, and both the name and and value in each field MUST be exact
-matches. If a client receives a Push ID that has already been promised
+matches. Clients SHOULD compare the request header sets for resources promised
+multiple times. If a client receives a Push ID that has already been promised
 and detects a mismatch, it MUST respond with a connection error of type
 H3_GENERAL_PROTOCOL_ERROR. If the decompressed header sets match exactly, the
 client MUST ignore the duplicate PUSH_PROMISE frame.
@@ -1261,7 +1262,7 @@ Allowing duplicate references to the same Push ID is primarily to reduce
 duplication caused by concurrent requests.  A server SHOULD avoid reusing a Push
 ID over a long period.  Clients are likely to consume server push responses and
 not retain them for reuse over time.  Clients that see a PUSH_PROMISE that uses
-a Push ID that they have since consumed and discarded are forced to ignore the
+a Push ID that they have already consumed and discarded are forced to ignore the
 PUSH_PROMISE.
 
 If a PUSH_PROMISE frame is received on the control stream, the client MUST

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -611,10 +611,11 @@ client making the indicated request.  This trades off network usage against a
 potential latency gain.  HTTP/3 server push is similar to what is described in
 HTTP/2 {{!HTTP2}}, but uses different mechanisms.
 
-Each server push is identified by a unique Push ID. This Push ID is used in all
-PUSH_PROMISE frames (see {{frame-push-promise}}) which carries the request
+Each server push is identified by a unique Push ID. This Push ID is used in one
+or more PUSH_PROMISE frames (see {{frame-push-promise}}) that carry the request
 headers, then included with the push stream which ultimately fulfills those
-promises.
+promises. When the same Push ID is promised on multiple request streams, the
+decompressed request header fields MUST be byte-for-byte identical.
 
 Server push is only enabled on a connection when a client sends a MAX_PUSH_ID
 frame (see {{frame-max-push-id}}). A server cannot use server push until it

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -615,8 +615,8 @@ Each server push is identified by a unique Push ID. This Push ID is used in one
 or more PUSH_PROMISE frames (see {{frame-push-promise}}) that carry the request
 headers, then included with the push stream which ultimately fulfills those
 promises. When the same Push ID is promised on multiple request streams, the
-decompressed request header set MUST contains the same set of fields in the
-same order, and in each field both the name and and value MUST be byte-for-byte
+decompressed request header set MUST contain the same set of fields in the
+same order, and in each field both the name and value MUST be byte-for-byte
 matches.
 
 Server push is only enabled on a connection when a client sends a MAX_PUSH_ID

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -388,7 +388,7 @@ An HTTP message (request or response) consists of:
    sent as a single HEADERS frame.
 
 A server MAY send one or more PUSH_PROMISE (see {{frame-push-promise}}) frames
-frames before, after, or interleaved with the frames of a response message.
+before, after, or interleaved with the frames of a response message.
 These PUSH_PROMISE frames are not part of the response; see {{server-push}} for
 more details.
 
@@ -632,7 +632,7 @@ requests MUST conform to the requirements in Section 8.2 of {{!HTTP2}}.
 Each pushed response is associated with one or more client requests.  The push
 is associated with the request stream on which the PUSH_PROMISE frame was
 received.  The same server push can be associated with additional client
-requests using a PUSH_PROMISE frame with the same push id on multiple request
+requests using a PUSH_PROMISE frame with the same Push ID on multiple request
 stream.  These associations do not affect the operation of the protocol, but MAY
 be used by user agents when deciding how to use pushed resources.
 

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1256,7 +1256,8 @@ matches. Clients SHOULD compare the request header sets for resources promised
 multiple times. If a client receives a Push ID that has already been promised
 and detects a mismatch, it MUST respond with a connection error of type
 H3_GENERAL_PROTOCOL_ERROR. If the decompressed header sets match exactly, the
-client MUST ignore the duplicate PUSH_PROMISE frame.
+client SHOULD associate the pushed content with each stream on which
+a PUSH_PROMISE was received.
 
 Allowing duplicate references to the same Push ID is primarily to reduce
 duplication caused by concurrent requests.  A server SHOULD avoid reusing a Push

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1257,6 +1257,13 @@ and detects a mismatch, it MUST respond with a connection error of type
 H3_GENERAL_PROTOCOL_ERROR. If the decompressed header sets match exactly, the
 client MUST ignore the duplicate PUSH_PROMISE frame.
 
+Allowing duplicate references to the same Push ID is primarily to reduce
+duplication caused by concurrent requests.  A server SHOULD avoid reusing a Push
+ID over a long period.  Clients are likely to consume server push responses and
+not retain them for reuse over time.  Clients that see a PUSH_PROMISE that uses
+a Push ID that they have since consumed and discarded are forced to ignore the
+PUSH_PROMISE.
+
 If a PUSH_PROMISE frame is received on the control stream, the client MUST
 respond with a connection error ({{errors}}) of type H3_FRAME_UNEXPECTED.
 


### PR DESCRIPTION
As proposed on the issue, this removes the DUPLICATE_PUSH frame and permits duplicate PUSH_PROMISE frames which are required to have identical headers.

Fixes #3275.