### PR TITLE
update kInitialRtt to 333ms, use that constant

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1062,7 +1062,7 @@ kGranularity:
 
 kInitialRtt:
 : The RTT used before an RTT sample is taken. The value recommended in
-{{pto-handshake}} is 500ms.
+{{pto-handshake}} is 333ms.
 
 kPacketNumberSpace:
 : An enum to enumerate the three packet number spaces.
@@ -1131,8 +1131,8 @@ follows:
    loss_detection_timer.reset()
    pto_count = 0
    latest_rtt = 0
-   smoothed_rtt = initial_rtt
-   rttvar = initial_rtt / 2
+   smoothed_rtt = kInitialRtt
+   rttvar = kInitialRtt / 2
    min_rtt = 0
    max_ack_delay = 0
    for pn_space in [ Initial, Handshake, ApplicationData ]:


### PR DESCRIPTION
In #3525, we changed the definition of initial PTO from 2x initial RTT to 3x, and therefore initial RTT had to be changed from 500ms to 333ms so that the initial PTO remains at the same value (1 second).

Unfortunately, the PR introduced a new variable called initial_rtt, and left kInitialRtt unmodified.

This PR fixes the editorial issue.

Closes #3822.