### PR TITLE
Simplify initial sending part state

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -460,9 +460,8 @@ allocating a stream ID to a stream until it sends the first STREAM frame and
 enters this state, which can allow for better stream prioritization.
 
 The sending part of a bidirectional stream initiated by a peer (type 0 for a
-server, type 1 for a client) enters the "Ready" state then immediately
-transitions to the "Send" state if the receiving part enters the "Recv" state
-({{stream-recv-states}}).
+server, type 1 for a client) starts the "Ready" state when the receiving part is
+created.
 
 In the "Send" state, an endpoint transmits - and retransmits as necessary -
 stream data in STREAM frames.  The endpoint respects the flow control limits set

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -460,8 +460,8 @@ allocating a stream ID to a stream until it sends the first STREAM frame and
 enters this state, which can allow for better stream prioritization.
 
 The sending part of a bidirectional stream initiated by a peer (type 0 for a
-server, type 1 for a client) starts the "Ready" state when the receiving part is
-created.
+server, type 1 for a client) starts in the "Ready" state when the receiving part
+is created.
 
 In the "Send" state, an endpoint transmits - and retransmits as necessary -
 stream data in STREAM frames.  The endpoint respects the flow control limits set


### PR DESCRIPTION
The description here was a little over enthusiastic: it only enters the
"Send" state when something is sent.

Closes #2636.