### PR TITLE
#3348 Clarify that you can use any issued CID at any time, even during the handshake

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1002,7 +1002,9 @@ When an endpoint issues a connection ID, it MUST accept packets that carry this
 connection ID for the duration of the connection or until its peer invalidates
 the connection ID via a RETIRE_CONNECTION_ID frame
 ({{frame-retire-connection-id}}).  Connection IDs that are issued and not
-retired are considered active; any active connection ID can be used.
+retired are considered active; any active connection ID is valid for use at any
+time, including during the handshake.  This includes the connection ID issued by
+the server via the preferred_address transport parameter.
 
 An endpoint SHOULD ensure that its peer has a sufficient number of available and
 unused connection IDs.  Endpoints store received connection IDs for future use

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1003,8 +1003,8 @@ connection ID for the duration of the connection or until its peer invalidates
 the connection ID via a RETIRE_CONNECTION_ID frame
 ({{frame-retire-connection-id}}).  Connection IDs that are issued and not
 retired are considered active; any active connection ID is valid for use at any
-time, including during the handshake.  This includes the connection ID issued by
-the server via the preferred_address transport parameter.
+time, in any packet type.  This includes the connection ID issued by the server
+via the preferred_address transport parameter.
 
 An endpoint SHOULD ensure that its peer has a sufficient number of available and
 unused connection IDs.  Endpoints store received connection IDs for future use


### PR DESCRIPTION
Note also the editorial changes in #3354, which are great and still needed: this adds a little bit more to the reference from those changes to do the key clarifying for #3348.

The remaining clarification about `preferred_address` is coming in the SPA PRs, but I wanted to look at this paragraph in one place.

Closes #3348.