### PR TITLE
Text/figure consistency

### DIFF
--- a/draft-ietf-quic-invariants.md
+++ b/draft-ietf-quic-invariants.md
@@ -129,8 +129,7 @@ version-specific and of arbitrary length.
 
 ## Long Header
 
-Long headers take the form described in {{fig-long}}.  Bits that have
-version-specific semantics are marked with an X.
+Long headers take the form described in {{fig-long}}.
 
 ~~~
 Long Header Packet {
@@ -138,9 +137,9 @@ Long Header Packet {
   Version-Specific Bits (7),
   Version (32),
   DCID Len (8),
-  Destination Connection ID (0..255),
+  Destination Connection ID (0..2040),
   SCID Len (8),
-  Source Connection ID (0..255),
+  Source Connection ID (0..2040),
   Version-Specific Data (..),
 }
 ~~~
@@ -166,8 +165,7 @@ The remainder of the packet contains version-specific content.
 
 ## Short Header
 
-Short headers take the form described in {{fig-short}}.  Bits that have
-version-specific semantics are marked with an X.
+Short headers take the form described in {{fig-short}}.
 
 ~~~~~
 Short Header Packet {

--- a/draft-ietf-quic-invariants.md
+++ b/draft-ietf-quic-invariants.md
@@ -138,9 +138,9 @@ Long Header Packet {
   Version-Specific Bits (7),
   Version (32),
   DCID Len (8),
-  Destination Connection ID (0..160),
+  Destination Connection ID (0..255),
   SCID Len (8),
-  Source Connection ID (0..160),
+  Source Connection ID (0..255),
   Version-Specific Data (..),
 }
 ~~~
@@ -156,10 +156,10 @@ The next byte contains the length in bytes of the Destination Connection ID (see
 unsigned integer.  The Destination Connection ID field follows the DCID Len
 field and is between 0 and 255 bytes in length.
 
-The next byte contains the length in bytes
-of the Source Connection ID field that follows it.  This length is encoded as
-a 8-bit unsigned integer.  The Source Connection ID field follows the SCID Len
-field and is between 0 and 255 bytes in length.
+The next byte contains the length in bytes of the Source Connection ID field
+that follows it.  This length is encoded as a 8-bit unsigned integer.  The
+Source Connection ID field follows the SCID Len field and is between 0 and 255
+bytes in length.
 
 The remainder of the packet contains version-specific content.
 


### PR DESCRIPTION
Happened to notice that the updated figure (didn't check the old one) was inconsistent with the text about the allowed length of the CID fields.  Should be editorial, since the text wins any conflicts.