### PR TITLE
A in AEAD, per RFC 5116

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3142,11 +3142,11 @@ after a connection is established and 1-RTT keys are available; see
 
 ## Protected Packets {#packet-protected}
 
-All QUIC packets except Version Negotiation packets use authenticated
-encryption with additional data (AEAD) {{!RFC5116}} to provide confidentiality
-and integrity protection.  Retry packets use AEAD to provide integrity
-protection.  Details of packet protection are found in {{QUIC-TLS}}; this
-section includes an overview of the process.
+All QUIC packets except Version Negotiation packets use authenticated encryption
+with associated data (AEAD) {{!RFC5116}} to provide confidentiality and
+integrity protection.  Retry packets use AEAD to provide integrity protection.
+Details of packet protection are found in {{QUIC-TLS}}; this section includes an
+overview of the process.
 
 Initial packets are protected using keys that are statically derived. This
 packet protection is not effective confidentiality protection.  Initial


### PR DESCRIPTION
I'd always heard this as "Authenticated Encryption with Additional Data," so it was -tls that sounded funny.  But looking at 5116, it's actually "Associated" data and -tls is correct.  Fixing in -transport.