### PR TITLE
Frame special rules

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3355,15 +3355,15 @@ N:
   {{generating-acks}}.
 
 C:
-: Packets containing only ACK frames do not count toward bytes in flight for
-  congestion control purposes; see {{QUIC-RECOVERY}}.
+: Packets containing only frames with this marking do not count toward bytes
+  in flight for congestion control purposes; see {{QUIC-RECOVERY}}.
 
 P:
 : Packets containing only frames with this marking can be used to probe new
   network paths during connection migration; see {{probing}}.
 
 F:
-: The content of the STREAM frame are flow controlled; see {{flow-control}}.
+: The content of frames with this marking are flow controlled; see {{flow-control}}.
 
 The "Pkts" and "Spec" columns in  {{frame-types}} does not form part of the IANA
 registry; see {{iana-frames}}.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3365,8 +3365,8 @@ P:
 F:
 : The content of the STREAM frame are flow controlled; see {{flow-control}}.
 
-The "Packets" and "Special" columns in  {{frame-types}} does not form part of
-the IANA registry; see {{iana-frames}}.
+The "Pkts" and "Spec" columns in  {{frame-types}} does not form part of the IANA
+registry; see {{iana-frames}}.
 
 An endpoint MUST treat the receipt of a frame of unknown type as a connection
 error of type FRAME_ENCODING_ERROR.
@@ -6901,7 +6901,7 @@ parameter registration is expected for most registrations; see
 needs to describe the format and assigned semantics of any fields in the frame.
 
 The initial contents of this registry are tabulated in {{frame-types}}.  Note
-that the registry does not include the "Packets" and "Special" columns from
+that the registry does not include the "Pkts" and "Spec" columns from
 {{frame-types}}.
 
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3363,7 +3363,8 @@ P:
   network paths during connection migration; see {{probing}}.
 
 F:
-: The content of frames with this marking are flow controlled; see {{flow-control}}.
+: The content of frames with this marking are flow controlled; see
+  {{flow-control}}.
 
 The "Pkts" and "Spec" columns in  {{frame-types}} does not form part of the IANA
 registry; see {{iana-frames}}.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3295,32 +3295,32 @@ CONNECTION_CLOSE frames is used to carry other frame-specific flags. For all
 other frames, the Frame Type field simply identifies the frame.  These
 frames are explained in more detail in {{frame-formats}}.
 
-| Type Value  | Frame Type Name      | Definition                     | Packets | Special |
-|:------------|:---------------------|:-------------------------------|----:----|----:----|
-| 0x00        | PADDING              | {{frame-padding}}              | IH01    | NP      |
-| 0x01        | PING                 | {{frame-ping}}                 | IH01    |         |
-| 0x02 - 0x03 | ACK                  | {{frame-ack}}                  | IH_1    | NC      |
-| 0x04        | RESET_STREAM         | {{frame-reset-stream}}         | __01    |         |
-| 0x05        | STOP_SENDING         | {{frame-stop-sending}}         | __01    |         |
-| 0x06        | CRYPTO               | {{frame-crypto}}               | IH_1    |         |
-| 0x07        | NEW_TOKEN            | {{frame-new-token}}            | ___1    |         |
-| 0x08 - 0x0f | STREAM               | {{frame-stream}}               | __01    | F       |
-| 0x10        | MAX_DATA             | {{frame-max-data}}             | __01    |         |
-| 0x11        | MAX_STREAM_DATA      | {{frame-max-stream-data}}      | __01    |         |
-| 0x12 - 0x13 | MAX_STREAMS          | {{frame-max-streams}}          | __01    |         |
-| 0x14        | DATA_BLOCKED         | {{frame-data-blocked}}         | __01    |         |
-| 0x15        | STREAM_DATA_BLOCKED  | {{frame-stream-data-blocked}}  | __01    |         |
-| 0x16 - 0x17 | STREAMS_BLOCKED      | {{frame-streams-blocked}}      | __01    |         |
-| 0x18        | NEW_CONNECTION_ID    | {{frame-new-connection-id}}    | __01    | P       |
-| 0x19        | RETIRE_CONNECTION_ID | {{frame-retire-connection-id}} | __01    |         |
-| 0x1a        | PATH_CHALLENGE       | {{frame-path-challenge}}       | __01    | P       |
-| 0x1b        | PATH_RESPONSE        | {{frame-path-response}}        | __01    | P       |
-| 0x1c - 0x1d | CONNECTION_CLOSE     | {{frame-connection-close}}     | ih01    |         |
-| 0x1e        | HANDSHAKE_DONE       | {{frame-handshake-done}}       | ___1    |         |
+| Type Value  | Frame Type Name      | Definition                     | Pkts | Spec |
+|:------------|:---------------------|:-------------------------------|------|------|
+| 0x00        | PADDING              | {{frame-padding}}              | IH01 | NP   |
+| 0x01        | PING                 | {{frame-ping}}                 | IH01 |      |
+| 0x02 - 0x03 | ACK                  | {{frame-ack}}                  | IH_1 | NC   |
+| 0x04        | RESET_STREAM         | {{frame-reset-stream}}         | __01 |      |
+| 0x05        | STOP_SENDING         | {{frame-stop-sending}}         | __01 |      |
+| 0x06        | CRYPTO               | {{frame-crypto}}               | IH_1 |      |
+| 0x07        | NEW_TOKEN            | {{frame-new-token}}            | ___1 |      |
+| 0x08 - 0x0f | STREAM               | {{frame-stream}}               | __01 | F    |
+| 0x10        | MAX_DATA             | {{frame-max-data}}             | __01 |      |
+| 0x11        | MAX_STREAM_DATA      | {{frame-max-stream-data}}      | __01 |      |
+| 0x12 - 0x13 | MAX_STREAMS          | {{frame-max-streams}}          | __01 |      |
+| 0x14        | DATA_BLOCKED         | {{frame-data-blocked}}         | __01 |      |
+| 0x15        | STREAM_DATA_BLOCKED  | {{frame-stream-data-blocked}}  | __01 |      |
+| 0x16 - 0x17 | STREAMS_BLOCKED      | {{frame-streams-blocked}}      | __01 |      |
+| 0x18        | NEW_CONNECTION_ID    | {{frame-new-connection-id}}    | __01 | P    |
+| 0x19        | RETIRE_CONNECTION_ID | {{frame-retire-connection-id}} | __01 |      |
+| 0x1a        | PATH_CHALLENGE       | {{frame-path-challenge}}       | __01 | P    |
+| 0x1b        | PATH_RESPONSE        | {{frame-path-response}}        | __01 | P    |
+| 0x1c - 0x1d | CONNECTION_CLOSE     | {{frame-connection-close}}     | ih01 |      |
+| 0x1e        | HANDSHAKE_DONE       | {{frame-handshake-done}}       | ___1 |      |
 {: #frame-types title="Frame Types"}
 
-The "Packets" column in {{frame-types}} lists the types of packets that each
-frame type could appear in, indicated by the following characters:
+The "Pkts" column in {{frame-types}} lists the types of packets that each frame
+type could appear in, indicated by the following characters:
 
 I:
 
@@ -3346,8 +3346,9 @@ ih:
 Section 4 of {{QUIC-TLS}} provides more detail about these restrictions.  Note
 that all frames can appear in 1-RTT packets.
 
-The "Special" column in  {{frame-types}} identifies special rules governing the
-identified frame type, as indicated by the following characters:
+The "Spec" column in  {{frame-types}} summarizes any special rules governing the
+processing or generation of the frame type, as indicated by the following
+characters:
 
 N:
 : Packets containing only frames with this marking are not ack-eliciting; see

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3295,33 +3295,32 @@ CONNECTION_CLOSE frames is used to carry other frame-specific flags. For all
 other frames, the Frame Type field simply identifies the frame.  These
 frames are explained in more detail in {{frame-formats}}.
 
-| Type Value  | Frame Type Name      | Definition                     | Packets |
-|:------------|:---------------------|:-------------------------------|---------|
-| 0x00        | PADDING              | {{frame-padding}}              | IH01    |
-| 0x01        | PING                 | {{frame-ping}}                 | IH01    |
-| 0x02 - 0x03 | ACK                  | {{frame-ack}}                  | IH_1    |
-| 0x04        | RESET_STREAM         | {{frame-reset-stream}}         | __01    |
-| 0x05        | STOP_SENDING         | {{frame-stop-sending}}         | __01    |
-| 0x06        | CRYPTO               | {{frame-crypto}}               | IH_1    |
-| 0x07        | NEW_TOKEN            | {{frame-new-token}}            | ___1    |
-| 0x08 - 0x0f | STREAM               | {{frame-stream}}               | __01    |
-| 0x10        | MAX_DATA             | {{frame-max-data}}             | __01    |
-| 0x11        | MAX_STREAM_DATA      | {{frame-max-stream-data}}      | __01    |
-| 0x12 - 0x13 | MAX_STREAMS          | {{frame-max-streams}}          | __01    |
-| 0x14        | DATA_BLOCKED         | {{frame-data-blocked}}         | __01    |
-| 0x15        | STREAM_DATA_BLOCKED  | {{frame-stream-data-blocked}}  | __01    |
-| 0x16 - 0x17 | STREAMS_BLOCKED      | {{frame-streams-blocked}}      | __01    |
-| 0x18        | NEW_CONNECTION_ID    | {{frame-new-connection-id}}    | __01    |
-| 0x19        | RETIRE_CONNECTION_ID | {{frame-retire-connection-id}} | __01    |
-| 0x1a        | PATH_CHALLENGE       | {{frame-path-challenge}}       | __01    |
-| 0x1b        | PATH_RESPONSE        | {{frame-path-response}}        | __01    |
-| 0x1c - 0x1d | CONNECTION_CLOSE     | {{frame-connection-close}}     | ih01    |
-| 0x1e        | HANDSHAKE_DONE       | {{frame-handshake-done}}       | ___1    |
+| Type Value  | Frame Type Name      | Definition                     | Packets | Special |
+|:------------|:---------------------|:-------------------------------|----:----|----:----|
+| 0x00        | PADDING              | {{frame-padding}}              | IH01    | NP      |
+| 0x01        | PING                 | {{frame-ping}}                 | IH01    |         |
+| 0x02 - 0x03 | ACK                  | {{frame-ack}}                  | IH_1    | NC      |
+| 0x04        | RESET_STREAM         | {{frame-reset-stream}}         | __01    |         |
+| 0x05        | STOP_SENDING         | {{frame-stop-sending}}         | __01    |         |
+| 0x06        | CRYPTO               | {{frame-crypto}}               | IH_1    |         |
+| 0x07        | NEW_TOKEN            | {{frame-new-token}}            | ___1    |         |
+| 0x08 - 0x0f | STREAM               | {{frame-stream}}               | __01    | F       |
+| 0x10        | MAX_DATA             | {{frame-max-data}}             | __01    |         |
+| 0x11        | MAX_STREAM_DATA      | {{frame-max-stream-data}}      | __01    |         |
+| 0x12 - 0x13 | MAX_STREAMS          | {{frame-max-streams}}          | __01    |         |
+| 0x14        | DATA_BLOCKED         | {{frame-data-blocked}}         | __01    |         |
+| 0x15        | STREAM_DATA_BLOCKED  | {{frame-stream-data-blocked}}  | __01    |         |
+| 0x16 - 0x17 | STREAMS_BLOCKED      | {{frame-streams-blocked}}      | __01    |         |
+| 0x18        | NEW_CONNECTION_ID    | {{frame-new-connection-id}}    | __01    | P       |
+| 0x19        | RETIRE_CONNECTION_ID | {{frame-retire-connection-id}} | __01    |         |
+| 0x1a        | PATH_CHALLENGE       | {{frame-path-challenge}}       | __01    | P       |
+| 0x1b        | PATH_RESPONSE        | {{frame-path-response}}        | __01    | P       |
+| 0x1c - 0x1d | CONNECTION_CLOSE     | {{frame-connection-close}}     | ih01    |         |
+| 0x1e        | HANDSHAKE_DONE       | {{frame-handshake-done}}       | ___1    |         |
 {: #frame-types title="Frame Types"}
 
-The "Packets" column in {{frame-types}} does not form part of the IANA registry;
-see {{iana-frames}}.  This column lists the types of packets that each frame
-type could appear in, indicated by the following characters:
+The "Packets" column in {{frame-types}} lists the types of packets that each
+frame type could appear in, indicated by the following characters:
 
 I:
 
@@ -3346,6 +3345,27 @@ ih:
 
 Section 4 of {{QUIC-TLS}} provides more detail about these restrictions.  Note
 that all frames can appear in 1-RTT packets.
+
+The "Special" column in  {{frame-types}} identifies special rules governing the
+identified frame type, as indicated by the following characters:
+
+N:
+: Packets containing only frames with this marking are not ack-eliciting; see
+  {{generating-acks}}.
+
+C:
+: Packets containing only ACK frames do not count toward bytes in flight for
+  congestion control purposes; see {{QUIC-RECOVERY}}.
+
+P:
+: Packets containing only frames with this marking can be used to probe new
+  network paths during connection migration; see {{probing}}.
+
+F:
+: The content of the STREAM frame are flow controlled; see {{flow-control}}.
+
+The "Packets" and "Special" columns in  {{frame-types}} does not form part of
+the IANA registry; see {{iana-frames}}.
 
 An endpoint MUST treat the receipt of a frame of unknown type as a connection
 error of type FRAME_ENCODING_ERROR.
@@ -6880,7 +6900,8 @@ parameter registration is expected for most registrations; see
 needs to describe the format and assigned semantics of any fields in the frame.
 
 The initial contents of this registry are tabulated in {{frame-types}}.  Note
-that the registry does not include the "Packets" column from {{frame-types}}.
+that the registry does not include the "Packets" and "Special" columns from
+{{frame-types}}.
 
 
 ## QUIC Transport Error Codes Registry {#iana-error-codes}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3366,7 +3366,7 @@ F:
 : The content of frames with this marking are flow controlled; see
   {{flow-control}}.
 
-The "Pkts" and "Spec" columns in  {{frame-types}} does not form part of the IANA
+The "Pkts" and "Spec" columns in  {{frame-types}} do not form part of the IANA
 registry; see {{iana-frames}}.
 
 An endpoint MUST treat the receipt of a frame of unknown type as a connection


### PR DESCRIPTION
After considering this a little more it seems helpful to bring some of the special handling rules up into the summary.  We don't really give up-front treatment of ack-eliciting, probing, and other important distinctions, so an extra column seemed useful.

A table of this size *just* fits in the text format.

Closes #3737.