### PR TITLE
Minor errors in new diagrams

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4294,8 +4294,6 @@ Handshake Packet {
   Destination Connection ID (0..160),
   SCID Length (8),
   Source Connection ID (0..160),
-  Token Length (i),
-  Token (..),
   Packet Number (8..32),
   Packet Payload (..),
 }
@@ -4334,7 +4332,7 @@ Retry Packet {
   Header Form (1) = 1,
   Fixed Bit (1) = 1,
   Long Packet Type (2) = 3,
-  Type-Specific Bits (4),
+  Unused (4),
   Version (32),
   DCID Length (8),
   Destination Connection ID (0..160),


### PR DESCRIPTION
Fixes two nits:
- Handshake packets showed a Token+length
- Retry packets had "Type-Specific Bits" where the text referred to "Unused"