### PR TITLE
Clarify client anti-amplification response

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1633,7 +1633,7 @@ acknowledged and it does not yet have Handshake data to send. In order to avoid
 this causing a handshake deadlock, clients MUST send a packet upon a probe
 timeout, as described in {{QUIC-RECOVERY}}. If the client has no data to
 retransmit, it MUST send an Initial packet in a UDP datagram of at least 1200
-bytes if it does not have Handshake keys and otherwise send a Handshake packet.
+bytes if it does not have Handshake keys, and otherwise send a Handshake packet.
 
 A server might wish to validate the client address before starting the
 cryptographic handshake. QUIC uses a token in the Initial packet to provide

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1627,16 +1627,16 @@ necessary. Sending padded datagrams ensures that the server is not overly
 constrained by the amplification restriction.
 
 Loss of an Initial or Handshake packet from the server can cause a deadlock if
-the client does not send additional Initial or Handshake packets. This can happen
-because the server can reach its anti-amplification limit, and if the client has
-received acknowledgements for all the data it has sent, it has no reason to send
-more packets. In this case, where the client would otherwise not send any
-additional packets, the server will be unable to send more data because it has
-not received enough bytes from the client or validated the client's address.
-To prevent this deadlock, clients MUST send a packet on a probe timeout (PTO,
-see Section 5.3 of {{QUIC-RECOVERY}}). Specifically, the client MUST send an
-Initial packet in a UDP datagram of at least 1200 bytes if it does not have
-Handshake keys, and otherwise send a Handshake packet.
+the client does not send additional Initial or Handshake packets. This happens
+when the server reaches its anti-amplification limit and the client has
+received acknowledgements for all the data it has sent.  In this case, when
+the client has no reason to send additional packets, the server will be unable
+to send more data because it has not validated the client's address or received
+enough bytes from the client. To prevent this deadlock, clients MUST send a
+packet on a probe timeout (PTO, see Section 5.3 of {{QUIC-RECOVERY}}).
+Specifically, the client MUST send an Initial packet in a UDP datagram of at
+least 1200 bytes if it does not have Handshake keys, and otherwise send a
+Handshake packet.
 
 A server might wish to validate the client address before starting the
 cryptographic handshake. QUIC uses a token in the Initial packet to provide

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1631,12 +1631,11 @@ the client does not send additional Initial or Handshake packets. A deadlock
 could occur when the server reaches its anti-amplification limit and the client
 has received acknowledgements for all the data it has sent.  In this case, when
 the client has no reason to send additional packets, the server will be unable
-to send more data because it has not validated the client's address or received
-enough bytes from the client. To prevent this deadlock, clients MUST send a
-packet on a probe timeout (PTO, see Section 5.3 of {{QUIC-RECOVERY}}).
-Specifically, the client MUST send an Initial packet in a UDP datagram of at
-least 1200 bytes if it does not have Handshake keys, and otherwise send a
-Handshake packet.
+to send more data because it has not validated the client's address. To prevent
+this deadlock, clients MUST send a packet on a probe timeout
+(PTO, see Section 5.3 of {{QUIC-RECOVERY}}). Specifically, the client MUST send
+an Initial packet in a UDP datagram of at least 1200 bytes if it does not have
+Handshake keys, and otherwise send a Handshake packet.
 
 A server might wish to validate the client address before starting the
 cryptographic handshake. QUIC uses a token in the Initial packet to provide

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1629,8 +1629,8 @@ constrained by the amplification restriction.
 Loss of an Initial or Handshake packet from the server can cause a deadlock if
 the client does not send additional Initial or Handshake packets. This can happen
 because the server can reach its anti-amplification limit, and if the client has
-receivedacknowledgements for all the data it has sent, it has no reason to send
-morepackets. In this case, where the client would otherwise not send any
+received acknowledgements for all the data it has sent, it has no reason to send
+more packets. In this case, where the client would otherwise not send any
 additional packets, the server will be unable to send more data because it has
 not received enough bytes from the client or validated the client's address.
 To prevent this deadlock, clients MUST send a packet on a probe timeout (PTO, 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1626,14 +1626,17 @@ payloads of at least 1200 bytes, adding padding to packets in the datagram as
 necessary. Sending padded datagrams ensures that the server is not overly
 constrained by the amplification restriction.
 
-Loss of an Initial or Handshake packet from the server can cause a situation in
-which the server cannot send due to the anti-amplification limit
-and the client has no data to send because client Initial data has been
-acknowledged and it does not yet have Handshake data to send. In order to avoid
-this causing a handshake deadlock, clients MUST send a packet upon a probe
-timeout, as described in {{QUIC-RECOVERY}}. If the client has no data to
-retransmit, it MUST send an Initial packet in a UDP datagram of at least 1200
-bytes if it does not have Handshake keys, and otherwise send a Handshake packet.
+Loss of an Initial or Handshake packet from the server can cause a deadlock if
+the client does not send additional Initial or Handshake packets. The server can
+reach its anti-amplification limit, but the clients Initial data has been
+acknowledged without receiving all the server's Handshake data. In this case,
+where the client would otherwise not send any additional packets, the server
+will be unable to send because it has not received enough from the client or
+validated the clients address. To prevent this deadlock, clients MUST send a
+packet on a probe timeout, or PTO; see Section 5.3 of {{QUIC-RECOVERY}}.
+In this case, the client MUST send an Initial packet in a UDP datagram of at
+least 1200 bytes if it does not have Handshake keys, and otherwise send a
+Handshake packet.
 
 A server might wish to validate the client address before starting the
 cryptographic handshake. QUIC uses a token in the Initial packet to provide

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1628,7 +1628,7 @@ constrained by the amplification restriction.
 
 Loss of an Initial or Handshake packet from the server can cause a situation in
 which the server cannot send due to the anti-amplification limit
-and the client has no data to send because client Initial packets have been
+and the client has no data to send because client Initial data has been
 acknowledged and it does not yet have Handshake data to send. In order to avoid
 this causing a handshake deadlock, clients MUST send a packet upon a probe
 timeout, as described in {{QUIC-RECOVERY}}. If the client has no data to

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1633,7 +1633,7 @@ received acknowledgements for all the data it has sent, it has no reason to send
 more packets. In this case, where the client would otherwise not send any
 additional packets, the server will be unable to send more data because it has
 not received enough bytes from the client or validated the client's address.
-To prevent this deadlock, clients MUST send a packet on a probe timeout (PTO, 
+To prevent this deadlock, clients MUST send a packet on a probe timeout (PTO,
 see Section 5.3 of {{QUIC-RECOVERY}}). Specifically, the client MUST send an
 Initial packet in a UDP datagram of at least 1200 bytes if it does not have
 Handshake keys, and otherwise send a Handshake packet.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1627,13 +1627,13 @@ necessary. Sending padded datagrams ensures that the server is not overly
 constrained by the amplification restriction.
 
 Loss of an Initial or Handshake packet from the server can cause a deadlock if
-the client does not send additional Initial or Handshake packets. This can happen because the server
-can reach its anti-amplification limit, and if the client has received
-acknowledgements for all the data it has sent, it has no reason to send more
-packets. In this case, where the client would otherwise not send any
-additional packets, the server will be unable to send more data because it has not
-received enough from the client or validated the clients address. To prevent
-this deadlock, clients MUST send a packet on a probe timeout (PTO, 
+the client does not send additional Initial or Handshake packets. This can happen
+because the server can reach its anti-amplification limit, and if the client has
+receivedacknowledgements for all the data it has sent, it has no reason to send
+morepackets. In this case, where the client would otherwise not send any
+additional packets, the server will be unable to send more data because it has
+not received enough bytes from the client or validated the client's address.
+To prevent this deadlock, clients MUST send a packet on a probe timeout (PTO, 
 see Section 5.3 of {{QUIC-RECOVERY}}). Specifically, the client MUST send an
 Initial packet in a UDP datagram of at least 1200 bytes if it does not have
 Handshake keys, and otherwise send a Handshake packet.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1627,13 +1627,13 @@ necessary. Sending padded datagrams ensures that the server is not overly
 constrained by the amplification restriction.
 
 Packet loss, in particular loss of a Handshake packet from the server, can cause
-a situation in which the server cannot send when the client has no data to send
-and the anti-amplification limit is reached. In order to avoid this causing a
-handshake deadlock, clients MUST send a packet upon a probe timeout, as
-described in {{QUIC-RECOVERY}}. If the client has no data to retransmit and does
-not have Handshake keys, it MUST send an Initial packet in a UDP datagram of
-at least 1200 bytes.  If the client has Handshake keys, it SHOULD send a
-Handshake packet.
+a situation in which the server cannot send due to the anti-amplification limit
+and the client has no data to send because client Initial packets have been
+acknowledged and it does not yet have Handshake data to send. In order to avoid
+this causing a handshake deadlock, clients MUST send a packet upon a probe
+timeout, as described in {{QUIC-RECOVERY}}. If the client has no data to
+retransmit, it MUST send an Initial packet in a UDP datagram of at least 1200
+bytes if it does not have Handshake keys and otherwise send a Handshake packet.
 
 A server might wish to validate the client address before starting the
 cryptographic handshake. QUIC uses a token in the Initial packet to provide

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1626,8 +1626,8 @@ payloads of at least 1200 bytes, adding padding to packets in the datagram as
 necessary. Sending padded datagrams ensures that the server is not overly
 constrained by the amplification restriction.
 
-Packet loss, in particular loss of a Handshake packet from the server, can cause
-a situation in which the server cannot send due to the anti-amplification limit
+Loss of an Initial or Handshake packet from the server can cause a situation in
+which the server cannot send due to the anti-amplification limit
 and the client has no data to send because client Initial packets have been
 acknowledged and it does not yet have Handshake data to send. In order to avoid
 this causing a handshake deadlock, clients MUST send a packet upon a probe

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1628,8 +1628,8 @@ constrained by the amplification restriction.
 
 Loss of an Initial or Handshake packet from the server can cause a deadlock if
 the client does not send additional Initial or Handshake packets. A deadlock
-occurs when the server reaches its anti-amplification limit and the client has
-received acknowledgements for all the data it has sent.  In this case, when
+could occur when the server reaches its anti-amplification limit and the client
+has received acknowledgements for all the data it has sent.  In this case, when
 the client has no reason to send additional packets, the server will be unable
 to send more data because it has not validated the client's address or received
 enough bytes from the client. To prevent this deadlock, clients MUST send a

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1627,16 +1627,16 @@ necessary. Sending padded datagrams ensures that the server is not overly
 constrained by the amplification restriction.
 
 Loss of an Initial or Handshake packet from the server can cause a deadlock if
-the client does not send additional Initial or Handshake packets. The server can
-reach its anti-amplification limit, but the clients Initial data has been
-acknowledged without receiving all the server's Handshake data. In this case,
-where the client would otherwise not send any additional packets, the server
-will be unable to send because it has not received enough from the client or
-validated the clients address. To prevent this deadlock, clients MUST send a
-packet on a probe timeout, or PTO; see Section 5.3 of {{QUIC-RECOVERY}}.
-In this case, the client MUST send an Initial packet in a UDP datagram of at
-least 1200 bytes if it does not have Handshake keys, and otherwise send a
-Handshake packet.
+the client does not send additional Initial or Handshake packets.  The server
+can reach its anti-amplification limit, but if the client has received
+acknowledgements for all the data is has sent, it has no reason to send more
+packets. In this case, where the client would otherwise not send any
+additional packets, the server will be unable to send because it has not
+received enough from the client or validated the clients address. To prevent
+this deadlock, clients MUST send a packet on a probe timeout, or PTO;
+see Section 5.3 of {{QUIC-RECOVERY}}. In this case, the client MUST send an
+Initial packet in a UDP datagram of at least 1200 bytes if it does not have
+Handshake keys, and otherwise send a Handshake packet.
 
 A server might wish to validate the client address before starting the
 cryptographic handshake. QUIC uses a token in the Initial packet to provide

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1627,8 +1627,8 @@ necessary. Sending padded datagrams ensures that the server is not overly
 constrained by the amplification restriction.
 
 Loss of an Initial or Handshake packet from the server can cause a deadlock if
-the client does not send additional Initial or Handshake packets. This happens
-when the server reaches its anti-amplification limit and the client has
+the client does not send additional Initial or Handshake packets. A deadlock
+occurs when the server reaches its anti-amplification limit and the client has
 received acknowledgements for all the data it has sent.  In this case, when
 the client has no reason to send additional packets, the server will be unable
 to send more data because it has not validated the client's address or received

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1627,14 +1627,14 @@ necessary. Sending padded datagrams ensures that the server is not overly
 constrained by the amplification restriction.
 
 Loss of an Initial or Handshake packet from the server can cause a deadlock if
-the client does not send additional Initial or Handshake packets.  The server
-can reach its anti-amplification limit, but if the client has received
-acknowledgements for all the data is has sent, it has no reason to send more
+the client does not send additional Initial or Handshake packets. This can happen because the server
+can reach its anti-amplification limit, and if the client has received
+acknowledgements for all the data it has sent, it has no reason to send more
 packets. In this case, where the client would otherwise not send any
-additional packets, the server will be unable to send because it has not
+additional packets, the server will be unable to send more data because it has not
 received enough from the client or validated the clients address. To prevent
-this deadlock, clients MUST send a packet on a probe timeout, or PTO;
-see Section 5.3 of {{QUIC-RECOVERY}}. In this case, the client MUST send an
+this deadlock, clients MUST send a packet on a probe timeout (PTO, 
+see Section 5.3 of {{QUIC-RECOVERY}}). Specifically, the client MUST send an
 Initial packet in a UDP datagram of at least 1200 bytes if it does not have
 Handshake keys, and otherwise send a Handshake packet.
 


### PR DESCRIPTION
Clarifies why a client might send a Handshake packet, as well as improving the surrounding anti-deadlock text.

Changes 2 SHOULDs to MUSTs to line up with recovery.

Fixes #2598