### PR TITLE
ROBUST: ePrint publication

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -2460,7 +2460,8 @@ document:
 - David Schinazi
 - Dragana Damjanovic
 - Eric Rescorla
-- <t><t><contact asciiFullname="Felix Guenther" fullname="Felix Günther"/></t></t>
+- <t><t><contact asciiFullname="Felix Guenther"
+  fullname="Felix Günther"/></t></t>
 - Ian Swett
 - Jana Iyengar
 - <t><t><contact asciiFullname="Kazuho Oku" fullname="奥 一穂"/></t></t>

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -2460,8 +2460,7 @@ document:
 - David Schinazi
 - Dragana Damjanovic
 - Eric Rescorla
-- <t><t><contact asciiFullname="Felix Guenther"
-  fullname="Felix Günther"/></t></t>
+- Felix Günther
 - Ian Swett
 - Jana Iyengar
 - <t><t><contact asciiFullname="Kazuho Oku" fullname="奥 一穂"/></t></t>

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -92,13 +92,13 @@ informative:
         role: editor
 
   ROBUST:
-    title: "Robust Channels: Handling Unreliable Networks in the Record Layers of QUIC and DTLS"
+    title: "Robust Channels: Handling Unreliable Networks in the Record Layers of QUIC and DTLS 1.3"
     author:
       - ins: M. Fischlin
       - ins: F. Günther
       - ins: C. Janson
-    date: 2020-02-21
-    target: "https://www.felixguenther.info/docs/QUIPS2020_RobustChannels.pdf"
+    date: 2020-05-16
+    target: "https://eprint.iacr.org/2020/718"
 
 
 --- abstract
@@ -2460,7 +2460,7 @@ document:
 - David Schinazi
 - Dragana Damjanovic
 - Eric Rescorla
-- Felix Günther
+- <t><t><contact asciiFullname="Felix Guenther" fullname="Felix Günther"/></t></t>
 - Ian Swett
 - Jana Iyengar
 - <t><t><contact asciiFullname="Kazuho Oku" fullname="奥 一穂"/></t></t>


### PR DESCRIPTION
Our paper on robust channels is now available in the IACR ePrint archive; I updated title + link.