### PR TITLE
Clarify section on negotiating connection IDs

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1451,11 +1451,11 @@ client's first Initial packet.
 
 Upon first receiving an Initial or Retry packet from the server, the client uses
 the SCID supplied by the server as the DCID for subsequent packets, including
-all subsequent Handshake and 0-RTT packets. This means that a client might
-change the DCID twice during connection establishment, once in response to a
-Retry and once in response to an Initial packet from the server. Once a client
-has received an Initial packet from the server, it MUST discard any subsequent
-packet it receives with a different Source Connection ID.
+all subsequent 0-RTT packets. This means that a client might change the DCID
+twice during connection establishment, once in response to a Retry and once in
+response to an Initial packet from the server. Once a client has received an
+Initial packet from the server, it MUST discard any subsequent packet it
+receives with a different Source Connection ID.
 
 A client MUST change the DCID value it sends in response to only the first
 received Initial or Retry packet.  A server MUST set its DCID value based on the

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1464,7 +1464,7 @@ A client MUST change the Destination Connection ID it uses for sending packets
 in response to only the first received Initial or Retry packet.  A server MUST
 set the Destination Connection ID it uses for sending packets based on the first
 received Initial packet. Any further changes to the Destination Connection ID
-are are only permitted if the values are taken from any received
+are only permitted if the values are taken from any received
 NEW_CONNECTION_ID frames; if subsequent Initial packets include a different
 Source Connection ID, they MUST be discarded.  This avoids unpredictable
 outcomes that might otherwise result from stateless processing of multiple

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1426,50 +1426,47 @@ Handshake[0]: CRYPTO[FIN], ACK[0]
 
 A connection ID is used to ensure consistent routing of packets, as described in
 {{connection-id}}.  The long header contains two connection IDs: the Destination
-Connection ID is chosen by the recipient of the packet and is used to provide
-consistent routing; the Source Connection ID is used to set the Destination
-Connection ID used by the peer.
+Connection ID (DCID) is chosen by the recipient of the packet and is used to
+provide consistent routing; the Source Connection ID (SCID) is used to set the
+Destination Connection ID used by the peer.
 
 During the handshake, packets with the long header ({{long-header}}) are used to
-establish the connection ID that each endpoint uses.  Each endpoint uses the
-Source Connection ID field to specify the connection ID that is used in the
-Destination Connection ID field of packets being sent to them.  Upon receiving a
-packet, each endpoint sets the Destination Connection ID it sends to match the
-value of the Source Connection ID that they receive.
+establish the connection IDs in each direction. Each endpoint uses the SCID
+field to specify the connection ID that is used in the DCID field of packets
+being sent to them. Upon receiving a packet, each endpoint sets the DCID it
+sends to match the value of the SCID that it receives.
 
 When an Initial packet is sent by a client that has not previously received an
-Initial or Retry packet from the server, it populates the Destination Connection
-ID field with an unpredictable value.  This MUST be at least 8 bytes in length.
-Until a packet is received from the server, the client MUST use the same value
-unless it abandons the connection attempt and starts a new one. The initial
-Destination Connection ID is used to determine packet protection keys for
-Initial packets.
+Initial or Retry packet from the server, the client populates the DCID field
+with an unpredictable value.  This DCID MUST be at least 8 bytes in length.
+Until a packet is received from the server, the client MUST use the same DCID
+value on all packets in this connection. This DCID is used to determine packet
+protection keys for Initial packets.
 
-The client populates the Source Connection ID field with a value of its choosing
-and sets the SCID Len field to indicate the length.
+The client populates the SCID field with a value of its choosing and sets the
+SCID Len field to indicate the length.
 
-The first flight of 0-RTT packets use the same Destination and Source Connection
-ID values as the client's first Initial.
+The first flight of 0-RTT packets use the same DCID and SCID values as the
+client's first Initial packet.
 
 Upon first receiving an Initial or Retry packet from the server, the client uses
-the Source Connection ID supplied by the server as the Destination Connection ID
-for subsequent packets, including any subsequent 0-RTT packets.  That means that
-a client might change the Destination Connection ID twice during connection
-establishment, once in response to a Retry and once in response to the first
-Initial packet from the server. Once a client has received an Initial packet
-from the server, it MUST discard any packet it receives with a different Source
-Connection ID.
+the SCID supplied by the server as the DCID for subsequent packets, including
+all subsequent Handshake and 0-RTT packets. This means that a client might
+change the DCID twice during connection establishment, once in response to a
+Retry and once in response to an Initial packet from the server. Once a client
+has received an Initial packet from the server, it MUST discard any subsequent
+packet it receives with a different Source Connection ID.
 
-A client MUST only change the value it sends in the Destination Connection ID in
-response to the first packet of each type it receives from the server (Retry or
-Initial); a server MUST set its value based on the Initial packet.  Any
-additional changes are not permitted; if subsequent packets of those types
-include a different Source Connection ID, they MUST be discarded.  This avoids
-problems that might arise from stateless processing of multiple Initial packets
-producing different connection IDs.
+A client MUST change the DCID value it sends in response to only the first
+received Initial or Retry packet.  A server MUST set its DCID value based on the
+first received Initial packet. Any further changes to the DCID are not
+permitted; if subsequent Initial packets include a different SCID, they MUST be
+discarded.  This avoids unpredictable outcomes that might otherwise result from
+stateless processing of multiple Initial packets with different SCIDs.
 
-The connection ID can change over the lifetime of a connection, especially in
-response to connection migration ({{migration}}); see {{issue-cid}} for details.
+The DCID that an endpoint sends can change over the lifetime of a connection,
+especially in response to connection migration ({{migration}}); see
+{{issue-cid}} for details.
 
 
 ## Transport Parameters {#transport-parameters}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1432,15 +1432,17 @@ Connection ID used by the peer.
 
 During the handshake, packets with the long header ({{long-header}}) are used to
 establish the connection IDs in each direction. Each endpoint uses the Source
-Connection ID field to specify the connection ID that is used in the DCID field
-of packets being sent to them. Upon receiving a packet, each endpoint sets the
-DCID it sends to match the value of the Source Connection ID that it receives.
+Connection ID field to specify the connection ID that is used in the Destination
+Connection ID field of packets being sent to them. Upon receiving a packet, each
+endpoint sets the Destination Connection ID it sends to match the value of the
+Source Connection ID that it receives.
 
 When an Initial packet is sent by a client that has not previously received an
-Initial or Retry packet from the server, the client populates the DCID field
-with an unpredictable value.  This DCID MUST be at least 8 bytes in length.
-Until a packet is received from the server, the client MUST use the same DCID
-value on all packets in this connection. This DCID is used to determine packet
+Initial or Retry packet from the server, the client populates the Destination
+Connection ID field with an unpredictable value.  This Destination Connection ID
+MUST be at least 8 bytes in length.  Until a packet is received from the server,
+the client MUST use the same Destination Connection ID value on all packets in
+this connection. This Destination Connection ID is used to determine packet
 protection keys for Initial packets.
 
 The client populates the Source Connection ID field with a value of its choosing

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1426,15 +1426,15 @@ Handshake[0]: CRYPTO[FIN], ACK[0]
 
 A connection ID is used to ensure consistent routing of packets, as described in
 {{connection-id}}.  The long header contains two connection IDs: the Destination
-Connection ID (DCID) is chosen by the recipient of the packet and is used to
-provide consistent routing; the Source Connection ID (SCID) is used to set the
-Destination Connection ID used by the peer.
+Connection ID is chosen by the recipient of the packet and is used to provide
+consistent routing; the Source Connection ID is used to set the Destination
+Connection ID used by the peer.
 
 During the handshake, packets with the long header ({{long-header}}) are used to
-establish the connection IDs in each direction. Each endpoint uses the SCID
-field to specify the connection ID that is used in the DCID field of packets
-being sent to them. Upon receiving a packet, each endpoint sets the DCID it
-sends to match the value of the SCID that it receives.
+establish the connection IDs in each direction. Each endpoint uses the Source
+Connection ID field to specify the connection ID that is used in the DCID field
+of packets being sent to them. Upon receiving a packet, each endpoint sets the
+DCID it sends to match the value of the Source Connection ID that it receives.
 
 When an Initial packet is sent by a client that has not previously received an
 Initial or Retry packet from the server, the client populates the DCID field
@@ -1443,30 +1443,34 @@ Until a packet is received from the server, the client MUST use the same DCID
 value on all packets in this connection. This DCID is used to determine packet
 protection keys for Initial packets.
 
-The client populates the SCID field with a value of its choosing and sets the
-SCID Len field to indicate the length.
+The client populates the Source Connection ID field with a value of its choosing
+and sets the SCID Len field to indicate the length.
 
-The first flight of 0-RTT packets use the same DCID and SCID values as the
-client's first Initial packet.
+The first flight of 0-RTT packets use the same Destination Connection ID and
+Source Connection ID values as the client's first Initial packet.
 
 Upon first receiving an Initial or Retry packet from the server, the client uses
-the SCID supplied by the server as the DCID for subsequent packets, including
-all subsequent 0-RTT packets. This means that a client might change the DCID
-twice during connection establishment, once in response to a Retry and once in
-response to an Initial packet from the server. Once a client has received an
-Initial packet from the server, it MUST discard any subsequent packet it
-receives with a different Source Connection ID.
+the Source Connection ID supplied by the server as the Destination Connection ID
+for subsequent packets, including all subsequent 0-RTT packets.  This means that
+a client might have to change the connection ID it sets in the Destination
+Connection ID field twice during connection establishment: once in response to a
+Retry, and once in response to an Initial packet from the server. Once a client
+has received an Initial packet from the server, it MUST discard any subsequent
+packet it receives with a different Source Connection ID.
 
-A client MUST change the DCID value it sends in response to only the first
-received Initial or Retry packet.  A server MUST set its DCID value based on the
-first received Initial packet. Any further changes to the DCID are not
-permitted; if subsequent Initial packets include a different SCID, they MUST be
-discarded.  This avoids unpredictable outcomes that might otherwise result from
-stateless processing of multiple Initial packets with different SCIDs.
+A client MUST change the Destination Connection ID it uses for sending packets
+in response to only the first received Initial or Retry packet.  A server MUST
+set the Destination Connection ID it uses for sending packets based on the first
+received Initial packet. Any further changes to the Destination Connection ID
+are are only permitted if the values are taken from any received
+NEW_CONNECTION_ID frames; if subsequent Initial packets include a different
+Source Connection ID, they MUST be discarded.  This avoids unpredictable
+outcomes that might otherwise result from stateless processing of multiple
+Initial packets with different Source Connection IDs.
 
-The DCID that an endpoint sends can change over the lifetime of a connection,
-especially in response to connection migration ({{migration}}); see
-{{issue-cid}} for details.
+The Destination Connection ID that an endpoint sends can change over the
+lifetime of a connection, especially in response to connection migration
+({{migration}}); see {{issue-cid}} for details.
 
 
 ## Transport Parameters {#transport-parameters}


### PR DESCRIPTION
In thinking about #3348, I started this editorial PR to clarify language in the section on negotiating connection IDs. I suspect much of it was left over from before we had the DCID / SCID split, and also before the new handshake was established.

Addresses #3348.