### PR TITLE
Consistency for VN, too

### DIFF
--- a/draft-ietf-quic-invariants.md
+++ b/draft-ietf-quic-invariants.md
@@ -233,9 +233,9 @@ Version Negotiation Packet {
   Unused (7),
   Version (32) = 0,
   DCID Len (8),
-  Destination Connection ID (0..160),
+  Destination Connection ID (0..2040),
   SCID Len (8),
-  Source Connection ID (0..160),
+  Source Connection ID (0..2040),
   Supported Version (32) ...,
 }
 ~~~

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4078,9 +4078,9 @@ Version Negotiation Packet {
   Unused (7),
   Version (32) = 0,
   DCID Length (8),
-  Destination Connection ID (0..160),
+  Destination Connection ID (0..2040),
   SCID Length (8),
-  Source Connection ID (0..160),
+  Source Connection ID (0..2040),
   Supported Version (32) ...,
 }
 ~~~


### PR DESCRIPTION
#3636 for Version Negotiation.  Includes Transport, where the text explicitly notes that VN packets might have longer CIDs because other versions permit it.