### PR TITLE
Cite a source for the 30s timeout

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2717,8 +2717,9 @@ A connection will time out if no packets are sent or received for a period
 longer than the time negotiated using the max_idle_timeout transport parameter;
 see {{termination}}.  However, state in middleboxes might time out earlier than
 that.  Though REQ-5 in {{?RFC4787}} recommends a 2 minute timeout interval,
-experience shows that sending packets every 15 to 30 seconds is necessary to
-prevent the majority of middleboxes from losing state for UDP flows.
+experience shows that sending packets every 30 seconds is necessary to prevent
+the majority of middleboxes from losing state for UDP flows
+{{?GATEWAY=DOI.10.1145/1879141.1879174}}.
 
 
 ## Immediate Close {#immediate-close}


### PR DESCRIPTION
Thanks to Lucas for finding the study.  Note that I found at least one
middlebox with a default timeout of 30s; that was not a home gateway
included in this study.

Closes #3799.