### PR TITLE
Recommend a 1ms timer granularity

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -428,8 +428,8 @@ as TCP-NCR {{?RFC4653}}, to improve QUIC's reordering resilience.
 Once a later packet within the same packet number space has been acknowledged,
 an endpoint SHOULD declare an earlier packet lost if it was sent a threshold
 amount of time in the past. To avoid declaring packets as lost too early, this
-time threshold MUST be set to at least the alarm granularity, as indicated by
-the kGranularity constant.  The time threshold is:
+time threshold MUST be set to at least the local alarm granularity, as
+indicated by the kGranularity constant.  The time threshold is:
 
 ~~~
 max(kTimeThreshold * max(smoothed_rtt, latest_rtt), kGranularity)

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -428,7 +428,8 @@ as TCP-NCR {{?RFC4653}}, to improve QUIC's reordering resilience.
 Once a later packet within the same packet number space has been acknowledged,
 an endpoint SHOULD declare an earlier packet lost if it was sent a threshold
 amount of time in the past. To avoid declaring packets as lost too early, this
-time threshold MUST be set to at least kGranularity.  The time threshold is:
+time threshold MUST be set to at least the alarm granularity, as indicated by
+the kGranularity constant.  The time threshold is:
 
 ~~~
 max(kTimeThreshold * max(smoothed_rtt, latest_rtt), kGranularity)
@@ -963,8 +964,8 @@ kTimeThreshold:
 
 kGranularity:
 
-: Timer granularity. This is a system-dependent value.  However, implementations
-  SHOULD use a value no smaller than 1ms.
+: Timer granularity. This is a system-dependent value, and the RECOMMENDED
+  value is 1ms.
 
 kInitialRtt:
 : The RTT used before an RTT sample is taken. The RECOMMENDED value is 500ms.

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -428,7 +428,7 @@ as TCP-NCR {{?RFC4653}}, to improve QUIC's reordering resilience.
 Once a later packet within the same packet number space has been acknowledged,
 an endpoint SHOULD declare an earlier packet lost if it was sent a threshold
 amount of time in the past. To avoid declaring packets as lost too early, this
-time threshold MUST be set to at least the local alarm granularity, as
+time threshold MUST be set to at least the local timer granularity, as
 indicated by the kGranularity constant.  The time threshold is:
 
 ~~~


### PR DESCRIPTION
Adds more text about what the constant kGranularity represents where it's first used and changes a SHOULD to a RECOMMENDED.

Inspired by #3388