### PR TITLE
Clarify when timer should be set

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -410,8 +410,9 @@ time threshold MUST be set to at least kGranularity.  The time threshold is:
 max(kTimeThreshold * max(smoothed_rtt, latest_rtt), kGranularity)
 ~~~
 
-If packets sent prior to the largest acknowledged packet cannot yet be declared
-lost, then a timer SHOULD be set for the remaining time.
+When an ACK frame is received and unacknowledged packets sent prior to the
+largest acknowledged packet cannot yet be declared lost, then a timer SHOULD
+be set for the remaining time.
 
 Using max(smoothed_rtt, latest_rtt) protects from the two following cases:
 


### PR DESCRIPTION
However, I'm not sure if normative language is correctly here, because use of a time is an implementation detail; important is that the packet is declared lost after the threshold time. I guess a timer is the only sensible implementation but we could just say:

"... a timer is set for the remaining time." 
or 
"... a timer should be set for the remaining time."
or
"... timer should be used to declare the packet lost if not acknowledged within the remaining time."