### PR TITLE
editorial: value for kGranularity (recovery)

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -404,7 +404,8 @@ as TCP-NCR {{?RFC4653}}, to improve QUIC's reordering resilience.
 Once a later packet within the same packet number space has been acknowledged,
 an endpoint SHOULD declare an earlier packet lost if it was sent a threshold
 amount of time in the past. To avoid declaring packets as lost too early, this
-time threshold MUST be set to at least kGranularity.  The time threshold is:
+time threshold MUST be set to at least kGranularity and kGranularity SHOULD NOT
+be smaller than 1ms. The time threshold is:
 
 ~~~
 max(kTimeThreshold * max(smoothed_rtt, latest_rtt), kGranularity)


### PR DESCRIPTION
This was only defined normatively in the appendix.