### PR TITLE
Add handling of all packets marked as CE

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3517,6 +3517,13 @@ use the following steps on receiving an ACK frame to validate ECN.
   corresponding ECT codepoint that are newly acknowledged in this ACK frame.
   This step detects any erroneous network remarking from ECT(0) to ECT(1) (or
   vice versa).
+  
+Another special case is when all packets are indicatd as CE marked,
+independtly of the initial codepode used, including Not-ECT. In this case
+it could be a network element overwriting the ECN field of all packets and
+thereby potentially concealing actual congestion information. Especially, 
+when it is recognized that Not-ECT packets get remarked to CE, ECN marking
+should be disabled and any received CE feedback should be treated with caution.
 
 Processing ECN counts out of order can result in validation failure.  An
 endpoint SHOULD NOT perform this validation if this ACK frame does not advance

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3519,7 +3519,7 @@ use the following steps on receiving an ACK frame to validate ECN.
   vice versa).
   
 Another special case is when all packets are marked ECN-CE,
-independtly of the initial codepode used, including Not-ECT. In this case
+independent of the marking used, including Not-ECT. In this case
 it could be a network element overwriting the ECN field of all packets and
 thereby potentially concealing actual congestion information. Especially, 
 when it is recognized that Not-ECT packets get remarked to CE, ECN marking

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3518,7 +3518,7 @@ use the following steps on receiving an ACK frame to validate ECN.
   This step detects any erroneous network remarking from ECT(0) to ECT(1) (or
   vice versa).
   
-Another special case is when all packets are indicatd as CE marked,
+Another special case is when all packets are marked ECN-CE,
 independtly of the initial codepode used, including Not-ECT. In this case
 it could be a network element overwriting the ECN field of all packets and
 thereby potentially concealing actual congestion information. Especially, 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3518,12 +3518,12 @@ use the following steps on receiving an ACK frame to validate ECN.
   This step detects any erroneous network remarking from ECT(0) to ECT(1) (or
   vice versa).
   
-Another special case is when all packets are marked ECN-CE,
-independent of the marking used, including Not-ECT. In this case
-it could be a network element overwriting the ECN field of all packets and
-thereby potentially concealing actual congestion information. Especially, 
-when it is recognized that Not-ECT packets get remarked to CE, ECN marking
-should be disabled and any received CE feedback should be treated with caution.
+Another special case is when all packets are marked ECN-CE, independent of the
+marking used, including Not-ECT.If this is caused by a network element
+erroneously overwriting the ECN code point field, it will also conceal actual
+congestion information. Therefore, if a peer indicates that all received packets
+are ECN-CE marked, endpoints MAY treat this as an ECN validation failure and
+ignore any ECN-CE counts in acknowledgments.
 
 Processing ECN counts out of order can result in validation failure.  An
 endpoint SHOULD NOT perform this validation if this ACK frame does not advance


### PR DESCRIPTION
This is actually a behaviour that has been observed a few time on the Internet. In TCP this case is encounter as ECN will be disabled if the SYN is CE marked (as the SYN should always be Not-ECT these days). I just realised that this validation is rather easy to detect if any Not-ECT have been sent, I think it would be good to mention is explicitly.