### PR TITLE
Clarify and split the "malformed" definition

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -403,8 +403,8 @@ A server MAY send one or more PUSH_PROMISE frames (see {{frame-push-promise}})
 before, after, or interleaved with the frames of a response message. These
 PUSH_PROMISE frames are not part of the response; see {{server-push}} for more
 details.  These frames are not permitted in pushed responses; a pushed response
-which includes PUSH_PROMISE or DUPLICATE_PUSH frames MUST be treated as a
-connection error of type H3_FRAME_UNEXPECTED.
+which includes PUSH_PROMISE frames MUST be treated as a connection error of type
+H3_FRAME_UNEXPECTED.
 
 Frames of unknown types ({{extensions}}), including reserved frames
 ({{frame-reserved}}) MAY be sent on a request or push stream before, after, or

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -402,7 +402,9 @@ connection error of type H3_FRAME_UNEXPECTED ({{errors}}).
 A server MAY send one or more PUSH_PROMISE frames (see {{frame-push-promise}})
 before, after, or interleaved with the frames of a response message. These
 PUSH_PROMISE frames are not part of the response; see {{server-push}} for more
-details.  These frames are not permitted in pushed responses.
+details.  These frames are not permitted in pushed responses; a pushed response
+is malformed ({{malformed}}) if it includes PUSH_PROMISE or DUPLICATE_PUSH
+frames.
 
 Frames of unknown types ({{extensions}}), including reserved frames
 ({{frame-reserved}}) MAY be sent on a request or push stream before, after, or
@@ -510,44 +512,45 @@ malformed ({{malformed}}).
 The following pseudo-header fields are defined for requests:
 
   ":method":
+
   : Contains the HTTP method ({{!RFC7231}}, Section 4)
 
   ":scheme":
+
   : Contains the scheme portion of the target URI ({{!RFC3986}}, Section 3.1)
 
-  : ":scheme" is not restricted to "http" and "https" schemed URIs.  A
-    proxy or gateway can translate requests for non-HTTP schemes,
-    enabling the use of HTTP to interact with non-HTTP services.
+  : ":scheme" is not restricted to "http" and "https" schemed URIs.  A proxy or
+    gateway can translate requests for non-HTTP schemes, enabling the use of
+    HTTP to interact with non-HTTP services.
 
   ":authority":
 
-  : Contains the authority portion of the target URI ([RFC3986], Section 3.2).
+  : Contains the authority portion of the target URI (Section 3.2 of [RFC3986]).
     The authority MUST NOT include the deprecated "userinfo" subcomponent for
     "http" or "https" schemed URIs.
 
-  : To ensure that the HTTP/1.1 request line can be reproduced
-    accurately, this pseudo-header field MUST be omitted when
-    translating from an HTTP/1.1 request that has a request target in
-    origin or asterisk form (see [RFC7230], Section 5.3).  Clients
-    that generate HTTP/3 requests directly SHOULD use the ":authority"
-    pseudo-header field instead of the Host header field.  An
-    intermediary that converts an HTTP/3 request to HTTP/1.1 MUST
-    create a Host header field if one is not present in a request by
-    copying the value of the ":authority" pseudo-header field.
+  : To ensure that the HTTP/1.1 request line can be reproduced accurately, this
+    pseudo-header field MUST be omitted when translating from an HTTP/1.1
+    request that has a request target in origin or asterisk form (see Section
+    5.3 of [RFC7230]).  Clients that generate HTTP/3 requests directly SHOULD
+    use the ":authority" pseudo-header field instead of the Host header field.
+    An intermediary that converts an HTTP/3 request to HTTP/1.1 MUST create a
+    Host header field if one is not present in a request by copying the value of
+    the ":authority" pseudo-header field.
 
   ":path":
 
   : Contains the path and query parts of the target URI (the "path-absolute"
-    production and optionally a '?' character followed by the "query"
-    production (see Sections 3.3 and 3.4 of [RFC3986]).  A request in asterisk
-    form includes the value '*' for the ":path" pseudo-header field.
+    production and optionally a '?' character followed by the "query" production
+    (see Sections 3.3 and 3.4 of [RFC3986]).  A request in asterisk form
+    includes the value '*' for the ":path" pseudo-header field.
 
-  : This pseudo-header field MUST NOT be empty for "http" or "https"
-    URIs; "http" or "https" URIs that do not contain a path component
-    MUST include a value of '/'.  The exception to this rule is an
-    OPTIONS request for an "http" or "https" URI that does not include
-    a path component; these MUST include a ":path" pseudo-header field
-    with a value of '*' (see [RFC7230], Section 5.3.4).
+  : This pseudo-header field MUST NOT be empty for "http" or "https" URIs;
+    "http" or "https" URIs that do not contain a path component MUST include a
+    value of '/'.  The exception to this rule is an OPTIONS request for an
+    "http" or "https" URI that does not include a path component; these MUST
+    include a ":path" pseudo-header field with a value of '*' (see Section 5.3.4
+    of [RFC7230]).
 
 All HTTP/3 requests MUST include exactly one value for the ":method", ":scheme",
 and ":path" pseudo-header fields, unless it is a CONNECT request ({{connect}}).
@@ -558,9 +561,9 @@ HTTP/3 does not define a way to carry the version identifier that is included in
 the HTTP/1.1 request line.
 
 For responses, a single ":status" pseudo-header field is defined that carries
-the HTTP status code field (see [RFC7231], Section 6).  This pseudo-header field
-MUST be included in all responses; otherwise, the response is malformed (Section
-8.1.2.6).
+the HTTP status code field (see Section 6 of [RFC7231]).  This pseudo-header
+field MUST be included in all responses; otherwise, the response is malformed
+({{malformed}}).
 
 HTTP/3 does not define a way to carry the version or reason phrase that is
 included in an HTTP/1.1 status line.
@@ -631,9 +634,10 @@ permitted (e.g., idempotent actions like GET, PUT, or DELETE).
 A malformed request or response is one that is an otherwise valid sequence of
 frames but is invalid due to:
 
-- the presence of prohibited header fields or pseudo-header fields
-- the absence of mandatory pseudo-header fields
-- invalid values for pseudo-header fields
+- the presence of prohibited header fields or pseudo-header fields,
+- the absence of mandatory pseudo-header fields,
+- invalid values for pseudo-header fields,
+- pseudo-header fields after header fields,
 - an invalid sequence of HTTP messages, or
 - the inclusion of uppercase header field names.
 

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -387,10 +387,13 @@ An HTTP message (request or response) consists of:
 3. optionally, trailing headers, if present (see Section 4.1.2 of {{!RFC7230}}),
    sent as a single HEADERS frame.
 
+Receipt of DATA and HEADERS frames in any other sequence MUST be treated as a
+connection error of type H3_FRAME_UNEXPECTED ({{errors}}).
+
 A server MAY send one or more PUSH_PROMISE frames (see {{frame-push-promise}})
-before, after, or interleaved with the frames of a response message.
-These PUSH_PROMISE frames are not part of the response; see {{server-push}} for
-more details.
+before, after, or interleaved with the frames of a response message. These
+PUSH_PROMISE frames are not part of the response; see {{server-push}} for more
+details.
 
 Frames of unknown types ({{extensions}}), including reserved frames
 ({{frame-reserved}}) MAY be sent on a request or push stream before, after, or
@@ -617,9 +620,9 @@ permitted (e.g., idempotent actions like GET, PUT, or DELETE).
 ### Malformed Requests and Responses {#malformed}
 
 A malformed request or response is one that is an otherwise valid sequence of
-frames but is invalid due to the presence of extraneous frames, prohibited
-header fields, the absence of mandatory header fields, or the inclusion of
-uppercase header field names.
+frames but is invalid due to the presence of prohibited header fields, the
+absence of mandatory header fields, or the inclusion of uppercase header field
+names.
 
 A request or response that includes a payload body can include a
 `content-length` header field.  A request or response is also malformed if the

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -520,9 +520,9 @@ The following pseudo-header fields are defined for requests:
     accurately, this pseudo-header field MUST be omitted when
     translating from an HTTP/1.1 request that has a request target in
     origin or asterisk form (see [RFC7230], Section 5.3).  Clients
-    that generate HTTP/2 requests directly SHOULD use the ":authority"
+    that generate HTTP/3 requests directly SHOULD use the ":authority"
     pseudo-header field instead of the Host header field.  An
-    intermediary that converts an HTTP/2 request to HTTP/1.1 MUST
+    intermediary that converts an HTTP/3 request to HTTP/1.1 MUST
     create a Host header field if one is not present in a request by
     copying the value of the ":authority" pseudo-header field.
 

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -506,7 +506,7 @@ The following pseudo-header fields are defined for requests:
   ":scheme":
   : Contains the scheme portion of the target URI ({{!RFC3986}}, Section 3.1)
 
-    ":scheme" is not restricted to "http" and "https" schemed URIs.  A
+  : ":scheme" is not restricted to "http" and "https" schemed URIs.  A
     proxy or gateway can translate requests for non-HTTP schemes,
     enabling the use of HTTP to interact with non-HTTP services.
 

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -403,8 +403,8 @@ A server MAY send one or more PUSH_PROMISE frames (see {{frame-push-promise}})
 before, after, or interleaved with the frames of a response message. These
 PUSH_PROMISE frames are not part of the response; see {{server-push}} for more
 details.  These frames are not permitted in pushed responses; a pushed response
-is malformed ({{malformed}}) if it includes PUSH_PROMISE or DUPLICATE_PUSH
-frames.
+which includes PUSH_PROMISE or DUPLICATE_PUSH frames MUST be treated as a
+connection error of type H3_FRAME_UNEXPECTED.
 
 Frames of unknown types ({{extensions}}), including reserved frames
 ({{frame-reserved}}) MAY be sent on a request or push stream before, after, or

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -376,6 +376,10 @@ A client MUST send only a single request on a given stream. A server sends zero
 or more non-final HTTP responses on the same stream as the request, followed by
 a single final HTTP response, as detailed below.
 
+On a given stream, receipt of multiple requests or receipt of an additional HTTP
+response following a final HTTP response MUST be treated as malformed
+({{malformed}}).
+
 An HTTP message (request or response) consists of:
 
 1. the message header (see Section 3.2 of {{!RFC7230}}), sent as a single
@@ -621,8 +625,8 @@ permitted (e.g., idempotent actions like GET, PUT, or DELETE).
 
 A malformed request or response is one that is an otherwise valid sequence of
 frames but is invalid due to the presence of prohibited header fields, the
-absence of mandatory header fields, or the inclusion of uppercase header field
-names.
+absence of mandatory header fields, an invalid sequence of HTTP messages, or the
+inclusion of uppercase header field names.
 
 A request or response that includes a payload body can include a
 `content-length` header field.  A request or response is also malformed if the


### PR DESCRIPTION
Lots of text, but it's basically all an import from RFC 7540 (which helps #3264, but doesn't totally resolve it).  This makes the definition of malformed requests entirely local and more precise than previously.

The odd item on the malformed list was "extraneous frames."  We're already fairly permissive about what other frames can show up interleaved with the actual request, so this requirement moved to that section -- receipt of DATA and HEADERS frames outside of the prescribed order is now a connection error.

Fixes #3345.