### PR TITLE
Gorrys invariant nits

### DIFF
--- a/draft-ietf-quic-invariants.md
+++ b/draft-ietf-quic-invariants.md
@@ -177,9 +177,9 @@ Long Header Packet {
   Header Form (1) = 1,
   Version-Specific Bits (7),
   Version (32),
-  DCID Length (8),
+  Destination Connection ID Length (8),
   Destination Connection ID (0..2040),
-  SCID Length (8),
+  Source Connection ID Length (8),
   Source Connection ID (0..2040),
   Version-Specific Data (..),
 }
@@ -193,13 +193,13 @@ The next four bytes include a 32-bit Version field (see {{version}}).
 
 The next byte contains the length in bytes of the Destination Connection ID (see
 {{connection-id}}) field that follows it.  This length is encoded as an 8-bit
-unsigned integer.  The Destination Connection ID field follows the DCID Length
-field and is between 0 and 255 bytes in length.
+unsigned integer.  The Destination Connection ID field follows the Destination
+Connection ID Length field and is between 0 and 255 bytes in length.
 
 The next byte contains the length in bytes of the Source Connection ID field
 that follows it.  This length is encoded as a 8-bit unsigned integer.  The
-Source Connection ID field follows the SCID Length field and is between 0 and
-255 bytes in length.
+Source Connection ID field follows the Source Connection ID Length field and is
+between 0 and 255 bytes in length.
 
 The remainder of the packet contains version-specific content.
 
@@ -274,9 +274,9 @@ Version Negotiation Packet {
   Header Form (1) = 1,
   Unused (7),
   Version (32) = 0,
-  DCID Length (8),
+  Destination Connection ID Length (8),
   Destination Connection ID (0..2040),
-  SCID Length (8),
+  Source Connection ID Length (8),
   Source Connection ID (0..2040),
   Supported Version (32) ...,
 }

--- a/draft-ietf-quic-invariants.md
+++ b/draft-ietf-quic-invariants.md
@@ -240,11 +240,11 @@ A connection ID is an opaque field of arbitrary length.
 
 The primary function of a connection ID is to ensure that changes in addressing
 at lower protocol layers (UDP, IP, and below) don't cause packets for a QUIC
-connection to be delivered to the wrong endpoint.  The connection ID is used by
-endpoints and the intermediaries that support them to ensure that each QUIC
-packet can be delivered to the correct instance of an endpoint.  At the
-endpoint, the connection ID is used to identify which QUIC connection the packet
-is intended for.
+connection to be delivered to the wrong transport endpoint.  The connection ID
+is used by endpoints and the intermediaries that support them to ensure that
+each QUIC packet can be delivered to the correct instance of an endpoint.  At
+the endpoint, the connection ID is used to identify which QUIC connection the
+packet is intended for.
 
 The connection ID is chosen by each endpoint using version-specific methods.
 Packets for the same QUIC connection might use different connection ID values.

--- a/draft-ietf-quic-invariants.md
+++ b/draft-ietf-quic-invariants.md
@@ -139,6 +139,9 @@ x (E) ...:
 : Indicates that x is repeated zero or more times (and that each instance is
   length E)
 
+This document uses network byte order (that is, big endian) values.  Fields
+are placed starting from the high-order bits of each byte.
+
 {{fig-ex-format}} shows an example structure:
 
 ~~~

--- a/draft-ietf-quic-invariants.md
+++ b/draft-ietf-quic-invariants.md
@@ -363,9 +363,8 @@ The following statements are NOT guaranteed to be true for every QUIC version:
 
 * The first packets exchanged on a flow use the long header
 
-* QUIC forbids acknowledgments of packets that only contain ACK frames,
-  therefore the last packet before a long period of quiescence might be assumed
-  to contain an acknowledgment
+* The last packet before a long period of quiescence might be assumed
+  to contain only an acknowledgment
 
 * QUIC uses an AEAD (AEAD_AES_128_GCM {{?RFC5116}}) to protect the packets it
   exchanges during connection establishment

--- a/draft-ietf-quic-invariants.md
+++ b/draft-ietf-quic-invariants.md
@@ -192,12 +192,14 @@ Long Header Packet {
 A QUIC packet with a long header has the high bit of the first byte set to 1.
 All other bits in that byte are version specific.
 
-The next four bytes include a 32-bit Version field (see {{version}}).
+The next four bytes include a 32-bit Version field.  Versions are described in
+{{version}}.
 
-The next byte contains the length in bytes of the Destination Connection ID (see
-{{connection-id}}) field that follows it.  This length is encoded as an 8-bit
-unsigned integer.  The Destination Connection ID field follows the Destination
-Connection ID Length field and is between 0 and 255 bytes in length.
+The next byte contains the length in bytes of the Destination Connection ID
+field that follows it.  This length is encoded as an 8-bit unsigned integer.
+The Destination Connection ID field follows the Destination Connection ID Length
+field and is between 0 and 255 bytes in length.  Connection IDs are described in
+{{connection-id}}.
 
 The next byte contains the length in bytes of the Source Connection ID field
 that follows it.  This length is encoded as a 8-bit unsigned integer.  The

--- a/draft-ietf-quic-invariants.md
+++ b/draft-ietf-quic-invariants.md
@@ -240,7 +240,7 @@ A connection ID is an opaque field of arbitrary length.
 
 The primary function of a connection ID is to ensure that changes in addressing
 at lower protocol layers (UDP, IP, and below) don't cause packets for a QUIC
-connection to be delivered to the wrong transport endpoint.  The connection ID
+connection to be delivered to the wrong QUIC endpoint.  The connection ID
 is used by endpoints and the intermediaries that support them to ensure that
 each QUIC packet can be delivered to the correct instance of an endpoint.  At
 the endpoint, the connection ID is used to identify which QUIC connection the

--- a/draft-ietf-quic-invariants.md
+++ b/draft-ietf-quic-invariants.md
@@ -226,7 +226,7 @@ A QUIC packet with a short header has the high bit of the first byte set to 0.
 A QUIC packet with a short header includes a Destination Connection ID
 immediately following the first byte.  The short header does not include the
 Connection ID Lengths, Source Connection ID, or Version fields.  The length of
-the Destination Connection ID is not specified in packets with a short header
+the Destination Connection ID is not encoded in packets with a short header
 and is not constrained by this specification.
 
 The remainder of the packet has version-specific semantics.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -275,6 +275,9 @@ x (E) ...:
 : Indicates that x is repeated zero or more times (and that each instance is
   length E)
 
+This document uses network byte order (that is, big endian) values.  Fields
+are placed starting from the high-order bits of each byte.
+
 By convention, individual fields reference a complex field by using the name of
 the complex field.
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1535,7 +1535,7 @@ this connection. This Destination Connection ID is used to determine packet
 protection keys for Initial packets.
 
 The client populates the Source Connection ID field with a value of its choosing
-and sets the SCID Length field to indicate the length.
+and sets the Source Connection ID Length field to indicate the length.
 
 The first flight of 0-RTT packets use the same Destination Connection ID and
 Source Connection ID values as the client's first Initial packet.
@@ -1608,9 +1608,10 @@ treat any of the following as a connection error of type PROTOCOL_VIOLATION:
 If a zero-length connection ID is selected, the corresponding transport
 parameter is included with a zero-length value.
 
-{{fig-auth-cid}} shows the connection IDs that are used in a complete
-handshake. The exchange of Initial packets is shown, plus the later exchange of
-1-RTT packets that includes the connection ID established during the handshake.
+{{fig-auth-cid}} shows the connection IDs (with DCID=Destination Connection ID,
+SCID=Source Connection ID) that are used in a complete handshake. The exchange
+of Initial packets is shown, plus the later exchange of 1-RTT packets that
+includes the connection ID established during the handshake.
 
 ~~~
 Client                                                  Server
@@ -4100,9 +4101,9 @@ Long Header Packet {
   Long Packet Type (2),
   Type-Specific Bits (4),
   Version (32),
-  DCID Length (8),
+  Destination Connection ID Length (8),
   Destination Connection ID (0..160),
-  SCID Length (8),
+  Source Connection ID Length (8),
   Source Connection ID (0..160),
 }
 ~~~~~
@@ -4140,7 +4141,7 @@ Version:
   indicates which version of QUIC is in use and determines how the rest of the
   protocol fields are interpreted.
 
-DCID Length:
+Destination Connection ID Length:
 
 : The byte following the version contains the length in bytes of the Destination
   Connection ID field that follows it.  This length is encoded as an 8-bit
@@ -4152,11 +4153,11 @@ DCID Length:
 
 Destination Connection ID:
 
-: The Destination Connection ID field follows the DCID Length field and is
-  between 0 and 20 bytes in length. {{negotiating-connection-ids}} describes
-  the use of this field in more detail.
+: The Destination Connection ID field follows the Destination Connection ID
+  Length field and is between 0 and 20 bytes in length.
+  {{negotiating-connection-ids}} describes the use of this field in more detail.
 
-SCID Length:
+Source Connection ID Length:
 
 : The byte following the Destination Connection ID contains the length in bytes
   of the Source Connection ID field that follows it.  This length is encoded as
@@ -4168,9 +4169,9 @@ SCID Length:
 
 Source Connection ID:
 
-: The Source Connection ID field follows the SCID Length field and is between 0
-  and 20 bytes in length. {{negotiating-connection-ids}} describes the use of
-  this field in more detail.
+: The Source Connection ID field follows the Source Connection ID Length field
+  and is between 0 and 20 bytes in length. {{negotiating-connection-ids}}
+  describes the use of this field in more detail.
 
 In this version of QUIC, the following packet types with the long header are
 defined:
@@ -4243,9 +4244,9 @@ Version Negotiation Packet {
   Header Form (1) = 1,
   Unused (7),
   Version (32) = 0,
-  DCID Length (8),
+  Destination Connection ID Length (8),
   Destination Connection ID (0..2040),
-  SCID Length (8),
+  Source Connection ID Length (8),
   Source Connection ID (0..2040),
   Supported Version (32) ...,
 }
@@ -4302,9 +4303,9 @@ Initial Packet {
   Reserved Bits (2),
   Packet Number Length (2),
   Version (32),
-  DCID Length (8),
+  Destination Connection ID Length (8),
   Destination Connection ID (0..160),
-  SCID Length (8),
+  Source Connection ID Length (8),
   Source Connection ID (0..160),
   Token Length (i),
   Token (..),
@@ -4317,8 +4318,8 @@ Initial Packet {
 
 The Initial packet contains a long header as well as the Length and Packet
 Number fields.  The first byte contains the Reserved and Packet Number Length
-bits.  Between the SCID and Length fields, there are two additional
-fields specific to the Initial packet.
+bits.  Between the Source Connection ID and Length fields, there are two
+additional fields specific to the Initial packet.
 
 Token Length:
 
@@ -4401,9 +4402,9 @@ limitations.
   Reserved Bits (2),
   Packet Number Length (2),
   Version (32),
-  DCID Length (8),
+  Destination Connection ID Length (8),
   Destination Connection ID (0..160),
-  SCID Length (8),
+  Source Connection ID Length (8),
   Source Connection ID (0..160),
   Length (i),
   Packet Number (8..32),
@@ -4458,9 +4459,9 @@ Handshake Packet {
   Reserved Bits (2),
   Packet Number Length (2),
   Version (32),
-  DCID Length (8),
+  Destination Connection ID Length (8),
   Destination Connection ID (0..160),
-  SCID Length (8),
+  Source Connection ID Length (8),
   Source Connection ID (0..160),
   Length (i),
   Packet Number (8..32),
@@ -4503,9 +4504,9 @@ Retry Packet {
   Long Packet Type (2) = 3,
   Unused (4),
   Version (32),
-  DCID Length (8),
+  Destination Connection ID Length (8),
   Destination Connection ID (0..160),
-  SCID Length (8),
+  Source Connection ID Length (8),
   Source Connection ID (0..160),
   Retry Token (..),
   Retry Integrity Tag (128),


### PR DESCRIPTION
Editorial NiTs when reviewing the invariant text. These NiTs address readability issues, and do not intend to change the meaning of the text.