### PR TITLE
Note that state needs to be maintained for each issued CID if the peer chooses to use it

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1028,8 +1028,9 @@ packet with a previously unused connection ID.  An endpoint MAY limit the
 frequency or the total number of connection IDs issued for each connection to
 avoid the risk of running out of connection IDs; see {{reset-token}}.  An
 endpoint MAY also limit the issuance of connection IDs to reduce the amount of
-per-path state it maintains, such as path validation status, as its peer can
-interact with as many paths as there are issued connection IDs.
+per-path state it maintains, such as path validation status, as its peer
+might interact with it over as many paths as there are issued connection
+IDs.
 
 An endpoint that initiates migration and requires non-zero-length connection IDs
 SHOULD ensure that the pool of connection IDs available to its peer allows the

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1022,11 +1022,14 @@ connection IDs than its advertised active_connection_id_limit MUST close the
 connection with an error of type CONNECTION_ID_LIMIT_ERROR.
 
 An endpoint SHOULD supply a new connection ID when the peer retires a connection
-ID. If an endpoint provided fewer connection IDs than the peer's
-active_connection_id_limit, it MAY supply a new connection ID when it receives
-a packet with a previously unused connection ID.  An endpoint MAY limit the
+ID.  If an endpoint provided fewer connection IDs than the peer's
+active_connection_id_limit, it MAY supply a new connection ID when it receives a
+packet with a previously unused connection ID.  An endpoint MAY limit the
 frequency or the total number of connection IDs issued for each connection to
-avoid the risk of running out of connection IDs; see {{reset-token}}.
+avoid the risk of running out of connection IDs; see {{reset-token}}.  An
+endpoint MAY also limit the issuance of connection IDs to reduce the amount of
+per-path state it maintains, such as path validation status, as its peer can
+interact with as many paths as there are issued connection IDs.
 
 An endpoint that initiates migration and requires non-zero-length connection IDs
 SHOULD ensure that the pool of connection IDs available to its peer allows the


### PR DESCRIPTION
Add another note when cautioning endpoints about how many CIDs to issue: in this case to note that if you issue a CID you need to be willing for the other endpoint to use 100% of the issued CIDs, which comes with an implicit willingness to maintain state for each path on which that CID could be used. (That's one per path, but # paths == # CIDs in the worst case.)

Fixes #3489.