### PR TITLE
Remove redundant requirement

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -444,8 +444,6 @@ conditions for opening a stream are slightly more complex for a bidirectional
 stream because the opening of either the send or receive side causes the stream
 to open in both directions.
 
-An endpoint MUST open streams of the same type in increasing order of stream ID.
-
 Note:
 
 : These states are largely informative.  This document uses stream states to


### PR DESCRIPTION
The text in 2.1 is more complete, so we don't need this.

Closes #3762.