### PR TITLE
Timeout handshake section in recovery draft

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -555,10 +555,10 @@ bytes.
 
 Initial packets and Handshake packets could be never acknowledged, but they are
 removed from bytes in flight when the Initial and Handshake keys are discarded,
-as further described below in Section {{discarding-packets}}. When Initial or
-Handshake keys are discarded, the PTO and loss detection timers MUST be reset,
-because discarding keys indicates forward progress and the loss detection
-timer might have been set for a now discarded packet number space.
+as described below in Section {{discarding-packets}}. When Initial or Handshake
+keys are discarded, the PTO and loss detection timers MUST be reset, because
+discarding keys indicates forward progress and the loss detection timer might
+have been set for a now discarded packet number space.
 
 ### Sending Probe Packets
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -496,7 +496,7 @@ detection timer is set.  The time threshold loss detection timer is expected
 to both expire earlier than the PTO and be less likely to spuriously retransmit
 data.
 
-## Handshakes and New Paths
+### Handshakes and New Paths
 
 The initial probe timeout for a new connection or new path SHOULD be
 set to twice the initial RTT.  Resumed connections over the same network
@@ -532,7 +532,8 @@ otherwise it MUST send an Initial packet in a UDP datagram of at least 1200
 bytes.
 
 Initial packets and Handshake packets could be never acknowledged, but they are
-removed from bytes in flight when the Initial and Handshake keys are discarded.
+removed from bytes in flight when the Initial and Handshake keys are discarded,
+as further described below in section {{discarding-packets}}.
 
 ### Sending Probe Packets
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -533,7 +533,7 @@ bytes.
 
 Initial packets and Handshake packets could be never acknowledged, but they are
 removed from bytes in flight when the Initial and Handshake keys are discarded,
-as further described below in section {{discarding-packets}}.
+as further described below in Section {{discarding-packets}}.
 
 ### Sending Probe Packets
 


### PR DESCRIPTION
I believe this section was mistakenly on the wrong level. I also added a reference to a later section to the last sentence. Alternatively this sentence could just be removed as this is normatively specified later on.