### PR TITLE
Better describe the use of Preferred Address

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4636,7 +4636,7 @@ preferred_address (0x000d):
   port (0.0.0.0:0 or ::.0) for the other family. IP addresses are encoded in
   network byte order. The Connection ID field and the Stateless Reset Token
   field contain the alternative connection ID that is assigned the sequence
-  number of one ({{issue-cid}}). Having them bundled with the  preferred address
+  number of one ({{issue-cid}}). Having them bundled with the preferred address
   ensures that there would be at least one unused active connection ID when the
   client initiates migration to the preferred address. The CID Length field
   contains the length of the Connection ID field.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2253,8 +2253,7 @@ IPv6) to allow clients to pick the one most suited to their network attachment.
 
 Once the handshake is confirmed, the client SHOULD select one of the two
 server's preferred addresses and initiate path validation (see
-{{migrate-validate}}) of that address using an active unused connection ID that
-it retains.
+{{migrate-validate}}) of that address using an active unused connection ID.
 
 If path validation succeeds, the client SHOULD immediately begin sending all
 future packets to the new server and discontinue use of the old server address.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2253,9 +2253,10 @@ transport parameter in the TLS handshake.
 Servers MAY communicate a preferred address of each address family (IPv4 and
 IPv6) to allow clients to pick the one most suited to their network attachment.
 
-Once the handshake is confirmed, the client SHOULD select one of the two
-server's preferred addresses and initiate path validation (see
-{{migrate-validate}}) of that address using an active unused connection ID.
+Once the handshake is confirmed (see Section 4.1.2 of {{QUIC-TLS}}), the client
+SHOULD select one of the two server's preferred addresses and initiate path
+validation (see {{migrate-validate}}) of that address using an active unused
+connection ID.
 
 If path validation succeeds, the client SHOULD immediately begin sending all
 future packets to the new server and discontinue use of the old server address.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4644,7 +4644,7 @@ preferred_address (0x000d):
   port (0.0.0.0:0 or ::.0) for the other family. IP addresses are encoded in
   network byte order. The Connection ID field and the Stateless Reset Token
   field contain an alternative connection ID that has a sequence
-  number of one ({{issue-cid}}). Having them bundled with the preferred address
+  number of 1 ({{issue-cid}}). Having these values bundled with the preferred address
   ensures that there will be at least one unused active connection ID when the
   client initiates migration to the preferred address. The CID Length field
   contains the length of the Connection ID field.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2251,7 +2251,7 @@ transport parameter in the TLS handshake.
 Servers MAY communicate a preferred address of each address family (IPv4 and
 IPv6) to allow clients to pick the one most suited to their network attachment.
 
-Once the handshake is finished, the client SHOULD select one of the two
+Once the handshake is confirmed, the client SHOULD select one of the two
 server's preferred addresses and initiate path validation (see
 {{migrate-validate}}) of that address using the connection ID provided in the
 preferred_address transport parameter.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4635,8 +4635,11 @@ preferred_address (0x000d):
   transport parameter is only sent by a server. Servers MAY choose to only send
   a preferred address of one address family by sending an all-zero address and
   port (0.0.0.0:0 or ::.0) for the other family. IP addresses are encoded in
-  network byte order. The CID Length field contains the length of the
-  Connection ID field.
+  network byte order. The Connection ID field and the Stateless Reset Token
+  field contain an alternative connection ID. Having them bundled with the
+  preferred address ensures that there would be at least one unused active
+  connection ID when the client initiates migration to the preferred address.
+  The CID Length field contains the length of the Connection ID field.
 
 ~~~
  0                   1                   2                   3

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2194,11 +2194,13 @@ linked by any other entity.
 At any time, endpoints MAY change the Destination Connection ID they send to a
 value that has not been used on another path.
 
-An endpoint MUST use a new connection ID if it initiates connection migration as
-described in {{initiating-migration}} or probes a new network path as described
-in {{probing}}.  An endpoint MUST use a new connection ID in response to a
-change in the address of a peer if the packet with the new peer address uses an
-active connection ID that has not been previously used by the peer.
+An endpoint MUST use a new connection ID when it initiates connection migration
+as described in {{initiating-migration}} or {{preferred-address}}, or when it
+probes a new network path as described in {{probing}}, and MUST NOT reuse
+connection IDs used on the existing network paths for packets being sent on the
+new path.  An endpoint MUST use a new connection ID in response to a change in
+the address of a peer if the packet with the new peer address uses an active
+connection ID that has not been previously used by the peer.
 
 Using different connection IDs for packets sent in both directions on each new
 network path eliminates the use of the connection ID for linking packets from

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2259,16 +2259,12 @@ validation (see {{migrate-validate}}) of that address using an active unused
 connection ID.
 
 If path validation succeeds, the client SHOULD immediately begin sending all
-future packets to the new server and discontinue use of the old server address.
-If path validation fails, the client MUST continue sending all future packets to
-the server's original IP address.
-
-When the client finishes migrating to the preferred address, it retires the
-connection ID that was used for the original path ({{retiring-cids}}).
-Similarly, a client that continues using the original server address SHOULD
-retire the connection ID provided by the preferred_address transport parameter.
-Retirement of either of these connection IDs notifies the server of the
-address the client has chosen.
+future packets to the new server and discontinue use of the old server address,
+and retire the connection ID that was used for the original path
+({{retiring-cids}}).  If path validation fails, or if the client decides not to
+migrate to the preferred address, it MUST continue sending all future packets to
+the server's original IP address, and retire the connection ID provided by the
+preferred_address transport parameter.  Retirement of either of these connection IDs notifies the server of the address the client has chosen.
 
 ### Responding to Connection Migration
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4636,10 +4636,11 @@ preferred_address (0x000d):
   a preferred address of one address family by sending an all-zero address and
   port (0.0.0.0:0 or ::.0) for the other family. IP addresses are encoded in
   network byte order. The Connection ID field and the Stateless Reset Token
-  field contain an alternative connection ID. Having them bundled with the
-  preferred address ensures that there would be at least one unused active
-  connection ID when the client initiates migration to the preferred address.
-  The CID Length field contains the length of the Connection ID field.
+  field contain the alternative connection ID that is assigned the sequence
+  number of one ({{issue-cid}}). Having them bundled with the  preferred address
+  ensures that there would be at least one unused active connection ID when the
+  client initiates migration to the preferred address. The CID Length field
+  contains the length of the Connection ID field.
 
 ~~~
  0                   1                   2                   3

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4642,7 +4642,7 @@ preferred_address (0x000d):
   port (0.0.0.0:0 or ::.0) for the other family. IP addresses are encoded in
   network byte order.
 
-  The Connection ID field and the Stateless Reset Token field contain an
+: The Connection ID field and the Stateless Reset Token field contain an
   alternative connection ID that has a sequence number of 1 ({{issue-cid}}).
   Having these values bundled with the preferred address ensures that there will
   be at least one unused active connection ID when the client initiates

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2264,7 +2264,8 @@ and retire the connection ID that was used for the original path
 ({{retiring-cids}}).  If path validation fails, or if the client decides not to
 migrate to the preferred address, it MUST continue sending all future packets to
 the server's original IP address, and retire the connection ID provided by the
-preferred_address transport parameter.  Retirement of either of these connection IDs notifies the server of the address the client has chosen.
+preferred_address transport parameter.  Retirement of either of these connection
+IDs notifies the server of the address the client has chosen.
 
 ### Responding to Connection Migration
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1036,9 +1036,9 @@ be used again and requests that the peer replace it with a new connection ID
 using a NEW_CONNECTION_ID frame.
 
 As discussed in {{migration-linkability}}, each connection ID MUST be used on
-packets sent from only one local address.  An endpoint that migrates away from a
-local address SHOULD retire all connection IDs used on that address once it no
-longer plans to use that address.
+packets sent from only one local address, and MUST NOT be used across multiple
+paths that are opened intentionally.  An endpoint SHOULD retire connection IDs
+as they become unusable.
 
 An endpoint can cause its peer to retire connection IDs by sending a
 NEW_CONNECTION_ID frame with an increased Retire Prior To field.  Upon receipt,

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2260,6 +2260,12 @@ future packets to the new server and discontinue use of the old server address.
 If path validation fails, the client MUST continue sending all future packets to
 the server's original IP address.
 
+When the client finishes migrating to the preferred address, it retires the
+connection ID that was used for the original path ({{retiring-cids}}).
+Similarly, a client that continues using the original server address SHOULD
+retire the connection ID provided by the preferred_address transport parameter.
+Retirement of either of these connection IDs notifies the server the server
+address the client has chosen.
 
 ### Responding to Connection Migration
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2264,7 +2264,7 @@ When the client finishes migrating to the preferred address, it retires the
 connection ID that was used for the original path ({{retiring-cids}}).
 Similarly, a client that continues using the original server address SHOULD
 retire the connection ID provided by the preferred_address transport parameter.
-Retirement of either of these connection IDs notifies the server the server
+Retirement of either of these connection IDs notifies the server of the
 address the client has chosen.
 
 ### Responding to Connection Migration

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2253,13 +2253,13 @@ IPv6) to allow clients to pick the one most suited to their network attachment.
 
 Once the handshake is confirmed, the client SHOULD select one of the two
 server's preferred addresses and initiate path validation (see
-{{migrate-validate}}) of that address using the connection ID provided in the
-preferred_address transport parameter.
+{{migrate-validate}}) of that address using an active unused connection ID that
+it retains.
 
 If path validation succeeds, the client SHOULD immediately begin sending all
-future packets to the new server address using the new connection ID and
-discontinue use of the old server address.  If path validation fails, the client
-MUST continue sending all future packets to the server's original IP address.
+future packets to the new server and discontinue use of the old server address.
+If path validation fails, the client MUST continue sending all future packets to
+the server's original IP address.
 
 
 ### Responding to Connection Migration

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4637,7 +4637,7 @@ preferred_address (0x000d):
   network byte order. The Connection ID field and the Stateless Reset Token
   field contain the alternative connection ID that is assigned the sequence
   number of one ({{issue-cid}}). Having them bundled with the preferred address
-  ensures that there would be at least one unused active connection ID when the
+  ensures that there will be at least one unused active connection ID when the
   client initiates migration to the preferred address. The CID Length field
   contains the length of the Connection ID field.
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4643,12 +4643,13 @@ preferred_address (0x000d):
   transport parameter is only sent by a server. Servers MAY choose to only send
   a preferred address of one address family by sending an all-zero address and
   port (0.0.0.0:0 or ::.0) for the other family. IP addresses are encoded in
-  network byte order. The Connection ID field and the Stateless Reset Token
-  field contain an alternative connection ID that has a sequence
-  number of 1 ({{issue-cid}}). Having these values bundled with the preferred address
-  ensures that there will be at least one unused active connection ID when the
-  client initiates migration to the preferred address. The CID Length field
-  contains the length of the Connection ID field.
+  network byte order.
+
+  The Connection ID field and the Stateless Reset Token field contain an
+  alternative connection ID that has a sequence number of 1 ({{issue-cid}}).
+  Having these values bundled with the preferred address ensures that there will
+  be at least one unused active connection ID when the client initiates
+  migration to the preferred address.
 
 ~~~
  0                   1                   2                   3

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4643,7 +4643,7 @@ preferred_address (0x000d):
   a preferred address of one address family by sending an all-zero address and
   port (0.0.0.0:0 or ::.0) for the other family. IP addresses are encoded in
   network byte order. The Connection ID field and the Stateless Reset Token
-  field contain the alternative connection ID that is assigned the sequence
+  field contain an alternative connection ID that has a sequence
   number of one ({{issue-cid}}). Having them bundled with the preferred address
   ensures that there will be at least one unused active connection ID when the
   client initiates migration to the preferred address. The CID Length field


### PR DESCRIPTION
This PR changes the following. FWIW, I think that the new text has been our intent when we introduced the concept of retiring CIDs.
* Better clarifies when the client should initiated migration to the preferred address (i.e., when the handshake is *confirmed*).
* States that an unused active connection ID should be used, rather than stating that the connection ID provided by TP.preferred_address have to be used. This fixes the ambiguity regarding the use of CID in relation to CID retirement. As noted in https://github.com/quicwg/base-drafts/issues/3353#issuecomment-575396028, this change does not require modification of existing code.
* Expand the explanation of the fields contained in TP.preferred_address.

closes #3353.