### PR TITLE
Clarify text on pacing

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -908,9 +908,10 @@ Or, expressed as an inter-packet interval:
 interval = smoothed_rtt * packet_size / congestion_window / N
 ~~~
 
-Using a value for `N` that is small, but at least 1 (for example, 1.25) ensures
-that variations in round-trip time don't result in under-utilization of the
-congestion window.
+Using a value for N that is low, but at least 1 (for example, 1.25) ensures that
+variations in round-trip time don't result in under-utilization of the
+congestion window. Note that a higher N results in the inter-packet interval
+becoming smaller, and a large enough N defeats purpose of pacing.
 
 Practical considerations, such as packetization, scheduling delays, and
 computational efficiency, can cause a sender to deviate from this rate over time

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -910,10 +910,7 @@ interval = smoothed_rtt * packet_size / congestion_window / N
 
 Using a value for `N` that is small, but at least 1 (for example, 1.25) ensures
 that variations in round-trip time don't result in under-utilization of the
-congestion window.  Values of 'N' larger than 1 ultimately result in sending
-packets as acknowledgments are received rather than when timers fire, provided
-the congestion window is fully utilized and acknowledgments arrive at regular
-intervals.
+congestion window.
 
 Practical considerations, such as packetization, scheduling delays, and
 computational efficiency, can cause a sender to deviate from this rate over time

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -911,7 +911,7 @@ interval = smoothed_rtt * packet_size / congestion_window / N
 Using a value for N that is low, but at least 1 (for example, 1.25) ensures that
 variations in round-trip time don't result in under-utilization of the
 congestion window. Note that a higher N results in the inter-packet interval
-becoming smaller, and a large enough N defeats purpose of pacing.
+becoming smaller, and a large enough N defeats the purpose of pacing.
 
 Practical considerations, such as packetization, scheduling delays, and
 computational efficiency, can cause a sender to deviate from this rate over time


### PR DESCRIPTION
N was introduced in #3630 to describe how a sender might pace at a rate that allows it to send a congestion window's worth of data in a period that is shorter than an RTT. This PR clarifies text that goes into unnecessary detail, trying to describe assumptions (the network is spreading the packets out, for example, resulting in an ack clock).
