### PR TITLE
A suggested text about a push stream after a CANCEL_PUSH

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1292,9 +1292,10 @@ corresponding promise to be fulfilled.
 Sending CANCEL_PUSH has no direct effect on the state of existing push streams.
 A server SHOULD NOT send a CANCEL_PUSH when it has already created a
 corresponding push stream, and a client SHOULD NOT send a CANCEL_PUSH when it
-has already received a corresponding push stream.  If a push stream arrives
-after a client has sent CANCEL_PUSH, this MAY be treated as a stream error of
-type H3_STREAM_CREATION_ERROR.
+has already received a corresponding push stream. A push stream may arrive
+after a client has sent CANCEL_PUSH, because a server may have not yet processed
+the CANCEL_PUSH. The client SHOULD abort reading the stream with an error code
+of H3_REQUEST_CANCELLED.
 
 A CANCEL_PUSH frame is sent on the control stream.  Receiving a CANCEL_PUSH
 frame on a stream other than the control stream MUST be treated as a connection


### PR DESCRIPTION
I found this while reading the draft. I think the text is a bit misleading. The current test suggests that this is a server error, but it may not be a server error:

> If a push stream arrives after a client has sent CANCEL_PUSH, this MAY be treated as a stream error of type H3_STREAM_CREATION_ERROR.

This PR is just a propose text that make this more clear and changes the error code.