### PR TITLE
redrawing handshake figures in ascending encryption-level order.

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1459,8 +1459,8 @@ Initial[1]: ACK[0]
 Handshake[0]: CRYPTO[FIN], ACK[0]
 1-RTT[0]: STREAM[0, "..."], ACK[0] ->
 
-                            1-RTT[1]: STREAM[3, "..."], ACK[0]
-                                       <- Handshake[1]: ACK[0]
+                                          Handshake[1]: ACK[0]
+                         <- 1-RTT[1]: STREAM[3, "..."], ACK[0]
 ~~~~
 {: #tls-1rtt-handshake title="Example 1-RTT Handshake"}
 
@@ -1483,8 +1483,8 @@ Initial[1]: ACK[0]
 Handshake[0]: CRYPTO[FIN], ACK[0]
 1-RTT[1]: STREAM[0, "..."] ACK[0] ->
 
-                            1-RTT[1]: STREAM[3, "..."], ACK[1]
-                                       <- Handshake[1]: ACK[0]
+                                          Handshake[1]: ACK[0]
+                         <- 1-RTT[1]: STREAM[3, "..."], ACK[1]
 ~~~~
 {: #tls-0rtt-handshake title="Example 0-RTT Handshake"}
 


### PR DESCRIPTION
This should fix #3632.