### PR TITLE
Remove pointer to appendix in PTO section (recovery)

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -453,9 +453,6 @@ the PTO period as follows:
 PTO = smoothed_rtt + max(4*rttvar, kGranularity) + max_ack_delay
 ~~~
 
-kGranularity, smoothed_rtt, rttvar, and max_ack_delay are defined in
-{{ld-consts-of-interest}} and {{ld-vars-of-interest}}.
-
 The PTO period is the amount of time that a sender ought to wait for an
 acknowledgement of a sent packet.  This time period includes the estimated
 network roundtrip-time (smoothed_rtt), the variation in the estimate (4*rttvar),


### PR DESCRIPTION
I proposed to remove this sentence here because all these values have actually been just defined in the previous sections. If a pointer to the appendix is desired, I think that should be mentioned earlier (e.g. in the intro already) that these lists existing in the appendix.