### PR TITLE
Add an example of a variable-length integer field

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -281,6 +281,7 @@ For example:
 Example Structure {
   One-bit Field (1),
   7-bit Field with Fixed Value (7) = 61,
+  Field with Variable-Length Intgeger (i),
   Arbitrary-Length Field (..),
   Variable-Length Field (8..24),
   Field With Minimum Length (16..),


### PR DESCRIPTION
The notations didn't have one of these previously, but were otherwise
thorough.  Might as well do that.