### PR TITLE
Update PTO pseudocode to better match text

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1186,6 +1186,7 @@ OnLossDetectionTimeout():
       time_of_last_sent_ack_eliciting_packet)
     SendOneOrTwoAckElicitingPackets(pn_space)
   else:
+    assert(endpoint is client without 1-RTT keys) 
     // Client sends an anti-deadlock packet: Initial is padded
     // to earn more anti-amplification credit,
     // a Handshake packet proves address ownership.

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1141,7 +1141,7 @@ SetLossDetectionTimer():
     // Time threshold loss detection.
     loss_detection_timer.update(earliest_loss_time)
     return
-    
+
   if (server is at anti-amplification limit):
     loss_detection_timer.cancel()
     return

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1179,7 +1179,13 @@ OnLossDetectionTimeout():
     SetLossDetectionTimer()
     return
 
-  if (endpoint is client without 1-RTT keys):
+  if (bytes_in_flight > 0):
+    // PTO. Send new data if available, else retransmit old data.
+    // If neither is available, send a single PING frame.
+    _, pn_space = GetEarliestTimeAndSpace(
+      time_of_last_sent_ack_eliciting_packet)
+    SendOneOrTwoAckElicitingPackets(pn_space)
+  else:
     // Client sends an anti-deadlock packet: Initial is padded
     // to earn more anti-amplification credit,
     // a Handshake packet proves address ownership.
@@ -1187,12 +1193,6 @@ OnLossDetectionTimeout():
       SendOneAckElicitingHandshakePacket()
     else:
       SendOneAckElicitingPaddedInitialPacket()
-  else:
-    // PTO. Send new data if available, else retransmit old data.
-    // If neither is available, send a single PING frame.
-    _, pn_space = GetEarliestTimeAndSpace(
-      time_of_last_sent_ack_eliciting_packet)
-    SendOneOrTwoAckElicitingPackets(pn_space)
 
   pto_count++
   SetLossDetectionTimer()

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1190,7 +1190,7 @@ OnLossDetectionTimeout():
       time_of_last_sent_ack_eliciting_packet)
     SendOneOrTwoAckElicitingPackets(pn_space)
   else:
-    assert(endpoint is client without 1-RTT keys) 
+    assert(endpoint is client without 1-RTT keys)
     // Client sends an anti-deadlock packet: Initial is padded
     // to earn more anti-amplification credit,
     // a Handshake packet proves address ownership.

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1143,11 +1143,14 @@ SetLossDetectionTimer():
     return
 
   if (server is at anti-amplification limit):
+    // The server's alarm is not set if nothing can be sent.
     loss_detection_timer.cancel()
     return
 
   if (no ack-eliciting packets in flight &&
       peer not awaiting address validation):
+    // There is nothing to detect lost and the server
+    // is not blocked by the anti-amplification limit.
     loss_detection_timer.cancel()
     return
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1149,9 +1149,9 @@ SetLossDetectionTimer():
 
   if (no ack-eliciting packets in flight &&
       peer not awaiting address validation):
-    // There is nothing to detect lost, so set no timer.
-    // However, the client still sets the timer if the server
-    // might be blocked by the anti-amplification limit.
+    // There is nothing to detect lost, so no timer is set.
+    // However, the client needs to arm the timer if the
+    // server might be blocked by the anti-amplification limit.
     loss_detection_timer.cancel()
     return
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1149,8 +1149,9 @@ SetLossDetectionTimer():
 
   if (no ack-eliciting packets in flight &&
       peer not awaiting address validation):
-    // There is nothing to detect lost and the server
-    // is not blocked by the anti-amplification limit.
+    // There is nothing to detect lost, so set no timer.
+    // However, the client still sets the timer if the server
+    // might be blocked by the anti-amplification limit.
     loss_detection_timer.cancel()
     return
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1141,6 +1141,10 @@ SetLossDetectionTimer():
     // Time threshold loss detection.
     loss_detection_timer.update(earliest_loss_time)
     return
+    
+  if (IsServerWhichReachedAddressValidationLimit()):
+    loss_detection_timer.cancel()
+    return
 
   if (no ack-eliciting packets in flight &&
       PeerNotAwaitingAddressValidation()):

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1142,12 +1142,12 @@ SetLossDetectionTimer():
     loss_detection_timer.update(earliest_loss_time)
     return
     
-  if (IsServerWhichReachedAddressValidationLimit()):
+  if (server is at anti-amplification limit):
     loss_detection_timer.cancel()
     return
 
   if (no ack-eliciting packets in flight &&
-      PeerNotAwaitingAddressValidation()):
+      peer not awaiting address validation):
     loss_detection_timer.cancel()
     return
 


### PR DESCRIPTION
If there are bytes_in_flight, then always do a standard PTO.
If not, it must be a client which is unsure if the peer has completed address validation.

Fixes #3070