### PR TITLE
Ack delays are adjusted by ack_delay_exponent

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -315,17 +315,16 @@ samples, and rttvar is the variation in the RTT samples, estimated using a
 mean variation.
 
 The calculation of smoothed_rtt uses path latency after adjusting RTT samples
-for ACK delays. ACK delays are communicated in the ack_delay field of the
-ACK frame and adjusted by the ack_delay_exponent transport parameter, see
-Section 19.3 of {{QUIC-TRANSPORT}}.  For packets sent in the ApplicationData
-packet number space, a peer limits any delay in sending an acknowledgement
-for an ack-eliciting packet to no greater than the value it advertised in
-the max_ack_delay transport parameter.  Consequently, when a peer reports
-an Ack Delay that is greater than its max_ack_delay, the delay is attributed
-to reasons out of the peer's control, such as scheduler latency at the peer
-or loss of previous ACK frames.  Any delays beyond the peer's max_ack_delay
-are therefore considered effectively part of path delay and incorporated into
-the smoothed_rtt estimate.
+for acknowledgement delays. These delays are computed using the ACK Delay
+field of the ACK frame as described in Section 19.3 of {{QUIC-TRANSPORT}}.
+For packets sent in the ApplicationData packet number space, a peer limits
+any delay in sending an acknowledgement for an ack-eliciting packet to no
+greater than the value it advertised in the max_ack_delay transport parameter.
+Consequently, when a peer reports an Ack Delay that is greater than its
+max_ack_delay, the delay is attributed to reasons out of the peer's control,
+such as scheduler latency at the peer or loss of previous ACK frames.  Any
+delays beyond the peer's max_ack_delay are therefore considered effectively
+part of path delay and incorporated into the smoothed_rtt estimate.
 
 When adjusting an RTT sample using peer-reported acknowledgement delays, an
 endpoint:

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -315,16 +315,17 @@ samples, and rttvar is the variation in the RTT samples, estimated using a
 mean variation.
 
 The calculation of smoothed_rtt uses path latency after adjusting RTT samples
-for ACK delays. ACK delays are communicated in the ACK frame as an ack_delay
-field adjusted by the ack_delay_exponent transport parameter.  For packets
-sent in the ApplicationData packet number space, a peer limits any delay in
-sending an acknowledgement for an ack-eliciting packet to no greater than the
-value it advertised in the max_ack_delay transport parameter.  Consequently,
-when a peer reports an Ack Delay that is greater than its max_ack_delay, the
-delay is attributed to reasons out of the peer's control, such as scheduler
-latency at the peer or loss of previous ACK frames.  Any delays beyond the
-peer's max_ack_delay are therefore considered effectively part of path delay
-and incorporated into the smoothed_rtt estimate.
+for ACK delays. ACK delays are communicated in the ack_delay field of the
+ACK frame and adjusted by the ack_delay_exponent transport parameter, see
+Section 19.3 of {{QUIC-TRANSPORT}}.  For packets sent in the ApplicationData
+packet number space, a peer limits any delay in sending an acknowledgement
+for an ack-eliciting packet to no greater than the value it advertised in
+the max_ack_delay transport parameter.  Consequently, when a peer reports
+an Ack Delay that is greater than its max_ack_delay, the delay is attributed
+to reasons out of the peer's control, such as scheduler latency at the peer
+or loss of previous ACK frames.  Any delays beyond the peer's max_ack_delay
+are therefore considered effectively part of path delay and incorporated into
+the smoothed_rtt estimate.
 
 When adjusting an RTT sample using peer-reported acknowledgement delays, an
 endpoint:

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -316,7 +316,7 @@ mean variation.
 
 The calculation of smoothed_rtt uses path latency after adjusting RTT samples
 for ACK delays. ACK delays are communicated in the ACK frame as an ack_delay
-field right shiften by the ack_delay_exponent transport parameter.  For packets
+field adjusted by the ack_delay_exponent transport parameter.  For packets
 sent in the ApplicationData packet number space, a peer limits any delay in
 sending an acknowledgement for an ack-eliciting packet to no greater than the
 value it advertised in the max_ack_delay transport parameter.  Consequently,

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -315,14 +315,16 @@ samples, and rttvar is the variation in the RTT samples, estimated using a
 mean variation.
 
 The calculation of smoothed_rtt uses path latency after adjusting RTT samples
-for ACK delays.  For packets sent in the ApplicationData packet number space,
-a peer limits any delay in sending an acknowledgement for an ack-eliciting
-packet to no greater than the value it advertised in the max_ack_delay transport
-parameter.  Consequently, when a peer reports an Ack Delay that is greater than
-its max_ack_delay, the delay is attributed to reasons out of the peer's control,
-such as scheduler latency at the peer or loss of previous ACK frames.  Any
-delays beyond the peer's max_ack_delay are therefore considered effectively
-part of path delay and incorporated into the smoothed_rtt estimate.
+for ACK delays. ACK delays are communicated in the ACK frame as an ack_delay
+field right shiften by the ack_delay_exponent transport parameter.  For packets
+sent in the ApplicationData packet number space, a peer limits any delay in
+sending an acknowledgement for an ack-eliciting packet to no greater than the
+value it advertised in the max_ack_delay transport parameter.  Consequently,
+when a peer reports an Ack Delay that is greater than its max_ack_delay, the
+delay is attributed to reasons out of the peer's control, such as scheduler
+latency at the peer or loss of previous ACK frames.  Any delays beyond the
+peer's max_ack_delay are therefore considered effectively part of path delay
+and incorporated into the smoothed_rtt estimate.
 
 When adjusting an RTT sample using peer-reported acknowledgement delays, an
 endpoint:


### PR DESCRIPTION
Notes that ack delays are right shifted by ack_delay_exponent when transmitted in ACK frames.

Fixes #3355