### PR TITLE
Clarify zero-length CIDs and active_connection_id_limit TP

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4697,11 +4697,11 @@ active_connection_id_limit (0x000e):
   to store. This value includes the connection ID received during the handshake,
   that received in the preferred_address transport parameter, and those received
   in NEW_CONNECTION_ID frames.
-  Unless the peer is using a zero-length connection ID, the value of the
-  active_connection_id_limit parameter MUST be no less than 2. If this
-  transport parameter is absent, a default of 2 is assumed.  When the client
-  is using a zero-length connection ID, the server MUST NOT send the
-  active_connection_id_limit parameter.
+  The value of the active_connection_id_limit parameter MUST be no less
+  than 2. If this transport parameter is absent, a default of 2 is assumed.
+  If an endpoint uses a zero-length connection ID, the
+  active_connection_id_limit value received from its peer is ignored and
+  not used.
 
 If present, transport parameters that set initial flow control limits
 (initial_max_stream_data_bidi_local, initial_max_stream_data_bidi_remote, and

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4697,7 +4697,7 @@ active_connection_id_limit (0x000e):
   to store. This value includes the connection ID received during the handshake,
   that received in the preferred_address transport parameter, and those received
   in NEW_CONNECTION_ID frames.
-  The value of the active_connection_id_limit parameter MUST be no less
+  The value of the active_connection_id_limit parameter MUST NOT be less
   than 2. If this transport parameter is absent, a default of 2 is assumed.
   If an endpoint uses a zero-length connection ID, the
   active_connection_id_limit value received from its peer is ignored and

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4698,6 +4698,8 @@ active_connection_id_limit (0x000e):
   that received in the preferred_address transport parameter, and those received
   in NEW_CONNECTION_ID frames.
   The value of the active_connection_id_limit parameter MUST be at least 2.
+  An endpoint that receives a value less than 2 MUST close the connection
+  with an error of type TRANSPORT_PARAMETER_ERROR.
   If this transport parameter is absent, a default of 2 is assumed.  If an
   endpoint uses a zero-length connection ID, the active_connection_id_limit
   value received from its peer is ignored and not used, as

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4697,11 +4697,11 @@ active_connection_id_limit (0x000e):
   to store. This value includes the connection ID received during the handshake,
   that received in the preferred_address transport parameter, and those received
   in NEW_CONNECTION_ID frames.
-  Unless a zero-length connection ID is being used, the value of the
+  Unless the peer is using a zero-length connection ID, the value of the
   active_connection_id_limit parameter MUST be no less than 2. If this
-  transport parameter is absent, a default of 2 is assumed.
-  When a zero-length connection ID is being used, the active_connection_id_limit
-  parameter MUST NOT be sent.
+  transport parameter is absent, a default of 2 is assumed.  When the client
+  is using a zero-length connection ID, the server MUST NOT send the
+  active_connection_id_limit parameter.
 
 If present, transport parameters that set initial flow control limits
 (initial_max_stream_data_bidi_local, initial_max_stream_data_bidi_remote, and

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4701,7 +4701,8 @@ active_connection_id_limit (0x000e):
   than 2. If this transport parameter is absent, a default of 2 is assumed.
   If an endpoint uses a zero-length connection ID, the
   active_connection_id_limit value received from its peer is ignored and
-  not used.
+  not used, as NEW_CONNECTION_ID frames cannot be sent by an endpoint that
+  opts for a zero-length connection ID.
 
 If present, transport parameters that set initial flow control limits
 (initial_max_stream_data_bidi_local, initial_max_stream_data_bidi_remote, and

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4697,12 +4697,12 @@ active_connection_id_limit (0x000e):
   to store. This value includes the connection ID received during the handshake,
   that received in the preferred_address transport parameter, and those received
   in NEW_CONNECTION_ID frames.
-  The value of the active_connection_id_limit parameter MUST NOT be less
-  than 2. If this transport parameter is absent, a default of 2 is assumed.
-  If an endpoint uses a zero-length connection ID, the
-  active_connection_id_limit value received from its peer is ignored and
-  not used, as NEW_CONNECTION_ID frames cannot be sent by an endpoint that
-  opts for a zero-length connection ID.
+  The value of the active_connection_id_limit parameter MUST be at least 2.
+  If this transport parameter is absent, a default of 2 is assumed.  If an
+  endpoint uses a zero-length connection ID, the active_connection_id_limit
+  value received from its peer is ignored and not used, as
+  NEW_CONNECTION_ID frames cannot be sent by an endpoint that opts for a
+  zero-length connection ID.
 
 If present, transport parameters that set initial flow control limits
 (initial_max_stream_data_bidi_local, initial_max_stream_data_bidi_remote, and

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4701,10 +4701,9 @@ active_connection_id_limit (0x000e):
   An endpoint that receives a value less than 2 MUST close the connection
   with an error of type TRANSPORT_PARAMETER_ERROR.
   If this transport parameter is absent, a default of 2 is assumed.  If an
-  endpoint uses a zero-length connection ID, the active_connection_id_limit
-  value received from its peer is ignored and not used, as
-  NEW_CONNECTION_ID frames cannot be sent by an endpoint that opts for a
-  zero-length connection ID.
+  endpoint issues a zero-length connection ID, it will never send a
+  NEW_CONNECTION_ID frame and therefore ignores the active_connection_id_limit
+  value received from its peer.
 
 If present, transport parameters that set initial flow control limits
 (initial_max_stream_data_bidi_local, initial_max_stream_data_bidi_remote, and


### PR DESCRIPTION
Fixes #3427.