### PR TITLE
Split PTO calculation into a dedicated method

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1281,7 +1281,7 @@ GetLossTimeAndSpace():
 GetPtoTimeAndSpace():
   duration = (smoothed_rtt + max(4 * rttvar, kGranularity))
       * (2 ^ pto_count)
-  # Arm PTO from now when there are no inflight packets
+  // Arm PTO from now when there are no inflight packets.
   if (no in-flight packets):
     assert(!PeerCompletedAddressValidation())
     if (has handshake keys):
@@ -1293,11 +1293,11 @@ GetPtoTimeAndSpace():
   for space in [ Initial, Handshake, ApplicationData ]:
     if (no in-flight packets in space):
         continue;
-    if space == ApplicationData:
+    if (space == ApplicationData):
       // Skip ApplicationData until handshake complete.
       if (handshake is not complete):
         return pto_timeout, pto_space
-      // ApplicationData include the max_ack_delay in PTO.
+      // Include max_ack_delay and backoff for ApplicationData.
       duration += max_ack_delay * (2 ^ pto_count)
 
     t = time_of_last_ack_eliciting_packet[space] + duration

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1283,7 +1283,7 @@ GetPtoTimeAndSpace():
       max(4 * rttvar, kGranularity) * (2 ^ pto_count)
   # Arm PTO from now when there are no inflight packets
   if (no in-flight packets):
-    return now() + duration, Initial
+    return (now() + duration), Initial
   timeout = infinite
   pn_space = Initial
   for space in [ Initial, Handshake, ApplicationData ]:
@@ -1296,10 +1296,9 @@ GetPtoTimeAndSpace():
       // ApplicationData include the max_ack_delay in PTO.
       duration += max_ack_delay * (2 ^ pto_count)
 
-    if (timeout >
-          time_of_last_ack_eliciting_packet[space] + duration):
-      timeout =
-          time_of_last_ack_eliciting_packet[space] + duration
+    t = time_of_last_ack_eliciting_packet[space] + duration
+    if (t < timeout):
+      timeout = t
       pn_space = space
   return timeout, space
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1110,7 +1110,7 @@ loss_detection_timer:
 pto_count:
 : The number of times a PTO has been sent without receiving an ack.
 
-time_of_last_sent_ack_eliciting_packet\[kPacketNumberSpace]:
+time_of_last_ack_eliciting_packet\[kPacketNumberSpace]:
 : The time the most recent ack-eliciting packet was sent.
 
 largest_acked_packet\[kPacketNumberSpace]:
@@ -1140,7 +1140,7 @@ follows:
    max_ack_delay = 0
    for pn_space in [ Initial, Handshake, ApplicationData ]:
      largest_acked_packet[pn_space] = infinite
-     time_of_last_sent_ack_eliciting_packet[pn_space] = 0
+     time_of_last_ack_eliciting_packet[pn_space] = 0
      loss_time[pn_space] = 0
 ~~~
 
@@ -1163,7 +1163,7 @@ Pseudocode for OnPacketSent follows:
    sent_packets[pn_space][packet_number].in_flight = in_flight
    if (in_flight):
      if (ack_eliciting):
-       time_of_last_sent_ack_eliciting_packet[pn_space] = now()
+       time_of_last_ack_eliciting_packet[pn_space] = now()
      OnPacketSentCC(sent_bytes)
      sent_packets[pn_space][packet_number].size = sent_bytes
      SetLossDetectionTimer()
@@ -1290,16 +1290,16 @@ GetPtoTimeAndSpace():
     if (no in-flight packets in space):
         continue;
     if space == ApplicationData:
-      // Don't arm PTO for ApplicationData until handshake complete.
+      // Skip ApplicationData until handshake complete.
       if (handshake is not complete):
         return timeout, pn_space
       // ApplicationData include the max_ack_delay in PTO.
       duration += max_ack_delay * (2 ^ pto_count)
 
     if (timeout >
-          time_of_last_sent_ack_eliciting_packet[space] + duration):
+          time_of_last_ack_eliciting_packet[space] + duration):
       timeout =
-          time_of_last_sent_ack_eliciting_packet[space] + duration
+          time_of_last_ack_eliciting_packet[space] + duration
       pn_space = space
   return timeout, space
 
@@ -1616,7 +1616,7 @@ OnPacketNumberSpaceDiscarded(pn_space):
       bytes_in_flight -= size
   sent_packets[pn_space].clear()
   // Reset the loss detection and PTO timer
-  time_of_last_sent_ack_eliciting_packet[kPacketNumberSpace] = 0
+  time_of_last_ack_eliciting_packet[kPacketNumberSpace] = 0
   loss_time[pn_space] = 0
   pto_count = 0
   SetLossDetectionTimer()

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1284,23 +1284,23 @@ GetPtoTimeAndSpace():
   # Arm PTO from now when there are no inflight packets
   if (no in-flight packets):
     return (now() + duration), Initial
-  timeout = infinite
-  pn_space = Initial
+  pto_timeout = infinite
+  pto_space = Initial
   for space in [ Initial, Handshake, ApplicationData ]:
     if (no in-flight packets in space):
         continue;
     if space == ApplicationData:
       // Skip ApplicationData until handshake complete.
       if (handshake is not complete):
-        return timeout, pn_space
+        return pto_timeout, pto_space
       // ApplicationData include the max_ack_delay in PTO.
       duration += max_ack_delay * (2 ^ pto_count)
 
     t = time_of_last_ack_eliciting_packet[space] + duration
-    if (t < timeout):
-      timeout = t
-      pn_space = space
-  return timeout, space
+    if (t < pto_timeout):
+      pto_timeout = t
+      pto_space = space
+  return pto_timeout, pto_space
 
 PeerCompletedAddressValidation():
   # Assume clients validate the server's address implicitly.

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1279,11 +1279,14 @@ GetLossTimeAndSpace():
   return time, space
 
 GetPtoTimeAndSpace():
-  duration = smoothed_rtt +
-      max(4 * rttvar, kGranularity) * (2 ^ pto_count)
+  duration = (smoothed_rtt + max(4 * rttvar, kGranularity))
+      * (2 ^ pto_count)
   # Arm PTO from now when there are no inflight packets
   if (no in-flight packets):
-    return (now() + duration), Initial
+    if (has handshake keys):
+      return (now() + duration), Handshake
+    else:
+      return (now() + duration), Initial
   pto_timeout = infinite
   pto_space = Initial
   for space in [ Initial, Handshake, ApplicationData ]:

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1280,8 +1280,10 @@ GetLossTimeAndSpace():
 
 GetPtoTimeAndSpace():
   duration = smoothed_rtt + max(4 * rttvar, kGranularity) * (2 ^ pto_count)
-  # Set PTO time for the case there are no inflight packets
-  timeout = now() + duration
+  # Arm PTO from now when there are no inflight packets
+  if (no in-flight packets):
+    return now() + duration, Initial
+  timeout = infinite
   pn_space = Initial
   for space in [ Initial, Handshake, ApplicationData ]:
     if (no in-flight packets in space):
@@ -1292,11 +1294,11 @@ GetPtoTimeAndSpace():
         return timeout, pn_space
       // ApplicationData include the max_ack_delay in PTO.
       duration += max_ack_delay * (2 ^ pto_count)
-    
-    if timeout > time_of_last_sent_ack_eliciting_packet[space] + duration
+
+    if (timeout > time_of_last_sent_ack_eliciting_packet[space] + duration):
       timeout = time_of_last_sent_ack_eliciting_packet[space] + duration
       pn_space = space
-  return timeout, space    
+  return timeout, space 
 
 PeerCompletedAddressValidation():
   # Assume clients validate the server's address implicitly.

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1283,6 +1283,7 @@ GetPtoTimeAndSpace():
       * (2 ^ pto_count)
   # Arm PTO from now when there are no inflight packets
   if (no in-flight packets):
+    assert(!PeerCompletedAddressValidation())
     if (has handshake keys):
       return (now() + duration), Handshake
     else:

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1274,7 +1274,7 @@ GetLossTimeAndSpace():
   space = Initial
   for pn_space in [ Handshake, ApplicationData ]:
     if (time == 0 || loss_time[pn_space] < time):
-      time = times[pn_space];
+      time = loss_times[pn_space];
       space = pn_space
   return time, space
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1279,7 +1279,8 @@ GetLossTimeAndSpace():
   return time, space
 
 GetPtoTimeAndSpace():
-  duration = smoothed_rtt + max(4 * rttvar, kGranularity) * (2 ^ pto_count)
+  duration = smoothed_rtt +
+      max(4 * rttvar, kGranularity) * (2 ^ pto_count)
   # Arm PTO from now when there are no inflight packets
   if (no in-flight packets):
     return now() + duration, Initial
@@ -1295,10 +1296,12 @@ GetPtoTimeAndSpace():
       // ApplicationData include the max_ack_delay in PTO.
       duration += max_ack_delay * (2 ^ pto_count)
 
-    if (timeout > time_of_last_sent_ack_eliciting_packet[space] + duration):
-      timeout = time_of_last_sent_ack_eliciting_packet[space] + duration
+    if (timeout >
+          time_of_last_sent_ack_eliciting_packet[space] + duration):
+      timeout =
+          time_of_last_sent_ack_eliciting_packet[space] + duration
       pn_space = space
-  return timeout, space 
+  return timeout, space
 
 PeerCompletedAddressValidation():
   # Assume clients validate the server's address implicitly.

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1274,7 +1274,7 @@ GetLossTimeAndSpace():
   space = Initial
   for pn_space in [ Handshake, ApplicationData ]:
     if (time == 0 || loss_time[pn_space] < time):
-      time = loss_times[pn_space];
+      time = loss_time[pn_space];
       space = pn_space
   return time, space
 


### PR DESCRIPTION
As @martinthomson pointed out in #3666, it was far too complex and error-prone as-is.

Fixes #3564 and #3674 by calculating the PTO timeout for each PN space and picking the earliest, as well as checking that there are inflight packets before calculating PTO for a PN space.