### PR TITLE
If PTO is armed for anti-deadlock, use now()

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1260,7 +1260,7 @@ SetLossDetectionTimer():
   sent_time, _ = GetEarliestTimeAndSpace(
     time_of_last_sent_ack_eliciting_packet)
   if (sent_time == 0)
-    assert(!PeerNotAwaitingAddressValidation())
+    assert(!PeerCompletedAddressValidation())
     sent_time = now()
   loss_detection_timer.update(sent_time + timeout)
 ~~~

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1092,13 +1092,13 @@ Pseudocode for OnPacketSent follows:
               in_flight, sent_bytes):
    sent_packets[pn_space][packet_number].packet_number =
                                             packet_number
-   sent_packets[pn_space][packet_number].time_sent = now
+   sent_packets[pn_space][packet_number].time_sent = now()
    sent_packets[pn_space][packet_number].ack_eliciting =
                                             ack_eliciting
    sent_packets[pn_space][packet_number].in_flight = in_flight
    if (in_flight):
      if (ack_eliciting):
-       time_of_last_sent_ack_eliciting_packet[pn_space] = now
+       time_of_last_sent_ack_eliciting_packet[pn_space] = now()
      OnPacketSentCC(sent_bytes)
      sent_packets[pn_space][packet_number].size = sent_bytes
      SetLossDetectionTimer()
@@ -1259,6 +1259,9 @@ SetLossDetectionTimer():
 
   sent_time, _ = GetEarliestTimeAndSpace(
     time_of_last_sent_ack_eliciting_packet)
+  if (sent_time == 0)
+    assert(endpoint is client)
+    sent_time = now()
   loss_detection_timer.update(sent_time + timeout)
 ~~~
 
@@ -1477,7 +1480,7 @@ window.
      // Start a new congestion event if packet was sent after the
      // start of the previous congestion recovery period.
      if (!InCongestionRecovery(sent_time)):
-       congestion_recovery_start_time = Now()
+       congestion_recovery_start_time = now()
        congestion_window *= kLossReductionFactor
        congestion_window = max(congestion_window, kMinimumWindow)
        ssthresh = congestion_window

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1260,7 +1260,7 @@ SetLossDetectionTimer():
   sent_time, _ = GetEarliestTimeAndSpace(
     time_of_last_sent_ack_eliciting_packet)
   if (sent_time == 0)
-    assert(endpoint is client)
+    assert(!PeerNotAwaitingAddressValidation())
     sent_time = now()
   loss_detection_timer.update(sent_time + timeout)
 ~~~


### PR DESCRIPTION
Use now() instead of setting the PTO based on an invalid time(0) when the PTO is armed for anti-deadlock and there are no bytes in flight.

Fixes #3554