### PR TITLE
Forbid zero-length connection ID with preferred addresses

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4740,6 +4740,14 @@ preferred_address (0x0d):
   be at least one unused active connection ID when the client initiates
   migration to the preferred address.
 
+: The Connection ID and Stateless Reset Token fields of a preferred address are
+  identical in syntax and semantics to the corresponding fields of a
+  NEW_CONNECTION_ID frame ({{frame-new-connection-id}}).  A server that chooses
+  a zero-length connection ID MUST NOT provide a preferred address.  Similarly,
+  a server MUST NOT include a zero-length connection ID in this transport
+  parameter.  A client MUST treat violation of these requirements as a
+  connection error of type TRANSPORT_PARAMETER_ERROR.
+
 ~~~
  0                   1                   2                   3
  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1


### PR DESCRIPTION
This is option 4 from the discussion in #3560.  That is, making
preferred_address equivalent to NEW_CONNECTION_ID with a sequence number
of 1 in every way that matters.

Closes #3560.