### PR TITLE
GOAWAY initiating a graceful shutdown can carry a huge stream ID

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -728,7 +728,7 @@ the last Stream ID, since clients might already have retried unprocessed
 requests on another connection.  A server that is attempting to gracefully shut
 down a connection SHOULD send an initial GOAWAY frame with the last Stream ID
 set to the maximum value allowed by the concurrency control of QUIC for the
-client-initiated, bidirectional streams (see section 4.5 of {{QUIC-TRANSPORT}})
+client-initiated, bidirectional streams (see Section 4.5 of {{QUIC-TRANSPORT}})
 or any value above that, and SHOULD NOT grant any more concurrency credit at the
 transport layer thereafter.  This signals to the client that a shutdown is
 imminent and that initiating further requests is prohibited.  After allowing

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -725,16 +725,18 @@ A client that is unable to retry requests loses all requests that are in flight
 when the server closes the connection.  A server MAY send multiple GOAWAY frames
 indicating different stream IDs, but MUST NOT increase the value they send in
 the last Stream ID, since clients might already have retried unprocessed
-requests on another connection.  A server that is attempting to gracefully shut
-down a connection SHOULD send an initial GOAWAY frame with the last Stream ID
-set to the maximum value currently allowed by the concurrency control of QUIC
-for the client-initiated, bidirectional streams (see Section 4.5 of
-{{QUIC-TRANSPORT}}) or any value above that, and SHOULD NOT grant any more
-concurrency credit at the transport layer thereafter.  This signals to the
-client that a shutdown is imminent and that initiating further requests is
-prohibited.  After allowing time for any in-flight requests (at least one
-round-trip time), the server MAY send another GOAWAY frame with an updated last
-Stream ID.  This ensures that a connection can be cleanly shut down without
+requests on another connection.
+
+A server that is attempting to gracefully shut down a connection SHOULD send an
+initial GOAWAY frame with the last Stream ID set to the maximum value currently
+allowed by the concurrency control of QUIC for the client-initiated,
+bidirectional streams (see Section 4.5 of {{QUIC-TRANSPORT}}) or any value above
+that.  This GOAWAY frame signals to the client that shutdown is imminent and
+that initiating further requests is prohibited.  In addition to sending this
+GOAWAY frame, the server SHOULD stop granting additional concurrency credits at
+the transport layer.  After allowing time for any in-flight requests (at least
+one round-trip time), the server MAY send another GOAWAY frame with an updated
+last Stream ID.  This ensures that a connection can be cleanly shut down without
 causing requests to fail.
 
 Once all accepted requests have been processed, the server can permit the

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -734,7 +734,8 @@ additional concurrency credits thereafter.  This signals to the client that a
 shutdown is imminent and that initiating further requests is prohibited.  After
 allowing time for any in-flight requests (at least one round-trip time), the
 server MAY send another GOAWAY frame with an updated last Stream ID.  This
-ensures that a connection can be cleanly shut down without losing requests.
+ensures that a connection can be cleanly shut down without causing requests to
+fail.
 
 Once all accepted requests have been processed, the server can permit the
 connection to become idle, or MAY initiate an immediate closure of the

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -727,12 +727,14 @@ indicating different stream IDs, but MUST NOT increase the value they send in
 the last Stream ID, since clients might already have retried unprocessed
 requests on another connection.  A server that is attempting to gracefully shut
 down a connection SHOULD send an initial GOAWAY frame with the last Stream ID
-set to the maximum value allowed by QUIC's MAX_STREAMS and SHOULD NOT increase
-the MAX_STREAMS limit thereafter.  This signals to the client that a shutdown is
-imminent and that initiating further requests is prohibited.  After allowing
-time for any in-flight requests (at least one round-trip time), the server MAY
-send another GOAWAY frame with an updated last Stream ID.  This ensures that a
-connection can be cleanly shut down without losing requests.
+set to the maximum value allowed by the concurrency control of QUIC for the
+client-initiated, bidirectional streams (see section 4.5 of {{QUIC-TRANSPORT}})
+or any value above that, and SHOULD forbid the QUIC transport from granting
+additional concurrency credits thereafter.  This signals to the client that a
+shutdown is imminent and that initiating further requests is prohibited.  After
+allowing time for any in-flight requests (at least one round-trip time), the
+server MAY send another GOAWAY frame with an updated last Stream ID.  This
+ensures that a connection can be cleanly shut down without losing requests.
 
 Once all accepted requests have been processed, the server can permit the
 connection to become idle, or MAY initiate an immediate closure of the

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -727,17 +727,14 @@ indicating different stream IDs, but MUST NOT increase the value they send in
 the last Stream ID, since clients might already have retried unprocessed
 requests on another connection.
 
-A server that is attempting to gracefully shut down a connection SHOULD send an
-initial GOAWAY frame with the last Stream ID set to the maximum value currently
-allowed by the concurrency control of QUIC for the client-initiated,
-bidirectional streams (see Section 4.5 of {{QUIC-TRANSPORT}}) or any value above
-that.  This GOAWAY frame signals to the client that shutdown is imminent and
-that initiating further requests is prohibited.  In addition to sending this
-GOAWAY frame, the server SHOULD stop granting additional concurrency credits at
-the transport layer.  After allowing time for any in-flight requests (at least
-one round-trip time), the server MAY send another GOAWAY frame with an updated
-last Stream ID.  This ensures that a connection can be cleanly shut down without
-causing requests to fail.
+A server that is attempting to gracefully shut down a connection can send an
+initial GOAWAY frame with the last Stream ID set to the maximum possible value
+for a client-initiated, bidirectional stream (i.e. 2^62-4 in case of QUIC
+version 1).  This GOAWAY frame signals to the client that shutdown is imminent
+and that initiating further requests is prohibited.  After allowing time for any
+in-flight requests (at least one round-trip time), the server would send another
+GOAWAY frame with an updated last Stream ID.  This ensures that a connection can
+be cleanly shut down without causing requests to fail.
 
 Once all accepted requests have been processed, the server can permit the
 connection to become idle, or MAY initiate an immediate closure of the

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -727,14 +727,15 @@ indicating different stream IDs, but MUST NOT increase the value they send in
 the last Stream ID, since clients might already have retried unprocessed
 requests on another connection.  A server that is attempting to gracefully shut
 down a connection SHOULD send an initial GOAWAY frame with the last Stream ID
-set to the maximum value allowed by the concurrency control of QUIC for the
-client-initiated, bidirectional streams (see Section 4.5 of {{QUIC-TRANSPORT}})
-or any value above that, and SHOULD NOT grant any more concurrency credit at the
-transport layer thereafter.  This signals to the client that a shutdown is
-imminent and that initiating further requests is prohibited.  After allowing
-time for any in-flight requests (at least one round-trip time), the server MAY
-send another GOAWAY frame with an updated last Stream ID.  This ensures that a
-connection can be cleanly shut down without causing requests to fail.
+set to the maximum value currently allowed by the concurrency control of QUIC
+for the client-initiated, bidirectional streams (see Section 4.5 of
+{{QUIC-TRANSPORT}}) or any value above that, and SHOULD NOT grant any more
+concurrency credit at the transport layer thereafter.  This signals to the
+client that a shutdown is imminent and that initiating further requests is
+prohibited.  After allowing time for any in-flight requests (at least one
+round-trip time), the server MAY send another GOAWAY frame with an updated last
+Stream ID.  This ensures that a connection can be cleanly shut down without
+causing requests to fail.
 
 Once all accepted requests have been processed, the server can permit the
 connection to become idle, or MAY initiate an immediate closure of the

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -729,13 +729,12 @@ requests on another connection.  A server that is attempting to gracefully shut
 down a connection SHOULD send an initial GOAWAY frame with the last Stream ID
 set to the maximum value allowed by the concurrency control of QUIC for the
 client-initiated, bidirectional streams (see section 4.5 of {{QUIC-TRANSPORT}})
-or any value above that, and SHOULD forbid the QUIC transport from granting
-additional concurrency credits thereafter.  This signals to the client that a
-shutdown is imminent and that initiating further requests is prohibited.  After
-allowing time for any in-flight requests (at least one round-trip time), the
-server MAY send another GOAWAY frame with an updated last Stream ID.  This
-ensures that a connection can be cleanly shut down without causing requests to
-fail.
+or any value above that, and SHOULD NOT grant any more concurrency credit at the
+transport layer thereafter.  This signals to the client that a shutdown is
+imminent and that initiating further requests is prohibited.  After allowing
+time for any in-flight requests (at least one round-trip time), the server MAY
+send another GOAWAY frame with an updated last Stream ID.  This ensures that a
+connection can be cleanly shut down without causing requests to fail.
 
 Once all accepted requests have been processed, the server can permit the
 connection to become idle, or MAY initiate an immediate closure of the


### PR DESCRIPTION
Clarify that when initiating a graceful shutdown, sending a stream ID that is greater than the current maximum communicated to the peer is as correct as sending the current maximum.

This is because we already state that _clients MUST NOT send new requests on the connection after receiving GOAWAY; a new connection MAY be established to send additional requests_ ([section 5.2](https://quicwg.org/base-drafts/draft-ietf-quic-http.html#section-5.2-3)).

As discussed in #3341, such change helps us minimize the API exposed by the QUIC transport.

In addition, the proposed text talks refers to the stream concurrency of QUIC as a concept, rather than talking about a specific frame (i.e. MAX_STREAMS).

Closes #3341.