### PR TITLE
Do not reset pto_count on Initial ACKs

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1154,8 +1154,8 @@ OnAckReceived(ack, pn_space):
     OnPacketsLost(lost_packets)
   OnPacketsAcked(newly_acked_packets)
 
-  // Reset pto_count unless the server has not yet
-  // validated the client's address.
+  // Reset pto_count unless the client is unsure if
+  // the server has validated the client's address.
   if (PeerCompletedAddressValidation()):
     pto_count = 0
   SetLossDetectionTimer()

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -501,7 +501,7 @@ and prevents a server from sending a 1-RTT packet on a PTO expiration before it
 has the keys to process an acknowledgement.
 
 When a PTO timer expires, the PTO period MUST be set to twice its current
-value. The PTO is set back to the original value upon receiving an
+value. The PTO period is set back to the original value upon receiving an
 acknowledgement for a non-Initial packet. The PTO timer is not decreased when
 the client receives an Initial ACK to ensure the client's anti-deadlock timer
 does not fire too aggressively when the server does not yet have handshake data

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1145,8 +1145,9 @@ OnAckReceived(ack, pn_space):
     OnPacketAcked(acked_packet.packet_number, pn_space)
 
   DetectLostPackets(pn_space)
-  // Reset pto_count, unless the client receives an Initial ACK
-  if (endpoint is server || pn_space != Initial)
+  // Reset pto_count unless the server has not yet
+  // validated the client's address.
+  if (PeerCompletedAddressValidation())
     pto_count = 0
 
   SetLossDetectionTimer()

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -616,7 +616,7 @@ packet drops, thus reducing the probability of consecutive PTO events.
 
 When the PTO timer expires, and there is new or previously sent unacknowledged
 data, it MUST be sent. A probe packet SHOULD carry new data when possible.
-A probe packet MAY carry retransmitted unacknowledged data when new data is 
+A probe packet MAY carry retransmitted unacknowledged data when new data is
 navailable, when flow control does not permit new data to be sent, or to
 opportunistically reduce loss recovery delay.  Implementations MAY use
 alternative strategies for determining the content of probe packets,

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -588,7 +588,6 @@ in the packet number space as a probe, unless there is no data available to
 send.  An endpoint MAY send up to two full-sized datagrams containing
 ack-eliciting packets, to avoid an expensive consecutive PTO expiration due
 to a single lost datagram or transmit data from multiple packet number spaces.
-All probe packets sent on a PTO MUST be ack-eliciting.
 
 In addition to sending data in the packet number space for which the timer
 expired, the sender SHOULD send ack-eliciting packets from other packet
@@ -596,6 +595,9 @@ number spaces with in-flight data, coalescing packets if possible.
 
 If the sender wants to elicit a faster acknowledgement on PTO, it can skip a
 packet number to eliminate the ack delay.
+
+When the PTO timer expires, and there is new or previously sent unacknowledged
+data, it MUST be sent. 
 
 It is possible the sender has no new or previously-sent data to send.
 As an example, consider the following sequence of events: new application data
@@ -614,12 +616,11 @@ recovery latency increases exponentially as packets continue to be dropped in
 the network.  Sending two packets on PTO expiration increases resilience to
 packet drops, thus reducing the probability of consecutive PTO events.
 
-When the PTO timer expires, and there is new or previously sent unacknowledged
-data, it MUST be sent. A probe packet SHOULD carry new data when possible.
-A probe packet MAY carry retransmitted unacknowledged data when new data is
-navailable, when flow control does not permit new data to be sent, or to
-opportunistically reduce loss recovery delay.  Implementations MAY use
-alternative strategies for determining the content of probe packets,
+Probe packets sent on a PTO MUST be ack-eliciting. A probe packet SHOULD carry
+new data when possible. A probe packet MAY carry retransmitted unacknowledged
+data when new data is unavailable, when flow control does not permit new data to
+be sent, or to opportunistically reduce loss recovery delay.  Implementations
+MAY use alternative strategies for determining the content of probe packets,
 including sending new or retransmitted data based on the application's
 priorities.
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -503,9 +503,10 @@ expiration before it has the keys to process an acknowledgement.
 When a PTO timer expires, the PTO backoff MUST be increased, resulting in the
 PTO period being set to twice its current value.  The PTO period is set based
 on the latest RTT information when receiving an acknowledgement. The client's
-PTO backoff is not decreased while the server is validating the client's address.
-Doing so ensures that the client's anti-deadlock timer is not set too
-aggressively when the server is slow in responding with handshake data.
+PTO backoff is reset unless the server is validating the client's address.
+Not resetting the backoff during peer addresss validation ensures the client's
+anti-deadlock timer is not set too aggressively when the server is slow in
+responding with handshake data.
 
 This exponential reduction in the sender's rate is important because
 consecutive PTOs might be caused by loss of packets or acknowledgements due to

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -505,7 +505,7 @@ PTO period being set to twice its current value.  The PTO period is set based
 on the latest RTT information after receiving an acknowledgement. The PTO
 backoff is reset upon receiving an acknowledgement unless it's a client unsure
 if the the server has validated the client's address. Not resetting the backoff
-during peer addresss validation ensures the client's anti-deadlock timer is not
+during peer address validation ensures the client's anti-deadlock timer is not
 set too aggressively when the server is slow in responding with handshake data.
 
 This exponential reduction in the sender's rate is important because

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -502,9 +502,10 @@ has the keys to process an acknowledgement.
 
 When a PTO timer expires, the PTO period MUST be set to twice its current
 value. The PTO is set back to the original value upon receiving an
-acknowledgement for a non-Initial packet. The PTO timer is not decreased upon
-receiving an Initial ACK to ensure the client's anti-deadlock timer doesn't
-fire too aggressively when the server does not yet have handshake data to send.
+acknowledgement for a non-Initial packet. The PTO timer is not decreased when
+the client receives an Initial ACK to ensure the client's anti-deadlock timer
+does not fire too aggressively when the server does not yet have handshake data
+to send.
 
 This exponential reduction in the sender's rate is important because
 consecutive PTOs might be caused by loss of packets or acknowledgements due to
@@ -1144,8 +1145,8 @@ OnAckReceived(ack, pn_space):
     OnPacketAcked(acked_packet.packet_number, pn_space)
 
   DetectLostPackets(pn_space)
-  // Reset pto_count, unless it's an Initial ACK.
-  if (pn_space != Initial)
+  // Reset pto_count, unless the client receives an Initial ACK
+  if (endpoint is server || pn_space != Initial)
     pto_count = 0
 
   SetLossDetectionTimer()

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -597,7 +597,7 @@ If the sender wants to elicit a faster acknowledgement on PTO, it can skip a
 packet number to eliminate the ack delay.
 
 When the PTO timer expires, and there is new or previously sent unacknowledged
-data, it MUST be sent. 
+data, it MUST be sent.
 
 It is possible the sender has no new or previously-sent data to send.
 As an example, consider the following sequence of events: new application data
@@ -616,8 +616,8 @@ recovery latency increases exponentially as packets continue to be dropped in
 the network.  Sending two packets on PTO expiration increases resilience to
 packet drops, thus reducing the probability of consecutive PTO events.
 
-Probe packets sent on a PTO MUST be ack-eliciting. A probe packet SHOULD carry
-new data when possible. A probe packet MAY carry retransmitted unacknowledged
+Probe packets sent on a PTO MUST be ack-eliciting.  A probe packet SHOULD carry
+new data when possible.  A probe packet MAY carry retransmitted unacknowledged
 data when new data is unavailable, when flow control does not permit new data to
 be sent, or to opportunistically reduce loss recovery delay.  Implementations
 MAY use alternative strategies for determining the content of probe packets,

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -502,7 +502,7 @@ expiration before it has the keys to process an acknowledgement.
 
 When a PTO timer expires, the PTO backoff MUST be increased, resulting in the
 PTO period being set to twice its current value.  The PTO period is set based
-on the latest RTT information when receiving an acknowledgement. The PTO
+on the latest RTT information after receiving an acknowledgement. The PTO
 backoff is reset upon receiving an acknowledgement unless it's a client unsure
 if the the server has validated the client's address. Not resetting the backoff
 during peer addresss validation ensures the client's anti-deadlock timer is not

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1547,6 +1547,7 @@ OnPacketNumberSpaceDiscarded(pn_space):
   // Reset the loss detection and PTO timer
   time_of_last_sent_ack_eliciting_packet[kPacketNumberSpace] = 0
   loss_time[pn_space] = 0
+  pto_count = 0
   SetLossDetectionTimer()
 ~~~
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -504,7 +504,7 @@ When a PTO timer expires, the PTO backoff MUST be increased, resulting in the
 PTO period being set to twice its current value.  The PTO period is set based
 on the latest RTT information when receiving an acknowledgement. The PTO backoff
 is reset upon receiving an acknowledgement unless it's a client unsure if the
-the server has validating the client's address. Not resetting the backoff during
+the server has validated the client's address. Not resetting the backoff during
 peer addresss validation ensures the client's anti-deadlock timer is not set too
 aggressively when the server is slow in responding with handshake data.
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -502,11 +502,11 @@ expiration before it has the keys to process an acknowledgement.
 
 When a PTO timer expires, the PTO backoff MUST be increased, resulting in the
 PTO period being set to twice its current value.  The PTO period is set based
-on the latest RTT information when receiving an acknowledgement. The client's
-PTO backoff is reset unless the server is validating the client's address.
-Not resetting the backoff during peer addresss validation ensures the client's
-anti-deadlock timer is not set too aggressively when the server is slow in
-responding with handshake data.
+on the latest RTT information when receiving an acknowledgement. The PTO backoff
+is reset upon receiving an acknowledgement unless it's a client unsure if the
+the server has validating the client's address. Not resetting the backoff during
+peer addresss validation ensures the client's anti-deadlock timer is not set too
+aggressively when the server is slow in responding with handshake data.
 
 This exponential reduction in the sender's rate is important because
 consecutive PTOs might be caused by loss of packets or acknowledgements due to

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -503,8 +503,8 @@ expiration before it has the keys to process an acknowledgement.
 When a PTO timer expires, the PTO period MUST be set to twice its current
 value.  The PTO period is set based on the latest RTT information when
 receiving an acknowledgement if the peer has completed address validation.
-The PTO timer is not decreased while the peer is validating the
-address, to ensure the endpoint's anti-deadlock timer does not fire too
+The PTO backoff is not decreased while the peer is validating the
+address, to ensure the client's anti-deadlock timer does not fire too
 aggressively when the server does not yet have handshake data to send.
 
 This exponential reduction in the sender's rate is important because

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -502,11 +502,11 @@ expiration before it has the keys to process an acknowledgement.
 
 When a PTO timer expires, the PTO backoff MUST be increased, resulting in the
 PTO period being set to twice its current value.  The PTO period is set based
-on the latest RTT information when receiving an acknowledgement. The PTO backoff
-is reset upon receiving an acknowledgement unless it's a client unsure if the
-the server has validated the client's address. Not resetting the backoff during
-peer addresss validation ensures the client's anti-deadlock timer is not set too
-aggressively when the server is slow in responding with handshake data.
+on the latest RTT information when receiving an acknowledgement. The PTO
+backoff is reset upon receiving an acknowledgement unless it's a client unsure
+if the the server has validated the client's address. Not resetting the backoff
+during peer addresss validation ensures the client's anti-deadlock timer is not
+set too aggressively when the server is slow in responding with handshake data.
 
 This exponential reduction in the sender's rate is important because
 consecutive PTOs might be caused by loss of packets or acknowledgements due to

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -502,10 +502,10 @@ expiration before it has the keys to process an acknowledgement.
 
 When a PTO timer expires, the PTO backoff MUST be increased, resulting in the
 PTO period being set to twice its current value.  The PTO period is set based
-on the latest RTT information when receiving an acknowledgement. The PTO backoff
-is not decreased while the server is validating the client's address, to ensure
-the client's anti-deadlock timer does not fire too aggressively when the server
-does not yet have handshake data to send.
+on the latest RTT information when receiving an acknowledgement. The client's
+PTO backoff is not decreased while the server is validating the client's address,
+to ensure the client's anti-deadlock timer does not fire too aggressively when
+the server does not yet have handshake data to send.
 
 This exponential reduction in the sender's rate is important because
 consecutive PTOs might be caused by loss of packets or acknowledgements due to

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -501,7 +501,7 @@ packet on a PTO expiration before confirming that the server is able to decrypt
 expiration before it has the keys to process an acknowledgement.
 
 When a PTO timer expires, the PTO period MUST be set to twice its current
-value.  The PTO period is reset based on the latest rtt information when
+value.  The PTO period is set based on the latest RTT information when
 receiving an acknowledgement if the peer has completed address validation.
 The PTO timer is not decreased while the peer is validating the
 address, to ensure the endpoint's anti-deadlock timer does not fire too

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1147,7 +1147,7 @@ OnAckReceived(ack, pn_space):
   DetectLostPackets(pn_space)
   // Reset pto_count unless the server has not yet
   // validated the client's address.
-  if (PeerCompletedAddressValidation())
+  if (PeerCompletedAddressValidation()):
     pto_count = 0
 
   SetLossDetectionTimer()

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -503,9 +503,9 @@ expiration before it has the keys to process an acknowledgement.
 When a PTO timer expires, the PTO backoff MUST be increased, resulting in the
 PTO period being set to twice its current value.  The PTO period is set based
 on the latest RTT information when receiving an acknowledgement. The client's
-PTO backoff is not decreased while the server is validating the client's address,
-to ensure the client's anti-deadlock timer does not fire too aggressively when
-the server does not yet have handshake data to send.
+PTO backoff is not decreased while the server is validating the client's address.
+Doing so ensures that the client's anti-deadlock timer is not set too
+aggressively when the server is slow in responding with handshake data.
 
 This exponential reduction in the sender's rate is important because
 consecutive PTOs might be caused by loss of packets or acknowledgements due to

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -500,12 +500,12 @@ packet on a PTO expiration before confirming that the server is able to decrypt
 0-RTT packets, and prevents a server from sending a 1-RTT packet on a PTO
 expiration before it has the keys to process an acknowledgement.
 
-When a PTO timer expires, the PTO period MUST be set to twice its current
-value.  The PTO period is set based on the latest RTT information when
-receiving an acknowledgement if the peer has completed address validation.
-The PTO backoff is not decreased while the peer is validating the
-address, to ensure the client's anti-deadlock timer does not fire too
-aggressively when the server does not yet have handshake data to send.
+When a PTO timer expires, the PTO backoff MUST be increased, resulting in the
+PTO period being set to twice its current value.  The PTO period is set based
+on the latest RTT information when receiving an acknowledgement. The PTO backoff
+is not decreased while the server is validating the client's address, to ensure
+the client's anti-deadlock timer does not fire too aggressively when the server
+does not yet have handshake data to send.
 
 This exponential reduction in the sender's rate is important because
 consecutive PTOs might be caused by loss of packets or acknowledgements due to

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -501,11 +501,11 @@ packet on a PTO expiration before confirming that the server is able to decrypt
 expiration before it has the keys to process an acknowledgement.
 
 When a PTO timer expires, the PTO period MUST be set to twice its current
-value. The PTO period is set back to the original value upon receiving an
-acknowledgement for a non-Initial packet. The PTO timer is not decreased when
-the client receives an Initial ACK to ensure the client's anti-deadlock timer
-does not fire too aggressively when the server does not yet have handshake data
-to send.
+value.  The PTO period is reset based on the latest rtt information when
+receiving an acknowledgement if the peer has completed address validation.
+The PTO timer is not decreased while the peer is validating the
+address, to ensure the endpoint's anti-deadlock timer does not fire too
+aggressively when the server does not yet have handshake data to send.
 
 This exponential reduction in the sender's rate is important because
 consecutive PTOs might be caused by loss of packets or acknowledgements due to


### PR DESCRIPTION
In order to avoid sending anti-deadlock packets too quickly when the server doesn't yet have anything to send.

Also sets pto_count to 0 in pseudocode when Initial or Handshake keys are dropped, lining it up with existing normative text.(this could be split into a separate non-design PR if people prefer)

Adds the term 'backoff' which is usually reset upon receiving an acknowledgement.  The lines up more closely with 'pto_count' in the pseudocode.

Fixes #3546