### PR TITLE
Remove a MUST accidentally introduced by #3315

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3290,9 +3290,8 @@ necessary if an ACK frame would be too large to fit in a packet, however
 receivers MAY also limit ACK frame size further to preserve space for other
 frames.
 
-When discarding unacknowledged ACK Ranges, a receiver MUST retain the largest
-received packet number. A receiver SHOULD retain ACK Ranges containing newly
-received packets or higher-numbered packets.
+When discarding unacknowledged ACK Ranges, a receiver SHOULD retain ACK Ranges
+containing newly received packets or higher-numbered packets.
 
 A receiver that sends only non-ack-eliciting packets, such as ACK frames, might
 not receive an acknowledgement for a long period of time.  This could cause the


### PR DESCRIPTION
I'm not sure I agree with it in all cases, and it's a new MUST, which makes #3315(Rewrite section on ack range limiting) inadvertently not editorial.

#3541 opened to discuss this issue.