### PR TITLE
Update reference to RFC8740

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -633,7 +633,7 @@ and deployment.
 A server MUST NOT use post-handshake client authentication (as defined in
 Section 4.6.2 of {{!TLS13}}), because the multiplexing offered by QUIC prevents
 clients from correlating the certificate request with the application-level
-event that triggered it (see {{?HTTP2-TLS13=I-D.ietf-httpbis-http2-tls13}}).
+event that triggered it (see {{?HTTP2-TLS13=RFC8740}}).
 More specifically, servers MUST NOT send post-handshake TLS CertificateRequest
 messages and clients MUST treat receipt of such messages as a connection error
 of type PROTOCOL_VIOLATION.


### PR DESCRIPTION
[draft-ietf-httpbis-http2-tls13](https://tools.ietf.org/html/draft-ietf-httpbis-http2-tls13) has now been published as [RFC8740](https://tools.ietf.org/html/rfc8740).