### PR TITLE
MUST verify => MUST NOT accept on fail

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -403,7 +403,10 @@ hostname in the URI is present in the authenticated certificate provided by the
 server, either as the CN field of the certificate subject or as a dNSName in the
 subjectAltName field of the certificate (see {{!RFC6125}}).  For a host that is
 an IP address, the client MUST verify that the address appears as an iPAddress
-in the subjectAltName field of the certificate.
+in the subjectAltName field of the certificate.  If the hostname or address is
+not present in the certificate, the client MUST NOT consider the server
+authoritative for origins containing that hostname or address.  See Section 5.4
+of {{!SEMANTICS}} for more detail on authoritative access.
 
 Clients SHOULD NOT open more than one HTTP/3 connection to a given host and port
 pair, where the host is derived from a URI, a selected alternative service


### PR DESCRIPTION
Addresses @ekr's comments on #3558.  While this adds a new MUST NOT, I believe it's editorial because it's simply stating the implicit result of the "MUST verify" in that PR.  If anyone disagrees, speak up and I'll change it.

Separately, I think there's a case for this "MUST NOT" to be a "SHOULD NOT," as we all know there are situations in which clients proceed through a certificate warning.  It's a reasonable semantic distinction whether the client does not consider the server authoritative but processes the result anyway (MUST NOT), or considers the server authoritative because the user told it to (SHOULD NOT).  Opinions on the bikeshed welcome.