### PR TITLE
Cumulative RCID frame (with gaps)

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -5600,7 +5600,7 @@ those that have been previously received, an endpoint MUST check that the sum of
 number of active connection IDs that it retains and the number of connection IDs
 that the peer would have sent (i.e., those with sequence numbers below or equal
 to the newly received one) is no greater than the active_connection_id_limit
-being adversited by the endpoint.  Doing so prevents malicious peers from
+being advertised by the endpoint.  Doing so prevents malicious peers from
 creating unbounded state on the endpoint.
 
 If an endpoint receives a NEW_CONNECTION_ID frame that repeats a previously


### PR DESCRIPTION
This PR fixes #3509, by doing the following:
* Require the receiver of NCID frames to check that the sender is not intentionally introducing gaps in the sequence numbers they send. By doing so, maximum number of gaps (i.e. the number of active CIDs below the largest CID being retired) is capped below the value advertised as active_connection_id_limit.
* Change the format of RCID frame, so that the all the CIDs that have been retired can be sent at once. This change caps the amount of state required for tracking RCID frames inflight (at the moment, the amount of state required for tracking those frames is also unbounded).