### PR TITLE
eliminate the difference between when having no RTT sample and having one

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -362,7 +362,7 @@ where rtt_sample is the initial RTT.
 
 On the first RTT sample for the network path, smoothed_rtt and rttvar are set to
 the values using the formula above, using that first RTT sample as rtt_sample.
-This ensures a measurement erases the history of any persisted or default value.
+This ensures that the first measurement erases the history of any persisted or default value.
 
 On subsequent RTT samples, smoothed_rtt and rttvar evolve as follows:
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -521,10 +521,11 @@ data.
 
 ### Handshakes and New Paths
 
-When no previous RTT is available, the initial RTT SHOULD be set to 333ms,
-resulting in a 1 second initial timeout as recommended in {{?RFC6298}}. Resumed
+Resumed
 connections over the same network SHOULD use the previous connection's final
-smoothed RTT value as the resumed connection's initial RTT.
+smoothed RTT value as the resumed connection's initial RTT. When no previous
+RTT is available, the initial RTT SHOULD be set to 333ms, resulting in a 1 second
+initial timeout, as recommended in {{?RFC6298}}.
 
 A connection MAY use the delay between sending a PATH_CHALLENGE and receiving a
 PATH_RESPONSE to set the initial RTT (see kInitialRtt in

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -360,12 +360,10 @@ smoothed_rtt = rtt_sample
 rttvar = rtt_sample / 2
 ~~~
 
-where rtt_sample is the initial RTT.
-
-On the first RTT sample for the network path, smoothed_rtt and rttvar are set to
-the values using the formula above, using that first RTT sample as rtt_sample.
+Before any RTT samples are available, the initial RTT is used as rtt_sample. 
+On the first RTT sample for the network path, that sample is used as rtt_sample.
 This ensures that the first measurement erases the history of any persisted or
-default value.
+default values.
 
 On subsequent RTT samples, smoothed_rtt and rttvar evolve as follows:
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -353,13 +353,16 @@ endpoint:
 On the first RTT sample for a network path, the smoothed_rtt is set to the
 latest_rtt.
 
-smoothed_rtt and rttvar are computed as follows, similar to {{?RFC6298}}.  On
-the first RTT sample for a network path:
+smoothed_rtt and rttvar are computed as follows, similar to {{?RFC6298}}.  When
+there is less than one sample for a network path:
 
 ~~~
-smoothed_rtt = latest_rtt
-rttvar = latest_rtt / 2
+smoothed_rtt = rtt_sample
+rttvar = rtt_sample / 2
 ~~~
+
+where rtt_sample is either the initial RTT when there is no sample, or the
+latest RTT when there is one.
 
 On subsequent RTT samples, smoothed_rtt and rttvar evolve as follows:
 
@@ -517,12 +520,10 @@ data.
 
 ### Handshakes and New Paths
 
-The initial probe timeout for a new connection or new path SHOULD be
-set to twice the initial RTT.  Resumed connections over the same network
-SHOULD use the previous connection's final smoothed RTT value as the resumed
-connection's initial RTT.  If no previous RTT is available, the initial RTT
-SHOULD be set to 500ms, resulting in a 1 second initial timeout as recommended
-in {{?RFC6298}}.
+When no previous RTT is available, the initial RTT SHOULD be set to 333ms,
+resulting in a 1 second initial timeout as recommended in {{?RFC6298}}. Resumed
+connections over the same network SHOULD use the previous connection's final
+smoothed RTT value as the resumed connection's initial RTT.
 
 A connection MAY use the delay between sending a PATH_CHALLENGE and receiving a
 PATH_RESPONSE to set the initial RTT (see kInitialRtt in
@@ -1054,8 +1055,8 @@ follows:
    loss_detection_timer.reset()
    pto_count = 0
    latest_rtt = 0
-   smoothed_rtt = 0
-   rttvar = 0
+   smoothed_rtt = initial_rtt
+   rttvar = initial_rtt / 2
    min_rtt = 0
    max_ack_delay = 0
    for pn_space in [ Initial, Handshake, ApplicationData ]:
@@ -1135,8 +1136,7 @@ OnAckReceived(ack, pn_space):
 
 
 UpdateRtt(ack_delay):
-  // First RTT sample.
-  if (smoothed_rtt == 0):
+  if (is first RTT sample):
     min_rtt = latest_rtt
     smoothed_rtt = latest_rtt
     rttvar = latest_rtt / 2
@@ -1225,13 +1225,8 @@ SetLossDetectionTimer():
     loss_detection_timer.cancel()
     return
 
-  // Use a default timeout if there are no RTT measurements
-  if (smoothed_rtt == 0):
-    timeout = 2 * kInitialRtt
-  else:
-    // Calculate PTO duration
-    timeout = smoothed_rtt + max(4 * rttvar, kGranularity) +
-      max_ack_delay
+  // Calculate PTO duration
+  timeout = smoothed_rtt + max(4 * rttvar, kGranularity) + max_ack_delay
   timeout = timeout * (2 ^ pto_count)
 
   sent_time, _ = GetEarliestTimeAndSpace(

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -350,8 +350,10 @@ endpoint:
   min_rtt.  This limits the underestimation that a misreporting peer can cause
   to the smoothed_rtt.
 
-smoothed_rtt and rttvar are computed as follows, similar to {{?RFC6298}}.  When
-there are no samples for a network path:
+smoothed_rtt and rttvar are computed as follows, similar to {{?RFC6298}}.
+
+When there are no samples for a network path, and on the first RTT sample for
+the network path:
 
 ~~~
 smoothed_rtt = rtt_sample

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -362,6 +362,7 @@ where rtt_sample is the initial RTT.
 
 On the first RTT sample for the network path, smoothed_rtt and rttvar are set to
 the values using the formula above, using that first RTT sample as rtt_sample.
+This ensures a measurement erases the history of any persisted or default value.
 
 On subsequent RTT samples, smoothed_rtt and rttvar evolve as follows:
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -360,7 +360,7 @@ rttvar = rtt_sample / 2
 
 where rtt_sample is the initial RTT.
 
-On the first RTT sample for the ntework path, smoothed_rtt and rttvar are set to
+On the first RTT sample for the network path, smoothed_rtt and rttvar are set to
 the values using the formula above, using that first RTT sample as rtt_sample.
 
 On subsequent RTT samples, smoothed_rtt and rttvar evolve as follows:

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -362,7 +362,8 @@ where rtt_sample is the initial RTT.
 
 On the first RTT sample for the network path, smoothed_rtt and rttvar are set to
 the values using the formula above, using that first RTT sample as rtt_sample.
-This ensures that the first measurement erases the history of any persisted or default value.
+This ensures that the first measurement erases the history of any persisted or
+default value.
 
 On subsequent RTT samples, smoothed_rtt and rttvar evolve as follows:
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -350,19 +350,18 @@ endpoint:
   min_rtt.  This limits the underestimation that a misreporting peer can cause
   to the smoothed_rtt.
 
-On the first RTT sample for a network path, the smoothed_rtt is set to the
-latest_rtt.
-
 smoothed_rtt and rttvar are computed as follows, similar to {{?RFC6298}}.  When
-there is less than one sample for a network path:
+there are no samples for a network path:
 
 ~~~
 smoothed_rtt = rtt_sample
 rttvar = rtt_sample / 2
 ~~~
 
-where rtt_sample is either the initial RTT when there is no sample, or the
-latest RTT when there is one.
+where rtt_sample is the initial RTT.
+
+On the first RTT sample for the ntework path, smoothed_rtt and rttvar are set to
+the values using the formula above, using that first RTT sample as rtt_sample.
 
 On subsequent RTT samples, smoothed_rtt and rttvar evolve as follows:
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -360,8 +360,8 @@ smoothed_rtt = rtt_sample
 rttvar = rtt_sample / 2
 ~~~
 
-Before any RTT samples are available, the initial RTT is used as rtt_sample. 
-On the first RTT sample for the network path, that sample is used as rtt_sample.
+Before any RTT samples are available, the initial RTT is used as rtt_sample.  On
+the first RTT sample for the network path, that sample is used as rtt_sample.
 This ensures that the first measurement erases the history of any persisted or
 default values.
 
@@ -521,11 +521,10 @@ data.
 
 ### Handshakes and New Paths
 
-Resumed
-connections over the same network SHOULD use the previous connection's final
-smoothed RTT value as the resumed connection's initial RTT. When no previous
-RTT is available, the initial RTT SHOULD be set to 333ms, resulting in a 1 second
-initial timeout, as recommended in {{?RFC6298}}.
+Resumed connections over the same network SHOULD use the previous connection's
+final smoothed RTT value as the resumed connection's initial RTT.  When no
+previous RTT is available, the initial RTT SHOULD be set to 333ms, resulting in
+a 1 second initial timeout, as recommended in {{?RFC6298}}.
 
 A connection MAY use the delay between sending a PATH_CHALLENGE and receiving a
 PATH_RESPONSE to set the initial RTT (see kInitialRtt in

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1250,7 +1250,8 @@ SetLossDetectionTimer():
     return
 
   // Calculate PTO duration
-  timeout = smoothed_rtt + max(4 * rttvar, kGranularity) + max_ack_delay
+  timeout = smoothed_rtt + max(4 * rttvar, kGranularity) +
+    max_ack_delay
   timeout = timeout * (2 ^ pto_count)
 
   sent_time, _ = GetEarliestTimeAndSpace(


### PR DESCRIPTION
As pointed out in #3524, I think that we should assume same amount of RTT variance when there is no RTT sample and when there is one sample, because variance is unknown in both cases.

This PR makes that change while keeping the initial PTO being the same (i.e. 1 second), and slightly simplifies the timeout logic.

Fixes #3524.