### PR TITLE
Fix reference to RFC5682

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -235,7 +235,7 @@ in-flight lost, QUIC allows probe packets to temporarily exceed the congestion
 window whenever the timer expires.
 
 In doing this, QUIC avoids unnecessary congestion window reductions, obviating
-the need for correcting mechanisms such as F-RTO {{!RFC5682}}. Since QUIC does
+the need for correcting mechanisms such as F-RTO {{?RFC5682}}. Since QUIC does
 not collapse the congestion window on a PTO expiration, a QUIC sender is not
 limited from sending more in-flight packets after a PTO expiration if it still
 has available congestion window. This occurs when a sender is


### PR DESCRIPTION
This wasn't meant to be normative.