### PR TITLE
Add a section on flow control performance

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -968,17 +968,18 @@ signal before advertising additional credit, since doing so will mean that the
 peer will be blocked for at least an entire round trip, and potentially for
 longer if the peer chooses to not send STREAMS_BLOCKED frames.
 
+
 ## Flow Control Performance
 
 An endpoint that is unable to ensure that a peer has flow control credit on the
 order of the current BDP will have receive throughput limited by flow control.
 Lost packets can cause gaps in the receive buffer, delaying the application
-from consuming data and freeing up flow control window. Timely sending of
-updates to flow control limits can improve performance. However, an excessive
-rate of updates can also adversely affect performance.
+from consuming data and freeing up flow control window.
 
-This document does not specify techniques for tuning flow control performance
-where resources allocated to receiving data are limited.
+Timely sending of updates to flow control limits can improve performance.
+Sending of packets just to provide flow control updates can increase network
+load and adversely affect performance. Sending flow control updates along with
+other frames, such as ACK frames, can reduce the cost of those updates.
 
 
 # Connections {#connections}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -968,6 +968,24 @@ signal before advertising additional credit, since doing so will mean that the
 peer will be blocked for at least an entire round trip, and potentially for
 longer if the peer chooses to not send STREAMS_BLOCKED frames.
 
+## Flow Control Performance
+
+Unlike TCP, QUIC decouples flow control from congestion control. This can
+release pressure on implementing a good flow control algorithm that governs both
+how limits are increased and when new limits are advertised. An endpoint can
+use flow control to constrain resource commitments without an optimized
+algorithm by allocating buffers for receiving data that are significantly larger
+than the bandwidth-delay product (BDP).  That is, by a factor of 2 or more.
+
+An endpoint that is unable to ensure that a peer has flow control credit in the
+order of the current BDP will have receive throughput limited by flow control
+and not other limiting factors like congestion control.  Timely sending of
+updates to flow control limits can improve performance, however an excessive
+rate of updates can also adversely affect performance.
+
+This document does not specify techniques for tuning flow control performance
+where resources allocated to receiving data are limited.
+
 
 # Connections {#connections}
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -970,10 +970,10 @@ longer if the peer chooses to not send STREAMS_BLOCKED frames.
 
 ## Flow Control Performance
 
-An endpoint that is unable to ensure that a peer has flow control credit in the
+An endpoint that is unable to ensure that a peer has flow control credit on the
 order of the current BDP will have receive throughput limited by flow control
 and not other limiting factors like congestion control.  Timely sending of
-updates to flow control limits can improve performance, however an excessive
+updates to flow control limits can improve performance. However, an excessive
 rate of updates can also adversely affect performance.
 
 This document does not specify techniques for tuning flow control performance

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -971,8 +971,9 @@ longer if the peer chooses to not send STREAMS_BLOCKED frames.
 ## Flow Control Performance
 
 An endpoint that is unable to ensure that a peer has flow control credit on the
-order of the current BDP will have receive throughput limited by flow control
-and not other limiting factors like congestion control.  Timely sending of
+order of the current BDP will have receive throughput limited by flow control.
+Lost packets can cause gaps in the receive buffer, delaying the application
+from consuming data and freeing up flow control window. Timely sending of
 updates to flow control limits can improve performance. However, an excessive
 rate of updates can also adversely affect performance.
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -970,13 +970,6 @@ longer if the peer chooses to not send STREAMS_BLOCKED frames.
 
 ## Flow Control Performance
 
-Unlike TCP, QUIC decouples flow control from congestion control. This can
-release pressure on implementing a good flow control algorithm that governs both
-how limits are increased and when new limits are advertised. An endpoint can
-use flow control to constrain resource commitments without an optimized
-algorithm by allocating buffers for receiving data that are significantly larger
-than the bandwidth-delay product (BDP).  That is, by a factor of 2 or more.
-
 An endpoint that is unable to ensure that a peer has flow control credit in the
 order of the current BDP will have receive throughput limited by flow control
 and not other limiting factors like congestion control.  Timely sending of

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -976,10 +976,10 @@ order of the current BDP will have receive throughput limited by flow control.
 Lost packets can cause gaps in the receive buffer, delaying the application
 from consuming data and freeing up flow control window.
 
-Timely sending of updates to flow control limits can improve performance.
-Sending of packets just to provide flow control updates can increase network
+Sending timely updates of flow control limits can improve performance.
+Sending packets only to provide flow control updates can increase network
 load and adversely affect performance. Sending flow control updates along with
-other frames, such as ACK frames, can reduce the cost of those updates.
+other frames, such as ACK frames, reduces the cost of those updates.
 
 
 # Connections {#connections}


### PR DESCRIPTION
QUIC doesn't really address the question of tuning flow control very
well.  This just admits that fact.

It also indicates why: which essentially boils down to "RAM is cheap".

Closes #3722.