### PR TITLE
Mention every Transport Parameter in section on values for 0-RTT

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1749,6 +1749,13 @@ values for 0-RTT.  This includes initial_max_data and either
 initial_max_streams_bidi and initial_max_stream_data_bidi_remote, or
 initial_max_streams_uni and initial_max_stream_data_uni.
 
+It is OPTIONAL for a server to be able to recover the previously sent values of
+the max_idle_timout, max_udp_payload_size, and disable_active_migration
+parameters. Lowering the values of these parameters while also accepting 0-RTT
+data could degrade the performance of the connection. Specifically, lowering the
+max_udp_payload_size could result in dropped packets leading to worse
+performance compared to rejecting 0-RTT data outright.
+
 A server MUST either reject 0-RTT data or abort a handshake if the implied
 values for transport parameters cannot be supported.
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1749,12 +1749,13 @@ values for 0-RTT.  This includes initial_max_data and either
 initial_max_streams_bidi and initial_max_stream_data_bidi_remote, or
 initial_max_streams_uni and initial_max_stream_data_uni.
 
-It is OPTIONAL for a server to be able to recover the previously sent values of
-the max_idle_timout, max_udp_payload_size, and disable_active_migration
-parameters. Lowering the values of these parameters while also accepting 0-RTT
-data could degrade the performance of the connection. Specifically, lowering the
-max_udp_payload_size could result in dropped packets leading to worse
-performance compared to rejecting 0-RTT data outright.
+A server MAY choose to store and recover the previously sent values of the
+max_idle_timout, max_udp_payload_size, and disable_active_migration parameters
+and reject 0-RTT if it selects smaller values. Lowering the values of these
+parameters while also accepting 0-RTT data could degrade the performance of the
+connection. Specifically, lowering the max_udp_payload_size could result in
+dropped packets leading to worse performance compared to rejecting 0-RTT data
+outright.
 
 A server MUST either reject 0-RTT data or abort a handshake if the implied
 values for transport parameters cannot be supported.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1749,7 +1749,7 @@ values for 0-RTT.  This includes initial_max_data and either
 initial_max_streams_bidi and initial_max_stream_data_bidi_remote, or
 initial_max_streams_uni and initial_max_stream_data_uni.
 
-A server MAY choose to store and recover the previously sent values of the
+A server MAY store and recover the previously sent values of the
 max_idle_timout, max_udp_payload_size, and disable_active_migration parameters
 and reject 0-RTT if it selects smaller values. Lowering the values of these
 parameters while also accepting 0-RTT data could degrade the performance of the


### PR DESCRIPTION
The section for "Values of Transport Parameters for 0-RTT" specifies
which parameters a client MUST or MUST NOT remember. It does not do the
same for a server. (It implies that ones a client MUST NOT remember also
don't need to be remembered by a server, and it lists a subset of the
remaining as ones the server MUST remember.) This commit adds the
remaining parameters to a list that the server need not remember.

Fixes #3755 