### PR TITLE
Small clarification and one nit (recovery)

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -467,14 +467,14 @@ Handshake packet number spaces, the max_ack_delay is 0, as specified in
 The PTO value MUST be set to at least kGranularity, to avoid the timer expiring
 immediately.
 
-A sender computes its PTO timer every time an ack-eliciting packet is sent.
+A sender resets its PTO timer every time an ack-eliciting packet is sent.
 When ack-eliciting packets are in-flight in multiple packet number spaces,
 the timer MUST be set for the packet number space with the earliest timeout,
 except for ApplicationData, which MUST be ignored until the handshake
 completes; see Section 4.1.1 of {{QUIC-TLS}}.  Not arming the PTO for
 ApplicationData prioritizes completing the handshake and prevents the server
-from sending a 1-RTT packet on a PTO before before it has the keys to process
-a 1-RTT packet.
+from sending a 1-RTT packet on a PTO before it has the keys to process a 1-RTT
+packet.
 
 When a PTO timer expires, the PTO period MUST be set to twice its current
 value. This exponential reduction in the sender's rate is important because


### PR DESCRIPTION
Btw. is it "a 1-RTT packet" or "an 1-RTT packet"? I found one occasion of "an 1-RTT packet" in the transport draft but otherwise there is always "a 1-RTT packet"... so I assume the one in the transport draft should be fixed...?