### PR TITLE
What if an ACK frame doesn't fit in a packet

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3184,7 +3184,7 @@ more out-of-order the packets are, the more important it is to send an updated
 ACK frame quickly, to prevent the peer from declaring a packet as lost and
 spuriously retransmitting the frames it contains.  The ACK frame is expected
 will be much smaller than a QUIC packet.  However, if the entire ACK frame
-does not fit into a single QUIC packet, older ranges (that is, those with the
+(those with the smallest packet numbers) are omitted.
 
 {{ack-tracking}} and {{ack-limiting}} describe an exemplary approach for
 determining what packets to acknowledge in each ACK frame.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3184,9 +3184,8 @@ more out-of-order the packets are, the more important it is to send an updated
 ACK frame quickly, to prevent the peer from declaring a packet as lost and
 spuriously retransmitting the frames it contains.  It's expected the ACK frame
 will be much smaller than a QUIC packet.  However, if the entire ACK frame
-does not fit into a single QUIC packet, older ranges (that is, those with 
-the smallest packet numbers) SHOULD be omitted.
-numbers SHOULD be omitted.
+does not fit into a single QUIC packet, older ranges (that is, those with the
+smallest packet numbers) SHOULD be omitted.
 
 {{ack-tracking}} and {{ack-limiting}} describe an exemplary approach for
 determining what packets to acknowledge in each ACK frame.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3184,7 +3184,8 @@ more out-of-order the packets are, the more important it is to send an updated
 ACK frame quickly, to prevent the peer from declaring a packet as lost and
 spuriously retransmitting the frames it contains.  It's expected the ACK frame
 will be much smaller than a QUIC packet.  However, if the entire ACK frame
-does not fit into a single QUIC packet, older ranges with the smallest packet
+does not fit into a single QUIC packet, older ranges (that is, those with 
+the smallest packet numbers) SHOULD be omitted.
 numbers SHOULD be omitted.
 
 {{ack-tracking}} and {{ack-limiting}} describe an exemplary approach for

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3182,7 +3182,7 @@ caused by losing previously sent ACK frames, at the cost of larger ACK frames.
 ACK frames SHOULD always acknowledge the most recently received packets, and the
 more out-of-order the packets are, the more important it is to send an updated
 ACK frame quickly, to prevent the peer from declaring a packet as lost and
-spuriously retransmitting the frames it contains.  The ACK frame is expected
+spuriously retransmitting the frames it contains.  An ACK frame is expected
 to fit within a single QUIC packet.  If it does not, then older ranges
 (those with the smallest packet numbers) are omitted.
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3183,7 +3183,7 @@ ACK frames SHOULD always acknowledge the most recently received packets, and the
 more out-of-order the packets are, the more important it is to send an updated
 ACK frame quickly, to prevent the peer from declaring a packet as lost and
 spuriously retransmitting the frames it contains.  The ACK frame is expected
-will be much smaller than a QUIC packet.  However, if the entire ACK frame
+to fit within a single QUIC packet.  If it does not, then older ranges
 (those with the smallest packet numbers) are omitted.
 
 {{ack-tracking}} and {{ack-limiting}} describe an exemplary approach for

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3182,7 +3182,7 @@ caused by losing previously sent ACK frames, at the cost of larger ACK frames.
 ACK frames SHOULD always acknowledge the most recently received packets, and the
 more out-of-order the packets are, the more important it is to send an updated
 ACK frame quickly, to prevent the peer from declaring a packet as lost and
-spuriously retransmitting the frames it contains.  It's expected the ACK frame
+spuriously retransmitting the frames it contains.  The ACK frame is expected
 will be much smaller than a QUIC packet.  However, if the entire ACK frame
 does not fit into a single QUIC packet, older ranges (that is, those with the
 smallest packet numbers) SHOULD be omitted.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3185,7 +3185,6 @@ ACK frame quickly, to prevent the peer from declaring a packet as lost and
 spuriously retransmitting the frames it contains.  The ACK frame is expected
 will be much smaller than a QUIC packet.  However, if the entire ACK frame
 does not fit into a single QUIC packet, older ranges (that is, those with the
-smallest packet numbers) SHOULD be omitted.
 
 {{ack-tracking}} and {{ack-limiting}} describe an exemplary approach for
 determining what packets to acknowledge in each ACK frame.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3182,7 +3182,10 @@ caused by losing previously sent ACK frames, at the cost of larger ACK frames.
 ACK frames SHOULD always acknowledge the most recently received packets, and the
 more out-of-order the packets are, the more important it is to send an updated
 ACK frame quickly, to prevent the peer from declaring a packet as lost and
-spuriously retransmitting the frames it contains.
+spuriously retransmitting the frames it contains.  It's expected the ACK frame
+will be much smaller than a QUIC packet.  However, if the entire ACK frame
+does not fit into a single QUIC packet, older ranges with the smallest packet
+numbers SHOULD be omitted.
 
 {{ack-tracking}} and {{ack-limiting}} describe an exemplary approach for
 determining what packets to acknowledge in each ACK frame.


### PR DESCRIPTION
If so, don't serialize the oldest ranges, as previously specified.

Fixes #3311