### PR TITLE
Second set of editorial nits

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3464,7 +3464,7 @@ the IP header SHOULD be acknowledged immediately, to reduce the peer's response
 time to congestion events.
 
 The algorithms in {{QUIC-RECOVERY}} are expected to be resilient to receivers
-that do not follow guidance offered above. However, an endpoint should only
+that do not follow guidance offered above. However, an implementation should only
 deviate from these requirements after careful consideration of the performance
 implications of a change, for connections made by the endpoint and for other
 users of the network.
@@ -3551,8 +3551,8 @@ SHOULD stop tracking those acknowledged ACK Ranges.
 It is possible that retaining many ACK Ranges could cause an ACK frame to become
 too large. A receiver can discard unacknowledged ACK Ranges to limit ACK frame
 size, at the cost of increased retransmissions from the sender. This is
-necessary if an ACK frame would be too large to fit in a packet, however
-receivers MAY also limit ACK frame size further to preserve space for other
+necessary if an ACK frame would be too large to fit in a packet.
+Receivers MAY also limit ACK frame size further to preserve space for other
 frames or to limit the capacity that acknowledgments consume.
 
 A receiver MUST retain an ACK Range unless it can ensure that it will not

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3553,7 +3553,7 @@ too large. A receiver can discard unacknowledged ACK Ranges to limit ACK frame
 size, at the cost of increased retransmissions from the sender. This is
 necessary if an ACK frame would be too large to fit in a packet, however
 receivers MAY also limit ACK frame size further to preserve space for other
-frames or to limit the bandwidth that acknowledgments consume.
+frames or to limit the capacity that acknowledgments consume.
 
 A receiver MUST retain an ACK Range unless it can ensure that it will not
 subsequently accept packets with numbers in that range. Maintaining a minimum

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3464,10 +3464,10 @@ the IP header SHOULD be acknowledged immediately, to reduce the peer's response
 time to congestion events.
 
 The algorithms in {{QUIC-RECOVERY}} are expected to be resilient to receivers
-that do not follow guidance offered above. However, an implementation should only
-deviate from these requirements after careful consideration of the performance
-implications of a change, for connections made by the endpoint and for other
-users of the network.
+that do not follow guidance offered above. However, an implementation should
+only deviate from these requirements after careful consideration of the
+performance implications of a change, for connections made by the endpoint and
+for other users of the network.
 
 An endpoint that is only sending ACK frames will not receive acknowledgments
 from its peer unless those acknowledgements are included in packets with


### PR DESCRIPTION
@gorryfair had some useful feedback in #3735.

This doesn't address the following items as numbered in the issue:

(2) Because the fix to (1) seems adequate by my reckoning.  That
addresses the question of considering the impact on other network users.

(6) This doesn't appear to be a problem.  It might be a formatting
issue, with the URL not appearing.

(7) This is addressed in the recent draft by adding [Section
10.2.2](https://quicwg.org/base-drafts/draft-ietf-quic-transport.html#name-deferring-idle-timeout)

(9) and (11) I can't find the rendering glitch mentioned.

The rest of these are good.

Closes #3735.