### PR TITLE
More detail regarding dropping of ACK Ranges

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3311,7 +3311,7 @@ with minimal state.
 
 Receivers can discard all ACK Ranges, but they MUST retain the largest packet
 number that has been successfully processed as that is used to recover packet
-numbers from subsequent packets.
+numbers from subsequent packets; see {{packet-encoding}}.
 
 A receiver SHOULD include an ACK Range containing the largest received packet
 number in every ACK frame. The Largest Acknowledged field is used in ECN

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3304,9 +3304,20 @@ necessary if an ACK frame would be too large to fit in a packet, however
 receivers MAY also limit ACK frame size further to preserve space for other
 frames.
 
-When discarding unacknowledged ACK Ranges, a receiver MUST retain the largest
-received packet number. A receiver SHOULD retain ACK Ranges containing newly
-received packets or higher-numbered packets.
+A receiver MUST retain an ACK Range unless it can ensure that it will not
+subsequently accept packets with numbers in that range. Maintaining a minimum
+packet number that increases as ranges are discarded is one way to achieve this
+with minimal state.
+
+Receivers can discard all ACK Ranges, but they MUST retain the largest packet
+number that has been successfully processed as that is used to recover packet
+numbers from subsequent packets.
+
+A receiver SHOULD include an ACK Range containing the largest received packet
+number in every ACK frame. The Largest Acknowledged field is used in ECN
+validation at a sender and including a lower value than what was included in a
+previous ACK frame could cause ECN to be unnecessarily disabled; see
+{{ecn-validation}}.
 
 A receiver that sends only non-ack-eliciting packets, such as ACK frames, might
 not receive an acknowledgement for a long period of time.  This could cause the


### PR DESCRIPTION
This explains what needs to be kept and why.  Specifically, you need to
keep ranges unless you have other means of ensuring that you don't
accept packets from those ranges again.  You also need to keep the
largest acknowledged so that you can get a packet number from subsequent
packets.

This also recommends that ACK frames include the largest acknowledged
always.  That is primarily to ensure that ECN works properly, and even
there, you only disable ECN if you get some weird reordering, so it's
probably not a big deal if you don't follow this recommendation.

The issue is marked design, but the resolution here is basically a restatement of other text.  I think we can run this through the design process, but it isn't really worth flagging this in a change log in my opinion.

Closes #3541.
Closes #3537.