### PR TITLE
Stop using CID acronym

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2584,14 +2584,14 @@ in compliance with {{!RFC6437}}, unless the local API does not allow
 setting IPv6 flow labels.
 
 The IPv6 flow label SHOULD be a pseudo-random function of the source and
-destination addresses, source and destination UDP ports, and the destination
-CID.  The flow label generation MUST be designed to minimize the chances of
-linkability with a previously used flow label, as this would enable correlating
-activity on multiple paths; see {{migration-linkability}}.
+destination addresses, source and destination UDP ports, and the Destination
+Connection ID field.  The flow label generation MUST be designed to minimize the
+chances of linkability with a previously used flow label, as this would enable
+correlating activity on multiple paths; see {{migration-linkability}}.
 
 A possible implementation is to compute the flow label as a cryptographic hash
 function of the source and destination addresses, source and destination
-UDP ports, destination CID, and a local secret.
+UDP ports, Destination Connection ID field, and a local secret.
 
 # Connection Termination {#termination}
 
@@ -5070,7 +5070,7 @@ Preferred Address {
   IPv4 Port (16),
   IPv6 Address (128),
   IPv6 Port (16),
-  CID Length (8),
+  Connection ID Length (8),
   Connection ID (..),
   Stateless Reset Token (128),
 }


### PR DESCRIPTION
We've been pretty disciplined about using "connection ID", except for
the text on flow labels and one mention in the diagram for
preferred_address.  Of course, the mentions in the flow label text were
specifically for the "Destination Connection ID field", so that is what
I used there.

Closes #3794.