### PR TITLE
use TRANSPORT_PARAMETER_ERROR when authenticating connection IDs

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1593,14 +1593,14 @@ TRANSPORT_PARAMETER_ERROR:
 * absence of the original_destination_connection_id transport parameter from
   the server,
 
+An endpoint MUST treat the following as a connection error of type
+PROTOCOL_VIOLATION:
+
 * absence of the retry_source_connection_id transport parameter from the server
   after receiving a Retry packet,
 
 * presence of the retry_source_connection_id transport parameter when no Retry
   packet was received.
-
-An endpoint MUST treat the following as a connection error of type
-PROTOCOL_VIOLATION:
 
 * a mismatch between values received from a peer in these transport parameters
   and the value sent in the corresponding Destination or Source Connection ID

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1584,7 +1584,8 @@ of Initial packets that it sent. Including connection ID values in transport
 parameters and verifying them ensures that that an attacker cannot influence
 the choice of connection ID for a successful connection by injecting packets
 carrying attacker-chosen connection IDs during the handshake. An endpoint MUST
-treat any of the following as a connection error of type PROTOCOL_VIOLATION:
+treat any of the following as a connection error of type
+TRANSPORT_PARAMETER_ERROR:
 
 * absence of the initial_source_connection_id transport parameter from either
   endpoint,
@@ -1596,7 +1597,10 @@ treat any of the following as a connection error of type PROTOCOL_VIOLATION:
   after receiving a Retry packet,
 
 * presence of the retry_source_connection_id transport parameter when no Retry
-  packet was received, or
+  packet was received.
+
+An endpoint MUST treat the following as a connection error of type
+PROTOCOL_VIOLATION:
 
 * a mismatch between values received from a peer in these transport parameters
   and the value sent in the corresponding Destination or Source Connection ID

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1591,13 +1591,13 @@ original_destination_connection_id transport parameter from the server as a
 connection error of type TRANSPORT_PARAMETER_ERROR.
 
 An endpoint MUST treat the following as a connection error of type
-PROTOCOL_VIOLATION:
+TRANSPORT_PARAMETER_ERROR or PROTOCOL_VIOLATION:
 
 * absence of the retry_source_connection_id transport parameter from the server
   after receiving a Retry packet,
 
 * presence of the retry_source_connection_id transport parameter when no Retry
-  packet was received.
+  packet was received, or
 
 * a mismatch between values received from a peer in these transport parameters
   and the value sent in the corresponding Destination or Source Connection ID


### PR DESCRIPTION
Fixes #3703.

As discussed in https://github.com/quicwg/base-drafts/pull/3499/files#r422775281, most of the errors that can occur when authenticating connection IDs should be TRANSPORT_PARAMETER_ERRORs, not PROTOCOL_VIOLATIONs.