### PR TITLE
Tickets and tokens are not for communication

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1765,9 +1765,10 @@ Note:
 : TLS session tickets and address validation tokens are used to carry QUIC
   configuration information between connections.  Specifically, to enable a
   server to efficiently recover state that is used in connection establishment
-  and address validation.  These have no application-level semantics; clients
-  MUST treat them as opaque values.  The potential for reuse of these tokens
-  means that they require stronger protections against replay.
+  and address validation.  These MUST NOT be used to communicate application
+  semantics between endpoints; clients MUST treat them as opaque values.  The
+  potential for reuse of these tokens means that they require stronger
+  protections against replay.
 
 A server that accepts 0-RTT on a connection incurs a higher cost than accepting
 a connection without 0-RTT.  This includes higher processing and computation

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1765,9 +1765,9 @@ Note:
 : TLS session tickets and address validation tokens are used to carry QUIC
   configuration information between connections.  Specifically, to enable a
   server to efficiently recover state that is used in connection establishment
-  and address validation.  These MUST NOT be used to communicate application
-  semantics between endpoints.  The potential for reuse of these tokens means
-  that they require stronger protections against replay.
+  and address validation.  These have no application-level semantics; clients
+  MUST treat them as opaque values.  The potential for reuse of these tokens
+  means that they require stronger protections against replay.
 
 A server that accepts 0-RTT on a connection incurs a higher cost than accepting
 a connection without 0-RTT.  This includes higher processing and computation

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1763,8 +1763,10 @@ those produced by the application protocol that QUIC serves.
 Note:
 
 : TLS session tickets and address validation tokens are used to carry QUIC
-  configuration information between connections.  These MUST NOT be used to
-  carry application semantics.  The potential for reuse of these tokens means
+  configuration information between connections.  Specifically, to enable a
+  server to efficiently recover state that is used in connection establishment
+  and address validation.  These MUST NOT be used to communicate application
+  semantics between endpoints.  The potential for reuse of these tokens means
   that they require stronger protections against replay.
 
 A server that accepts 0-RTT on a connection incurs a higher cost than accepting


### PR DESCRIPTION
The text here was perhaps a little unclear on this point.  The point is
that these don't carry information from server to client or client to
server, they carry information from server (previous) to server (next).

Closes #3817.