### PR TITLE
Added a word of caution before abandoning Initial packets

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3701,6 +3701,8 @@ flight or awaiting acknowledgment, no further Initial packets need to be
 exchanged beyond this point.  Initial packet protection keys are discarded (see
 Section 4.10 of {{QUIC-TLS}}) along with any loss recovery and congestion
 control state (see Sections 5.3.1.2 and 6.9 of {{QUIC-RECOVERY}}).
+(This can be safely done because of the protection against loss of
+Handshake packet specified in {{validate-handshake}}.)
 
 Any data in CRYPTO frames is discarded - and no longer retransmitted - when
 Initial keys are discarded.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3700,9 +3700,9 @@ when it receives its first Handshake packet.  Though packets might still be in
 flight or awaiting acknowledgment, no further Initial packets need to be
 exchanged beyond this point.  Initial packet protection keys are discarded (see
 Section 4.10 of {{QUIC-TLS}}) along with any loss recovery and congestion
-control state (see Sections 5.3.1.2 and 6.9 of {{QUIC-RECOVERY}}).
-(This can be safely done because of the protection against loss of
-Handshake packet specified in {{validate-handshake}}.)
+control state (see Sections 5.3.1.2 and 6.9 of {{QUIC-RECOVERY}}). This is safe
+because of the additional safeguards against loss of Handshake packets in
+{{validate-handshake}}.
 
 Any data in CRYPTO frames is discarded - and no longer retransmitted - when
 Initial keys are discarded.


### PR DESCRIPTION
This addresses the concerns that I expressed in issue #3395 