### PR TITLE
DPLPMTU merge tweaks

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3808,6 +3808,13 @@ across a network path using a single packet. Any maximum packet size larger than
 (PMTUD; see {{pmtud}}) or Datagram Packetization Layer PMTU Discovery (DPLPMTUD;
 see {{dplpmtud}}).
 
+Enforcement of the max_udp_payload_size transport parameter
+({{transport-parameter-definitions}}) might act as an additional limit on the
+maximum packet size. A sender can avoid exceeding this limit, once the value is
+known.  However, prior to learning the value of the transport parameter,
+endpoints risk datagrams being lost if they send packets larger than the
+smallest allowed maximum packet size of 1200 bytes.
+
 A client MUST expand the payload of all UDP datagrams carrying Initial packets
 to at least the smallest allowed maximum packet size (1200 bytes) by adding
 PADDING frames to the Initial packet or by coalescing the Initial packet; see
@@ -3817,13 +3824,6 @@ Transmission Unit (PMTU).  This also helps reduce the amplitude of amplification
 attacks caused by server responses toward an unverified client address; see
 {{address-validation}}.
 
-Enforcement of the max_udp_payload_size transport parameter
-({{transport-parameter-definitions}}) might act as an additional limit on the
-maximum packet size. A sender can avoid exceeding this limit, once the value is
-known.  However, prior to learning the value of the transport parameter,
-endpoints risk datagrams being lost if they send packets larger than the
-smallest allowed maximum packet size of 1200 bytes.
-
 Datagrams containing Initial packets MAY exceed 1200 bytes if the client
 believes that the network path and peer both support the size that it chooses.
 
@@ -3831,7 +3831,7 @@ UDP datagrams MUST NOT be fragmented at the IP layer.  In IPv4
 {{!IPv4=RFC0791}}, the DF bit MUST be set to prevent fragmentation on the path.
 
 A server MUST discard an Initial packet that is carried in a UDP datagram with a
-payload that is less than the smallest allowed maximum packet size  of 1200
+payload that is less than the smallest allowed maximum packet size of 1200
 bytes.  A server MAY also immediately close the connection by sending a
 CONNECTION_CLOSE frame with an error code of PROTOCOL_VIOLATION; see
 {{immediate-close-hs}}.
@@ -3852,7 +3852,7 @@ referred to as the endpoint's maximum packet size.
 An endpoint SHOULD use DPLPMTUD ({{dplpmtud}}) or PMTUD ({{pmtud}}) to determine
 whether the path to a destination will support a desired message size without
 fragmentation.  In the absence of these mechanisms, QUIC endpoints SHOULD NOT
-send IP packets larger than the minimum QUIC packet size.
+send IP packets larger than the smallest allowed maximum packet size.
 
 Both DPLPMTUD and PMTUD send IP packets that are larger than the current maximum
 packet size.  We refer to these as PMTU probes.  All QUIC packets that are not
@@ -3862,8 +3862,8 @@ avoid the packet being fragmented or dropped {{?RFC8085}}.
 If a QUIC endpoint determines that the PMTU between any pair of local and remote
 IP addresses has fallen below the smallest allowed maximum packet size of 1200
 bytes, it MUST immediately cease sending QUIC packets, except for those in PMTU
-probes, on the affected path.  An endpoint MAY terminate the connection if an
-alternative path cannot be found.
+probes or those containing CONNECTION_CLOSE frames, on the affected path.  An
+endpoint MAY terminate the connection if an alternative path cannot be found.
 
 Each pair of local and remote addresses could have a different PMTU.  QUIC
 implementations that implement any kind of PMTU discovery therefore SHOULD
@@ -3921,12 +3921,6 @@ MIN_PLPMTU is the same as the BASE_PMTU.
 
 QUIC endpoints implementing DPLPMTUD maintain a maximum packet size (DPLPMTUD
 MPS) for each combination of local and remote IP addresses.
-
-If a QUIC endpoint determines that the PLPMTU between any pair of local and
-remote IP addresses has fallen below the size needed to support the minimum QUIC
-packet size (BASE_PLPMTU), it MUST immediately cease sending QUIC packets on the
-affected path. An endpoint MAY terminate the connection if an alternative path
-cannot be found.
 
 
 ### DPLPMTUD and Initial Connectivity

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3804,7 +3804,7 @@ packet size of 1232 bytes for IPv6 and 1252 bytes for IPv4.
 
 The QUIC maximum packet size is the largest size of QUIC packet that can be sent
 across a network path using a single packet. Any maximum packet size larger than
-1200 bytes is discovered using PMTUD/DPLPMTUD.
+1200 bytes can be discovered using PMTUD/DPLPMTUD.
 
 A client MUST expand the payload of all UDP datagrams carrying Initial packets
 to at least the smallest allowed maximum packet size (1200 bytes)
@@ -3931,7 +3931,7 @@ when the QUIC connection handshake has been completed.
 ### Sending QUIC DPLPMTUD Probe Packets
 
 DPLPMTU probe packets are ack-eliciting packets.  Probe packets that use the
-PADDING frame therefore implement "Probing using padding data", as defined in
+PADDING frame implement "Probing using padding data", as defined in
 Section 4.1 of {{!DPLPMTUD}}.  Endpoints could limit the content of probe
 packets to PING and PADDING frames as packets that are larger than the current
 maximum packet size are more likely to be dropped by the network.
@@ -3943,7 +3943,8 @@ transmission by an application.
 ### Validating the QUIC Path with DPLPMTUD
 
 QUIC provides an acknowledged PL, therefore a sender does not implement the
-DPLPMTUD CONFIRMATION_TIMER while in the SEARCH_COMPLETE state.
+DPLPMTUD CONFIRMATION_TIMER while in the SEARCH_COMPLETE state; see Section
+5.2 of {{!DPLPMTUD}}.
 
 
 ### Handling of ICMP Messages by DPLPMTUD

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3916,9 +3916,9 @@ MPS) for each combination of local and remote IP addresses.
 
 If a QUIC endpoint determines that the PLPMTU between any pair of local and
 remote IP addresses has fallen below the size needed to support the minimum QUIC
-packet size (BASE_PLPMTU), it MUST immediately cease sending QUIC packets,
-except for DPLPMTUD probe packets, on the affected path. An endpoint MAY
-terminate the connection if an alternative path cannot be found.
+packet size (BASE_PLPMTU), it MUST immediately cease sending QUIC packets on the
+affected path. An endpoint MAY terminate the connection if an alternative path
+cannot be found.
 
 
 ### DPLPMTUD and Initial Connectivity

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3879,7 +3879,7 @@ attacks that successfully guess the addresses used on the path and reduce the
 PMTU to a bandwidth-inefficient value.
 
 An endpoint MUST ignore an ICMP message that claims the PMTU has decreased below
-the minimum QUIC packet size bytes.
+the minimum QUIC packet size.
 
 The requirements for generating ICMP ({{?RFC1812}}, {{?RFC4443}}) state that the
 quoted packet should contain as much of the original packet as possible without

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3959,7 +3959,8 @@ In addition to UDP Port
 validation, QUIC validates an ICMP message by using other PL
 information (e.g., validation of connection identifiers (CIDs) in the
 quoted packet of any received ICMP message). 
-The further considerations for processing ICMP messages described in the previous section also
+
+The considerations for processing ICMP messages described in {{icmp-pmtud}} also
 apply if these messages are used by DPLPMTUD.
 
 ## PMTUD/DPLPMTUD Probes Containing Source Connection ID {#pmtu-probes-src-cid}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3804,7 +3804,7 @@ Assuming the minimum IP header size, this results in a
 QUIC maximum packet size of 1232 bytes for IPv6 and 1252 bytes for IPv4. 
 
 A client MUST expand the payload of all UDP datagrams carrying Initial packets
-to at least the minimum QUIC packet size, by adding PADDING frames to the Initial packet or by
+to at least 1200 bytes, by adding PADDING frames to the Initial packet or by
 coalescing the Initial packet; see {{packet-coalesce}}.  Sending a UDP datagram
 of this size ensures that the network path from the client to the server
 supports a reasonable Path Maximum Transmission Unit (PMTU).  Padding datagrams also

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3797,25 +3797,24 @@ later time in the connection.
 The QUIC packet size includes the QUIC header and protected payload, but not the
 UDP or IP header.
 
-QUIC depends upon a minimum packet size of at least 1280 bytes.
-This is the IPv6 minimum size
-{{?RFC8200}} and is also supported by most modern IPv4 networks.
-Assuming the minimum IP header size, this results in a
-QUIC maximum packet size of 1232 bytes for IPv6 and 1252 bytes for IPv4. 
+QUIC depends upon a minimum packet size of at least 1280 bytes.  This is the
+IPv6 minimum size {{?RFC8200}} and is also supported by most modern IPv4
+networks.  Assuming the minimum IP header size, this results in a QUIC maximum
+packet size of 1232 bytes for IPv6 and 1252 bytes for IPv4.
 
 A client MUST expand the payload of all UDP datagrams carrying Initial packets
 to at least 1200 bytes, by adding PADDING frames to the Initial packet or by
 coalescing the Initial packet; see {{packet-coalesce}}.  Sending a UDP datagram
 of this size ensures that the network path from the client to the server
-supports a reasonable Path Maximum Transmission Unit (PMTU).  Padding datagrams also
-helps reduce the amplitude of amplification attacks caused by server responses
-toward an unverified client address; see {{address-validation}}.
+supports a reasonable Path Maximum Transmission Unit (PMTU).  Padding datagrams
+also helps reduce the amplitude of amplification attacks caused by server
+responses toward an unverified client address; see {{address-validation}}.
 
 Enforcement of the max_udp_payload_size transport parameter
-({{transport-parameter-definitions}}) might act as an additional limit on
-the maximum packet size. A sender can avoid exceeding this limit, once the value is known.
-However, prior to learning the value of the transport parameter, endpoints risk
-datagrams being lost if they send packets larger than 1200 bytes.
+({{transport-parameter-definitions}}) might act as an additional limit on the
+maximum packet size. A sender can avoid exceeding this limit, once the value is
+known.  However, prior to learning the value of the transport parameter,
+endpoints risk datagrams being lost if they send packets larger than 1200 bytes.
 
 Datagrams containing Initial packets MAY exceed 1200 bytes if the client
 believes that the network path and peer both support the size that it chooses.
@@ -3844,37 +3843,35 @@ referred to as the endpoint's maximum packet size.
 An endpoint SHOULD use Datagram Packetization Layer PMTU Discovery
 ({{!DPLPMTUD=I-D.ietf-tsvwg-datagram-plpmtud}}) or implement Path MTU Discovery
 (PMTUD) {{!RFC1191}} {{!RFC8201}} to determine whether the path to a destination
-will support a desired message size without fragmentation.
-In the absence of these mechanisms, QUIC endpoints SHOULD NOT send IP packets
-larger than the minimum QUIC packet size. 
+will support a desired message size without fragmentation.  In the absence of
+these mechanisms, QUIC endpoints SHOULD NOT send IP packets
+larger than the minimum QUIC packet size.
 
-All QUIC
-packets other than PMTUD/DPLPMTUD probe packets SHOULD be sized to fit within the
-maximum packet size to avoid the packet being fragmented or dropped
+All QUIC packets other than PMTUD/DPLPMTUD probe packets SHOULD be sized to fit
+within the maximum packet size to avoid the packet being fragmented or dropped
 {{?RFC8085}}.
 
 If a QUIC endpoint determines that the PMTU between any pair of local and remote
-IP addresses has fallen below the smallest allowed maximum packet size, it MUST immediately 
-cease sending QUIC packets, except for
-PMTUD or DPLPMTUD probe packets, on the affected path.  An endpoint MAY terminate the
-connection if an alternative path cannot be found.
+IP addresses has fallen below the smallest allowed maximum packet size, it MUST
+immediately cease sending QUIC packets, except for PMTUD or DPLPMTUD probe
+packets, on the affected path.  An endpoint MAY terminate the connection if an
+alternative path cannot be found.
 
 Each pair of local and remote addresses could have a different PMTU.  QUIC
 implementations that implement any kind of PMTU discovery therefore SHOULD
 maintain a maximum packet size for each combination of local and remote IP
 addresses.
 
-A QUIC
-implementation MAY be more conservative in computing the maximum packet
+A QUIC implementation MAY be more conservative in computing the maximum packet
 size to allow for unknown tunnel overheads or IP header options/extensions.
 
 
 ### Handling of ICMP Messages by PMTUD {#icmp-pmtud}
 
-PMTUD {{!RFC1191}} {{!RFC8201}} relies on reception of ICMP messages
-(e.g., IPv6 Packet Too Big messages) that indicate when a packet is dropped
-because it is larger than the local router MTU. DPLPMTUD can also optionally use
-these messages.  This use of ICMP messages is potentially vulnerable to off-path
+PMTUD {{!RFC1191}} {{!RFC8201}} relies on reception of ICMP messages (e.g., IPv6
+Packet Too Big messages) that indicate when a packet is dropped because it is
+larger than the local router MTU. DPLPMTUD can also optionally use these
+messages.  This use of ICMP messages is potentially vulnerable to off-path
 attacks that successfully guess the addresses used on the path and reduce the
 PMTU to a bandwidth-inefficient value.
 
@@ -3887,18 +3884,20 @@ exceeding the minimum MTU for the IP version.  The size of the quoted packet can
 actually be smaller, or the information unintelligible, as described in Section
 1.1 of {{!DPLPMTUD}}.
 
-QUIC endpoints using PMTUD SHOULD validate ICMP messages to protect from off-path injection
-as specified in {{!RFC8201}} and Section 5.2 of {{!RFC8085}}. This validation
-SHOULD use the quoted packet supplied in the payload of an ICMP message to
-associate the message with a corresponding transport connection (see Section 4.6.1 of {{!DPLPMTUD}}).
-ICMP message validation MUST include matching IP addresses and UDP ports
-{{!RFC8085}} and, when possible, connection IDs to an active QUIC session.
-The endpoint SHOULD ignore all ICMP messages that fail validation.
+QUIC endpoints using PMTUD SHOULD validate ICMP messages to protect from
+off-path injection as specified in {{!RFC8201}} and Section 5.2 of {{!RFC8085}}.
+This validation SHOULD use the quoted packet supplied in the payload of an ICMP
+message to associate the message with a corresponding transport connection (see
+Section 4.6.1 of {{!DPLPMTUD}}).  ICMP message validation MUST include matching
+IP addresses and UDP ports {{!RFC8085}} and, when possible, connection IDs to an
+active QUIC session.  The endpoint SHOULD ignore all ICMP messages that fail
+validation.
 
 An endpoint MUST NOT increase PMTU based on ICMP messages; see Section 3, clause
 6 of {{!DPLPMTUD}}.  Any reduction in the QUIC maximum packet size in response
 to ICMP messages MAY be provisional until QUIC's loss detection algorithm
 determines that the quoted packet has actually been lost.
+
 
 ### PMTUD Probes with Handshake packets
 
@@ -3911,67 +3910,69 @@ first part of the datagram will be quoted in that message.  If the source
 connection ID is within the quoted portion of the UDP datagram, that could be
 used for routing.
 
+
 ## Datagram Packetization Layer PMTU Discovery
 
-When implementing the algorithm in Section 5 of {{!DPLPMTUD}}, the
-initial value of BASE_PMTU SHOULD be consistent with the minimum QUIC
-packet size. The MIN_PLPMTU is the same as the BASE_PMTU.
+When implementing the algorithm in Section 5 of {{!DPLPMTUD}}, the initial value
+of BASE_PMTU SHOULD be consistent with the minimum QUIC packet size. The
+MIN_PLPMTU is the same as the BASE_PMTU.
 
-QUIC endpoints implementing DPLPMTUD maintain a maximum packet size 
-(DPLPMTUD MPS) for each combination of local and remote IP
-addresses.
+QUIC endpoints implementing DPLPMTUD maintain a maximum packet size (DPLPMTUD
+MPS) for each combination of local and remote IP addresses.
 
-If a QUIC endpoint determines that the PLPMTU between any pair of local
-and remote IP addresses has fallen below the size needed to support
-the minimum QUIC packet size (BASE_PLPMTU), it MUST immediately cease
-sending QUIC packets, except for DPLPMTUD probe packets, on the affected
-path. An endpoint MAY terminate the connection if an alternative
-path cannot be found.
+If a QUIC endpoint determines that the PLPMTU between any pair of local and
+remote IP addresses has fallen below the size needed to support the minimum QUIC
+packet size (BASE_PLPMTU), it MUST immediately cease sending QUIC packets,
+except for DPLPMTUD probe packets, on the affected path. An endpoint MAY
+terminate the connection if an alternative path cannot be found.
 
-###  DPLPMTUD and Initial Connectivity
 
-From the perspective of DPLPMTUD, QUIC transport is an 
-acknowledged packetization layer (PL). A sender can therefore enter the DPLPMTUD BASE
-state when the QUIC connection handshake has been completed and
-the endpoint has established a 1-RTT key.
+### DPLPMTUD and Initial Connectivity
 
-###  Sending QUIC DPLPMTUD Probe Packets
+From the perspective of DPLPMTUD, QUIC transport is an acknowledged
+packetization layer (PL). A sender can therefore enter the DPLPMTUD BASE state
+when the QUIC connection handshake has been completed and the endpoint has
+established a 1-RTT key.
+
+
+### Sending QUIC DPLPMTUD Probe Packets
 
 DPLPMTU probe packets are ack-eliciting packets.  Probe packets that use the
 PADDING frame therefore implement "Probing using padding data", as defined in
-Section 4.1 of {{!DPLPMTUD}}.
-These can be generated without affecting the transfer of other QUIC frames.
-The PING Frame is used to trigger generation of an acknowledgement.
-Multiple PADDING Frames are used together to control the length of the probe packet.  
-These frames might not be retransmitted if a probe packet containing
-them is lost.  The frames consume congestion window,
-which could delay subsequent transmission by an application.
+Section 4.1 of {{!DPLPMTUD}}.  These can be generated without affecting the
+transfer of other QUIC frames.  The PING Frame is used to trigger generation of
+an acknowledgement.  Multiple PADDING Frames are used together to control the
+length of the probe packet.  These frames might not be retransmitted if a probe
+packet containing them is lost.  The frames consume congestion window, which
+could delay subsequent transmission by an application.
 
-###  Validating the QUIC Path with DPLPMTUD
 
-QUIC provides an acknowledged PL, therefore a sender does not
-implement the DPLPMTUD CONFIRMATION_TIMER while in the SEARCH_COMPLETE state.
+### Validating the QUIC Path with DPLPMTUD
+
+QUIC provides an acknowledged PL, therefore a sender does not implement the
+DPLPMTUD CONFIRMATION_TIMER while in the SEARCH_COMPLETE state.
+
 
 ###  Handling of ICMP Messages by DPLPMTUD
 
-An endpoint using DPLPMTUD requires the validation of any received PTB message 
-before using the PTB information, as defined in section 4.6 of {{!DPLPMTUD}}.
-In addition to UDP Port
-validation, QUIC validates an ICMP message by using other PL
-information (e.g., validation of connection identifiers (CIDs) in the
-quoted packet of any received ICMP message). 
+An endpoint using DPLPMTUD requires the validation of any received PTB message
+before using the PTB information, as defined in Section 4.6 of {{!DPLPMTUD}}.
+In addition to UDP Port validation, QUIC validates an ICMP message by using
+other PL information (e.g., validation of connection identifiers (CIDs) in the
+quoted packet of any received ICMP message).
 
 The considerations for processing ICMP messages described in {{icmp-pmtud}} also
 apply if these messages are used by DPLPMTUD.
 
+
 ## PMTUD/DPLPMTUD Probes Containing Source Connection ID {#pmtu-probes-src-cid}
 
 Endpoints that rely on the destination connection ID for routing incoming QUIC
-packets are likely to require that the connection ID be included in PMTUD/DPLPMTUD probe
-packets to route any resulting ICMP messages ({{icmp-pmtud}}) back to the
-correct endpoint.  However, only long header packets ({{long-header}}) contain
-source connection IDs, and long header packets are not decrypted or acknowledged
-by the peer once the handshake is complete.
+packets are likely to require that the connection ID be included in
+PMTUD/DPLPMTUD probe packets to route any resulting ICMP messages
+({{icmp-pmtud}}) back to the correct endpoint.  However, only long header
+packets ({{long-header}}) contain source connection IDs, and long header packets
+are not decrypted or acknowledged by the peer once the handshake is complete.
 
 
 # Versions {#versions}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3828,11 +3828,11 @@ believes that the network path and peer both support the size that it chooses.
 UDP datagrams MUST NOT be fragmented at the IP layer.  In IPv4
 {{!IPv4=RFC0791}}, the DF bit MUST be set to prevent fragmentation on the path.
 
-A server MUST discard an Initial packet that is carried in a UDP datagram with
-a payload that is less than the smallest allowed maximum packet size (1200 bytes).
-A server MAY also immediately close the
-connection by sending a CONNECTION_CLOSE frame with an error code of
-PROTOCOL_VIOLATION; see {{immediate-close-hs}}.
+A server MUST discard an Initial packet that is carried in a UDP datagram with a
+payload that is less than the smallest allowed maximum packet size  of 1200
+bytes.  A server MAY also immediately close the connection by sending a
+CONNECTION_CLOSE frame with an error code of PROTOCOL_VIOLATION; see
+{{immediate-close-hs}}.
 
 The server MUST also limit the number of bytes it sends before validating the
 address of the client; see {{address-validation}}.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3797,7 +3797,7 @@ later time in the connection.
 The QUIC packet size includes the QUIC header and protected payload, but not the
 UDP or IP headers.
 
-QUIC depends upon a minimum packet size of at least 1280 bytes.  This is the
+QUIC depends upon a minimum IP packet size of at least 1280 bytes.  This is the
 IPv6 minimum size {{?RFC8200}} and is also supported by most modern IPv4
 networks.  Assuming the minimum IP header size, this results in a QUIC maximum
 packet size of 1232 bytes for IPv6 and 1252 bytes for IPv4.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3937,9 +3937,9 @@ the endpoint has established a 1-RTT key.
 
 ###  Sending QUIC DPLPMTUD Probe Packets
 
-DPLPMTU Probe packets consists of a QUIC Header and a payload containing a
-PING Frame and multiple PADDING Frames, this can implement
-"Probing using padding data" (see section 4.1 of {{!DPLPMTUD}}. 
+DPLPMTU probe packets are ack-eliciting packets.  Probe packets that use the
+PADDING frame therefore implement "Probing using padding data", as defined in
+Section 4.1 of {{!DPLPMTUD}}.
 These can be generated without affecting the transfer of other QUIC frames.
 The PING Frame is used to trigger generation of an acknowledgement.
 Multiple PADDING Frames are used together to control the length of the probe packet.  

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3928,18 +3928,6 @@ packetization layer (PL). A sender can therefore enter the DPLPMTUD BASE state
 when the QUIC connection handshake has been completed.
 
 
-### Sending QUIC DPLPMTUD Probe Packets
-
-DPLPMTU probe packets are ack-eliciting packets.  Probe packets that use the
-PADDING frame implement "Probing using padding data", as defined in
-Section 4.1 of {{!DPLPMTUD}}.  Endpoints could limit the content of probe
-packets to PING and PADDING frames as packets that are larger than the current
-maximum packet size are more likely to be dropped by the network.
-
-DPLPMTU probe packets consume congestion window, which could delay subsequent
-transmission by an application.
-
-
 ### Validating the QUIC Path with DPLPMTUD
 
 QUIC provides an acknowledged PL, therefore a sender does not implement the
@@ -3957,6 +3945,20 @@ any received ICMP message).
 
 The considerations for processing ICMP messages described in {{icmp-pmtud}} also
 apply if these messages are used by DPLPMTUD.
+
+
+## Sending QUIC DPLPMTUD Probe Packets
+
+DPLPMTU probe packets are ack-eliciting packets.  Probe packets that use the
+PADDING frame therefore implement "Probing using padding data", as defined in
+Section 4.1 of {{!DPLPMTUD}}.  Endpoints could limit the content of probe
+packets to PING and PADDING frames as packets that are larger than the current
+maximum packet size are more likely to be dropped by the network.   Loss of a
+probe packet is therefore not a reliable indication of congestion and SHOULD NOT
+trigger a congestion control reaction; see Section 3, Bullet 7 of {{!DPLPMTUD}}.
+DPLPMTU probe packets consume congestion window, which could delay subsequent
+transmission by an application.
+
 
 
 ## PMTUD/DPLPMTUD Probes Containing Source Connection ID {#pmtu-probes-src-cid}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3869,7 +3869,7 @@ implementation MAY be more conservative in computing the maximum packet
 size to allow for unknown tunnel overheads or IP header options/extensions.
 
 
-### Handling of ICMP PTB Messages by PMTUD {#icmp-pmtud}
+### Handling of ICMP Messages by PMTUD {#icmp-pmtud}
 
 PMTUD {{!RFC1191}} {{!RFC8201}} relies on reception of ICMP messages
 (e.g., IPv6 Packet Too Big messages) that indicate when a packet is dropped

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3797,7 +3797,7 @@ later time in the connection.
 The QUIC packet size includes the QUIC header and protected payload, but not the
 UDP or IP header.
 
-QUIC defines the minimum QUIC packet size as at least 1280 bytes.
+QUIC depends upon a minimum packet size of at least 1280 bytes.
 This is the IPv6 minimum size
 {{?RFC8200}} and is also supported by most modern IPv4 networks.
 Assuming the minimum IP header size, this results in a

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3930,7 +3930,7 @@ path cannot be found.
 ###  DPLPMTUD and Initial Connectivity
 
 From the perspective of DPLPMTUD, QUIC transport is an 
-acknowledged PL. A sender can therefore enter the DPLPMTUD BASE
+acknowledged packetization layer (PL). A sender can therefore enter the DPLPMTUD BASE
 state when the QUIC connection handshake has been completed and
 the endpoint has established a 1-RTT key.
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3852,10 +3852,10 @@ within the maximum packet size to avoid the packet being fragmented or dropped
 {{?RFC8085}}.
 
 If a QUIC endpoint determines that the PMTU between any pair of local and remote
-IP addresses has fallen below the smallest allowed maximum packet size, it MUST
-immediately cease sending QUIC packets, except for PMTUD or DPLPMTUD probe
-packets, on the affected path.  An endpoint MAY terminate the connection if an
-alternative path cannot be found.
+IP addresses has fallen below the smallest allowed maximum packet size of 1200
+bytes, it MUST immediately cease sending QUIC packets, except for PMTUD or
+DPLPMTUD probe packets, on the affected path.  An endpoint MAY terminate the
+connection if an alternative path cannot be found.
 
 Each pair of local and remote addresses could have a different PMTU.  QUIC
 implementations that implement any kind of PMTU discovery therefore SHOULD

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3945,7 +3945,7 @@ The PING Frame is used to trigger generation of an acknowledgement.
 Multiple PADDING Frames are used together to control the length of the probe packet.  
 These frames might not be retransmitted if a probe packet containing
 them is lost.  The frames consume congestion window,
-which could dela subsequent transmission by application.
+which could delay subsequent transmission by an application.
 
 ###  Validating the QUIC Path with DPLPMTUD
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3945,7 +3945,7 @@ The PING Frame is used to trigger generation of an acknowledgement.
 Multiple PADDING Frames are used together to control the length of the probe packet.  
 These frames might not be retransmitted if a probe packet containing
 them is lost.  The frames consume congestion window,
-which could delay the transmission of subsequent application data.
+which could dela subsequent transmission by application.
 
 ###  Validating the QUIC Path with DPLPMTUD
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3951,7 +3951,7 @@ which could delay the transmission of subsequent application data.
 QUIC provides an acknowledged PL, therefore a sender does not
 implement the DPLPMTUD CONFIRMATION_TIMER while in the SEARCH_COMPLETE state.
 
-###  Handling of ICMP PTB Messages by DPLPMTUD
+###  Handling of ICMP Messages by DPLPMTUD
 
 An endpoint using DPLPMTUD requires the validation of any received PTB message 
 before using the PTB information, as defined in section 4.6 of {{!DPLPMTUD}}.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3849,7 +3849,7 @@ In the absence of these mechanisms, QUIC endpoints SHOULD NOT send IP packets
 larger than the minimum QUIC packet size. 
 
 All QUIC
-packets (except for PMTUD/DPLPMTUD probe packets) SHOULD be sized to fit within the
+packets other than PMTUD/DPLPMTUD probe packets SHOULD be sized to fit within the
 maximum packet size to avoid the packet being fragmented or dropped
 {{?RFC8085}}.
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3927,12 +3927,12 @@ established a 1-RTT key.
 
 DPLPMTU probe packets are ack-eliciting packets.  Probe packets that use the
 PADDING frame therefore implement "Probing using padding data", as defined in
-Section 4.1 of {{!DPLPMTUD}}.  These can be generated without affecting the
-transfer of other QUIC frames.  The PING Frame is used to trigger generation of
-an acknowledgement.  Multiple PADDING Frames are used together to control the
-length of the probe packet.  These frames might not be retransmitted if a probe
-packet containing them is lost.  The frames consume congestion window, which
-could delay subsequent transmission by an application.
+Section 4.1 of {{!DPLPMTUD}}.  Endpoints could limit the content of probe
+packets to PING and PADDING frames as packets that are larger than the current
+maximum packet size are more likely to be dropped by the network.
+
+DPLPMTU probe packets consume congestion window, which could delay subsequent
+transmission by an application.
 
 
 ### Validating the QUIC Path with DPLPMTUD

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3890,7 +3890,7 @@ actually be smaller, or the information unintelligible, as described in Section
 QUIC endpoints using PMTUD SHOULD validate ICMP messages to protect from off-path injection
 as specified in {{!RFC8201}} and Section 5.2 of {{!RFC8085}}. This validation
 SHOULD use the quoted packet supplied in the payload of an ICMP message to
-associate the message with a corresponding transport connection (e.g., {{!DPLPMTUD}}).
+associate the message with a corresponding transport connection (see Section 4.6.1 of {{!DPLPMTUD}}).
 ICMP message validation MUST include matching IP addresses and UDP ports
 {{!RFC8085}} and, when possible, connection IDs to an active QUIC session.
 The endpoint SHOULD ignore all ICMP messages that fail validation.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3850,9 +3850,9 @@ over time.  The largest UDP payload an endpoint sends at any given time is
 referred to as the endpoint's maximum packet size.
 
 An endpoint SHOULD use DPLPMTUD ({{dplpmtud}}) or PMTUD ({{pmtud}}) to determine
-whether the path to a destination will support a desired message size without
-fragmentation.  In the absence of these mechanisms, QUIC endpoints SHOULD NOT
-send IP packets larger than the smallest allowed maximum packet size.
+whether the path to a destination will support a desired maximum packet size
+without fragmentation.  In the absence of these mechanisms, QUIC endpoints
+SHOULD NOT send IP packets larger than the smallest allowed maximum packet size.
 
 Both DPLPMTUD and PMTUD send IP packets that are larger than the current maximum
 packet size.  We refer to these as PMTU probes.  All QUIC packets that are not

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3899,18 +3899,6 @@ to ICMP messages MAY be provisional until QUIC's loss detection algorithm
 determines that the quoted packet has actually been lost.
 
 
-### PMTUD Probes with Handshake packets
-
-One way to construct a PMTU probe is to coalesce (see
-{{packet-coalesce}}) a Handshake packet ({{packet-handshake}}) with a short
-header packet in a single UDP datagram.  If the UDP datagram reaches the
-endpoint, the Handshake packet will be ignored, but the short header packet will
-be acknowledged.  If the UDP datagram causes an ICMP message to be sent, the
-first part of the datagram will be quoted in that message.  If the source
-connection ID is within the quoted portion of the UDP datagram, that could be
-used for routing.
-
-
 ## Datagram Packetization Layer PMTU Discovery
 
 When implementing the algorithm in Section 5 of {{!DPLPMTUD}}, the initial value
@@ -3953,7 +3941,7 @@ QUIC provides an acknowledged PL, therefore a sender does not implement the
 DPLPMTUD CONFIRMATION_TIMER while in the SEARCH_COMPLETE state.
 
 
-###  Handling of ICMP Messages by DPLPMTUD
+### Handling of ICMP Messages by DPLPMTUD
 
 An endpoint using DPLPMTUD requires the validation of any received PTB message
 before using the PTB information, as defined in Section 4.6 of {{!DPLPMTUD}}.
@@ -3973,6 +3961,15 @@ PMTUD/DPLPMTUD probe packets to route any resulting ICMP messages
 ({{icmp-pmtud}}) back to the correct endpoint.  However, only long header
 packets ({{long-header}}) contain source connection IDs, and long header packets
 are not decrypted or acknowledged by the peer once the handshake is complete.
+
+One way to construct a PMTU probe is to coalesce (see
+{{packet-coalesce}}) a Handshake packet ({{packet-handshake}}) with a short
+header packet in a single UDP datagram.  If the UDP datagram reaches the
+endpoint, the Handshake packet will be ignored, but the short header packet will
+be acknowledged.  If the UDP datagram causes an ICMP message to be sent, the
+first part of the datagram will be quoted in that message.  If the source
+connection ID is within the quoted portion of the UDP datagram, that could be
+used for routing.
 
 
 # Versions {#versions}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3951,8 +3951,8 @@ DPLPMTUD CONFIRMATION_TIMER while in the SEARCH_COMPLETE state.
 An endpoint using DPLPMTUD requires the validation of any received PTB message
 before using the PTB information, as defined in Section 4.6 of {{!DPLPMTUD}}.
 In addition to UDP Port validation, QUIC validates an ICMP message by using
-other PL information (e.g., validation of connection identifiers (CIDs) in the
-quoted packet of any received ICMP message).
+other PL information (e.g., validation of connection IDs in the quoted packet of
+any received ICMP message).
 
 The considerations for processing ICMP messages described in {{icmp-pmtud}} also
 apply if these messages are used by DPLPMTUD.
@@ -3964,8 +3964,9 @@ Endpoints that rely on the destination connection ID for routing incoming QUIC
 packets are likely to require that the connection ID be included in
 PMTUD/DPLPMTUD probe packets to route any resulting ICMP messages
 ({{icmp-pmtud}}) back to the correct endpoint.  However, only long header
-packets ({{long-header}}) contain source connection IDs, and long header packets
-are not decrypted or acknowledged by the peer once the handshake is complete.
+packets ({{long-header}}) contain the Source Connection ID field, and long
+header packets are not decrypted or acknowledged by the peer once the handshake
+is complete.
 
 One way to construct a PMTUD or DPLPMTUD probe is to coalesce (see
 {{packet-coalesce}}) a packet with a long header, such as a Handshake or 0-RTT
@@ -3973,15 +3974,15 @@ packet ({{long-header}}), with a short header packet in a single UDP datagram.
 If the UDP datagram reaches the endpoint, the packet with the long header will
 be ignored, but the short header packet will be acknowledged.  If the UDP
 datagram causes an ICMP message to be sent, the first part of the datagram will
-be quoted in that message.  If the source connection ID is within the quoted
-portion of the UDP datagram, that could be used for routing.
+be quoted in that message.  If the Source Connection ID field is within the
+quoted portion of the UDP datagram, that could be used for routing or validation
+of the ICMP message.
 
 Note:
 : The purpose of using a packet with a long header is only to ensure that the
   quoted packet contained in the ICMP message contains a Source Connection ID
-  field that can be use for routing.  This packet does not need to be a valid
-  packet and it can be sent even if there is no current use for packets of that
-  type.
+  field.  This packet does not need to be a valid packet and it can be sent even
+  if there is no current use for packets of that type.
 
 
 # Versions {#versions}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3854,7 +3854,7 @@ maximum packet size to avoid the packet being fragmented or dropped
 {{?RFC8085}}.
 
 If a QUIC endpoint determines that the PMTU between any pair of local and remote
-IP addresses has fallen below the minimum QUIC packet size, it MUST immediately 
+IP addresses has fallen below the smallest allowed maximum packet size, it MUST immediately 
 cease sending QUIC packets, except for
 PMTUD or DPLPMTUD probe packets, on the affected path.  An endpoint MAY terminate the
 connection if an alternative path cannot be found.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3925,8 +3925,7 @@ terminate the connection if an alternative path cannot be found.
 
 From the perspective of DPLPMTUD, QUIC transport is an acknowledged
 packetization layer (PL). A sender can therefore enter the DPLPMTUD BASE state
-when the QUIC connection handshake has been completed and the endpoint has
-established a 1-RTT key.
+when the QUIC connection handshake has been completed.
 
 
 ### Sending QUIC DPLPMTUD Probe Packets

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3871,16 +3871,6 @@ addresses.
 A QUIC implementation MAY be more conservative in computing the maximum packet
 size to allow for unknown tunnel overheads or IP header options/extensions.
 
-### PMTUD Probes with Handshake packets
-
-One way to construct a PMTU probe is to coalesce (see
-{{packet-coalesce}}) a Handshake packet ({{packet-handshake}}) with a short
-header packet in a single UDP datagram. If the UDP datagram reaches the
-endpoint, the Handshake packet will be ignored, but the short header packet will
-be acknowledged.  If the UDP datagram causes an ICMP message to be sent, the
-first part of the datagram will be quoted in that message.  If the source
-connection ID is within the quoted portion of the UDP datagram, that could be
-used for routing.
 
 ### Handling of ICMP Messages by PMTUD {#icmp-pmtud}
 
@@ -3978,14 +3968,14 @@ PMTUD/DPLPMTUD probe packets to route any resulting ICMP messages
 packets ({{long-header}}) contain source connection IDs, and long header packets
 are not decrypted or acknowledged by the peer once the handshake is complete.
 
-One way to construct a PMTU probe is to coalesce (see {{packet-coalesce}}) a
-packet with a long header, such as a Handshake or 0-RTT packet
-({{long-header}}), with a short header packet in a single UDP datagram.  If the
-UDP datagram reaches the endpoint, the packet with the long header will be
-ignored, but the short header packet will be acknowledged.  If the UDP datagram
-causes an ICMP message to be sent, the first part of the datagram will be quoted
-in that message.  If the source connection ID is within the quoted portion of
-the UDP datagram, that could be used for routing.
+One way to construct a PMTUD or DPLPMTUD probe is to coalesce (see
+{{packet-coalesce}}) a packet with a long header, such as a Handshake or 0-RTT
+packet ({{long-header}}), with a short header packet in a single UDP datagram.
+If the UDP datagram reaches the endpoint, the packet with the long header will
+be ignored, but the short header packet will be acknowledged.  If the UDP
+datagram causes an ICMP message to be sent, the first part of the datagram will
+be quoted in that message.  If the source connection ID is within the quoted
+portion of the UDP datagram, that could be used for routing.
 
 Note:
 : The purpose of using a packet with a long header is only to ensure that the

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3962,14 +3962,21 @@ PMTUD/DPLPMTUD probe packets to route any resulting ICMP messages
 packets ({{long-header}}) contain source connection IDs, and long header packets
 are not decrypted or acknowledged by the peer once the handshake is complete.
 
-One way to construct a PMTU probe is to coalesce (see
-{{packet-coalesce}}) a Handshake packet ({{packet-handshake}}) with a short
-header packet in a single UDP datagram.  If the UDP datagram reaches the
-endpoint, the Handshake packet will be ignored, but the short header packet will
-be acknowledged.  If the UDP datagram causes an ICMP message to be sent, the
-first part of the datagram will be quoted in that message.  If the source
-connection ID is within the quoted portion of the UDP datagram, that could be
-used for routing.
+One way to construct a PMTU probe is to coalesce (see {{packet-coalesce}}) a
+packet with a long header, such as a Handshake or 0-RTT packet
+({{long-header}}), with a short header packet in a single UDP datagram.  If the
+UDP datagram reaches the endpoint, the packet with the long header will be
+ignored, but the short header packet will be acknowledged.  If the UDP datagram
+causes an ICMP message to be sent, the first part of the datagram will be quoted
+in that message.  If the source connection ID is within the quoted portion of
+the UDP datagram, that could be used for routing.
+
+Note:
+: The purpose of using a packet with a long header is only to ensure that the
+  quoted packet contained in the ICMP message contains a Source Connection ID
+  field that can be use for routing.  This packet does not need to be a valid
+  packet and it can be sent even if there is no current use for packets of that
+  type.
 
 
 # Versions {#versions}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3919,7 +3919,8 @@ packet size. The MIN_PLPMTU is the same as the BASE_PMTU.
 
 QUIC endpoints implementing DPLPMTUD maintain a maximum packet size 
 (DPLPMTUD MPS) for each combination of local and remote IP
-addresses. 
+addresses.
+
 If a QUIC endpoint determines that the PLPMTU between any pair of local
 and remote IP addresses has fallen below the size needed to support
 the minimum QUIC packet size (BASE_PLPMTU), it MUST immediately cease


### PR DESCRIPTION
This is #3693 with some minor additional changes:

1. Reflow.
2. Move the odd text about using Handshake back where it belongs.
3. Make the language about how to construct a probe less prescriptive.
4. Mention 1200 when referring to the "smallest allowed maximum packet size" so it is clear what that means.

Closes #3693.
Closes #3695.