### PR TITLE
Add a changelog for http, qpack, tls, and recovery since -25

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -2123,6 +2123,12 @@ Error codes need to be defined for HTTP/2 and HTTP/3 separately.  See
 > **RFC Editor's Note:**  Please remove this section prior to publication of a
 > final version of this document.
 
+## Since draft-ietf-quic-http-25
+
+- Require QUICv1 for HTTP/3 (#3117, #3323)
+- Remove DUPLICATE_PUSH and allow duplicate PUSH_PROMISE (#3275, #3309)
+- Clarify the definition of "malformed" (#3352, #3345)
+
 ## Since draft-ietf-quic-http-24
 
 - Removed H3_EARLY_RESPONSE error code; H3_NO_ERROR is recommended instead

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -1362,6 +1362,10 @@ return controlBuffer, prefixBuffer + streamBuffer
 > **RFC Editor's Note:** Please remove this section prior to publication of a
 > final version of this document.
 
+## Since draft-ietf-quic-qpack-12
+
+Editorial changes only
+
 ## Since draft-ietf-quic-qpack-11
 
 Editorial changes only

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1441,6 +1441,10 @@ Invoked from DetectLostPackets when packets are deemed lost.
 
 Issue and pull request numbers are listed with a leading octothorp.
 
+## Since draft-ietf-quic-recovery-25
+
+No significant changes.
+
 ## Since draft-ietf-quic-recovery-24
 
 - Require congestion control of some sort (#3247, #3244, #3248)

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1994,6 +1994,10 @@ ffff0000190008f067a5502a4262b574 6f6b656e1e5ec5b014cbb1f0fd93df40
 
 Issue and pull request numbers are listed with a leading octothorp.
 
+## Since draft-ietf-quic-tls-25
+
+- No changes
+
 ## Since draft-ietf-quic-tls-24
 
 - Rewrite key updates (#3050)


### PR DESCRIPTION
Only HTTP had design changes.