### PR TITLE
In an unlikely event of emergency.... set ECN marks

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3487,7 +3487,7 @@ packets on a new path to a peer:
 
 During the initial deployment of ECN an implementation bug was observed that
 led to black-holing of ECN-marked packet (mostly in home router equipment).
-While this case if unlikely in the Internet today, if this is as a concern for
+While this case is unlikely in the Internet today, if this is as a concern for
 a certain network, an endpoint could set the ECT(0) codepoint only in, e.g., the
 first ten outgoing packets on a path, or for a period of, e.g., three RTTs,
 whichever occurs first, to reduce the chances of misinterpreting congestive

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3485,10 +3485,13 @@ packets on a new path to a peer:
 * If all packets that were sent with the ECT(0) codepoint are eventually deemed
   lost {{QUIC-RECOVERY}}, validation is deemed to have failed.
 
-To reduce the chances of misinterpreting congestive loss as packets dropped by a
-faulty network element, an endpoint could set the ECT(0) codepoint in the first
-ten outgoing packets on a path, or for a period of three RTTs, whichever occurs
-first.
+During the initial deployment of ECN an implementation bug was observed that
+led to black-holing of ECN-marked packet (mostly in home router equipment).
+While this case if unlikely in the Internet today, if this is as a concern for
+a certain network, an endpoint could set the ECT(0) codepoint only in, e.g., the
+first ten outgoing packets on a path, or for a period of, e.g., three RTTs,
+whichever occurs first, to reduce the chances of misinterpreting congestive
+loss as packets dropped by a faulty network element.
 
 Implementations MAY experiment with and use other strategies for use of ECN.
 Other methods of probing paths for ECN support are possible, as are different


### PR DESCRIPTION
This is an editorial change marking clear that ECN-based black-holing is rather unlikely today.