### PR TITLE
Add OnPacketReceived to pseudocode

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1147,7 +1147,7 @@ Pseudocode for OnPacketSent follows:
 When a server is blocked by anti-amplification limits, receiving
 a datagram unblocks it, even if none of the packets in the
 datagram are successfully processed. In such a case, the PTO
-timer may need to be armed.
+timer will need to be re-armed.
 
 Pseudocode for OnDatagramReceived follows:
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1142,20 +1142,20 @@ Pseudocode for OnPacketSent follows:
      SetLossDetectionTimer()
 ~~~
 
-## On Receiving a Packet
+## On Receiving a Datagram
 
-When a packet is received, it may allow the server to send
-if the server was previously amplification limited.
+When a datagram is received, it may allow the server to send
+if the server was previously amplification limited, even if
+none of the packets in it can be processed.
 
-Psuedocode for OnPacketReceived follows:
+Pseudocode for OnDatagramReceived follows:
 
 ~~~
-OnPacketReceived(packet):
+OnDatagramReceived(datagram):
   // If this packet unblocks the server, arm the
-  // timer to ensure forward progress resumes
+  // PTO timer to avoid deadlock.
   if (server was at anti-amplification limit):
     SetLossDetectionTimer()
-  DecryptAndProcessFrames()
 ~~~
 
 ## On Receiving an Acknowledgment

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1144,9 +1144,10 @@ Pseudocode for OnPacketSent follows:
 
 ## On Receiving a Datagram
 
-When a datagram is received, it may allow the server to send
-if the server was previously amplification limited, even if
-none of the packets in it can be processed.
+Receiving a datagram might allow the server to send additional data if the
+server was previously blocked by the anti-amplification limits; see
+{{before-address-validation}}. This is necessary even if none of the packets in
+the datagram are successfully processed.
 
 Pseudocode for OnDatagramReceived follows:
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1142,6 +1142,20 @@ Pseudocode for OnPacketSent follows:
      SetLossDetectionTimer()
 ~~~
 
+## On Receiving a Packet
+
+When a packet is received, it may 
+
+Psuedocode for OnPacketReceived follows:
+
+~~~
+OnPacketReceived(packet):
+  // If this packet unblocks the server, arm the
+  // timer to ensure forward progress resumes
+  if (server was at anti-amplification limit):
+    SetLossDetectionTimer()
+  DecryptAndProcessFrames()
+~~~
 
 ## On Receiving an Acknowledgment
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1144,10 +1144,10 @@ Pseudocode for OnPacketSent follows:
 
 ## On Receiving a Datagram
 
-Receiving a datagram might allow the server to send if the
-server was previously blocked by the anti-amplification limits.
-This is necessary even if none of the packets in the datagram
-are successfully processed.
+When a server is  blocked by anti-amplification limits, receiving
+a datagram unblocks it, even if none of the packets in the
+datagram are successfully processed. In such a case, the PTO
+timer is now set, since data is in flight and probes can be sent.
 
 Pseudocode for OnDatagramReceived follows:
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1144,7 +1144,8 @@ Pseudocode for OnPacketSent follows:
 
 ## On Receiving a Packet
 
-When a packet is received, it may 
+When a packet is received, it may allow the server to send
+if the server was previously amplification limited.
 
 Psuedocode for OnPacketReceived follows:
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1144,10 +1144,10 @@ Pseudocode for OnPacketSent follows:
 
 ## On Receiving a Datagram
 
-Receiving a datagram might allow the server to send additional data if the
-server was previously blocked by the anti-amplification limits; see
-{{before-address-validation}}. This is necessary even if none of the packets in
-the datagram are successfully processed.
+Receiving a datagram might allow the server to send if the
+server was previously blocked by the anti-amplification limits.
+This is necessary even if none of the packets in the datagram
+are successfully processed.
 
 Pseudocode for OnDatagramReceived follows:
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1144,10 +1144,10 @@ Pseudocode for OnPacketSent follows:
 
 ## On Receiving a Datagram
 
-When a server is  blocked by anti-amplification limits, receiving
+When a server is blocked by anti-amplification limits, receiving
 a datagram unblocks it, even if none of the packets in the
 datagram are successfully processed. In such a case, the PTO
-timer is now set, since data is in flight and probes can be sent.
+timer may need to be armed.
 
 Pseudocode for OnDatagramReceived follows:
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1152,7 +1152,7 @@ Pseudocode for OnDatagramReceived follows:
 
 ~~~
 OnDatagramReceived(datagram):
-  // If this packet unblocks the server, arm the
+  // If this datagram unblocks the server, arm the
   // PTO timer to avoid deadlock.
   if (server was at anti-amplification limit):
     SetLossDetectionTimer()


### PR DESCRIPTION
Pseudocode for re-arming the PTO when "If no additional data can be sent, the server's PTO timer MUST NOT be armed until datagrams have been received from the client, because packets sent on PTO count against the anti-amplification limit. "

I'll note that OnPacketReceived actually needs to do a lot more than this, but this is the portion relevant to PTO.

Fixes #3639 