### PR TITLE
Fix name of the Transport Parameter Length field

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4613,7 +4613,7 @@ Transport Parameter {
 ~~~
 {: #transport-parameter-encoding-fig title="Transport Parameter Encoding"}
 
-The Transport Param Length field contains the length of the Transport
+The Transport Parameter Length field contains the length of the Transport
 Parameter Value field.
 
 QUIC encodes transport parameters into a sequence of bytes, which are then


### PR DESCRIPTION
(It's "Parameter," not "Param.")