### PR TITLE
Why min CWND of 2 instead of 1

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -248,8 +248,8 @@ prior to a dramatic decrease in congestion window; see
 ### The Minimum Congestion Window is Two Packets
 
 TCP uses a minimum congestion window of one packet. However, loss of
-a single packet sent with that window causes the sender to waiting for a PTO
-({{pto}}) to recover from that loss, which is much longer than a round trip.
+that single packet means that the sender needs to waiting for a PTO
+({{pto}}) to recover, which can be much longer than a round-trip time.
 Sending a single ack-eliciting packet also increases the chances of incurring
 additional latency when a receiver delays its acknowledgement.
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -245,7 +245,7 @@ QUIC specifies a time-based definition to ensure one or more packets are sent
 prior to a dramatic decrease in congestion window; see
 {{persistent-congestion}}.
 
-### Increase the min congestion window to 2 packets
+### The Minimum Congestion Window is 2 Packets
 
 QUIC recommends a minimum congestion window of 2 packets instead of TCP's 1.
 2 packets avoid waiting for a delayed acknowledgement and allow the PTO to

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -247,7 +247,8 @@ prior to a dramatic decrease in congestion window; see
 
 ### The Minimum Congestion Window is 2 Packets
 
-QUIC recommends a minimum congestion window of 2 packets instead of TCP's 1.
+QUIC recommends that the minimum congestion window be 2 packets instead 
+of the 1 packet minimum in TCP.
 2 packets avoid waiting for a delayed acknowledgement and allow the PTO to
 send 2 packets instead of 1, which can be particularly important during the
 handshake.

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -245,6 +245,13 @@ QUIC specifies a time-based definition to ensure one or more packets are sent
 prior to a dramatic decrease in congestion window; see
 {{persistent-congestion}}.
 
+### Increase the min congestion window to 2 packets
+
+QUIC recommends a minimum congestion window of 2 packets instead of TCP's 1.
+2 packets avoid waiting for a delayed acknowledgement and allow the PTO to
+send 2 packets instead of 1, which can be particularly important during the
+handshake.
+
 
 # Estimating the Round-Trip Time {#compute-rtt}
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -245,7 +245,7 @@ QUIC specifies a time-based definition to ensure one or more packets are sent
 prior to a dramatic decrease in congestion window; see
 {{persistent-congestion}}.
 
-### The Minimum Congestion Window is 2 Packets
+### The Minimum Congestion Window is Two Packets
 
 QUIC recommends that the minimum congestion window be 2 packets instead
 of the 1 packet minimum in TCP. A 2 packet minimum congestion window avoids

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -252,7 +252,7 @@ of the 1 packet minimum in TCP. A minimum of 2 packets avoids waiting for a
 delayed acknowledgement, which can substantially decrease throughput,
 particularly if the max_ack_delay is larger than the round trip time.
 A 2 packet minimum congestion window also avoids waiting for a probe
-timeout(see {{pto}}) every time a single packet is lost.
+timeout (see {{pto}}) every time a single packet is lost.
 
 
 # Estimating the Round-Trip Time {#compute-rtt}

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -248,11 +248,11 @@ prior to a dramatic decrease in congestion window; see
 ### The Minimum Congestion Window is 2 Packets
 
 QUIC recommends that the minimum congestion window be 2 packets instead
-of the 1 packet minimum in TCP. A 2 packet minimum congestion window also
-avoids waiting for a probe timeout (see {{pto}}) every time a single packet
-is lost. A minimum of 2 packets avoids waiting for a delayed acknowledgement,
-which can substantially decrease throughput, particularly if the max_ack_delay
-is larger than the round trip time.
+of the 1 packet minimum in TCP. A 2 packet minimum congestion window avoids
+waiting for a probe timeout (see {{pto}}) every time a single packet is lost.
+A minimum of 2 packets also avoids waiting for a delayed acknowledgement, which
+can substantially decrease throughput, particularly if the max_ack_delay is
+larger than the round trip time.
 
 
 # Estimating the Round-Trip Time {#compute-rtt}

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -248,11 +248,11 @@ prior to a dramatic decrease in congestion window; see
 ### The Minimum Congestion Window is 2 Packets
 
 QUIC recommends that the minimum congestion window be 2 packets instead
-of the 1 packet minimum in TCP. A minimum of 2 packets avoids waiting for a
-delayed acknowledgement, which can substantially decrease throughput,
-particularly if the max_ack_delay is larger than the round trip time.
-A 2 packet minimum congestion window also avoids waiting for a probe
-timeout (see {{pto}}) every time a single packet is lost.
+of the 1 packet minimum in TCP. A 2 packet minimum congestion window also
+avoids waiting for a probe timeout (see {{pto}}) every time a single packet
+is lost. A minimum of 2 packets avoids waiting for a delayed acknowledgement,
+which can substantially decrease throughput, particularly if the max_ack_delay
+is larger than the round trip time.
 
 
 # Estimating the Round-Trip Time {#compute-rtt}

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -248,9 +248,9 @@ prior to a dramatic decrease in congestion window; see
 ### The Minimum Congestion Window is Two Packets
 
 TCP uses a minimum congestion window of one packet. However, loss of
-a single packet sent with that window limits the sender to waiting for a PTO
-({{pto}}) to recover from that loss, which can be a substantial period of time.
-Sending a single data packet also increases the chances of incurring
+a single packet sent with that window causes the sender to waiting for a PTO
+({{pto}}) to recover from that loss, which is much longer than a round trip.
+Sending a single ack-eliciting packet also increases the chances of incurring
 additional latency when a receiver delays its acknowledgement.
 
 QUIC therefore recommends that the minimum congestion window be two

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -247,12 +247,16 @@ prior to a dramatic decrease in congestion window; see
 
 ### The Minimum Congestion Window is Two Packets
 
-QUIC recommends that the minimum congestion window be 2 packets instead
-of the 1 packet minimum in TCP. A 2 packet minimum congestion window avoids
-waiting for a probe timeout (see {{pto}}) every time a single packet is lost.
-A minimum of 2 packets also avoids waiting for a delayed acknowledgement, which
-can substantially decrease throughput, particularly if the max_ack_delay is
-larger than the round trip time.
+TCP uses a minimum congestion window of one packet. However, loss of
+a single packet sent with that window limits the sender to waiting for a PTO
+({{pto}}) to recover from that loss, which can be a substantial period of time.
+Sending a single data packet also increases the chances of incurring
+additional latency when a receiver delays its acknowledgement.
+
+QUIC therefore recommends that the minimum congestion window be two
+packets. While this increases network load, it is considered safe, since the
+sender will still reduce its sending rate exponentially under persistent
+congestion ({{pto}}).
 
 
 # Estimating the Round-Trip Time {#compute-rtt}

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -248,10 +248,9 @@ prior to a dramatic decrease in congestion window; see
 ### The Minimum Congestion Window is 2 Packets
 
 QUIC recommends that the minimum congestion window be 2 packets instead 
-of the 1 packet minimum in TCP.
-2 packets avoid waiting for a delayed acknowledgement and allow the PTO to
-send 2 packets instead of 1, which can be particularly important during the
-handshake.
+of the 1 packet minimum in TCP. A minimum of 2 packets avoids waiting for a
+delayed acknowledgement, which can substantially decrease throughput,
+particularly if the max_ack_delay is larger than the round trip time.
 
 
 # Estimating the Round-Trip Time {#compute-rtt}

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -247,7 +247,7 @@ prior to a dramatic decrease in congestion window; see
 
 ### The Minimum Congestion Window is 2 Packets
 
-QUIC recommends that the minimum congestion window be 2 packets instead 
+QUIC recommends that the minimum congestion window be 2 packets instead
 of the 1 packet minimum in TCP. A minimum of 2 packets avoids waiting for a
 delayed acknowledgement, which can substantially decrease throughput,
 particularly if the max_ack_delay is larger than the round trip time.

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -251,6 +251,8 @@ QUIC recommends that the minimum congestion window be 2 packets instead
 of the 1 packet minimum in TCP. A minimum of 2 packets avoids waiting for a
 delayed acknowledgement, which can substantially decrease throughput,
 particularly if the max_ack_delay is larger than the round trip time.
+A 2 packet minimum congestion window also avoids waiting for a probe
+timeout(see {{pto}}) every time a single packet is lost.
 
 
 # Estimating the Round-Trip Time {#compute-rtt}


### PR DESCRIPTION
Feel free to suggest better text or other reasons, but this is what I came up with.

Fixes #3261