### PR TITLE
Migration with zero-length CID is inadvisable

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2246,7 +2246,7 @@ that packet numbers cannot be used to correlate activity.  This does not prevent
 other properties of packets, such as timing and size, from being used to
 correlate activity.
 
-An endpoint SHOULD NOT initiate migration with a peer that uses a zero-length
+An endpoint SHOULD NOT initiate migration with a peer that has requested a zero-length
 connection ID, because traffic over the new path might be trivially linkable to
 traffic over the old one. If the server is able to route packets with a
 zero-length connection ID to the right connection, it means that the server is

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2249,7 +2249,7 @@ correlate activity.
 An endpoint SHOULD NOT initiate migration with a peer that uses a zero-length
 connection ID, for two reasons. First, if the peer routes incoming packets using
 the packets' source address, migration might not be successful. Second, if
-such a  peer routes incoming packets by assigning a unique destination address
+such a peer routes incoming packets by assigning a unique destination address
 to the connection, which can be achieved using using the preferred_address
 transport parameter (see {{preferred-address}}), packets sent by this
 endpoint over multiple paths are trivially linkable.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2247,12 +2247,14 @@ other properties of packets, such as timing and size, from being used to
 correlate activity.
 
 An endpoint SHOULD NOT initiate migration with a peer that uses a zero-length
-connection ID, for two reasons. First, if the peer routes incoming packets using
-the packets' source address, migration might not be successful. Second, if
-such a peer routes incoming packets by assigning a unique destination address
-to the connection, which can be achieved using using the preferred_address
-transport parameter (see {{preferred-address}}), packets sent by this
-endpoint over multiple paths are trivially linkable.
+connection ID, because traffic over the new path might be trivially linkable to
+traffic over the old one. If the server is able to route packets with a
+zero-length connection ID to the right connection, it means that the server is
+using other information to demultiplex packets. For example, the server can
+assign an address that is unique to the connection using the preferred_address
+transport parameter; see {{preferred-address}}.  Information that might allow
+correct routing of packets across multiple network paths will also allow
+activity on those paths to be linked by entities other than the peer.
 
 Unintentional changes in path without a change in connection ID are possible.
 For example, after a period of network inactivity, NAT rebinding might cause

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2250,11 +2250,11 @@ An endpoint SHOULD NOT initiate migration with a peer that uses a zero-length
 connection ID, because traffic over the new path might be trivially linkable to
 traffic over the old one. If the server is able to route packets with a
 zero-length connection ID to the right connection, it means that the server is
-using other information to demultiplex packets. For example, the server can
-assign an address that is unique to the connection using the preferred_address
-transport parameter; see {{preferred-address}}.  Information that might allow
-correct routing of packets across multiple network paths will also allow
-activity on those paths to be linked by entities other than the peer.
+using other information to demultiplex packets. For example, a server might
+provide a unique address to every client, for instance using HTTP alternative
+services {{?ALTSVC=RFC7838}}.  Information that might allow correct routing of
+packets across multiple network paths will also allow activity on those paths to
+be linked by entities other than the peer.
 
 Unintentional changes in path without a change in connection ID are possible.
 For example, after a period of network inactivity, NAT rebinding might cause

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2246,6 +2246,13 @@ that packet numbers cannot be used to correlate activity.  This does not prevent
 other properties of packets, such as timing and size, from being used to
 correlate activity.
 
+An endpoint SHOULD NOT initiate migration when a peer that requests the use of
+a zero-length connection ID. If the peer routes incoming packets using the
+source address, migration might not be successful. If the peer routes incoming
+packets by assigning a unique destination address to the connection, which
+might be achieved using using the preferred_address transport parameter (see
+{{preferred-address}}), packets sent on different paths will be linkable.
+
 Unintentional changes in path without a change in connection ID are possible.
 For example, after a period of network inactivity, NAT rebinding might cause
 packets to be sent on a new path when the client resumes sending.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2246,15 +2246,15 @@ that packet numbers cannot be used to correlate activity.  This does not prevent
 other properties of packets, such as timing and size, from being used to
 correlate activity.
 
-An endpoint SHOULD NOT initiate migration with a peer that has requested a zero-length
-connection ID, because traffic over the new path might be trivially linkable to
-traffic over the old one. If the server is able to route packets with a
-zero-length connection ID to the right connection, it means that the server is
-using other information to demultiplex packets. For example, a server might
-provide a unique address to every client, for instance using HTTP alternative
-services {{?ALTSVC=RFC7838}}.  Information that might allow correct routing of
-packets across multiple network paths will also allow activity on those paths to
-be linked by entities other than the peer.
+An endpoint SHOULD NOT initiate migration with a peer that has requested a
+zero-length connection ID, because traffic over the new path might be trivially
+linkable to traffic over the old one. If the server is able to route packets
+with a zero-length connection ID to the right connection, it means that the
+server is using other information to demultiplex packets. For example, a server
+might provide a unique address to every client, for instance using HTTP
+alternative services {{?ALTSVC=RFC7838}}.  Information that might allow correct
+routing of packets across multiple network paths will also allow activity on
+those paths to be linked by entities other than the peer.
 
 Unintentional changes in path without a change in connection ID are possible.
 For example, after a period of network inactivity, NAT rebinding might cause

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2246,13 +2246,13 @@ that packet numbers cannot be used to correlate activity.  This does not prevent
 other properties of packets, such as timing and size, from being used to
 correlate activity.
 
-An endpoint SHOULD NOT initiate migration when a peer requests the use of a
-zero-length connection ID. If the peer routes incoming packets using the source
-address, migration might not be successful. If the peer routes incoming packets
-by assigning a unique destination address to the connection, which might be
-achieved using using the preferred_address transport parameter (see
-{{preferred-address}}), packets sent on different paths are likely to be
-linkable.
+An endpoint SHOULD NOT initiate migration with a peer that uses a zero-length
+connection ID, for two reasons. First, if the peer routes incoming packets using
+the packets' source address, migration might not be successful. Second, if
+such a  peer routes incoming packets by assigning a unique destination address
+to the connection, which can be achieved using using the preferred_address
+transport parameter (see {{preferred-address}}), packets sent by this
+endpoint over multiple paths are trivially linkable.
 
 Unintentional changes in path without a change in connection ID are possible.
 For example, after a period of network inactivity, NAT rebinding might cause

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2246,12 +2246,13 @@ that packet numbers cannot be used to correlate activity.  This does not prevent
 other properties of packets, such as timing and size, from being used to
 correlate activity.
 
-An endpoint SHOULD NOT initiate migration when a peer that requests the use of
-a zero-length connection ID. If the peer routes incoming packets using the
-source address, migration might not be successful. If the peer routes incoming
-packets by assigning a unique destination address to the connection, which
-might be achieved using using the preferred_address transport parameter (see
-{{preferred-address}}), packets sent on different paths will be linkable.
+An endpoint SHOULD NOT initiate migration when a peer requests the use of a
+zero-length connection ID. If the peer routes incoming packets using the source
+address, migration might not be successful. If the peer routes incoming packets
+by assigning a unique destination address to the connection, which might be
+achieved using using the preferred_address transport parameter (see
+{{preferred-address}}), packets sent on different paths are likely to be
+linkable.
 
 Unintentional changes in path without a change in connection ID are possible.
 For example, after a period of network inactivity, NAT rebinding might cause


### PR DESCRIPTION
Not making a design/editorial call here.  There is new normative language, so maybe it is design.  But this is really just documenting an emergent property of the existing system.  There are no concrete changes other than a stronger recommendation against migration in cases where it either doesn't work or would not provide the privacy properties we have attempted to guarantee.

Closes #3559.