### PR TITLE
Define an anti-forgery limit

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1550,12 +1550,13 @@ number of attempts to forge packets. TLS achieves this by closing connections
 after any record fails an authentication check. In comparison, QUIC ignores any
 packet that cannot be authenticated, allowing multiple forgery attempts.
 
-Endpoints MUST count the number of received packets that fail authentication.
-If the number of packets that fail authentication with the same key exceeds a
-limit that is specific to the AEAD in use, the endpoint MUST immediately close
-the connection.  Endpoints MUST initiate a key update before reaching this
-limit.  Applying a limit reduces the probability that an attacker is able to
-successfully forge a packet; see {{AEBounds}} and {{ROBUST}}.
+Endpoints MUST count the number of received packets that fail authentication for
+each set of keys.  If the number of packets that fail authentication with the
+same key exceeds a limit that is specific to the AEAD in use, the endpoint MUST
+stop using those keys.  Endpoints MUST initiate a key update before reaching
+this limit.  If a key update is not possible, the endpoints MUST immediately
+close the connection.  Applying a limit reduces the probability that an attacker
+is able to successfully forge a packet; see {{AEBounds}} and {{ROBUST}}.
 
 For AEAD_AES_128_GCM, AEAD_AES_256_GCM, and AEAD_CHACHA20_POLY1305, the limit on
 the number of packets that fail authentication is 2^36.  Note that the analysis

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -70,6 +70,15 @@ informative:
     date: 2016-03-08
     target: "http://www.isg.rhul.ac.uk/~kp/TLS-AEbounds.pdf"
 
+  ROBUST:
+    title: "Robust Channels: Handling Unreliable Networks in the Record Layers of QUIC and DTLS"
+    author:
+      - ins: M. Fischlin
+      - ins: F. Günther
+      - ins: C. Janson
+    date: 2020-02-21
+    target: "https://felixguenther.info/Q20_RC.pdf"
+
   IMC:
     title: "Introduction to Modern Cryptography, Second Edition"
     author:
@@ -1519,12 +1528,32 @@ After this period, old read keys and their corresponding secrets SHOULD be
 discarded.
 
 
-## Key Update Frequency
+## Minimum Key Update Frequency
 
 Key updates MUST be initiated before usage limits on packet protection keys are
 exceeded.  For the cipher suites mentioned in this document, the limits in
 Section 5.5 of {{!TLS13}} apply.  Other cipher suites MUST define usage limits
 in order to be used with QUIC.
+
+The usage limits defined in TLS 1.3 exist to provide protection against attacks
+on confidentiality and apply to successful applications of AEAD protection. The
+integrity protections in authenticated encryption also depend on limiting the
+number of attempts to forge packets. TLS achieves this by closing connections
+after any record fails an authentication check. In comparison, QUIC ignores any
+packet that cannot be authenticated, allowing an attacker to make multiple
+attempts to defeat integrity protection.
+
+Packet protection keys MUST NOT be used for removing packet protection after
+authentication fails on more than 2^36 packets. Endpoints MUST initiate a key
+update before the number of packets that fail authentication exceeds 2^36. This
+limit reduces the probability than attacker is able to create a successful
+packet forgery to 2^-57, see {{AEBounds}} and {{ROBUST}}.
+
+This limit of 2^36 unsuccessfully authenticated packets applies only to the
+AEAD algorithms that are defined for use in QUIC (AEAD_AES_128_GCM,
+AEAD_AES_256_GCM, AEAD_AES_128_CCM(?!?! - no analysis to support the inclusion
+of CCM), and AEAD_CHACHA20_POLY1305). Any TLS cipher suite that is specified
+for use with QUIC MUST specify a limit specific to the packet protection AEAD.
 
 
 ## Key Update Error Code {#key-update-error}
@@ -2203,6 +2232,7 @@ Christopher Wood,
 David Schinazi,
 Dragana Damjanovic,
 Eric Rescorla,
+Felix Günther,
 Ian Swett,
 Jana Iyengar, <contact
  asciiFullname="Kazuho Oku" fullname="奥 一穂"/>,

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -2161,7 +2161,7 @@ result. This produces the relation:
 v + q <= 2^24.5
 ~~~
 
-Using the previously-established value of 2^24 for `q` and rounding, this leads
+Using the previously-established value of 2^23 for `q` and rounding, this leads
 to an upper limit on `v` of 2^23.5. That is, endpoints cannot attempt to
 authenticate more than 2^23.5 packets with the same set of keys without causing
 an attacker to gain an larger advantage than the target of 2^-57.

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1555,7 +1555,7 @@ Endpoints MUST count the number of packets that are received but cannot be
 authenticated. Packet protection keys MUST NOT be used for removing packet
 protection after authentication fails on more than a per-AEAD limit. Endpoints
 MUST initiate a key update before reaching this limit. Applying a limit reduces
-the probability than attacker is able to successfully forge a packet; see
+the probability that an attacker is able to successfully forge a packet; see
 {{AEBounds}} and {{ROBUST}}.
 
 For AEAD_AES_128_GCM, AEAD_AES_256_GCM, and AEAD_CHACHA20_POLY1305 the

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -77,7 +77,7 @@ informative:
       - ins: F. Günther
       - ins: C. Janson
     date: 2020-02-21
-    target: "https://felixguenther.info/Q20_RC.pdf"
+    target: "https://www.felixguenther.info/docs/QUIPS2020_RobustChannels.pdf"
 
   IMC:
     title: "Introduction to Modern Cryptography, Second Edition"

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1552,19 +1552,18 @@ packet that cannot be authenticated, allowing multiple attempts at defeating
 integrity protection.
 
 Endpoints MUST count the number of packets that are received but cannot be
-authenticated. Packet protection keys MUST NOT be used for removing packet
-protection after authentication fails on more than a limit that is specific to
-the AEAD in use. Endpoints MUST initiate a key update before reaching this
-limit. Applying a limit reduces the probability that an attacker is able to
+authenticated.  If the number of packets that fail authentication exceeds a
+limit that is specific to the AEAD in use, the endpoint MUST immediately close
+the connection.  Endpoints MUST initiate a key update before reaching this
+limit.  Applying a limit reduces the probability that an attacker is able to
 successfully forge a packet; see {{AEBounds}} and {{ROBUST}}.
 
-For AEAD_AES_128_GCM, AEAD_AES_256_GCM, and AEAD_CHACHA20_POLY1305, if the
-number of packets that fail authentication exceeds 2^36, the endpoint MUST
-immediately close the connection.  Note that the analysis in {{AEBounds}}
-supports a higher limit for the AEAD_AES_128_GCM and AEAD_AES_256_GCM, but this
-specification recommends a lower limit.  For AEAD_AES_128_CCM, if the number of
-packets that fail authentication exceeds 2^24.5, the endpoint MUST immediately
-close the connection; see {{ccm-bounds}}.
+For AEAD_AES_128_GCM, AEAD_AES_256_GCM, and AEAD_CHACHA20_POLY1305, the limit on
+the number of packets that fail authentication is 2^36.  Note that the analysis
+in {{AEBounds}} supports a higher limit for the AEAD_AES_128_GCM and
+AEAD_AES_256_GCM, but this specification recommends a lower limit.  For
+AEAD_AES_128_CCM, ithe limit on the number of packets that fail authentication
+is 2^24.5; see {{ccm-bounds}}.
 
 Note:
 

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -2096,8 +2096,9 @@ n:
 
 l:
 
-: The number of blocks in each packet. To match the analysis in {{AEBounds}},
-  this analysis uses a value of 2^10.
+: The number of blocks in each packet. In this case, this is the number of
+  16-byte AES blocks in a packet. To match the analysis in {{AEBounds}}, this
+  analysis uses a value of 2^10, which assumes a limit on packet size of 2^14.
 
 q:
 

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -2104,9 +2104,7 @@ n:
 
 l:
 
-: The number of blocks in each packet. In this case, this is the number of
-  16-byte AES blocks in a packet. To match the analysis in {{AEBounds}}, this
-  analysis uses a value of 2^10, which assumes a limit on packet size of 2^14.
+: The number of blocks in each packet (see below).
 
 q:
 
@@ -2119,6 +2117,19 @@ v:
 : The number of forged packets that endpoints will accept. This value is the
   bound on the number of forged packets that an endpoint can reject before
   updating keys.
+
+The analysis of AEAD_AES_128_CCM relies on a count of the number of block
+operations involved in producing each message. For simplicity, and to match the
+analysis of other AEAD functions in {{AEBounds}}, this analysis assumes a
+packet length of 2^10 blocks and a packet size limit of 2^14.
+
+For AEAD_AES_128_CCM, the total number of block cipher operations is the sum
+of: the length of the associated data in blocks, the length of the ciphertext
+in blocks, the length of the plaintext in blocks, plus 1. In this analysis,
+this is simplified to a value of twice the length of the packet in blocks (that
+is, `2l = 2^11`). This simplification is based on the packet containing all of
+the associated data and ciphertext. This results in a negligible 1 to 3 block
+overestimation of the number of operations.
 
 
 ## Confidentiality Limits

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -2133,9 +2133,9 @@ overestimation of the number of operations.
 
 ## Confidentiality Limits
 
-For confidentiality, Theorem 2 in {{?CCM-ANALYSIS}} establishes that an
-attacker gains a distinguishing advantage over an ideal pseudorandom permutation (PRP) of no
-more than:
+For confidentiality, Theorem 2 in {{?CCM-ANALYSIS}} establishes that an attacker
+gains a distinguishing advantage over an ideal pseudorandom permutation (PRP) of
+no more than:
 
 ~~~
 (2l * q)^2 / 2^n

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1543,16 +1543,15 @@ AEAD_AES_128_CCM, but the analysis in {{ccm-bounds}} shows that a limit of 2^23
 packets can be used to obtain the same confidentiality protection as the limits
 specified in TLS.
 
-The usage limits defined in TLS 1.3 exist to provide protection against attacks
+The usage limits defined in TLS 1.3 exist for protection against attacks
 on confidentiality and apply to successful applications of AEAD protection. The
 integrity protections in authenticated encryption also depend on limiting the
 number of attempts to forge packets. TLS achieves this by closing connections
 after any record fails an authentication check. In comparison, QUIC ignores any
-packet that cannot be authenticated, allowing multiple attempts at defeating
-integrity protection.
+packet that cannot be authenticated, allowing multiple forgery attempts.
 
-Endpoints MUST count the number of packets that are received but cannot be
-authenticated.  If the number of packets that fail authentication exceeds a
+Endpoints MUST count the number of received packets that fail authentication.
+If the number of packets that fail authentication exceeds a
 limit that is specific to the AEAD in use, the endpoint MUST immediately close
 the connection.  Endpoints MUST initiate a key update before reaching this
 limit.  Applying a limit reduces the probability that an attacker is able to
@@ -2135,7 +2134,7 @@ overestimation of the number of operations.
 ## Confidentiality Limits
 
 For confidentiality, Theorem 2 in {{?CCM-ANALYSIS}} establishes that an
-attacker gains an advantage over an ideal pseudorandom permutation (PRP) of no
+attacker gains a distinguishing advantage over an ideal pseudorandom permutation (PRP) of no
 more than:
 
 ~~~

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1554,7 +1554,7 @@ Endpoints MUST count the number of received packets that fail authentication for
 each set of keys.  If the number of packets that fail authentication with the
 same key exceeds a limit that is specific to the AEAD in use, the endpoint MUST
 stop using those keys.  Endpoints MUST initiate a key update before reaching
-this limit.  If a key update is not possible, the endpoints MUST immediately
+this limit.  If a key update is not possible, the endpoint MUST immediately
 close the connection.  Applying a limit reduces the probability that an attacker
 is able to successfully forge a packet; see {{AEBounds}} and {{ROBUST}}.
 

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1553,24 +1553,18 @@ integrity protection.
 
 Endpoints MUST count the number of packets that are received but cannot be
 authenticated. Packet protection keys MUST NOT be used for removing packet
-protection after authentication fails on more than a per-AEAD limit. Endpoints
-MUST initiate a key update before reaching this limit. Applying a limit reduces
-the probability that an attacker is able to successfully forge a packet; see
-{{AEBounds}} and {{ROBUST}}.
+protection after authentication fails on more than a limit that is specific to
+the AEAD in use. Endpoints MUST initiate a key update before reaching this
+limit. Applying a limit reduces the probability that an attacker is able to
+successfully forge a packet; see {{AEBounds}} and {{ROBUST}}.
 
-For AEAD_AES_128_GCM, AEAD_AES_256_GCM, and AEAD_CHACHA20_POLY1305 the
-number of packets that fail authentication MUST NOT exceed 2^36. Note that the
-analysis in {{AEBounds}} supports a higher limit for the AEAD_AES_128_GCM and
-AEAD_AES_256_GCM, but this specification recommends a lower limit. For
-AEAD_AES_128_CCM the number of packets that fail authentication MUST NOT exceed
-2^24.5; see {{ccm-bounds}}.
-
-Any TLS cipher suite that is specified for use with QUIC MUST define limits on
-the use of the associated AEAD function that preserves margins for
-confidentiality and integrity. That is, limits MUST be specified for the number
-of packets that can be authenticated and for the number packets that can fail
-authentication.  Any limits SHOULD reference any analysis upon which values are
-based and describe any assumptions used in that analysis.
+For AEAD_AES_128_GCM, AEAD_AES_256_GCM, and AEAD_CHACHA20_POLY1305, if the
+number of packets that fail authentication exceeds 2^36, the endpoint MUST
+immediately close the connection.  Note that the analysis in {{AEBounds}}
+supports a higher limit for the AEAD_AES_128_GCM and AEAD_AES_256_GCM, but this
+specification recommends a lower limit.  For AEAD_AES_128_CCM, if the number of
+packets that fail authentication exceeds 2^24.5, the endpoint MUST immediately
+close the connection; see {{ccm-bounds}}.
 
 Note:
 
@@ -1580,6 +1574,14 @@ Note:
   expected that QUIC packets will generally be smaller than TLS records.
   Where packets might be larger than 2^14 bytes in length, smaller limits might
   be needed.
+
+Any TLS cipher suite that is specified for use with QUIC MUST define limits on
+the use of the associated AEAD function that preserves margins for
+confidentiality and integrity. That is, limits MUST be specified for the number
+of packets that can be authenticated and for the number packets that can fail
+authentication.  Providing a reference to any analysis upon which values are
+based - and any assumptions used in that analysis - allows limits to be adapted
+to varying usage conditions.
 
 
 ## Key Update Error Code {#key-update-error}

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1539,7 +1539,7 @@ discarded.
 Key updates MUST be initiated before usage limits on packet protection keys are
 exceeded. For the cipher suites mentioned in this document, the limits in
 Section 5.5 of {{!TLS13}} apply. {{!TLS13}} does not specify a limit for
-AEAD_AES_128_CCM, but the analysis in {{ccm-bounds}} shows that a limit of 2^24
+AEAD_AES_128_CCM, but the analysis in {{ccm-bounds}} shows that a limit of 2^23
 packets can be used to obtain the same confidentiality protection as the limits
 specified in TLS.
 
@@ -1562,8 +1562,8 @@ For AEAD_AES_128_GCM, AEAD_AES_256_GCM, and AEAD_CHACHA20_POLY1305, the limit on
 the number of packets that fail authentication is 2^36.  Note that the analysis
 in {{AEBounds}} supports a higher limit for the AEAD_AES_128_GCM and
 AEAD_AES_256_GCM, but this specification recommends a lower limit.  For
-AEAD_AES_128_CCM, ithe limit on the number of packets that fail authentication
-is 2^24.5; see {{ccm-bounds}}.
+AEAD_AES_128_CCM, the limit on the number of packets that fail authentication
+is 2^23.5; see {{ccm-bounds}}.
 
 Note:
 
@@ -2128,17 +2128,17 @@ attacker gains an advantage over an ideal pseudorandom permutation (PRP) of no
 more than:
 
 ~~~
-(l * q)^2 / 2^n
+(2l * q)^2 / 2^n
 ~~~
 
 For a target advantage of 2^-60, which matches that used by {{!TLS13}}, this
 results in the relation:
 
 ~~~
-q <= 2^24
+q <= 2^23
 ~~~
 
-That is, endpoints cannot protect more than 2^24 packets with the same set of
+That is, endpoints cannot protect more than 2^23 packets with the same set of
 keys without causing an attacker to gain an larger advantage than the target of
 2^-60.
 
@@ -2149,7 +2149,7 @@ For integrity, Theorem 1 in {{?CCM-ANALYSIS}} establishes that an attacker
 gains an advantage over an ideal PRP of no more than:
 
 ~~~
-v / 2^t + (l * (v + q))^2 / 2^n
+v / 2^t + (2l * (v + q))^2 / 2^n
 ~~~
 
 The goal is to limit this advantage to 2^-57, to match the target in
@@ -2158,12 +2158,12 @@ to the second, so that term can be removed without a significant effect on the
 result. This produces the relation:
 
 ~~~
-v + q <= 2^25.5
+v + q <= 2^24.5
 ~~~
 
 Using the previously-established value of 2^24 for `q` and rounding, this leads
-to an upper limit on `v` of 2^24.5. That is, endpoints cannot attempt to
-authenticate more than 2^24.5 packets with the same set of keys without causing
+to an upper limit on `v` of 2^23.5. That is, endpoints cannot attempt to
+authenticate more than 2^23.5 packets with the same set of keys without causing
 an attacker to gain an larger advantage than the target of 2^-57.
 
 

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1551,7 +1551,7 @@ after any record fails an authentication check. In comparison, QUIC ignores any
 packet that cannot be authenticated, allowing multiple forgery attempts.
 
 Endpoints MUST count the number of received packets that fail authentication.
-If the number of packets that fail authentication exceeds a
+If the number of packets that fail authentication with the same key exceeds a
 limit that is specific to the AEAD in use, the endpoint MUST immediately close
 the connection.  Endpoints MUST initiate a key update before reaching this
 limit.  Applying a limit reduces the probability that an attacker is able to

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1558,7 +1558,7 @@ MUST initiate a key update before reaching this limit. Applying a limit reduces
 the probability than attacker is able to successfully forge a packet; see
 {{AEBounds}} and {{ROBUST}}.
 
-For AEAD_AES_128_GCM and AEAD_AES_256_GCM, and AEAD_CHACHA20_POLY1305 the
+For AEAD_AES_128_GCM, AEAD_AES_256_GCM, and AEAD_CHACHA20_POLY1305 the
 number of packets that fail authentication MUST NOT exceed 2^36. Note that the
 analysis in {{AEBounds}} supports a higher limit for the AEAD_AES_128_GCM and
 AEAD_AES_256_GCM, but this specification recommends a lower limit. For
@@ -1574,7 +1574,7 @@ based and describe any assumptions used in that analysis.
 
 Note:
 
-: These limits were originally calculated based using assumptions about the
+: These limits were originally calculated using assumptions about the
   limits on TLS record size. The maximum size of a TLS record is 2^14 bytes.
   In comparison, QUIC packets can be up to 2^16 bytes.  However, it is
   expected that QUIC packets will generally be smaller than TLS records.


### PR DESCRIPTION
This defines a limit on the number of packets that can fail
authentication before you have to use new keys.

There is a big hole here in that AES-CCM (that is, the AEAD based on
CBC-MAC) is currently permitted, but we have no analysis to support
either the confidentiality limits in TLS 1.3 or the integrity limits in
this document.  It is probably OK, but that is not the standard we apply
here.

So this might have to remain open until we get some sort of resolution
on that issue.  My initial opinion is to cut CCM from the draft
until/unless an analysis is produced.

Closes #3619.