### PR TITLE
Deadlocks, and how to avoid them

### DIFF
--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -281,6 +281,26 @@ table entries which have been acknowledged, but this could mean using
 literals. Since literals make the header block larger, this can result in the
 encoder becoming blocked on congestion or flow control limits.
 
+### Avoiding Flow Control Deadlocks
+
+Encoding using blocked streams can interact with flow control to produce
+deadlocks. A decoder might stop issuing flow control credit on the stream that
+carries a header block until the necessary updates are received on the encoder
+stream. If the granting of flow control credit on the encoder stream (or the
+connection as a whole) depends on the consumption and release of data on the
+stream carrying the header block, a deadlock might result.
+
+An encoder can avoid potential deadlocks by ensuring that instructions on the
+encoder stream are only written when there is sufficient flow control credit
+for the instruction at both the connection and stream level. To avoid deadlock,
+an encoder SHOULD avoid writing encoder instructions unless sufficient stream
+and connection flow control credit is available.
+
+Encoders SHOULD avoid any instruction exceeding the available flow control
+space on a stream. A stream containing a large instruction can become
+deadlocked if the decoder withholds flow control credit until the instruction
+is complete.
+
 ### Known Received Count
 
 The Known Received Count is the total number of dynamic table insertions and

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -283,23 +283,22 @@ encoder becoming blocked on congestion or flow control limits.
 
 ### Avoiding Flow Control Deadlocks
 
-Encoding using blocked streams can interact with flow control to produce
-deadlocks. A decoder might stop issuing flow control credit on the stream that
-carries a header block until the necessary updates are received on the encoder
+Writing instructions on streams that are limited by flow control can produce
+deadlocks.
+
+A decoder might stop issuing flow control credit on the stream that carries a
+header block until the necessary updates are received on the encoder
 stream. If the granting of flow control credit on the encoder stream (or the
 connection as a whole) depends on the consumption and release of data on the
 stream carrying the header block, a deadlock might result.
 
-An encoder can avoid potential deadlocks by ensuring that instructions on the
-encoder stream are only written when there is sufficient flow control credit
-for the instruction at both the connection and stream level. To avoid deadlock,
-an encoder SHOULD avoid writing encoder instructions unless sufficient stream
-and connection flow control credit is available.
+More generally, a stream containing a large instruction can become deadlocked if
+the decoder withholds flow control credit until the instruction is completely
+received.
 
-Encoders SHOULD avoid any instruction exceeding the available flow control
-space on a stream. A stream containing a large instruction can become
-deadlocked if the decoder withholds flow control credit until the instruction
-is complete.
+To avoid these deadlocks, an encoder SHOULD avoid writing an instruction unless
+sufficient stream and connection flow control credit is available for the entire
+instruction.
 
 ### Known Received Count
 


### PR DESCRIPTION
Much belated, this attempts to address the concerns about deadlocking.
Basically, this says that you should avoid instructions that don't have
flow control credit.  It doesn't say how an encoder might learn what
limits are, but we've seen a range of tactics being used in
implementations and I don't want to get into transport API debates.

This doesn't cover the memory exhaustion attack that @kazuho suggests on
the issue; I think that is better covered more generally by the
connection-level flow control limits.

Closes #1420.