### PR TITLE
Packets might be integrity protected

### DIFF
--- a/draft-ietf-quic-invariants.md
+++ b/draft-ietf-quic-invariants.md
@@ -156,7 +156,7 @@ Example Structure {
 {: #fig-ex-format title="Example Format"}
 
 
-# QUIC Packet Headers
+# QUIC Packets
 
 QUIC endpoints exchange UDP datagrams that contain one or more QUIC packets.
 This section describes the invariant characteristics of a QUIC packet.  A
@@ -166,6 +166,9 @@ the invariant properties only describe the first packet in a datagram.
 QUIC defines two types of packet header: long and short.  Packets with long
 headers are identified by the most significant bit of the first byte being set;
 packets with a short header have that bit cleared.
+
+QUIC packets might be integrity protected, including the header.  However, QUIC
+Version Negotiation packets are not integrity protected; see {{vn}}.
 
 Aside from the values described here, the payload of QUIC packets is
 version-specific and of arbitrary length.
@@ -253,8 +256,8 @@ Packets for the same QUIC connection might use different connection ID values.
 ## Version
 
 QUIC versions are identified with a 32-bit integer, encoded in network byte
-order.  Version 0 is reserved for version negotiation (see
-{{version-negotiation}}).  All other version numbers are potentially valid.
+order.  Version 0 is reserved for version negotiation (see {{vn}}).  All other
+version numbers are potentially valid.
 
 The properties described in this document apply to all versions of QUIC. A
 protocol that does not conform to the properties described in this document is
@@ -262,7 +265,7 @@ not QUIC.  Future documents might describe additional properties which apply to
 a specific QUIC version, or to a range of QUIC versions.
 
 
-# Version Negotiation {#version-negotiation}
+# Version Negotiation {#vn}
 
 A QUIC endpoint that receives a packet with a long header and a version it
 either does not understand or does not support might send a Version Negotiation


### PR DESCRIPTION
Or MAY, but let's leave this probabilistic, because in practice there is
no uncertainty: packets are protected.

I've changed the header of the section because it isn't just about the
header: the subsections are about the specific headers, but this one is
about packets as a whole.