### PR TITLE
Kramdown usage updates

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -85,11 +85,11 @@ subsumed by QUIC, and describes how HTTP/2 extensions can be ported to HTTP/3.
 
 Discussion of this draft takes place on the QUIC working group mailing list
 (quic@ietf.org), which is archived at
-<https://mailarchive.ietf.org/arch/search/?email_list=quic>.
+[](https://mailarchive.ietf.org/arch/search/?email_list=quic).
 
-Working Group information can be found at <https://github.com/quicwg>; source
+Working Group information can be found at [](https://github.com/quicwg); source
 code and issues list for this draft can be found at
-<https://github.com/quicwg/base-drafts/labels/-http>.
+[](https://github.com/quicwg/base-drafts/labels/-http).
 
 
 --- middle
@@ -205,10 +205,7 @@ Additional resources are provided in the final sections:
 
 ## Conventions and Terminology
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
-"SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this
-document are to be interpreted as described in BCP 14 {{!RFC2119}} {{!RFC8174}}
-when, and only when, they appear in all capitals, as shown here.
+{::boilerplate bcp14}
 
 Field definitions are given in Augmented Backus-Naur Form (ABNF), as defined in
 {{!RFC5234}}.
@@ -491,7 +488,7 @@ the body of the request and close the stream normally.
 HTTP messages carry metadata as a series of key-value pairs, called HTTP fields.
 For a listing of registered HTTP fields, see the "Hypertext Transfer Protocol
 (HTTP) Field Name Registry" maintained at
-<https://www.iana.org/assignments/http-fields/>.
+[](https://www.iana.org/assignments/http-fields/).
 
 As in previous versions of HTTP, field names are strings containing a subset of
 ASCII characters that are compared in a case-insensitive fashion.  Properties of

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -84,7 +84,7 @@ subsumed by QUIC, and describes how HTTP/2 extensions can be ported to HTTP/3.
 --- note_Note_to_Readers
 
 Discussion of this draft takes place on the QUIC working group mailing list
-(quic@ietf.org), which is archived at
+([quic@ietf.org](mailto:quic@ietf.org)), which is archived at
 [](https://mailarchive.ietf.org/arch/search/?email_list=quic).
 
 Working Group information can be found at [](https://github.com/quicwg); source
@@ -298,7 +298,8 @@ experimental implementation based on draft-ietf-quic-http-09 which reserves an
 extra stream for unsolicited transmission of 1980s pop music might identify
 itself as "h3-09-rickroll". Note that any label MUST conform to the "token"
 syntax defined in Section 4.4.1.1 of {{!SEMANTICS}}. Experimenters are
-encouraged to coordinate their experiments on the quic@ietf.org mailing list.
+encouraged to coordinate their experiments on the
+[quic@ietf.org](mailto:quic@ietf.org) mailing list.
 
 ## Discovering an HTTP/3 Endpoint {#discovery}
 

--- a/draft-ietf-quic-invariants.md
+++ b/draft-ietf-quic-invariants.md
@@ -68,11 +68,11 @@ developed.
 
 Discussion of this draft takes place on the QUIC working group mailing list
 (quic@ietf.org), which is archived at
-<https://mailarchive.ietf.org/arch/search/?email_list=quic>.
+[](https://mailarchive.ietf.org/arch/search/?email_list=quic).
 
-Working Group information can be found at <https://github.com/quicwg>; source
+Working Group information can be found at [](https://github.com/quicwg); source
 code and issues list for this draft can be found at
-<https://github.com/quicwg/base-drafts/labels/-invariants>.
+[](https://github.com/quicwg/base-drafts/labels/-invariants).
 
 
 --- middle
@@ -101,10 +101,7 @@ version of QUIC.
 
 # Conventions and Definitions
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
-"SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this
-document are to be interpreted as described in BCP 14 {{!RFC2119}} {{!RFC8174}}
-when, and only when, they appear in all capitals, as shown here.
+{::boilerplate bcp14}
 
 This document uses terms and notational conventions from {{QUIC-TRANSPORT}}.
 

--- a/draft-ietf-quic-invariants.md
+++ b/draft-ietf-quic-invariants.md
@@ -67,7 +67,7 @@ developed.
 --- note_Note_to_Readers
 
 Discussion of this draft takes place on the QUIC working group mailing list
-(quic@ietf.org), which is archived at
+([quic@ietf.org](mailto:quic@ietf.org)), which is archived at
 [](https://mailarchive.ietf.org/arch/search/?email_list=quic).
 
 Working Group information can be found at [](https://github.com/quicwg); source

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -71,7 +71,7 @@ HPACK header compression that seeks to reduce head-of-line blocking.
 --- note_Note_to_Readers
 
 Discussion of this draft takes place on the QUIC working group mailing list
-(quic@ietf.org), which is archived at
+([quic@ietf.org](mailto:quic@ietf.org)), which is archived at
 [](https://mailarchive.ietf.org/arch/search/?email_list=quic).
 
 Working Group information can be found at [](https://github.com/quicwg); source

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -72,11 +72,11 @@ HPACK header compression that seeks to reduce head-of-line blocking.
 
 Discussion of this draft takes place on the QUIC working group mailing list
 (quic@ietf.org), which is archived at
-<https://mailarchive.ietf.org/arch/search/?email_list=quic>.
+[](https://mailarchive.ietf.org/arch/search/?email_list=quic).
 
-Working Group information can be found at <https://github.com/quicwg>; source
+Working Group information can be found at [](https://github.com/quicwg); source
 code and issues list for this draft can be found at
-<https://github.com/quicwg/base-drafts/labels/-qpack>.
+[](https://github.com/quicwg/base-drafts/labels/-qpack).
 
 --- middle
 
@@ -96,10 +96,7 @@ with substantially less head-of-line blocking under the same loss conditions.
 
 ## Conventions and Definitions
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
-"SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this
-document are to be interpreted as described in BCP 14 {{!RFC2119}} {{!RFC8174}}
-when, and only when, they appear in all capitals, as shown here.
+{::boilerplate bcp14}
 
 Definitions of terms that are used in this document:
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -79,7 +79,7 @@ QUIC.
 --- note_Note_to_Readers
 
 Discussion of this draft takes place on the QUIC working group mailing list
-(quic@ietf.org), which is archived at
+([quic@ietf.org](mailto:quic@ietf.org)), which is archived at
 [](https://mailarchive.ietf.org/arch/search/?email_list=quic).
 
 Working Group information can be found at [](https://github.com/quicwg); source

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -80,11 +80,11 @@ QUIC.
 
 Discussion of this draft takes place on the QUIC working group mailing list
 (quic@ietf.org), which is archived at
-<https://mailarchive.ietf.org/arch/search/?email_list=quic>.
+[](https://mailarchive.ietf.org/arch/search/?email_list=quic).
 
-Working Group information can be found at <https://github.com/quicwg>; source
+Working Group information can be found at [](https://github.com/quicwg); source
 code and issues list for this draft can be found at
-<https://github.com/quicwg/base-drafts/labels/-recovery>.
+[](https://github.com/quicwg/base-drafts/labels/-recovery).
 
 --- middle
 
@@ -99,10 +99,7 @@ TCP implementations.
 
 # Conventions and Definitions
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
-"SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this
-document are to be interpreted as described in BCP 14 {{!RFC2119}} {{!RFC8174}}
-when, and only when, they appear in all capitals, as shown here.
+{::boilerplate bcp14}
 
 Definitions of terms that are used in this document:
 

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -100,7 +100,7 @@ QUIC.
 --- note_Note_to_Readers
 
 Discussion of this draft takes place on the QUIC working group mailing list
-(quic@ietf.org), which is archived at
+([quic@ietf.org](mailto:quic@ietf.org)), which is archived at
 [](https://mailarchive.ietf.org/arch/search/?email_list=quic).
 
 Working Group information can be found at [](https://github.com/quicwg); source

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -101,11 +101,11 @@ QUIC.
 
 Discussion of this draft takes place on the QUIC working group mailing list
 (quic@ietf.org), which is archived at
-<https://mailarchive.ietf.org/arch/search/?email_list=quic>.
+[](https://mailarchive.ietf.org/arch/search/?email_list=quic).
 
-Working Group information can be found at <https://github.com/quicwg>; source
+Working Group information can be found at [](https://github.com/quicwg); source
 code and issues list for this draft can be found at
-<https://github.com/quicwg/base-drafts/labels/-tls>.
+[](https://github.com/quicwg/base-drafts/labels/-tls).
 
 --- middle
 
@@ -125,10 +125,7 @@ This document describes how TLS acts as a security component of QUIC.
 
 # Notational Conventions
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
-"SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this
-document are to be interpreted as described in BCP 14 {{!RFC2119}} {{!RFC8174}}
-when, and only when, they appear in all capitals, as shown here.
+{::boilerplate bcp14}
 
 This document uses the terminology established in {{QUIC-TRANSPORT}}.
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -105,7 +105,7 @@ Discussion of this draft takes place on the QUIC working group mailing list
 
 Working Group information can be found at [](https://github.com/quicwg); source
 code and issues list for this draft can be found at
-()[https://github.com/quicwg/base-drafts/labels/-transport).
+[](https://github.com/quicwg/base-drafts/labels/-transport).
 
 --- middle
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -101,11 +101,11 @@ TLS for key negotiation.
 
 Discussion of this draft takes place on the QUIC working group mailing list
 (quic@ietf.org), which is archived at
-\<https://mailarchive.ietf.org/arch/search/?email_list=quic\>.
+[](https://mailarchive.ietf.org/arch/search/?email_list=quic)
 
-Working Group information can be found at \<https://github.com/quicwg\>; source
+Working Group information can be found at [](https://github.com/quicwg); source
 code and issues list for this draft can be found at
-\<https://github.com/quicwg/base-drafts/labels/-transport\>.
+()[https://github.com/quicwg/base-drafts/labels/-transport).
 
 --- middle
 
@@ -173,10 +173,7 @@ in {{QUIC-INVARIANTS}}.
 
 ## Terms and Definitions
 
-The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
-"SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this
-document are to be interpreted as described in BCP 14 {{!RFC2119}} {{!RFC8174}}
-when, and only when, they appear in all capitals, as shown here.
+{::boilerplate bcp14}
 
 Commonly used terms in the document are described below.
 
@@ -3775,7 +3772,7 @@ identified as 0xff00000D.
 
 Implementors are encouraged to register version numbers of QUIC that they are
 using for private experimentation on the GitHub wiki at
-\<https://github.com/quicwg/base-drafts/wiki/QUIC-Versions\>.
+[](https://github.com/quicwg/base-drafts/wiki/QUIC-Versions).
 
 
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -100,7 +100,7 @@ TLS for key negotiation.
 --- note_Note_to_Readers
 
 Discussion of this draft takes place on the QUIC working group mailing list
-(quic@ietf.org), which is archived at
+([quic@ietf.org](mailto:quic@ietf.org)), which is archived at
 [](https://mailarchive.ietf.org/arch/search/?email_list=quic)
 
 Working Group information can be found at [](https://github.com/quicwg); source
@@ -6556,7 +6556,7 @@ All registrations made by Standards Track publications MUST be permanent.
 
 All registrations in this document are assigned a permanent status and list as
 contact both the IESG (ietf@ietf.org) and the QUIC working group
-(quic@ietf.org).
+([quic@ietf.org](mailto:quic@ietf.org)).
 
 
 ## QUIC Transport Parameter Registry {#iana-transport-parameters}


### PR DESCRIPTION
Two things:

* Links are better as `[](link)` than `<link>` as the latter puts the link in the text output twice (HTML is fine).

* Boilerplate is more concise if we let kramdown-rfc2629 add it.