### PR TITLE
Scrub for backticks

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -664,7 +664,7 @@ on the uncompressed size of fields, including the length of the name and value
 in bytes plus an overhead of 32 bytes for each field.
 
 If an implementation wishes to advise its peer of this limit, it can be conveyed
-as a number of bytes in the `SETTINGS_MAX_FIELD_SECTION_SIZE` parameter. An
+as a number of bytes in the SETTINGS_MAX_FIELD_SECTION_SIZE parameter. An
 implementation which has received this parameter SHOULD NOT send an HTTP message
 header which exceeds the indicated size, as the peer will likely refuse to
 process it.  However, because this limit is applied at each hop, messages below
@@ -715,7 +715,7 @@ frames but is invalid due to:
 - the inclusion of invalid characters in field names or values
 
 A request or response that includes a payload body can include a
-`content-length` header field.  A request or response is also malformed if the
+Content-Length header field.  A request or response is also malformed if the
 value of a content-length header field does not equal the sum of the DATA frame
 payload lengths that form the body.  A response that is defined to have no
 payload, as described in Section 6.3.3 of {{!SEMANTICS}} can have a non-zero
@@ -1116,7 +1116,7 @@ the reception of the unidirectional stream header.
 
 ### Control Streams
 
-A control stream is indicated by a stream type of `0x00`.  Data on this stream
+A control stream is indicated by a stream type of 0x00.  Data on this stream
 consists of HTTP/3 frames, as defined in {{frames}}.
 
 Each side MUST initiate a single control stream at the beginning of the
@@ -1141,7 +1141,7 @@ Server push is an optional feature introduced in HTTP/2 that allows a server to
 initiate a response before a request has been made.  See {{server-push}} for
 more details.
 
-A push stream is indicated by a stream type of `0x01`, followed by the Push ID
+A push stream is indicated by a stream type of 0x01, followed by the Push ID
 of the promise that it fulfills, encoded as a variable-length integer. The
 remaining data on this stream consists of HTTP/3 frames, as defined in
 {{frames}}, and fulfills a promised server push by zero or more interim HTTP
@@ -2014,7 +2014,7 @@ The entries in {{iana-frame-table}} are registered by this document.
 {: #iana-frame-table title="Initial HTTP/3 Frame Types"}
 
 Additionally, each code of the format `0x1f * N + 0x21` for non-negative integer
-values of N (that is, `0x21`, `0x40`, ..., through `0x3FFFFFFFFFFFFFFE`) MUST
+values of N (that is, 0x21, 0x40, ..., through 0x3FFFFFFFFFFFFFFE) MUST
 NOT be assigned by IANA.
 
 ### Settings Parameters {#iana-settings}
@@ -2056,7 +2056,7 @@ The entries in {{iana-setting-table}} are registered by this document.
 {: #iana-setting-table title="Initial HTTP/3 Settings"}
 
 Additionally, each code of the format `0x1f * N + 0x21` for non-negative integer
-values of N (that is, `0x21`, `0x40`, ..., through `0x3FFFFFFFFFFFFFFE`) MUST
+values of N (that is, 0x21, 0x40, ..., through 0x3FFFFFFFFFFFFFFE) MUST
 NOT be assigned by IANA.
 
 ### Error Codes {#iana-error-codes}
@@ -2108,7 +2108,7 @@ The entries in the {{iana-error-table}} are registered by this document.
 {: #iana-error-table title="Initial HTTP/3 Error Codes"}
 
 Additionally, each code of the format `0x1f * N + 0x21` for non-negative integer
-values of N (that is, `0x21`, `0x40`, ..., through `0x3FFFFFFFFFFFFFFE`) MUST
+values of N (that is, 0x21, 0x40, ..., through 0x3FFFFFFFFFFFFFFE) MUST
 NOT be assigned by IANA.
 
 ### Stream Types {#iana-stream-types}
@@ -2144,7 +2144,7 @@ The entries in the following table are registered by this document.
 | ---------------- | ------ | -------------------------- | ------ |
 
 Additionally, each code of the format `0x1f * N + 0x21` for non-negative integer
-values of N (that is, `0x21`, `0x40`, ..., through `0x3FFFFFFFFFFFFFFE`) MUST
+values of N (that is, 0x21, 0x40, ..., through 0x3FFFFFFFFFFFFFFE) MUST
 NOT be assigned by IANA.
 
 --- back

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -625,11 +625,11 @@ and follows the definitions in [RFC7541] without modification.
 
 QPACK defines two unidirectional stream types:
 
- - An encoder stream is a unidirectional stream of type `0x02`.
+ - An encoder stream is a unidirectional stream of type 0x02.
    It carries an unframed sequence of encoder instructions from encoder
    to decoder.
 
- - A decoder stream is a unidirectional stream of type `0x03`.
+ - A decoder stream is a unidirectional stream of type 0x03.
    It carries an unframed sequence of decoder instructions from decoder
    to encoder.
 

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1597,7 +1597,7 @@ protection for these values.
    } ExtensionType;
 ~~~
 
-The `extension_data` field of the quic_transport_parameters extension contains a
+The extension_data field of the quic_transport_parameters extension contains a
 value that is defined by the version of QUIC that is in use.
 
 The quic_transport_parameters extension is carried in the ClientHello and the

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2046,7 +2046,7 @@ duration of the handshake.  An endpoint MUST NOT initiate connection migration
 before the handshake is confirmed, as defined in section 4.1.2 of {{QUIC-TLS}}.
 
 An endpoint also MUST NOT send packets from a different local address, actively
-initiating migration, if the peer sent the `disable_active_migration` transport
+initiating migration, if the peer sent the disable_active_migration transport
 parameter during the handshake. An endpoint which has sent this transport
 parameter, but detects that a peer has nonetheless migrated to a different
 network MUST either drop the incoming packets on that path without generating a
@@ -3258,7 +3258,7 @@ contract: an endpoint promises to never intentionally delay acknowledgments
 of an ack-eliciting packet by more than the indicated value. If it does,
 any excess accrues to the RTT estimate and could result in spurious or
 delayed retransmissions from the peer. For Initial and Handshake packets,
-a max_ack_delay of 0 is used. The sender uses the receiver's `max_ack_delay`
+a max_ack_delay of 0 is used. The sender uses the receiver's max_ack_delay
 value in determining timeouts for timer-based retransmission, as detailed in
 Section 5.2.1 of {{QUIC-RECOVERY}}.
 
@@ -4578,7 +4578,7 @@ connection.
 
 # Transport Parameter Encoding {#transport-parameter-encoding}
 
-The `extension_data` field of the quic_transport_parameters extension defined in
+The extension_data field of the quic_transport_parameters extension defined in
 {{QUIC-TLS}} contains the QUIC transport parameters. They are encoded as a
 sequence of transport parameters, as shown in {{transport-parameter-sequence}}:
 
@@ -4897,7 +4897,7 @@ ACK Delay:
   when this ACK was sent and when the largest acknowledged packet, as indicated
   in the Largest Acknowledged field, was received by this peer.  The value of
   the ACK Delay field is scaled by multiplying the encoded value by 2 to the
-  power of the value of the `ack_delay_exponent` transport parameter set by the
+  power of the value of the ack_delay_exponent transport parameter set by the
   sender of the ACK frame; see {{transport-parameter-definitions}}.  Scaling in
   this fashion allows for a larger range of values with a shorter encoding at
   the cost of lower resolution.  Because the receiver doesn't use the ACK Delay
@@ -6560,7 +6560,7 @@ The initial contents of this registry are shown in {{iana-tp-table}}.
 {: #iana-tp-table title="Initial QUIC Transport Parameters Entries"}
 
 Additionally, each value of the format `31 * N + 27` for integer values of N
-(that is, `27`, `58`, `89`, ...) are reserved and MUST NOT be assigned by IANA.
+(that is, 27, 58, 89, ...) are reserved and MUST NOT be assigned by IANA.
 
 
 ## QUIC Frame Type Registry {#iana-frames}


### PR DESCRIPTION
This doesn't do qpack because qpack is weird and needs a lot more work.

The places where I kept backticks are for the inline formulae that were
used for the reserved codepoints.  That seemed like it was worth quoting
somehow still.  I also kept backticks for references to variables in
examples.

However, this last principle really hurts in qpack and I don't know what
to do about that.

Closes #3609 (we'll need another issue for qpack).