### PR TITLE
Limit connection drops from Version Negotiation

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1270,10 +1270,11 @@ Version Negotiation packets when attempting to establish a connection using this
 version.
 
 A client that supports only this version of QUIC MUST abandon the current
-connection attempt if it receives a Version Negotiation packet.  However, a
-client MUST discard any Version Negotiation packet if is has received and
-successfully processed a packet.  In addition, a client MUST discard a Version
-Negotiation packet that lists the QUIC version selected by the client.
+connection attempt if it receives a Version Negotiation packet, with the
+following two exceptions. A client MUST discard any Version Negotiation packet
+if it has received and successfully processed any other packet, including an
+earlier Version Negotiation packet. A client MUST discard a Version Negotiation
+packet that lists the QUIC version selected by the client.
 
 How to perform version negotiation is left as future work defined by future
 versions of QUIC.  In particular, that future work will ensure robustness

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1263,15 +1263,21 @@ expectation that it will eventually receive an Initial packet.
 
 ## Handling Version Negotiation Packets {#handle-vn}
 
-When a client receives a Version Negotiation packet, it MUST abandon the
-current connection attempt.  Version Negotiation packets are designed to allow
-future versions of QUIC to negotiate the version in use between endpoints.
-Future versions of QUIC might change how implementations that support multiple
-versions of QUIC react to Version Negotiation packets when attempting to
-establish a connection using this version.  How to perform version negotiation
-is left as future work defined by future versions of QUIC.  In particular,
-that future work will need to ensure robustness against version downgrade
-attacks; see {{version-downgrade}}.
+Version Negotiation packets are designed to allow future versions of QUIC to
+negotiate the version in use between endpoints.  Future versions of QUIC might
+change how implementations that support multiple versions of QUIC react to
+Version Negotiation packets when attempting to establish a connection using this
+version.
+
+A client that supports only this version of QUIC MUST abandon the current
+connection attempt if it receives a Version Negotiation packet.  However, a
+client MUST discard any Version Negotiation packet if is has received and
+successfully processed a packet.  In addition, a client MUST discard a Version
+Negotiation packet that lists the QUIC version selected by the client.
+
+How to perform version negotiation is left as future work defined by future
+versions of QUIC.  In particular, that future work will ensure robustness
+against version downgrade attacks; see {{version-downgrade}}.
 
 
 ### Version Negotiation Between Draft Versions


### PR DESCRIPTION
The text was a little too broad.  This breaks up the text and adds two
caveats to handling rules:

1. If you have handled another packet, then assume that everything is good.

2. If you the VN includes QUIC v1, then assume that something got corrupted.

The issue addresses the second, but I think we were implying the first for some time.

Closes #3532.