### PR TITLE
Scope of disable_active_migration

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1230,11 +1230,10 @@ when a client's address changes.
   address. Note that clients could choose not to use the preferred address.
 
 A server in a deployment that does not implement a solution to maintain
-connection continuity when the client address changes SHOULD indicate migration is not supported
-using the disable_active_migration transport parameter.  The
-disable_active_migration transport parameter does not prohibit
-connection migration after a client has acted on the preferred_address transport
-parameter.
+connection continuity when the client address changes SHOULD indicate migration
+is not supported using the disable_active_migration transport parameter.  The
+disable_active_migration transport parameter does not prohibit connection
+migration after a client has acted on the preferred_address transport parameter.
 
 Server deployments that use this simple form of load balancing MUST avoid the
 creation of a stateless reset oracle; see {{reset-oracle}}.
@@ -2152,15 +2151,15 @@ The design of QUIC relies on endpoints retaining a stable address for the
 duration of the handshake.  An endpoint MUST NOT initiate connection migration
 before the handshake is confirmed, as defined in section 4.1.2 of {{QUIC-TLS}}.
 
-An endpoint also MUST NOT send packets from a different local address, actively
-initiating migration, if the peer sent the disable_active_migration transport
-parameter during the handshake. An endpoint which has sent this transport
-parameter, but detects that a peer has nonetheless migrated to a different
-network MUST either drop the incoming packets on that path without generating a
-stateless reset or proceed with path validation and allow the peer to migrate.
-Generating a stateless reset or closing the connection would allow third parties
-in the network to cause connections to close by spoofing or otherwise
-manipulating observed traffic.
+If the peer sent the disable_active_migration transport parameter, an endpoint
+also MUST NOT send packets (including probing packets; see {{probing}}) from a
+different local address to the address the peer used during the handshake. An
+endpoint which has sent this transport parameter, but detects that a peer has
+nonetheless migrated to a different network MUST either drop the incoming
+packets on that path without generating a stateless reset or proceed with path
+validation and allow the peer to migrate. Generating a stateless reset or
+closing the connection would allow third parties in the network to cause
+connections to close by spoofing or otherwise manipulating observed traffic.
 
 Not all changes of peer address are intentional, or active, migrations. The peer
 could experience NAT rebinding: a change of address due to a middlebox, usually
@@ -4875,10 +4874,10 @@ disable_active_migration (0x0c):
 
 : The disable active migration transport parameter is included if the endpoint
   does not support active connection migration ({{migration}}) on the address
-  being used during the handshake.  Peers of an endpoint that sets this
-  transport parameter MUST NOT send any packets, including probing packets
-  ({{probing}}), from a local address or port other than that used to perform
-  the handshake. This parameter is a zero-length value.
+  being used during the handshake.  When a peer sets this transport parameter,
+  the recipient MUST NOT send any packets to the address the peer used to
+  perform the handshake from a local address or port other than that used to
+  perform the handshake.  This parameter is a zero-length value.
 
 preferred_address (0x0d):
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1229,9 +1229,11 @@ when a client's address changes.
   transport parameter to request that clients move connections to that dedicated
   address. Note that clients could choose not to use the preferred address.
 
-A server in a deployment that does not implement a solution to
-maintain connection continuity during connection migration
-SHOULD disallow migration using the disable_active_migration transport
+A server in a deployment that does not implement a solution to maintain
+connection continuity during connection migration SHOULD disallow migration
+using the disable_active_migration transport parameter.  The
+disable_active_migration transport parameter does not prohibit subsequent
+connection migration after a client has acted on the preferred_address transport
 parameter.
 
 Server deployments that use this simple form of load balancing MUST avoid the
@@ -4872,11 +4874,11 @@ max_ack_delay (0x0b):
 disable_active_migration (0x0c):
 
 : The disable active migration transport parameter is included if the endpoint
-  does not support active connection migration ({{migration}}). Peers of an
-  endpoint that sets this transport parameter MUST NOT send any packets,
-  including probing packets ({{probing}}), from a local address or port other
-  than that used to perform the handshake.  This parameter is a zero-length
-  value.
+  does not support active connection migration ({{migration}}) on the address
+  being used during the handshake.  Peers of an endpoint that sets this
+  transport parameter MUST NOT send any packets, including probing packets
+  ({{probing}}), from a local address or port other than that used to perform
+  the handshake. This parameter is a zero-length value.
 
 preferred_address (0x0d):
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1230,9 +1230,9 @@ when a client's address changes.
   address. Note that clients could choose not to use the preferred address.
 
 A server in a deployment that does not implement a solution to maintain
-connection continuity during connection migration SHOULD disallow migration
+connection continuity when the client address changes SHOULD indicate migration is not supported
 using the disable_active_migration transport parameter.  The
-disable_active_migration transport parameter does not prohibit subsequent
+disable_active_migration transport parameter does not prohibit
 connection migration after a client has acted on the preferred_address transport
 parameter.
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1233,7 +1233,7 @@ A server in a deployment that does not implement a solution to maintain
 connection continuity when the client address changes SHOULD indicate migration
 is not supported using the disable_active_migration transport parameter.  The
 disable_active_migration transport parameter does not prohibit connection
-migration after a client has acted on the preferred_address transport parameter.
+migration after a client has acted on a preferred_address transport parameter.
 
 Server deployments that use this simple form of load balancing MUST avoid the
 creation of a stateless reset oracle; see {{reset-oracle}}.
@@ -2154,8 +2154,8 @@ before the handshake is confirmed, as defined in section 4.1.2 of {{QUIC-TLS}}.
 If the peer sent the disable_active_migration transport parameter, an endpoint
 also MUST NOT send packets (including probing packets; see {{probing}}) from a
 different local address to the address the peer used during the handshake. An
-endpoint which has sent this transport parameter, but detects that a peer has
-nonetheless migrated to a different network MUST either drop the incoming
+endpoint that has sent this transport parameter, but detects that a peer has
+nonetheless migrated to a different remote address MUST either drop the incoming
 packets on that path without generating a stateless reset or proceed with path
 validation and allow the peer to migrate. Generating a stateless reset or
 closing the connection would allow third parties in the network to cause
@@ -4875,9 +4875,8 @@ disable_active_migration (0x0c):
 : The disable active migration transport parameter is included if the endpoint
   does not support active connection migration ({{migration}}) on the address
   being used during the handshake.  When a peer sets this transport parameter,
-  the recipient MUST NOT send any packets to the address the peer used to
-  perform the handshake from a local address or port other than that used to
-  perform the handshake.  This parameter is a zero-length value.
+  an endpoint MUST NOT use a new local address when sending to the address
+  that the peer used during the handshake.  This parameter is a zero-length value.
 
 preferred_address (0x0d):
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4875,8 +4875,10 @@ disable_active_migration (0x0c):
 : The disable active migration transport parameter is included if the endpoint
   does not support active connection migration ({{migration}}) on the address
   being used during the handshake.  When a peer sets this transport parameter,
-  an endpoint MUST NOT use a new local address when sending to the address
-  that the peer used during the handshake.  This parameter is a zero-length value.
+  an endpoint MUST NOT use a new local address when sending to the address that
+  the peer used during the handshake.  This transport parameter does not
+  prohibit connection migration after a client has acted on a preferred_address
+  transport parameter.  This parameter is a zero-length value.
 
 preferred_address (0x0d):
 


### PR DESCRIPTION
Following on @janaiyengar's insight that disable_active_migration is a property of an address, not a peer, we simply need to say which address the TP applies to.

This PR fixes #3608 by scoping the definition of disable_active_migration to the handshake address only.  This means that existing clients remain fully compliant, albeit slightly more conservative than necessary.

While I find @kazuho's argument convincing that a server capable of using SPA is highly unlikely to be unable to handle migration, it would be trivial for a future extension to define an additional transport parameter carrying two bits that disable active migration for those addresses as well.