### PR TITLE
Encryption level of CRYPTO determines packet type

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -431,8 +431,8 @@ the packet type and keys that are used for protecting data.
 Each encryption level is associated with a different sequence of bytes, which is
 reliably transmitted to the peer in CRYPTO frames. When TLS provides handshake
 bytes to be sent, they are appended to the handshake bytes for the current
-encryption level. Any packet that includes the CRYPTO frame is protected using
-keys from the corresponding encryption level.
+encryption level. The encryption level then determines the type of packet that
+the resulting CRYPTO frame is carried in; see {{packet-types-keys}}.
 
 Four encryption levels are used, producing keys for Initial, 0-RTT, Handshake,
 and 1-RTT packets. CRYPTO frames are carried in just three of these levels,


### PR DESCRIPTION
The text implied the opposite.