### PR TITLE
Early CONNECTION_CLOSE fixes

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -324,7 +324,7 @@ Some frames are prohibited in different packet number spaces. The rules here
 generalize those of TLS, in that frames associated with establishing the
 connection can usually appear in packets in any packet number space, whereas
 those associated with transferring data can only appear in the application
-packet number space:
+data packet number space:
 
 - PADDING, PING, and CRYPTO frames MAY appear in any packet number space.
 
@@ -336,7 +336,7 @@ packet number space:
 - ACK frames MAY appear in any packet number space, but can only acknowledge
   packets which appeared in that packet number space.
 
-- All other frame types MUST only be sent in the application packet number
+- All other frame types MUST only be sent in the application data packet number
   space.
 
 Note that it is not possible to send the following frames in 0-RTT packets for

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -334,7 +334,8 @@ data packet number space:
   number space.
 
 - ACK frames MAY appear in any packet number space, but can only acknowledge
-  packets which appeared in that packet number space.
+  packets which appeared in that packet number space.  However, as noted below,
+  0-RTT packets cannot contain ACK frames.
 
 - All other frame types MUST only be sent in the application data packet number
   space.

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -328,8 +328,7 @@ encryption levels:
 
 - PADDING and PING frames MAY appear in packets of any encryption level.
 
-- CRYPTO frames and CONNECTION_CLOSE frames signaling errors at the QUIC layer
-  (type 0x1c) MAY appear in packets of any encryption level except 0-RTT.
+- CRYPTO frames MAY appear in packets of any encryption level except 0-RTT.
 
 - CONNECTION_CLOSE frames signaling application errors (type 0x1d) MUST only be
   sent in packets at the 1-RTT encryption level.
@@ -717,7 +716,7 @@ Section 6 of {{!TLS13}}.
 A TLS alert is turned into a QUIC connection error by converting the one-byte
 alert description into a QUIC error code.  The alert description is added to
 0x100 to produce a QUIC error code from the range reserved for CRYPTO_ERROR.
-The resulting value is sent in a QUIC CONNECTION_CLOSE frame.
+The resulting value is sent in a QUIC CONNECTION_CLOSE frame of type 0x1c.
 
 The alert level of all TLS alerts is "fatal"; a TLS stack MUST NOT generate
 alerts at the "warning" level.

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -427,7 +427,7 @@ encryption level. Four encryption levels are used, producing keys for Initial,
 0-RTT, Handshake, and 1-RTT packets. CRYPTO frames are carried in just three of
 these levels, omitting the 0-RTT level. These four levels correspond to three packet
 number spaces: Initial and Handshake encrypted packets use their own separate
-spaces; 0-RTT and 1-RTT packets use the application data packet number space. 
+spaces; 0-RTT and 1-RTT packets use the application data packet number space.
 
 QUIC takes the unprotected content of TLS handshake records as the content of
 CRYPTO frames. TLS record protection is not used by QUIC. QUIC assembles

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -330,7 +330,7 @@ data packet number space:
 
 - CONNECTION_CLOSE frames signaling errors at the QUIC layer (type 0x1c) MAY
   appear in any packet number space. CONNECTION_CLOSE frames signaling
-  application errors (type 0x1d) MUST only appear in the Application packet
+  application errors (type 0x1d) MUST only appear in the application data packet
   number space.
 
 - ACK frames MAY appear in any packet number space, but can only acknowledge
@@ -349,14 +349,14 @@ indicate which keys were used to protect a given packet, as shown in
 {{packet-types-keys}}. When packets of different types need to be sent,
 endpoints SHOULD use coalesced packets to send them in the same UDP datagram.
 
-| Packet Type         | Encryption Keys | PN Space    |
-|:--------------------|:----------------|:------------|
-| Initial             | Initial secrets | Initial     |
-| 0-RTT Protected     | 0-RTT           | Application |
-| Handshake           | Handshake       | Handshake   |
-| Retry               | Retry           | N/A         |
-| Version Negotiation | N/A             | N/A         |
-| Short Header        | 1-RTT           | Application |
+| Packet Type         | Encryption Keys | PN Space         |
+|:--------------------|:----------------|:-----------------|
+| Initial             | Initial secrets | Initial          |
+| 0-RTT Protected     | 0-RTT           | Application data |
+| Handshake           | Handshake       | Handshake        |
+| Retry               | Retry           | N/A              |
+| Version Negotiation | N/A             | N/A              |
+| Short Header        | 1-RTT           | Application data |
 {: #packet-types-keys title="Encryption Keys by Packet Type"}
 
 Section 17 of {{QUIC-TRANSPORT}} shows how packets at the various encryption

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -330,8 +330,8 @@ packet number space:
 
 - CONNECTION_CLOSE frames signaling errors at the QUIC layer (type 0x1c) MAY
   appear in any packet number space. CONNECTION_CLOSE frames signaling
-  application errors (type 0x1d) MAY appear in every packet number space other
-  than Initial.
+  application errors (type 0x1d) MUST only appear in the Application packet
+  number space.
 
 - ACK frames MAY appear in any packet number space, but can only acknowledge
   packets which appeared in that packet number space.

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -341,7 +341,8 @@ packet number space:
 
 Note that it is not possible to send the following frames in 0-RTT packets for
 various reasons: ACK, CRYPTO, HANDSHAKE_DONE, NEW_TOKEN, PATH_RESPONSE, and
-RETIRE_CONNECTION_ID.
+RETIRE_CONNECTION_ID.  A server MAY treat receipt of these frames in 0-RTT
+packets as a connection error of type PROTOCOL_VIOLATION.
 
 Because packets could be reordered on the wire, QUIC uses the packet type to
 indicate which keys were used to protect a given packet, as shown in

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -420,7 +420,7 @@ At any time, the TLS stack at an endpoint will have a current sending
 encryption level and receiving encryption level. Encryption levels determine
 the packet type and keys that are used for protecting data.
 
-Each encryption level is associated with a different flow of bytes, which is
+Each encryption level is associated with a different sequence of bytes, which is
 reliably transmitted to the peer in CRYPTO frames. When TLS provides handshake
 bytes to be sent, they are appended to the current flow. Any packet that
 includes the CRYPTO frame is protected using keys from the corresponding

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -416,17 +416,18 @@ acquires handshake bytes before sending its first packet.  A QUIC server starts
 the process by providing TLS with the client's handshake bytes.
 
 At any time, the TLS stack at an endpoint will have a current sending
-encryption level and receiving encryption level. Encryption levels correspond
-roughly to packet number spaces and determine the packet type and keys that are
-used for protecting data.
+encryption level and receiving encryption level. Encryption levels determine
+the packet type and keys that are used for protecting data.
 
 Each encryption level is associated with a different flow of bytes, which is
 reliably transmitted to the peer in CRYPTO frames. When TLS provides handshake
-bytes to be sent, they are appended to the current flow and any packet that
+bytes to be sent, they are appended to the current flow. Any packet that
 includes the CRYPTO frame is protected using keys from the corresponding
 encryption level. Four encryption levels are used, producing keys for Initial,
 0-RTT, Handshake, and 1-RTT packets. CRYPTO frames are carried in just three of
-these levels, omitting the 0-RTT level.
+these levels, omitting the 0-RTT level. These four levels correspond to three packet
+number spaces: Initial and Handshake encrypted packets use their own separate
+spaces; 0-RTT and 1-RTT packets use the application data packet number space. 
 
 QUIC takes the unprotected content of TLS handshake records as the content of
 CRYPTO frames. TLS record protection is not used by QUIC. QUIC assembles

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -316,47 +316,47 @@ same keys even if TLS has already updated to newer keys.
 
 One important difference between TLS records (used with TCP) and QUIC CRYPTO
 frames is that in QUIC multiple frames may appear in the same QUIC packet as
-long as they are associated with the same encryption level. For instance, an
-implementation might bundle a Handshake message and an ACK for some Handshake
-data into the same packet.
+long as they are associated with the same packet number space. For instance,
+an endpoint can bundle a Handshake message and an ACK for some Handshake data
+into the same packet.
 
-Some frames are prohibited in different encryption levels, others cannot be
-sent. The rules here generalize those of TLS, in that frames associated with
-establishing the connection can usually appear at any encryption level, whereas
-those associated with transferring data can only appear in the 0-RTT and 1-RTT
-encryption levels:
+Some frames are prohibited in different packet number spaces. The rules here
+generalize those of TLS, in that frames associated with establishing the
+connection can usually appear in packets in any packet number space, whereas
+those associated with transferring data can only appear in the application
+packet number space:
 
-- PADDING and PING frames MAY appear in packets of any encryption level.
+- PADDING, PING, and CRYPTO frames MAY appear in any packet number space.
 
-- CRYPTO frames MAY appear in packets of any encryption level except 0-RTT.
+- CONNECTION_CLOSE frames signaling errors at the QUIC layer (type 0x1c) MAY
+  appear in any packet number space. CONNECTION_CLOSE frames signaling
+  application errors (type 0x1d) MAY appear in every packet number space other
+  than Initial.
 
-- CONNECTION_CLOSE frames signaling application errors (type 0x1d) MUST only be
-  sent in packets at the 1-RTT encryption level.
+- ACK frames MAY appear in any packet number space, but can only acknowledge
+  packets which appeared in that packet number space.
 
-- ACK frames MAY appear in packets of any encryption level other than 0-RTT, but
-  can only acknowledge packets which appeared in that packet number space.
+- All other frame types MUST only be sent in the application packet number
+  space.
 
-- All other frame types MUST only be sent in the 0-RTT and 1-RTT levels.
-
-Note that it is not possible to send the following frames in 0-RTT for various
-reasons: ACK, CRYPTO, HANDSHAKE_DONE, NEW_TOKEN, PATH_RESPONSE, and
+Note that it is not possible to send the following frames in 0-RTT packets for
+various reasons: ACK, CRYPTO, HANDSHAKE_DONE, NEW_TOKEN, PATH_RESPONSE, and
 RETIRE_CONNECTION_ID.
 
 Because packets could be reordered on the wire, QUIC uses the packet type to
-indicate which level a given packet was encrypted under, as shown in
-{{packet-types-levels}}. When multiple packets of different encryption levels
-need to be sent, endpoints SHOULD use coalesced packets to send them in the same
-UDP datagram.
+indicate which keys were used to protect a given packet, as shown in
+{{packet-types-keys}}. When packets of different types need to be sent,
+endpoints SHOULD use coalesced packets to send them in the same UDP datagram.
 
-| Packet Type         | Encryption Level | PN Space  |
-|:--------------------|:-----------------|:----------|
-| Initial             | Initial secrets  | Initial   |
-| 0-RTT Protected     | 0-RTT            | 0/1-RTT   |
-| Handshake           | Handshake        | Handshake |
-| Retry               | N/A              | N/A       |
-| Version Negotiation | N/A              | N/A       |
-| Short Header        | 1-RTT            | 0/1-RTT   |
-{: #packet-types-levels title="Encryption Levels by Packet Type"}
+| Packet Type         | Encryption Keys | PN Space    |
+|:--------------------|:----------------|:------------|
+| Initial             | Initial secrets | Initial     |
+| 0-RTT Protected     | 0-RTT           | Application |
+| Handshake           | Handshake       | Handshake   |
+| Retry               | Retry           | N/A         |
+| Version Negotiation | N/A             | N/A         |
+| Short Header        | 1-RTT           | Application |
+{: #packet-types-keys title="Encryption Keys by Packet Type"}
 
 Section 17 of {{QUIC-TRANSPORT}} shows how packets at the various encryption
 levels fit into the handshake process.
@@ -414,12 +414,18 @@ A QUIC client starts TLS by requesting TLS handshake bytes from TLS.  The client
 acquires handshake bytes before sending its first packet.  A QUIC server starts
 the process by providing TLS with the client's handshake bytes.
 
-At any time, the TLS stack at an endpoint will have a current sending encryption
-level and receiving encryption level. Each encryption level is associated with a
-different flow of bytes, which is reliably transmitted to the peer in CRYPTO
-frames. When TLS provides handshake bytes to be sent, they are appended to the
-current flow and any packet that includes the CRYPTO frame is protected using
-keys from the corresponding encryption level.
+At any time, the TLS stack at an endpoint will have a current sending
+encryption level and receiving encryption level. Encryption levels correspond
+roughly to packet number spaces and determine the packet type and keys that are
+used for protecting data.
+
+Each encryption level is associated with a different flow of bytes, which is
+reliably transmitted to the peer in CRYPTO frames. When TLS provides handshake
+bytes to be sent, they are appended to the current flow and any packet that
+includes the CRYPTO frame is protected using keys from the corresponding
+encryption level. Four encryption levels are used, producing keys for Initial,
+0-RTT, Handshake, and 1-RTT packets. CRYPTO frames are carried in just three of
+these levels, omitting the 0-RTT level.
 
 QUIC takes the unprotected content of TLS handshake records as the content of
 CRYPTO frames. TLS record protection is not used by QUIC. QUIC assembles
@@ -699,13 +705,13 @@ requirements for determining whether to accept or reject early data.
 
 ## HelloRetryRequest
 
-In TLS over TCP, the HelloRetryRequest feature (see Section 4.1.4 of {{!TLS13}})
-can be used to correct a client's incorrect KeyShare extension as well as for a
-stateless round-trip check. From the perspective of QUIC, this just looks like
-additional messages carried in the Initial encryption level. Although it is in
-principle possible to use this feature for address verification in QUIC, QUIC
-implementations SHOULD instead use the Retry feature (see Section 8.1 of
-{{QUIC-TRANSPORT}}).  HelloRetryRequest is still used to request key shares.
+In TLS over TCP, the HelloRetryRequest feature (see Section 4.1.4 of
+{{!TLS13}}) can be used to correct a client's incorrect KeyShare extension as
+well as for a stateless round-trip check. From the perspective of QUIC, this
+just looks like additional messages carried in Initial packets. Although it is
+in principle possible to use this feature for address verification in QUIC,
+QUIC implementations SHOULD instead use the Retry feature (see Section 8.1 of
+{{QUIC-TRANSPORT}}). HelloRetryRequest is still used to request key shares.
 
 
 ## TLS Errors

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -426,9 +426,10 @@ bytes to be sent, they are appended to the current flow. Any packet that
 includes the CRYPTO frame is protected using keys from the corresponding
 encryption level. Four encryption levels are used, producing keys for Initial,
 0-RTT, Handshake, and 1-RTT packets. CRYPTO frames are carried in just three of
-these levels, omitting the 0-RTT level. These four levels correspond to three packet
-number spaces: Initial and Handshake encrypted packets use their own separate
-spaces; 0-RTT and 1-RTT packets use the application data packet number space.
+these levels, omitting the 0-RTT level. These four levels correspond to three
+packet number spaces: Initial and Handshake encrypted packets use their own
+separate spaces; 0-RTT and 1-RTT packets use the application data packet number
+space.
 
 QUIC takes the unprotected content of TLS handshake records as the content of
 CRYPTO frames. TLS record protection is not used by QUIC. QUIC assembles

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2515,9 +2515,10 @@ that uses a lower packet protection level.  More specifically:
   packet.
 
 An CONNECTION_CLOSE of type 0x1d MUST be replaced by a CONNECTION_CLOSE of type
-1c when sending the frame in Initial packets. Otherwise, information about the
-application state might be revealed. Endpoints SHOULD use the APPLICATION_ERROR
-code when performing this conversion.
+0x1c when sending the frame in Initial packets. Otherwise, information about
+the application state might be revealed. Endpoints MUST clear the value of the
+Reason Phrase field and SHOULD use the APPLICATION_ERROR code when converting
+to a CONNECTION_CLOSE of type 0x1c.
 
 CONNECTION_CLOSE frames sent in multiple packets can be coalesced into a single
 UDP datagram; see {{packet-coalesce}}.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2510,12 +2510,12 @@ that uses a lower packet protection level.  More specifically:
   0x1c in an Initial packet makes it more likely that the server can receive
   the close signal, even if the application error code might not be received.
 
-* A peer might be unable to read 1-RTT packets, so an endpoint SHOULD send
-  CONNECTION_CLOSE in Handshake and 1-RTT packets prior to confirming the
-  handshake.
+* Prior to confirming the handshake, a peer might be unable to process 1-RTT
+  packets, so an endpoint SHOULD send CONNECTION_CLOSE in both Handshake and
+  1-RTT packets.
 
-CONNECTION_CLOSE frames that are sent in multiple packets can be coalesced into
-a single UDP datagram; see {{packet-coalesce}}.
+CONNECTION_CLOSE frames sent in multiple packets can be coalesced into a single
+UDP datagram; see {{packet-coalesce}}.
 
 
 ## Stateless Reset {#stateless-reset}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2506,13 +2506,19 @@ that uses a lower packet protection level.  More specifically:
   that at least one of them is processable by the client.
 
 * A client that sends CONNECTION_CLOSE in a 0-RTT packet cannot be assured of
-  the server has accepted 0-RTT and so sending a CONNECTION_CLOSE frame of type
-  0x1c in an Initial packet makes it more likely that the server can receive
-  the close signal, even if the application error code might not be received.
+  the server has accepted 0-RTT and so sending a CONNECTION_CLOSE frame in an
+  Initial packet makes it more likely that the server can receive the close
+  signal, even if the application error code might not be received.
 
 * Prior to confirming the handshake, a peer might be unable to process 1-RTT
   packets, so an endpoint SHOULD send CONNECTION_CLOSE in both Handshake and
-  1-RTT packets.
+  1-RTT packets.  A server SHOULD also send CONNECTION_CLOSE in an Initial
+  packet.
+
+An CONNECTION_CLOSE of type 0x1d MUST be replaced by a CONNECTION_CLOSE of type
+1c when sending the frame in Initial packets. Otherwise, information about the
+application state might be revealed. Endpoints SHOULD use the APPLICATION_ERROR
+code when performing this conversion.
 
 CONNECTION_CLOSE frames sent in multiple packets can be coalesced into a single
 UDP datagram; see {{packet-coalesce}}.
@@ -5691,8 +5697,8 @@ Reason Phrase:
 The application-specific variant of CONNECTION_CLOSE (type 0x1d) can only be
 sent using 0-RTT or 1-RTT packets ({{QUIC-TLS}}, Section 4).  When an
 application wishes to abandon a connection during the handshake, an endpoint
-can send a CONNECTION_CLOSE frame (type 0x1c) with an error code of 0x15a
-("user_canceled" alert; see {{?TLS13}}) in an Initial or a Handshake packet.
+can send a CONNECTION_CLOSE frame (type 0x1c) with an error code of
+APPLICATION_ERROR in an Initial or a Handshake packet.
 
 
 ## HANDSHAKE_DONE frame {#frame-handshake-done}
@@ -5797,6 +5803,10 @@ PROTOCOL_VIOLATION (0xA):
 
 INVALID_TOKEN (0xB):
 : A server received a Retry Token in a client Initial that is invalid.
+
+APPLICATION_ERROR (0xC):
+
+: The application or application protocol caused the connection to be closed.
 
 CRYPTO_BUFFER_EXCEEDED (0xD):
 
@@ -6584,6 +6594,7 @@ The initial contents of this registry are shown in {{iana-error-table}}.
 | 0x9   | CONNECTION_ID_LIMIT_ERROR | Too many connection IDs received | {{error-codes}} |
 | 0xA   | PROTOCOL_VIOLATION        | Generic protocol violation    | {{error-codes}} |
 | 0xB   | INVALID_TOKEN             | Invalid Token Received        | {{error-codes}} |
+| 0xC   | APPLICATION_ERROR         | Application error             | {{error-codes}} |
 | 0xD   | CRYPTO_BUFFER_EXCEEDED    | CRYPTO data buffer overflowed | {{error-codes}} |
 {: #iana-error-table title="Initial QUIC Transport Error Codes Entries"}
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2495,8 +2495,8 @@ level of packet protection to avoid the packet being discarded.  After the
 handshake is confirmed (see Section 4.1.2 of {{QUIC-TLS}}), an endpoint MUST
 send any CONNECTION_CLOSE frames in a 1-RTT packet.  However, prior to
 confirming the handshake, it is possible that more advanced packet protection
-keys are not available to the peer, so the frame MAY be replicated in a packet
-that uses a lower packet protection level.  More specifically:
+keys are not available to the peer, so another CONNECTION_CLOSE frame MAY be
+sent in a packet that uses a lower packet protection level.  More specifically:
 
 * A client will always know whether the server has Handshake keys (see
   {{discard-initial}}), but it is possible that a server does not know whether

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1367,8 +1367,8 @@ frame carrying the ClientHello.
 Note that multiple QUIC packets -- even of different packet types -- can be
 coalesced into a single UDP datagram (see {{packet-coalesce}}), and so this
 handshake may consist of as few as 4 UDP datagrams, or any number more. For
-instance, the server's first flight contains Initial packets (obfuscation),
-Handshake packets, and "0.5-RTT data" in packets with a short header.
+instance, the server's first flight contains Initial packets,
+Handshake packets, and "0.5-RTT data" in 1-RTT packets with a short header.
 
 ~~~~
 Client                                                  Server

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3029,7 +3029,7 @@ frames are explained in more detail in {{frame-formats}}.
 | 0x19        | RETIRE_CONNECTION_ID | {{frame-retire-connection-id}} | __01    |
 | 0x1a        | PATH_CHALLENGE       | {{frame-path-challenge}}       | __01    |
 | 0x1b        | PATH_RESPONSE        | {{frame-path-response}}        | __01    |
-| 0x1c - 0x1d | CONNECTION_CLOSE     | {{frame-connection-close}}     | IH01*   |
+| 0x1c - 0x1d | CONNECTION_CLOSE     | {{frame-connection-close}}     | iH01    |
 | 0x1e        | HANDSHAKE_DONE       | {{frame-handshake-done}}       | ___1    |
 {: #frame-types title="Frame Types"}
 
@@ -3053,11 +3053,9 @@ H:
 
 : 1-RTT ({{short-header}})
 
-*:
+i:
 
-: A CONNECTION_CLOSE frame of type 0x1c can appear in Initial, Handshake,
-  0-RTT, and 1-RTT packets, whereas a CONNECTION_CLOSE of type 0x1d can only
-  appear in 0-RTT and 1-RTT packets.
+: A CONNECTION_CLOSE frame of type 0x1d cannot appear in Initial packets.
 
 Section 4 of {{QUIC-TLS}} provides more detail about these restrictions.  Note
 that all frames can appear in 1-RTT packets.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2514,11 +2514,11 @@ that uses a lower packet protection level.  More specifically:
   1-RTT packets.  A server SHOULD also send CONNECTION_CLOSE in an Initial
   packet.
 
-An CONNECTION_CLOSE of type 0x1d MUST be replaced by a CONNECTION_CLOSE of type
-0x1c when sending the frame in Initial packets. Otherwise, information about
-the application state might be revealed. Endpoints MUST clear the value of the
-Reason Phrase field and SHOULD use the APPLICATION_ERROR code when converting
-to a CONNECTION_CLOSE of type 0x1c.
+A CONNECTION_CLOSE of type 0x1d MUST be replaced by a CONNECTION_CLOSE of type
+0x1c when sending the frame in Initial or Handshake packets. Otherwise,
+information about the application state might be revealed. Endpoints MUST clear
+the value of the Reason Phrase field and SHOULD use the APPLICATION_ERROR code
+when converting to a CONNECTION_CLOSE of type 0x1c.
 
 CONNECTION_CLOSE frames sent in multiple packets can be coalesced into a single
 UDP datagram; see {{packet-coalesce}}.
@@ -3029,7 +3029,7 @@ frames are explained in more detail in {{frame-formats}}.
 | 0x19        | RETIRE_CONNECTION_ID | {{frame-retire-connection-id}} | __01    |
 | 0x1a        | PATH_CHALLENGE       | {{frame-path-challenge}}       | __01    |
 | 0x1b        | PATH_RESPONSE        | {{frame-path-response}}        | __01    |
-| 0x1c - 0x1d | CONNECTION_CLOSE     | {{frame-connection-close}}     | iH01    |
+| 0x1c - 0x1d | CONNECTION_CLOSE     | {{frame-connection-close}}     | ih01    |
 | 0x1e        | HANDSHAKE_DONE       | {{frame-handshake-done}}       | ___1    |
 {: #frame-types title="Frame Types"}
 
@@ -3053,9 +3053,10 @@ H:
 
 : 1-RTT ({{short-header}})
 
-i:
+ih:
 
-: A CONNECTION_CLOSE frame of type 0x1d cannot appear in Initial packets.
+: A CONNECTION_CLOSE frame of type 0x1d cannot appear in Initial or Handshake
+  packets.
 
 Section 4 of {{QUIC-TLS}} provides more detail about these restrictions.  Note
 that all frames can appear in 1-RTT packets.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2514,14 +2514,16 @@ that uses a lower packet protection level.  More specifically:
   1-RTT packets.  A server SHOULD also send CONNECTION_CLOSE in an Initial
   packet.
 
-A CONNECTION_CLOSE of type 0x1d MUST be replaced by a CONNECTION_CLOSE of type
+Sending a CONNECTION_CLOSE of type 0x1d in an Initial or Handshake packet could
+expose application state or be used to alter application state. A
+CONNECTION_CLOSE of type 0x1d MUST be replaced by a CONNECTION_CLOSE of type
 0x1c when sending the frame in Initial or Handshake packets. Otherwise,
 information about the application state might be revealed. Endpoints MUST clear
 the value of the Reason Phrase field and SHOULD use the APPLICATION_ERROR code
 when converting to a CONNECTION_CLOSE of type 0x1c.
 
-CONNECTION_CLOSE frames sent in multiple packets can be coalesced into a single
-UDP datagram; see {{packet-coalesce}}.
+CONNECTION_CLOSE frames sent in multiple packet types can be coalesced into a
+single UDP datagram; see {{packet-coalesce}}.
 
 
 ## Stateless Reset {#stateless-reset}


### PR DESCRIPTION
This allows us to avoid treating 0-RTT specially more generally.

The advice on where to send CONNECTION_CLOSE seems ornate, but it reduces to "send CONNECTION_CLOSE in every space you have keys for".

The trick is that we don't want to allow application error codes to leak in Initial (edit: and Handshake) packets, so this defines an error code in the transport space that says "the application decided to close the connection".  I think that this is better than relying on the proxied TLS alert code, so I changed the recommendation to use 0x15a to refer to this new APPLICATION_ERROR error code.

Closes #3435.
Closes #3446.
Closes #3430.