### PR TITLE
Notify the congestion controller of losses first

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1410,8 +1410,8 @@ increases bytes_in_flight.
 
 ## On Packet Acknowledgement
 
-Invoked from OnCongestionEvent and is supplied with the
-acked_packet from sent_packets.
+Invoked from loss detection's OnPacketAcked and is supplied with the
+newly acked_packets from sent_packets.
 
 ~~~
    InLossRecovery(sent_time):

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1431,10 +1431,10 @@ newly acked_packets from sent_packets.
        if (congestion_window < ssthresh):
          // Slow start.
          congestion_window += packet.size
-       else:
-         // Congestion avoidance.
-         congestion_window += max_datagram_size * acked_packet.size
-             / congestion_window
+         return
+       // Congestion avoidance.
+       congestion_window += max_datagram_size * acked_packet.size
+           / congestion_window
 ~~~
 
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1410,7 +1410,7 @@ increases bytes_in_flight.
 
 ## On Packet Acknowledgement
 
-Invoked from loss detection's OnPacketAcked and is supplied with the
+Invoked from loss detection's OnAckReceived and is supplied with the
 newly acked_packets from sent_packets.
 
 ~~~

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1131,7 +1131,9 @@ OnAckReceived(ack, pn_space):
       ProcessECN(ack, pn_space)
 
   lost_packets = DetectLostPackets(pn_space)
-  OnCongestionEvent(acked_packets, lost_packets)
+  if (!lost_packets.empty()):
+    OnPacketsLost(lost_packets)
+  OnPacketsAcked(newly_acked_packets)
 
   pto_count = 0
   SetLossDetectionTimer()

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1247,6 +1247,7 @@ OnLossDetectionTimeout():
   if (earliest_loss_time != 0):
     // Time threshold loss Detection
     lost_packets = DetectLostPackets(pn_space)
+    assert(!lost_packets.empty())
     OnPacketsLost(lost_packets)
     SetLossDetectionTimer()
     return

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1414,14 +1414,14 @@ Invoked from loss detection's OnPacketAcked and is supplied with the
 newly acked_packets from sent_packets.
 
 ~~~
-   InLossRecovery(sent_time):
+   InCongestionRecovery(sent_time):
      return sent_time <= congestion_recovery_start_time
 
    OnPacketsAcked(acked_packets):
      for (packet in acked_packets):
        // Remove from bytes_in_flight.
        bytes_in_flight -= packet.size
-       if (InLossRecovery(packet.time_sent)):
+       if (InCongestionRecovery(packet.time_sent)):
          // Do not increase congestion window in recovery period.
          return
        if (IsAppOrFlowControlLimited()):

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1110,7 +1110,7 @@ OnAckReceived(ack, pn_space):
 
   // DetectNewlyAckedPackets finds packets have been newly acknowledged and removes
   // them from sent_packets.
-  newly_acked_packets = DetectNewlyAckedPackets(ack, pn_space)
+  newly_acked_packets = DetectAndRemoveAckedPackets(ack, pn_space)
   // Nothing to do if there are no newly acked packets.
   if (newly_acked_packets.empty()):
     return

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1483,7 +1483,7 @@ Invoked from DetectLostPackets when packets are deemed lost.
        max_ack_delay
      congestion_period = pto * kPersistentCongestionThreshold
      // Determine if all packets in the time period before the
-     // newest lost packet, including the edges, are marked
+     // largest newly lost packet, including the edges, are marked
      // lost
      return AreAllPacketsLost(lost_packets, congestion_period)
 
@@ -1492,7 +1492,7 @@ Invoked from DetectLostPackets when packets are deemed lost.
      for (lost_packet : lost_packets):
        bytes_in_flight -= lost_packet.size
      largest_lost_packet = lost_packets.last()
-     CongestionEvent(largest_lost_packet.time_sent)
+     CongestionEvent(lost_packets.largest().time_sent)
 
      // Collapse congestion window if persistent congestion
      if (InPersistentCongestion(lost_packets)):

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1273,8 +1273,8 @@ OnLossDetectionTimeout():
 ## Detecting Lost Packets
 
 DetectLostPackets is called every time an ACK is received or the time threshold
-loss detection timer expires and operates on the sent_packets for that packet
-number space.
+loss detection timer expires. This function operates on the sent_packets for that
+packet number space and returns a list of packets newly detected as lost.
 
 Pseudocode for DetectLostPackets follows:
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1110,14 +1110,16 @@ OnAckReceived(ack, pn_space):
 
   // DetectNewlyAckedPackets finds packets that are newly
   // acknowledged and removes them from sent_packets.
-  newly_acked_packets = DetectAndRemoveAckedPackets(ack, pn_space)
+  newly_acked_packets =
+      DetectAndRemoveAckedPackets(ack, pn_space)
   // Nothing to do if there are no newly acked packets.
   if (newly_acked_packets.empty()):
     return
 
   // If the largest acknowledged is newly acked and
   // at least one ack-eliciting was newly acked, update the RTT.
-  if (newly_acked_packets.largest().packet_number == ack.largest_acked &&
+  if (newly_acked_packets.largest().packet_number ==
+          ack.largest_acked &&
       IncludesAckEliciting(newly_acked_packets)):
     latest_rtt =
       now - sent_packets[pn_space][ack.largest_acked].time_sent
@@ -1483,8 +1485,8 @@ Invoked from DetectLostPackets when packets are deemed lost.
        max_ack_delay
      congestion_period = pto * kPersistentCongestionThreshold
      // Determine if all packets in the time period before the
-     // largest newly lost packet, including the edges, are marked
-     // lost
+     // largest newly lost packet, including the edges, are
+     // marked lost
      return AreAllPacketsLost(lost_packets, congestion_period)
 
    OnPacketsLost(lost_packets):

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1417,23 +1417,24 @@ acked_packet from sent_packets.
    InLossRecovery(sent_time):
      return sent_time <= congestion_recovery_start_time
 
-   OnPacketAcked(acked_packet):
-     // Remove from bytes_in_flight.
-     bytes_in_flight -= acked_packet.size
-     if (InLossRecovery(acked_packet.time_sent)):
-       // Do not increase congestion window in recovery period.
-       return
-     if (IsAppOrFlowControlLimited()):
-       // Do not increase congestion_window if application
-       // limited or flow control limited.
-       return
-     if (congestion_window < ssthresh):
-       // Slow start.
-       congestion_window += acked_packet.size
-     else:
-       // Congestion avoidance.
-       congestion_window += max_datagram_size * acked_packet.size
-           / congestion_window
+   OnPacketsAcked(acked_packets):
+     for (packet in acked_packets):
+       // Remove from bytes_in_flight.
+       bytes_in_flight -= packet.size
+       if (InLossRecovery(packet.time_sent)):
+         // Do not increase congestion window in recovery period.
+         return
+       if (IsAppOrFlowControlLimited()):
+         // Do not increase congestion_window if application
+         // limited or flow control limited.
+         return
+       if (congestion_window < ssthresh):
+         // Slow start.
+         congestion_window += packet.size
+       else:
+         // Congestion avoidance.
+         congestion_window += max_datagram_size * acked_packet.size
+             / congestion_window
 ~~~
 
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1117,7 +1117,7 @@ OnAckReceived(ack, pn_space):
 
   // If the largest acknowledged is newly acked and
   // at least one ack-eliciting was newly acked, update the RTT.
-  if (newly_acked_packets.largest == ack.largest_acked &&
+  if (newly_acked_packets.largest().packet_number == ack.largest_acked &&
       IncludesAckEliciting(newly_acked_packets)):
     latest_rtt =
       now - sent_packets[pn_space][ack.largest_acked].time_sent
@@ -1491,7 +1491,6 @@ Invoked from DetectLostPackets when packets are deemed lost.
      // Remove lost packets from bytes_in_flight.
      for (lost_packet : lost_packets):
        bytes_in_flight -= lost_packet.size
-     largest_lost_packet = lost_packets.last()
      CongestionEvent(lost_packets.largest().time_sent)
 
      // Collapse congestion window if persistent congestion

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1130,7 +1130,7 @@ OnAckReceived(ack, pn_space):
   if (ACK frame contains ECN information):
       ProcessECN(ack, pn_space)
 
-  lost_packets = DetectLostPackets(pn_space)
+  lost_packets = DetectAndRemoveLostPackets(pn_space)
   if (!lost_packets.empty()):
     OnPacketsLost(lost_packets)
   OnPacketsAcked(newly_acked_packets)

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1108,7 +1108,7 @@ OnAckReceived(ack, pn_space):
     largest_acked_packet[pn_space] =
         max(largest_acked_packet[pn_space], ack.largest_acked)
 
-  // DetectNewlyAckedPackets finds packets have been newly
+  // DetectNewlyAckedPackets finds packets that are newly
   // acknowledged and removes them from sent_packets.
   newly_acked_packets = DetectAndRemoveAckedPackets(ack, pn_space)
   // Nothing to do if there are no newly acked packets.

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1108,7 +1108,7 @@ OnAckReceived(ack, pn_space):
     largest_acked_packet[pn_space] =
         max(largest_acked_packet[pn_space], ack.largest_acked)
 
-  // Determine which packets have been acknowledged and remove
+  // DetectNewlyAckedPackets finds packets have been newly acknowledged and removes
   // them from sent_packets.
   newly_acked_packets = DetectNewlyAckedPackets(ack, pn_space)
   // Nothing to do if there are no newly acked packets.

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1108,8 +1108,8 @@ OnAckReceived(ack, pn_space):
     largest_acked_packet[pn_space] =
         max(largest_acked_packet[pn_space], ack.largest_acked)
 
-  // DetectNewlyAckedPackets finds packets have been newly acknowledged and removes
-  // them from sent_packets.
+  // DetectNewlyAckedPackets finds packets have been newly
+  // acknowledged and removes them from sent_packets.
   newly_acked_packets = DetectAndRemoveAckedPackets(ack, pn_space)
   // Nothing to do if there are no newly acked packets.
   if (newly_acked_packets.empty()):
@@ -1272,14 +1272,15 @@ OnLossDetectionTimeout():
 
 ## Detecting Lost Packets
 
-DetectLostPackets is called every time an ACK is received or the time threshold
-loss detection timer expires. This function operates on the sent_packets for that
-packet number space and returns a list of packets newly detected as lost.
+DetectAndRemoveLostPackets is called every time an ACK is received or the time
+threshold loss detection timer expires. This function operates on the
+sent_packets for that packet number space and returns a list of packets newly
+detected as lost.
 
-Pseudocode for DetectLostPackets follows:
+Pseudocode for DetectAndRemoveLostPackets follows:
 
 ~~~
-DetectLostPackets(pn_space):
+DetectAndRemoveLostPackets(pn_space):
   assert(largest_acked_packet[pn_space] != infinite)
   loss_time[pn_space] = 0
   lost_packets = {}


### PR DESCRIPTION
Fixes #3495 and #3288 by notifying the congestion controller of lost packets prior to notifying it of acknowledged packets and passing all lost packets into InPersistentCongestion().

The diff is a bit large because I also inlined OnPacketAcked and renamed OnPacketAckedCC to OnPacketAcked.