### PR TITLE
should -> SHOULD when bundling ACK frames

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3152,7 +3152,7 @@ ack-eliciting packets cause an ACK frame to be sent within the maximum ack
 delay.  Packets that are not ack-eliciting are only acknowledged when an ACK
 frame is sent for other reasons.
 
-When sending a packet for any reason, an endpoint should attempt to bundle an
+When sending a packet for any reason, an endpoint SHOULD attempt to bundle an
 ACK frame if one has not been sent recently. Doing so helps with timely loss
 detection at the peer.
 


### PR DESCRIPTION
I believe this always should have been normative, so this change is editorial, but I'll let the editors confirm that.