### PR TITLE
Improve HTTP draft wording: frames carry identifier values

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -954,7 +954,7 @@ might have acted on.
 A client that is unable to retry requests loses all requests that are in flight
 when the server closes the connection.  An endpoint MAY send multiple GOAWAY
 frames indicating different identifiers, but MUST NOT increase the identifier
-value they send, since clients might already have retried unprocessed requests
+value they carry, since clients might already have retried unprocessed requests
 on another connection.
 
 An endpoint that is attempting to gracefully shut down a connection can send a

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -953,7 +953,7 @@ might have acted on.
 
 A client that is unable to retry requests loses all requests that are in flight
 when the server closes the connection.  An endpoint MAY send multiple GOAWAY
-frames indicating different identifiers, but MUST NOT increase the identifier
+frames indicating different identifiers, but the identifier in each frame
 value they carry, since clients might already have retried unprocessed requests
 on another connection.
 

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -954,8 +954,8 @@ might have acted on.
 A client that is unable to retry requests loses all requests that are in flight
 when the server closes the connection.  An endpoint MAY send multiple GOAWAY
 frames indicating different identifiers, but the identifier in each frame
-value they carry, since clients might already have retried unprocessed requests
-on another connection.
+MUST NOT be greater than the identifier in any previous frame, since clients
+might already have retried unprocessed requests on another connection.
 
 An endpoint that is attempting to gracefully shut down a connection can send a
 GOAWAY frame with a value set to the maximum possible value (2^62-4 for servers,


### PR DESCRIPTION
The endpoint sends frames, which *carry* -- not send -- identifier values.