### PR TITLE
Add missing Length field to header protection example.

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1043,6 +1043,7 @@ Initial Packet {
   Source Connection ID (0..160),
   Token Length (i),
   Token (..),
+  Length (i),
   Packet Number (8..32),     # Protected
   Protected Payload (0..24), # Skipped Part
   Protected Payload (128),   # Sampled Part


### PR DESCRIPTION
I was trying to figure out how multiple packets could be coalesced together, and realized that the example that I was looking at was missing a field. For [reference](https://datatracker.ietf.org/doc/html/draft-ietf-quic-transport-28#section-17.2.2).