### PR TITLE
Unknown error codes are equivalent to NO_ERROR

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1385,9 +1385,9 @@ the entire connection when an error is encountered.  These are referred to as
 connection error.
 
 Because new error codes can be defined without negotiation (see {{extensions}}),
-receipt of an unknown error code or use of an error code in an unexpected
-context MUST NOT be treated as an error.  However, closing a stream can
-constitute an error regardless of the error code (see {{request-response}}).
+use of an error code in an unexpected context or receipt of an unknown error
+code MUST be treated as equivalent to H3_NO_ERROR.  However, closing a stream
+can have other effects regardless of the error code (see {{request-response}}).
 
 This section describes HTTP/3-specific error codes which can be used to express
 the cause of a connection or stream error.


### PR DESCRIPTION
Fixes #3276; closes #3239.

This is not quite editorial.  We previously cautioned implementations not to freak out about unexpected uses of error codes; this text requires them to treat unknown/unexpected codes as equivalent to H3_NO_ERROR.