### PR TITLE
Move out-of-order packets definition

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -131,12 +131,6 @@ Ack-eliciting Packets:
 : Packets that contain ack-eliciting frames elicit an ACK from the receiver
   within the maximum ack delay and are called ack-eliciting packets.
 
-Out-of-order Packets:
-
-: Packets that do not increase the largest received packet number for its
-  packet number space by exactly one. Packets arrive out of order
-  when earlier packets are lost or delayed.
-
 # Design of the QUIC Transmission Machinery
 
 All transmissions in QUIC are sent with a packet-level header, which indicates

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -196,6 +196,12 @@ Ack-eliciting Packet:
   CONNECTION_CLOSE. These cause a recipient to send an acknowledgment (see
   {{sending-acknowledgements}}).
 
+Out-of-order Packets:
+
+: Packets that do not increase the largest received packet number for its
+  packet number space by exactly one. Packets arrive out of order
+  when earlier packets are lost or delayed.
+
 Endpoint:
 
 : An entity that can participate in a QUIC connection by generating,

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -196,11 +196,11 @@ Ack-eliciting Packet:
   CONNECTION_CLOSE. These cause a recipient to send an acknowledgment (see
   {{sending-acknowledgements}}).
 
-Out-of-order Packets:
+Out-of-order packet:
 
-: Packets that do not increase the largest received packet number for its
-  packet number space by exactly one. Packets arrive out of order
-  when earlier packets are lost or delayed.
+: A packet that does not increase the largest received packet number for its
+  packet number space by exactly one. A packet can arrive out of order
+  if it is delayed or if earlier packets are lost or delayed.
 
 Endpoint:
 


### PR DESCRIPTION
From recovery to transport.

Fixes #3347 