### PR TITLE
Remove "Ignoring Loss of Undecryptable Packets"

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -687,15 +687,6 @@ The recovery period limits congestion window reduction to once per round trip.
 During recovery, the congestion window remains unchanged irrespective of new
 losses or increases in the ECN-CE counter.
 
-## Ignoring Loss of Undecryptable Packets
-
-During the handshake, some packet protection keys might not be
-available when a packet arrives. In particular, Handshake and 0-RTT packets
-cannot be processed until the Initial packets arrive, and 1-RTT packets
-cannot be processed until the handshake completes.  Endpoints MAY
-ignore the loss of Handshake, 0-RTT, and 1-RTT packets that might arrive before
-the peer has packet protection keys to process those packets.
-
 ## Probe Timeout
 
 Probe packets MUST NOT be blocked by the congestion controller.  A sender MUST


### PR DESCRIPTION
Now that QUIC has separate packet number spaces, it's impossible to declare a packet lost without the relevant keys being present at both peers, because an ACK needs to be sent by one and processed by the other.

So this text is OBE and potentially confusing.