### PR TITLE
Clarify not arming PTO for ApplicationData before completion

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -479,7 +479,7 @@ completes; see Section 4.1.1 of {{QUIC-TLS}}.  Not arming the PTO for
 ApplicationData prioritizes completing the handshake, prevents the client
 from sending a 0-RTT packet on a PTO before it knows the server has accepted
 0-RTT, and prevents the server from sending a 1-RTT packet on a PTO before
-before it has the keys to process a 1-RTT acknowledgment.
+it has the keys to process a 1-RTT acknowledgment.
 
 When a PTO timer expires, the PTO period MUST be set to twice its current
 value. This exponential reduction in the sender's rate is important because

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -476,10 +476,10 @@ When ack-eliciting packets are in-flight in multiple packet number spaces,
 the timer MUST be set for the packet number space with the earliest timeout,
 except for ApplicationData, which MUST be ignored until the handshake
 completes; see Section 4.1.1 of {{QUIC-TLS}}.  Not arming the PTO for
-ApplicationData prioritizes completing the handshake and prevents the client
+ApplicationData prioritizes completing the handshake, prevents the client
 from sending a 0-RTT packet on a PTO before it knows the server has accepted
-0-RTT and prevents the server from sending a 1-RTT packet on a PTO before
-before it has the keys to process a 1-RTT packet.
+0-RTT, and prevents the server from sending a 1-RTT packet on a PTO before
+before it has the keys to process a 1-RTT acknowledgment.
 
 When a PTO timer expires, the PTO period MUST be set to twice its current
 value. This exponential reduction in the sender's rate is important because

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -476,10 +476,10 @@ When ack-eliciting packets are in-flight in multiple packet number spaces,
 the timer MUST be set for the packet number space with the earliest timeout,
 except for ApplicationData, which MUST be ignored until the handshake
 completes; see Section 4.1.1 of {{QUIC-TLS}}.  Not arming the PTO for
-ApplicationData prioritizes completing the handshake, prevents the client
-from sending a 0-RTT packet on a PTO before it knows the server has accepted
-0-RTT, and prevents the server from sending a 1-RTT packet on a PTO before
-it has the keys to process a 1-RTT acknowledgment.
+ApplicationData prevents a client from retransmitting a 0-RTT packet on a PTO
+expiration before confirming that the server is able to decrypt 0-RTT packets,
+and prevents a server from sending a 1-RTT packet on a PTO expiration before it
+has the keys to process an acknowledgement.
 
 When a PTO timer expires, the PTO period MUST be set to twice its current
 value. This exponential reduction in the sender's rate is important because

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -476,9 +476,10 @@ When ack-eliciting packets are in-flight in multiple packet number spaces,
 the timer MUST be set for the packet number space with the earliest timeout,
 except for ApplicationData, which MUST be ignored until the handshake
 completes; see Section 4.1.1 of {{QUIC-TLS}}.  Not arming the PTO for
-ApplicationData prioritizes completing the handshake and prevents the server
-from sending a 1-RTT packet on a PTO before before it has the keys to process
-a 1-RTT packet.
+ApplicationData prioritizes completing the handshake and prevents the client
+from sending a 0-RTT packet on a PTO before it knows the server has accepted
+0-RTT and prevents the server from sending a 1-RTT packet on a PTO before
+before it has the keys to process a 1-RTT packet.
 
 When a PTO timer expires, the PTO period MUST be set to twice its current
 value. This exponential reduction in the sender's rate is important because


### PR DESCRIPTION
Clarifies exactly what the implications of not arming PTO for ApplicationData prior to handshake complete.

This came from a discussion with a coworker who read the transport and recovery drafts, but not TLS.