### PR TITLE
Document TCP RTO vs QUIC PTO

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -233,13 +233,14 @@ more accurate round-trip time estimate (see Section 13.2 of {{QUIC-TRANSPORT}}).
 QUIC uses a probe timeout (see {{pto}}), with a timer based on TCP's RTO
 computation.  QUIC's PTO includes the peer's maximum expected acknowledgement
 delay instead of using a fixed minimum timeout. Unlike TCP, which collapses
-the congestion window upon expiry of an RTO, QUIC does not change the congestion
+the congestion window upon expiry of an RTO, QUIC does not collapse the congestion
 window until persistent congestion {{persistent-congestion}} is declared and
 instead allows probe packets to temporarily exceed the congestion window
-whenever the timer expires.  This is similar to TCP with F-RTO, but it does
-allow more packets to be sent when the congestion window was not fully utilized
-prior to the probe timeout expiring. Though this is slightly more aggressive than
-TCP RTO, it's less aggressive than if the connection was not application limited.
+whenever the timer expires.  In practice, this is similar to TCP with F-RTO,
+but it does allow more packets to be sent when the congestion window was not
+fully utilized prior to the probe timeout expiring. Though this is slightly
+more aggressive than TCP RTO, it's less aggressive than if the connection was
+not application limited.
 
 A single packet loss at the tail does not indicate persistent congestion, so
 QUIC specifies a time-based definition (see {{persistent-congestion}}) to

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -239,12 +239,12 @@ declared and instead allows probe packets to temporarily exceed the congestion
 window whenever the timer expires.
 
 In doing this, QUIC avoids unnecessary congestion window reductions, obviating
-the need for correcting mechanisms such as F-RTO {{!RFC5682}}.
-Since QUIC does not collapse the congestion window on a PTO expiration, a QUIC
-sender is not limited from sending more in-flight packets after a PTO expiration
-if it still has available congestion window. This occurs when a sender is
-application-limited and then the PTO timer expires. This is more aggressive than
-TCP's RTO mechanism when application-limited, but identical when not
+the need for correcting mechanisms such as F-RTO {{!RFC5682}}. Since QUIC does
+not collapse the congestion window on a PTO expiration, a QUIC sender is not
+limited from sending more in-flight packets after a PTO expiration if it still
+has available congestion window. This occurs when a sender is
+application-limited and then the PTO timer expires. This is more aggressive
+than TCP's RTO mechanism when application-limited, but identical when not
 application-limited.
 
 A single packet loss at the tail does not indicate persistent congestion, so

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -235,9 +235,9 @@ RTO timeout.  Unlike TCP's RTO, which collapses the congestion window upon
 expiry, QUIC does not change the congestion window and instead allows sending
 probe packets whenever the timer expires.  This is similar to TCP with F-RTO,
 but it does allow more packets to be sent when the congestion window was not
-fully utilized when the probe timeout expires. In this case, sending was not
-congestion controller limited, so though this is slightly more aggressive than
-TCP RTO is, it's less aggressive than the congestion controller allowed.
+fully utilized when the probe timeout expires. Though this is slightly more
+aggressive than TCP RTO is, it's less aggressive than the congestion controller
+allowed.
 
 
 # Estimating the Round-Trip Time {#compute-rtt}

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -236,11 +236,16 @@ delay instead of using a fixed minimum timeout. Unlike TCP, which collapses
 the congestion window upon expiry of an RTO, QUIC does not collapse the
 congestion window until persistent congestion ({{persistent-congestion}}) is
 declared and instead allows probe packets to temporarily exceed the congestion
-window whenever the timer expires.  In comparison to TCP with F-RTO
-{{!RFC5682}}, which corrects an unnecessary collapse of the congestion window,
-this design aims to prevent the window from collapsing. Though this is slightly
-more aggressive than TCP RTO, it's less aggressive than if the connection was
-not application limited.
+window whenever the timer expires.
+
+In doing this, QUIC avoids unnecessary congestion window reductions, obviating
+the need for correcting mechanisms such as F-RTO {{!RFC5682}}.
+Since QUIC does not collapse the congestion window on a PTO expiration, a QUIC
+sender is not limited from sending more in-flight packets after a PTO expiration
+if it still has available congestion window. This occurs when a sender is
+application-limited and then the PTO timer expires. This is more aggressive than
+TCP's RTO mechanism when application-limited, but identical when not
+application-limited.
 
 A single packet loss at the tail does not indicate persistent congestion, so
 QUIC specifies a time-based definition to ensure one or more packets are sent

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -237,8 +237,8 @@ the congestion window upon expiry, QUIC does not change the congestion window
 and instead allows sending probe packets whenever the timer expires.  This is
 similar to TCP with F-RTO, but it does allow more packets to be sent when the
 congestion window was not fully utilized when the probe timeout expires. Though
-this is slightly more aggressive than TCP RTO, it's less aggressive than the
-congestion controller allowed.
+this is slightly more aggressive than TCP RTO, it's less aggressive than if the
+connection was not application limited.
 
 A single packet loss at the tail does not indicate persistent congestion, so
 QUIC defines a time-based definition (see {{persistent-congestion}}) to

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -236,9 +236,9 @@ delay instead of using a fixed minimum timeout. Unlike TCP, which collapses
 the congestion window upon expiry of an RTO, QUIC does not collapse the
 congestion window until persistent congestion ({{persistent-congestion}}) is
 declared and instead allows probe packets to temporarily exceed the congestion
-window whenever the timer expires.  In practice, this is similar to TCP with
-F-RTO, but it does allow more packets to be sent when the congestion window was
-not fully utilized prior to the probe timeout expiring. Though this is slightly
+window whenever the timer expires.  In comparison to TCP with F-RTO
+{{!RFC5682}}, which corrects an unnecessary collapse of the congestion window,
+this design aims to prevent the window from collapsing. Though this is slightly
 more aggressive than TCP RTO, it's less aggressive than if the connection was
 not application limited.
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -228,6 +228,18 @@ QUIC endpoints measure the delay incurred between when a packet is received and
 when the corresponding acknowledgment is sent, allowing a peer to maintain a
 more accurate round-trip time estimate (see Section 13.2 of {{QUIC-TRANSPORT}}).
 
+### Probe Timeout Replaces RTO and TLP
+
+QUIC uses a probe timeout (see {{pto}}), which uses a timer based on TCP's
+RTO timeout.  Unlike TCP's RTO, which collapses the congestion window upon
+timeout, QUIC does not change the congestion window and allows sending a
+probe timeout whenever the timer fires.  This is similar to TCP with F-RTO,
+but it does allow more packets to be sent in the case when the congestion
+window was not fully utilized when the probe timeout expires. In this case,
+sending was not congestion controller limited, so though this is slightly
+more aggressive than TCP is, it's less aggressive than the congestion
+controller allowed.
+
 
 # Estimating the Round-Trip Time {#compute-rtt}
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -232,11 +232,11 @@ more accurate round-trip time estimate (see Section 13.2 of {{QUIC-TRANSPORT}}).
 
 QUIC uses a probe timeout (see {{pto}}), with a timer based on TCP's RTO
 computation.  QUIC's PTO includes the peer's maximum expected acknowledgement
-delay instead of using a fixed minimum timeout. Unlike TCP, which collapses
-the congestion window upon expiry of an RTO, QUIC does not collapse the
+delay instead of using a fixed minimum timeout. QUIC does not collapse the
 congestion window until persistent congestion ({{persistent-congestion}}) is
-declared and instead allows probe packets to temporarily exceed the congestion
-window whenever the timer expires.
+declared, unlike TCP, which collapses the congestion window upon expiry of an
+RTO.  Instead of collapsing the congestion window, QUIC allows probe packets
+to temporarily exceed the congestion window whenever the timer expires.
 
 In doing this, QUIC avoids unnecessary congestion window reductions, obviating
 the need for correcting mechanisms such as F-RTO {{!RFC5682}}. Since QUIC does

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -722,7 +722,7 @@ packets might cause the sender's bytes in flight to exceed the congestion window
 until an acknowledgement is received that establishes loss or delivery of
 packets.
 
-## Persistent Congestion
+## Persistent Congestion {#persistent-congestion}
 
 When an ACK frame is received that establishes loss of all in-flight packets
 sent over a long enough period of time, the network is considered to be

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -232,13 +232,12 @@ more accurate round-trip time estimate (see Section 13.2 of {{QUIC-TRANSPORT}}).
 
 QUIC uses a probe timeout (see {{pto}}), which uses a timer based on TCP's
 RTO timeout.  Unlike TCP's RTO, which collapses the congestion window upon
-timeout, QUIC does not change the congestion window and allows sending a
-probe timeout whenever the timer fires.  This is similar to TCP with F-RTO,
-but it does allow more packets to be sent in the case when the congestion
-window was not fully utilized when the probe timeout expires. In this case,
-sending was not congestion controller limited, so though this is slightly
-more aggressive than TCP is, it's less aggressive than the congestion
-controller allowed.
+expiry, QUIC does not change the congestion window and instead allows sending
+probe packets whenever the timer expires.  This is similar to TCP with F-RTO,
+but it does allow more packets to be sent when the congestion window was not
+fully utilized when the probe timeout expires. In this case, sending was not
+congestion controller limited, so though this is slightly more aggressive than
+TCP RTO is, it's less aggressive than the congestion controller allowed.
 
 
 # Estimating the Round-Trip Time {#compute-rtt}

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -236,7 +236,7 @@ expiry, QUIC does not change the congestion window and instead allows sending
 probe packets whenever the timer expires.  This is similar to TCP with F-RTO,
 but it does allow more packets to be sent when the congestion window was not
 fully utilized when the probe timeout expires. Though this is slightly more
-aggressive than TCP RTO is, it's less aggressive than the congestion controller
+aggressive than TCP RTO, it's less aggressive than the congestion controller
 allowed.
 
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -238,7 +238,7 @@ window until persistent congestion {{persistent-congestion}} is declared and
 instead allows probe packets to temporarily exceed the congestion window
 whenever the timer expires.  This is similar to TCP with F-RTO, but it does
 allow more packets to be sent when the congestion window was not fully utilized
-when the probe timeout expires. Though this is slightly more aggressive than
+prior to the probe timeout expiring. Though this is slightly more aggressive than
 TCP RTO, it's less aggressive than if the connection was not application limited.
 
 A single packet loss at the tail does not indicate persistent congestion, so

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -231,17 +231,17 @@ more accurate round-trip time estimate (see Section 13.2 of {{QUIC-TRANSPORT}}).
 ### Probe Timeout Replaces RTO and TLP
 
 QUIC uses a probe timeout (see {{pto}}), with a timer based on TCP's
-RTO timeout.  QUIC PTO includes the peer's max_ack_delay in the calculation,
-instead of relying upon a fixed minimum RTO.  Unlike TCP's RTO, which collapses
-the congestion window upon expiry, QUIC does not change the congestion window
-and instead allows sending probe packets whenever the timer expires.  This is
+RTO period computation.  QUIC's PTO period includes the peer's maximum expected acknowledgement delay (max_ack_delay, Section XX),
+instead of using a fixed minimum period.  Unlike TCP, which collapses
+the congestion window upon expiry of an RTO, QUIC does not change the congestion window
+and instead sends probe packets whenever the timer expires.  This is
 similar to TCP with F-RTO, but it does allow more packets to be sent when the
 congestion window was not fully utilized when the probe timeout expires. Though
 this is slightly more aggressive than TCP RTO, it's less aggressive than if the
 connection was not application limited.
 
 A single packet loss at the tail does not indicate persistent congestion, so
-QUIC defines a time-based definition (see {{persistent-congestion}}) to
+QUIC specifies a time-based definition (see {{persistent-congestion}}) to
 ensure one or more packets are sent prior to a dramatic decrease in
 congestion window.
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -234,7 +234,7 @@ QUIC uses a probe timeout (see {{pto}}), with a timer based on TCP's RTO
 computation.  QUIC's PTO includes the peer's maximum expected acknowledgement
 delay instead of using a fixed minimum timeout. Unlike TCP, which collapses
 the congestion window upon expiry of an RTO, QUIC does not collapse the
-congestion window until persistent congestion {{persistent-congestion}} is
+congestion window until persistent congestion ({{persistent-congestion}}) is
 declared and instead allows probe packets to temporarily exceed the congestion
 window whenever the timer expires.  In practice, this is similar to TCP with
 F-RTO, but it does allow more packets to be sent when the congestion window was

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -230,7 +230,7 @@ more accurate round-trip time estimate (see Section 13.2 of {{QUIC-TRANSPORT}}).
 
 ### Probe Timeout Replaces RTO and TLP
 
-QUIC uses a probe timeout (see {{pto}}), which uses a timer based on TCP's
+QUIC uses a probe timeout (see {{pto}}), with a timer based on TCP's
 RTO timeout.  Unlike TCP's RTO, which collapses the congestion window upon
 expiry, QUIC does not change the congestion window and instead allows sending
 probe packets whenever the timer expires.  This is similar to TCP with F-RTO,

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -233,12 +233,12 @@ more accurate round-trip time estimate (see Section 13.2 of {{QUIC-TRANSPORT}}).
 QUIC uses a probe timeout (see {{pto}}), with a timer based on TCP's RTO
 computation.  QUIC's PTO includes the peer's maximum expected acknowledgement
 delay instead of using a fixed minimum timeout. Unlike TCP, which collapses
-the congestion window upon expiry of an RTO, QUIC does not collapse the congestion
-window until persistent congestion {{persistent-congestion}} is declared and
-instead allows probe packets to temporarily exceed the congestion window
-whenever the timer expires.  In practice, this is similar to TCP with F-RTO,
-but it does allow more packets to be sent when the congestion window was not
-fully utilized prior to the probe timeout expiring. Though this is slightly
+the congestion window upon expiry of an RTO, QUIC does not collapse the
+congestion window until persistent congestion {{persistent-congestion}} is
+declared and instead allows probe packets to temporarily exceed the congestion
+window whenever the timer expires.  In practice, this is similar to TCP with
+F-RTO, but it does allow more packets to be sent when the congestion window was
+not fully utilized prior to the probe timeout expiring. Though this is slightly
 more aggressive than TCP RTO, it's less aggressive than if the connection was
 not application limited.
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -231,13 +231,19 @@ more accurate round-trip time estimate (see Section 13.2 of {{QUIC-TRANSPORT}}).
 ### Probe Timeout Replaces RTO and TLP
 
 QUIC uses a probe timeout (see {{pto}}), with a timer based on TCP's
-RTO timeout.  Unlike TCP's RTO, which collapses the congestion window upon
-expiry, QUIC does not change the congestion window and instead allows sending
-probe packets whenever the timer expires.  This is similar to TCP with F-RTO,
-but it does allow more packets to be sent when the congestion window was not
-fully utilized when the probe timeout expires. Though this is slightly more
-aggressive than TCP RTO, it's less aggressive than the congestion controller
-allowed.
+RTO timeout.  QUIC PTO includes the peer's max_ack_delay in the calculation,
+instead of relying upon a fixed minimum RTO.  Unlike TCP's RTO, which collapses
+the congestion window upon expiry, QUIC does not change the congestion window
+and instead allows sending probe packets whenever the timer expires.  This is
+similar to TCP with F-RTO, but it does allow more packets to be sent when the
+congestion window was not fully utilized when the probe timeout expires. Though
+this is slightly more aggressive than TCP RTO, it's less aggressive than the
+congestion controller allowed.
+
+A single packet loss at the tail does not indicate persistent congestion, so
+QUIC defines a time-based definition (see {{persistent-congestion}}) to
+ensure one or more packets are sent prior to a dramatic decrease in
+congestion window.
 
 
 # Estimating the Round-Trip Time {#compute-rtt}

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -234,11 +234,12 @@ QUIC uses a probe timeout (see {{pto}}), with a timer based on TCP's RTO
 computation.  QUIC's PTO includes the peer's maximum expected acknowledgement
 delay instead of using a fixed minimum timeout. Unlike TCP, which collapses
 the congestion window upon expiry of an RTO, QUIC does not change the congestion
-window and instead sends probe packets whenever the timer expires.  This is
-similar to TCP with F-RTO, but it does allow more packets to be sent when the
-congestion window was not fully utilized when the probe timeout expires. Though
-this is slightly more aggressive than TCP RTO, it's less aggressive than if the
-connection was not application limited.
+window until persistent congestion {{persistent-congestion}} is declared and
+instead allows probe packets to temporarily exceed the congestion window
+whenever the timer expires.  This is similar to TCP with F-RTO, but it does
+allow more packets to be sent when the congestion window was not fully utilized
+when the probe timeout expires. Though this is slightly more aggressive than
+TCP RTO, it's less aggressive than if the connection was not application limited.
 
 A single packet loss at the tail does not indicate persistent congestion, so
 QUIC specifies a time-based definition (see {{persistent-congestion}}) to

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -243,9 +243,9 @@ more aggressive than TCP RTO, it's less aggressive than if the connection was
 not application limited.
 
 A single packet loss at the tail does not indicate persistent congestion, so
-QUIC specifies a time-based definition (see {{persistent-congestion}}) to
-ensure one or more packets are sent prior to a dramatic decrease in
-congestion window.
+QUIC specifies a time-based definition to ensure one or more packets are sent
+prior to a dramatic decrease in congestion window; see
+{{persistent-congestion}}.
 
 
 # Estimating the Round-Trip Time {#compute-rtt}

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -230,11 +230,11 @@ more accurate round-trip time estimate (see Section 13.2 of {{QUIC-TRANSPORT}}).
 
 ### Probe Timeout Replaces RTO and TLP
 
-QUIC uses a probe timeout (see {{pto}}), with a timer based on TCP's
-RTO period computation.  QUIC's PTO period includes the peer's maximum expected acknowledgement delay (max_ack_delay, Section XX),
-instead of using a fixed minimum period.  Unlike TCP, which collapses
-the congestion window upon expiry of an RTO, QUIC does not change the congestion window
-and instead sends probe packets whenever the timer expires.  This is
+QUIC uses a probe timeout (see {{pto}}), with a timer based on TCP's RTO
+computation.  QUIC's PTO includes the peer's maximum expected acknowledgement
+delay instead of using a fixed minimum timeout. Unlike TCP, which collapses
+the congestion window upon expiry of an RTO, QUIC does not change the congestion
+window and instead sends probe packets whenever the timer expires.  This is
 similar to TCP with F-RTO, but it does allow more packets to be sent when the
 congestion window was not fully utilized when the probe timeout expires. Though
 this is slightly more aggressive than TCP RTO, it's less aggressive than if the

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -235,16 +235,17 @@ computation.  QUIC's PTO includes the peer's maximum expected acknowledgement
 delay instead of using a fixed minimum timeout. QUIC does not collapse the
 congestion window until persistent congestion ({{persistent-congestion}}) is
 declared, unlike TCP, which collapses the congestion window upon expiry of an
-RTO.  Instead of collapsing the congestion window, QUIC allows probe packets
-to temporarily exceed the congestion window whenever the timer expires.
+RTO.  Instead of collapsing the congestion window and declaring everything
+in-flight lost, QUIC allows probe packets to temporarily exceed the congestion
+window whenever the timer expires.
 
 In doing this, QUIC avoids unnecessary congestion window reductions, obviating
 the need for correcting mechanisms such as F-RTO {{!RFC5682}}. Since QUIC does
 not collapse the congestion window on a PTO expiration, a QUIC sender is not
 limited from sending more in-flight packets after a PTO expiration if it still
 has available congestion window. This occurs when a sender is
-application-limited and then the PTO timer expires. This is more aggressive
-than TCP's RTO mechanism when application-limited, but identical when not
+application-limited and the PTO timer expires. This is more aggressive than
+TCP's RTO mechanism when application-limited, but identical when not
 application-limited.
 
 A single packet loss at the tail does not indicate persistent congestion, so


### PR DESCRIPTION
Fixes #3259 and fixes #3260 by documenting the core difference between TCP's RTO and QUIC's PTO.