### PR TITLE
ACK-only packets are not congestion controlled

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -643,7 +643,7 @@ If an endpoint uses a different controller than that specified in this document,
 the chosen controller MUST conform to the congestion control guidelines
 specified in Section 3.1 of {{!RFC8085}}.
 
-Similar to TCP, Packets only containing ACK frames do not count towards bytes
+Similar to TCP, packets containing only ACK frames do not count towards bytes
 in flight and are not congestion controlled.  Unlike TCP, QUIC can detect the
 loss of these packets and MAY use that information to adjust the congestion
 controller or the rate of ACK-only packets being sent, but this document does

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -643,6 +643,12 @@ If an endpoint uses a different controller than that specified in this document,
 the chosen controller MUST conform to the congestion control guidelines
 specified in Section 3.1 of {{!RFC8085}}.
 
+Similar to TCP, Packets only containing ACK frames do not count towards bytes
+in flight and are not congestion controlled.  Unlike TCP, QUIC can detect the
+loss of these packets and MAY use that information to adjust the congestion
+controller or the rate of ACK-only packets being sent, but this document does
+not describe a mechanism for doing so.
+
 The algorithm in this document specifies and uses the controller's congestion
 window in bytes.
 


### PR DESCRIPTION
Clarifies that losing ACK-only packets is detectable in QUIC, but this draft specifies no response to their loss.

Possibly this isn't the right spot for this text.  If so, please suggest an alternate location.

Fixes #3451