### PR TITLE
Text on session resumption

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -648,6 +648,31 @@ messages and clients MUST treat receipt of such messages as a connection error
 of type PROTOCOL_VIOLATION.
 
 
+## Session Resumption
+
+QUIC can use the session resumption feature of TLS 1.3. It does this by
+carrying NewSessionTicket messages in CRYPTO frames after the handshake is
+complete. Session resumption is the basis of 0-RTT, but can be used without
+also enabling 0-RTT.
+
+Endpoints that use sesion resumption might need to remember some information
+about the current connection when creating a resumed connection. TLS requires
+that some information be retained; see Section 4.6.1 of {{!TLS13}}. QUIC itself
+does not depend on any state being retained when resuming a connection, unless
+0-RTT is also used; see {{enable-0rtt}} and Section 7.3.1 of
+{{QUIC-TRANSPORT}}. Application protocols could depend on state that is
+retained between resumed connections.
+
+Clients can store any state required for resumption along with the session
+ticket. Servers can use the session ticket to help carry state.
+
+Session resumption allows servers to link activity on the original connection
+with the resumed connection, which might be a privacy issue for clients.
+Clients can choose not to enable resumption to avoid creating this correlation.
+Client SHOULD NOT reuse tickets as that allows entities other than the server
+to correlate connection; see Section C.4 of {{!TLS13}}.
+
+
 ## Enabling 0-RTT {#enable-0rtt}
 
 To communicate their willingness to process 0-RTT data, servers send a

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -670,7 +670,7 @@ Session resumption allows servers to link activity on the original connection
 with the resumed connection, which might be a privacy issue for clients.
 Clients can choose not to enable resumption to avoid creating this correlation.
 Client SHOULD NOT reuse tickets as that allows entities other than the server
-to correlate connection; see Section C.4 of {{!TLS13}}.
+to correlate connections; see Section C.4 of {{!TLS13}}.
 
 
 ## Enabling 0-RTT {#enable-0rtt}

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -655,7 +655,7 @@ carrying NewSessionTicket messages in CRYPTO frames after the handshake is
 complete. Session resumption is the basis of 0-RTT, but can be used without
 also enabling 0-RTT.
 
-Endpoints that use sesion resumption might need to remember some information
+Endpoints that use session resumption might need to remember some information
 about the current connection when creating a resumed connection. TLS requires
 that some information be retained; see Section 4.6.1 of {{!TLS13}}. QUIC itself
 does not depend on any state being retained when resuming a connection, unless

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -648,7 +648,7 @@ messages and clients MUST treat receipt of such messages as a connection error
 of type PROTOCOL_VIOLATION.
 
 
-## Session Resumption
+## Session Resumption {#resumption}
 
 QUIC can use the session resumption feature of TLS 1.3. It does this by
 carrying NewSessionTicket messages in CRYPTO frames after the handshake is
@@ -1639,6 +1639,12 @@ of issues is well captured in the relevant sections of the main text.
 
 Never assume that because it isn't in the security considerations section it
 doesn't affect security.  Most of this document does.
+
+
+## Session Linkability
+
+Use of TLS session tickets allows servers and possibly other entities to
+correlate connections made by the same client; see {{resumption}} for details.
 
 
 ## Replay Attacks with 0-RTT

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1634,11 +1634,13 @@ As a result, EndOfEarlyData does not appear in the TLS handshake transcript.
 
 # Security Considerations
 
-There are likely to be some real clangers here eventually, but the current set
-of issues is well captured in the relevant sections of the main text.
+All of the security considerations that apply to TLS also apply to the use of
+TLS in QUIC. Reading all of {{!TLS13}} and its appendices is the best way to
+gain an understanding of the security properties of QUIC.
 
-Never assume that because it isn't in the security considerations section it
-doesn't affect security.  Most of this document does.
+This section summarizes some of the more important security aspects specific to
+the TLS integration, though there are many security-relevant details in the
+remainder of the document.
 
 
 ## Session Linkability


### PR DESCRIPTION
In looking at #3028, I realized that we had nowhere that addressed the basic concept of resumption.  This is, I hope, all that we need to say on the subject.  It talks about state and then the privacy implications of using resumption.

I found less in the TLS 1.3 RFC on this subject than I might have liked to see.  It only really addressed ticket reuse.  So this is a little more verbose than is ideal.

Oh, and there are new requirements here, but as they are restatements of existing requirements, I don't think that this needs to be a design change.  But I will happily switch to treating this as a design issue if anyone asks.

Closes #3028.