### PR TITLE
Expand AEAD limits to consider multi-user security.

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -2407,8 +2407,8 @@ without a significant effect on the result. This produces the relation:
 v + q <= 2^24.5
 ~~~
 
-Assuming `q = v`, endpoints cannot attempt to protect or authenticate more than 
-2^23.5 packets with the same set of keys without causing an attacker to gain an larger 
+Assuming `q = v`, endpoints cannot attempt to protect or authenticate more than
+2^23.5 packets with the same set of keys without causing an attacker to gain an larger
 advantage than the target of 2^-57 in forging packets.
 
 

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -2266,7 +2266,7 @@ For integrity, Theorem (4.3) in {{?GCM-MU}} establishes that an attacker gains
 an advantage in successfully forging a packet of no more than:
 
 ~~~
-(1 / 2^(8 * n)) + ((2 * v) / 2^2*n) + ((2 * o * v) / 2^(k + n))
+(1 / 2^(8 * n)) + ((2 * v) / 2^(2 * n)) + ((2 * o * v) / 2^(k + n))
         + (n * (v + (v * l)) / 2^k)
 ~~~
 

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1567,18 +1567,15 @@ AEAD_AES_128_CCM, the confidentiality limit is 2^23 encrypted packets; see
 
 In addition to counting packets sent, endpoints MUST count the number of
 received packets that fail authentication during the lifetime of a connection.
-If the number of packets sent or fail authentication within the connection
-(across all keys) exceeds a limit that is specific to the AEAD in use, the
-endpoint MUST immediately close the connection and not attempt to process any
-further packets.  Applying a limit reduces the probability that an attacker can
-successfully forge a packet; see {{AEBounds}}, {{ROBUST}}, and {{?GCM-MU}}.
-
-A connection MUST be closed if the number of packets that fail authentication
-exceed the integrity limit for the selected AEAD. For AEAD_AES_128_GCM, and the
-integrity limit is 2^54 encrypted or forged packets; see {{gcm-bounds}}.  For
-AEAD_CHACHA20_POLY1305, the limit on number of packets that fail authentication
-is 2^36; see {{AEBounds}}.  For AEAD_AES_128_CCM, the integrity limit is 2^23.5
-forged packets; see {{ccm-bounds}}.
+If the total number of received packets that fail authentication within the
+connection, across all keys, exceeds the integrity limit for the selected AEAD,
+the endpoint MUST immediately close the connection and not process any more
+packets. For AEAD_AES_128_GCM, the integrity limit is 2^54 forged packets; see
+{{gcm-bounds}}. For AEAD_CHACHA20_POLY1305, the integrity limit is 2^36
+forged packets; see {{AEBounds}}. For AEAD_AES_128_CCM, the integrity limit
+is 2^23.5 forged packets; see {{ccm-bounds}}. Applying this limit reduces the
+probability that an attacker can successfully forge a packet; see {{AEBounds}},
+{{ROBUST}}, and {{?GCM-MU}}.
 
 Future analyses and specifications MAY relax confidentiality or integrity limits
 for an AEAD.

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -2408,8 +2408,8 @@ v + q <= 2^24.5
 ~~~
 
 Assuming `q = v`, endpoints cannot attempt to protect or authenticate more than
-2^23.5 packets with the same set of keys without causing an attacker to gain an larger
-advantage than the target of 2^-57 in forging packets.
+2^23.5 packets with the same set of keys without causing an attacker to gain a
+larger advantage in forging packets than the target of 2^-57.
 
 
 # Change Log

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -2177,9 +2177,10 @@ packet = 4cfe4189655e5cd55c41f69080575d7999c25a5bfb
 # AEAD Algorithm Analysis
 
 This section documents analyses used in deriving AEAD algorithm limits for
-AEAD_AES_128_GCM, AEAD_AES_128_CCM, and AEAD_AES_256_GCM. The analyses that follow
-use symbols for multiplication (*), division (/), and exponentiation (^), plus
-parentheses for establishing precedence. The following symbols are also used:
+AEAD_AES_128_GCM, AEAD_AES_128_CCM, and AEAD_AES_256_GCM. The analyses that
+follow use symbols for multiplication (*), division (/), and exponentiation (^),
+plus parentheses for establishing precedence. The following symbols are also
+used:
 
 t:
 
@@ -2209,10 +2210,10 @@ o:
 
 : The amount of offline ideal cipher queries made by an adversary.
 
-The analyses that follow rely on a count of the number of block operations involved
-in producing each message. For simplicity, and to match the analysis of other AEAD
-functions in {{AEBounds}}, this analysis assumes a packet length of 2^10 blocks;
-that is, a packet size limit of 2^14 bytes.
+The analyses that follow rely on a count of the number of block operations
+involved in producing each message. For simplicity, and to match the analysis of
+other AEAD functions in {{AEBounds}}, this analysis assumes a packet length of
+2^10 blocks; that is, a packet size limit of 2^14 bytes.
 
 For AEAD_AES_128_CCM, the total number of block cipher operations is the sum
 of: the length of the associated data in blocks, the length of the ciphertext
@@ -2228,8 +2229,9 @@ overestimation of the number of operations.
 used in TLS 1.3 and QUIC. This section documents this analysis using several
 simplifying assumptions:
 
-- The number of ciphertext blocks an attacker uses in forgery attempts is bounded
-by v * l, the number of forgery attempts and the size of each packet (in blocks).
+- The number of ciphertext blocks an attacker uses in forgery attempts is
+bounded by v * l, the number of forgery attempts and the size of each packet (in
+blocks).
 
 - The amount of offline work done by an attacker does not dominate other factors
 in the analysis.
@@ -2239,8 +2241,9 @@ The bounds in {{?GCM-MU}} are tighter and more complete than those used in
 
 ### Confidentiality Limit
 
-For confidentiality, Equation (1) in {{?GCM-MU}} establishes that an attacker gains
-a distinguishing advantage between a real and random AEAD algorithm of no more than:
+For confidentiality, Equation (1) in {{?GCM-MU}} establishes that an attacker
+gains a distinguishing advantage between a real and random AEAD algorithm of no
+more than:
 
 ~~~
 ((q + v) * l)^2 / 2^128

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1540,7 +1540,7 @@ discarded.
 
 This document sets usage limits for AEAD algorithms to ensure that overuse does
 not give an adversary a disproportionate advantage in attacking the
-confidentiality and integrity of communications.
+confidentiality and integrity of communications when using QUIC.
 
 The usage limits defined in TLS 1.3 exist for protection against attacks
 on confidentiality and apply to successful applications of AEAD protection. The

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1638,7 +1638,7 @@ type AEAD_LIMIT_REACHED and not process any more packets.
 For AEAD_AES_128_GCM and AEAD_AES_256_GCM, the integrity limit is 2^54 forged
 packets; see {{gcm-bounds}}. For AEAD_CHACHA20_POLY1305, the integrity limit is
 2^36 forged packets; see {{AEBounds}}. For AEAD_AES_128_CCM, the integrity limit
-is 2^23.5 forged packets; see {{ccm-bounds}}. Applying this limit reduces the
+is 2^23.5 invalid packets; see {{ccm-bounds}}. Applying this limit reduces the
 probability that an attacker can successfully forge a packet; see {{AEBounds}},
 {{ROBUST}}, and {{?GCM-MU}}.
 

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -2293,7 +2293,7 @@ the associated data and ciphertext. This results in a negligible 1 to 3 block
 overestimation of the number of operations.
 
 
-## Analysis AEAD_AES_128_GCM and AEAD_AES_256_GCM Usage Limits {#gcm-bounds}
+## Analysis of AEAD_AES_128_GCM and AEAD_AES_256_GCM Usage Limits {#gcm-bounds}
 
 {{?GCM-MU}} specify concrete bounds for AEAD_AES_128_GCM and AEAD_AES_256_GCM as
 used in TLS 1.3 and QUIC. This section documents this analysis using several
@@ -2312,7 +2312,7 @@ The bounds in {{?GCM-MU}} are tighter and more complete than those used in
 
 ### Confidentiality Limit
 
-For confidentiality, Theorum (4.3) in {{?GCM-MU}} establish that - for a single
+For confidentiality, Theorum (4.3) in {{?GCM-MU}} establishes that - for a single
 user that does not repeat nonces - the dominant term in determining the
 distinguishing advantage between a real and random AEAD algorithm gained by an
 attacker is:

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1635,12 +1635,12 @@ connection, across all keys, exceeds the integrity limit for the selected AEAD,
 the endpoint MUST immediately close the connection with a connection error of
 type AEAD_LIMIT_REACHED and not process any more packets.
 
-For AEAD_AES_128_GCM and AEAD_AES_256_GCM, the integrity limit is 2^54 forged
+For AEAD_AES_128_GCM and AEAD_AES_256_GCM, the integrity limit is 2^54 invalid
 packets; see {{gcm-bounds}}. For AEAD_CHACHA20_POLY1305, the integrity limit is
-2^36 forged packets; see {{AEBounds}}. For AEAD_AES_128_CCM, the integrity limit
-is 2^23.5 invalid packets; see {{ccm-bounds}}. Applying this limit reduces the
-probability that an attacker can successfully forge a packet; see {{AEBounds}},
-{{ROBUST}}, and {{?GCM-MU}}.
+2^36 invalid packets; see {{AEBounds}}. For AEAD_AES_128_CCM, the integrity
+limit is 2^23.5 invalid packets; see {{ccm-bounds}}. Applying this limit reduces
+the probability that an attacker can successfully forge a packet; see
+{{AEBounds}}, {{ROBUST}}, and {{?GCM-MU}}.
 
 Future analyses and specifications MAY relax confidentiality or integrity limits
 for an AEAD.

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -2312,8 +2312,8 @@ The bounds in {{?GCM-MU}} are tighter and more complete than those used in
 
 ### Confidentiality Limit
 
-For confidentiality, Theorum (4.3) in {{?GCM-MU}} establishes that - for a single
-user that does not repeat nonces - the dominant term in determining the
+For confidentiality, Theorum (4.3) in {{?GCM-MU}} establishes that - for a
+single user that does not repeat nonces - the dominant term in determining the
 distinguishing advantage between a real and random AEAD algorithm gained by an
 attacker is:
 

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1603,16 +1603,22 @@ number of attempts to forge packets. TLS achieves this by closing connections
 after any record fails an authentication check. In comparison, QUIC ignores any
 packet that cannot be authenticated, allowing multiple forgery attempts.
 
+QUIC accounts for AEAD confidentiality and integrity limits separately. The
+confidentiality limit applies to the number of packets encrypted with a given
+key. The integrity limit applies to the number of packets decrypted within a
+given connection. Details on enforcing these limits for each AEAD algorithm
+follow below.
+
 Endpoints MUST count the number of encrypted packets for each set of keys. If
 the total number of encrypted packets with the same key exceeds the
 confidentiality limit for the selected AEAD, the endpoint MUST stop using those
 keys. Endpoints MUST initiate a key update before sending more protected packets
 than the confidentiality limit for the selected AEAD permits. If a key update
 is not possible or integrity limits are reached, the endpoint MUST stop using
-the connection and only send stateless resets in response receiving packets. It
-is RECOMMENDED that endpoints immediately close the connection with a connection
-error of type PROTOCOL_VIOLATION before reaching a state where key updates are
-not possible.
+the connection and only send stateless resets in response to receiving packets.
+It is RECOMMENDED that endpoints immediately close the connection with a
+connection error of type AEAD_LIMIT_REACHED before reaching a state where key
+updates are not possible.
 
 For AEAD_AES_128_GCM and AEAD_AES_256_GCM, the confidentiality limit is 2^25
 encrypted packets; see {{gcm-bounds}}. For AEAD_CHACHA20_POLY1305, the
@@ -1626,8 +1632,8 @@ In addition to counting packets sent, endpoints MUST count the number of
 received packets that fail authentication during the lifetime of a connection.
 If the total number of received packets that fail authentication within the
 connection, across all keys, exceeds the integrity limit for the selected AEAD,
-the endpoint MUST immediately close the connection and not process any more
-packets.
+the endpoint MUST immediately close the connection with a connection error of
+type AEAD_LIMIT_REACHED and not process any more packets.
 
 For AEAD_AES_128_GCM and AEAD_AES_256_GCM, the integrity limit is 2^54 forged
 packets; see {{gcm-bounds}}. For AEAD_CHACHA20_POLY1305, the integrity limit is

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -6167,6 +6167,11 @@ CRYPTO_BUFFER_EXCEEDED (0xD):
 
 : An endpoint has received more data in CRYPTO frames than it can buffer.
 
+AEAD_LIMIT_REACHED (0xE):
+
+: An endpoint has reached the confidentiality or integrity limit for the AEAD
+  algorithm used by the given connection.
+
 CRYPTO_ERROR (0x1XX):
 
 : The cryptographic handshake failed.  A range of 256 values is reserved for


### PR DESCRIPTION
Closes #3788.

In a typical multi-user setting, the adversary is assumed to perform some
(massive) amount of offline work to break the integrity of a single random
connection. Each user is represented as a unique (key, nonce) pair. In
considering the same threat model, we must treat each key resulting from
a KeyUpdate event as a unique user. As a result, roughly speaking, bounds
implied from the multi-user setting imply (minimally) for the lifetime of
a single connection.

Hoang et al. [1] present tight multi-user security bounds for randomized AES-GCM
(as is used in TLS 1.3 and QUIC), so we can take advantage of those for
per-connection integrity limits. (Confidentiality limits still apply per-key, as
the analysis considers only encrypted blocks, which would not change if an endpoint
updated its key or created a new connection.) In contrast, there are no multi-user
security bounds for AEAD_CHACHA20_POLY1305 or AEAD_AES_128_CCM, so we must use the
single-user bounds in their stead.

[1] https://dl.acm.org/doi/10.1145/3243734.3243816