### PR TITLE
Grease HTTP error codes

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -925,9 +925,9 @@ transferred. Endpoints MUST NOT consider these streams to have any meaning upon
 receipt.
 
 The payload and length of the stream are selected in any manner the
-implementation chooses.  Implementations MAY terminate these streams cleanly,
-or MAY abruptly terminate them with an error code of the implementation's
-choice, including reserved error codes ({{http-error-codes}}).
+implementation chooses.  Implementations MAY terminate these streams cleanly, or
+MAY abruptly terminate them.  When terminating abruptly, the error code
+H3_NO_ERROR or a reserved error code ({{http-error-codes}}) SHOULD be used.
 
 
 # HTTP Framing Layer {#http-framing-layer}

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -925,7 +925,9 @@ transferred. Endpoints MUST NOT consider these streams to have any meaning upon
 receipt.
 
 The payload and length of the stream are selected in any manner the
-implementation chooses.
+implementation chooses.  Implementations MAY terminate these streams cleanly,
+or MAY abruptly terminate them with an error code of the implementation's
+choice, including reserved error codes ({{http-error-codes}}).
 
 
 # HTTP Framing Layer {#http-framing-layer}
@@ -1458,6 +1460,11 @@ H3_VERSION_FALLBACK (0x110):
 : The requested operation cannot be served over HTTP/3.  The peer should
   retry over HTTP/1.1.
 
+Error codes of the format `0x1f * N + 0x21` for integer values of N are reserved
+to exercise the requirement that unknown error codes be ignored
+({{extensions}}). Implementations SHOULD select an error code from this space
+with some probability when they would have sent H3_NO_ERROR.
+
 # Extensions to HTTP/3 {#extensions}
 
 HTTP/3 permits extension of the protocol.  Within the limitations described in
@@ -1712,6 +1719,10 @@ The entries in the {{iana-error-table}} are registered by this document.
 | H3_VERSION_FALLBACK               | 0x0110     | Retry over HTTP/1.1                      | {{http-error-codes}}   |
 | --------------------------------- | ---------- | ---------------------------------------- | ---------------------- |
 {: #iana-error-table title="Initial HTTP/3 Error Codes"}
+
+Additionally, each code of the format `0x1f * N + 0x21` for integer values of N
+(that is, `0x21`, `0x40`, ..., through `0x3FFFFFFFFFFFFFFE`) MUST NOT be
+assigned by IANA.
 
 ### Stream Types {#iana-stream-types}
 

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1461,9 +1461,9 @@ H3_VERSION_FALLBACK (0x110):
   retry over HTTP/1.1.
 
 Error codes of the format `0x1f * N + 0x21` for integer values of N are reserved
-to exercise the requirement that unknown error codes be ignored
-({{extensions}}). Implementations SHOULD select an error code from this space
-with some probability when they would have sent H3_NO_ERROR.
+to exercise the requirement that unknown error codes be treated as equivalent to
+H3_NO_ERROR ({{extensions}}). Implementations SHOULD select an error code from
+this space with some probability when they would have sent H3_NO_ERROR.
 
 # Extensions to HTTP/3 {#extensions}
 


### PR DESCRIPTION
Fixes #3325.

Pleasantly, the same formula we've used for grease values elsewhere in HTTP/3 does not collide with any currently-assigned error code, so I've just reused it.  (We'll need to be cautious about 0x119, though.)  The same logic could be applied to transport error codes, but there's not much point.  If you're intolerant of the way your peer closed the connection, you might erroneously... close the connection?

Editorial-ish:  A recommendation which reserves some error code space we haven't used; modifies the IANA instructions.  Doesn't mandate or prohibit anything new.