### PR TITLE
Reorder TLS interface summary

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -548,7 +548,7 @@ use.
 ### TLS Interface Summary
 
 {{exchange-summary}} summarizes the exchange between QUIC and TLS for both
-client and server. Solid arrows indicate packets that carry CRYPTO frames;
+client and server. Solid arrows indicate packets that carry handshake data;
 dashed arrows show where application data can be sent.  Each arrow is tagged
 with the encryption level used for that transmission.
 

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -548,47 +548,50 @@ use.
 ### TLS Interface Summary
 
 {{exchange-summary}} summarizes the exchange between QUIC and TLS for both
-client and server. Each arrow is tagged with the encryption level used for that
-transmission.
+client and server. Solid arrows indicate packets that carry CRYPTO frames;
+dashed arrows show where application data can be sent.  Each arrow is tagged
+with the encryption level used for that transmission.
 
 ~~~
 Client                                                    Server
+======                                                    ======
 
 Get Handshake
                      Initial ------------->
-                                              Handshake Received
 Install tx 0-RTT Keys
-                     0-RTT --------------->
+                     0-RTT - - - - - - - ->
+
+                                              Handshake Received
                                                    Get Handshake
                      <------------- Initial
-Handshake Received
-Install Handshake keys
                                            Install rx 0-RTT keys
                                           Install Handshake keys
                                                    Get Handshake
                      <----------- Handshake
-Handshake Received
                                            Install tx 1-RTT keys
-                     <--------------- 1-RTT
+                     <- - - - - - - - 1-RTT
+
+Handshake Received (Initial)
+Install Handshake keys
+Handshake Received (Handshake)
 Get Handshake
-Handshake Complete
                      Handshake ----------->
-                                              Handshake Received
-                                           Install rx 1-RTT keys
-                                              Handshake Complete
+Handshake Complete
 Install 1-RTT keys
-                     1-RTT --------------->
-                                                   Get Handshake
-                     <--------------- 1-RTT
-Handshake Received
+                     1-RTT - - - - - - - ->
+
+                                              Handshake Received
+                                              Handshake Complete
+                                           Install rx 1-RTT keys
 ~~~
 {: #exchange-summary title="Interaction Summary between QUIC and TLS"}
 
 {{exchange-summary}} shows the multiple packets that form a single "flight" of
 messages being processed individually, to show what incoming messages trigger
-different actions.  New handshake messages are requested after all incoming
-packets have been processed.  This process might vary depending on how QUIC
-implementations and the packets they receive are structured.
+different actions.  New handshake messages are requested after incoming packets
+have been processed.  This process varies based on the structure of endpoint
+implementations and the order in which packets arrive; this is intended to
+illustrate the steps involved in a single handshake exchange.
 
 
 ## TLS Version {#tls-version}


### PR DESCRIPTION
I came back to this today and found that the ordering was inconsistent
and not sufficiently clear.

Changing this so that all the actions for a single endpoint were grouped
seemed to be the best arrangement.  All events and actions are as close
as possible in the ordering to the preceding event that caused or
enabled it.

The application data packets are displayed with a different marking,
which helps distinguish those that carry CRYPTO frames.

The final implied exchange for Get Handshake was removed.  This was, I
think, intended to imply something about session tickets.  Without
explanation, it is confusing.

This doesn't show HANDSHAKE_DONE, nor do I think that it should, because
that is something that the transport does once it gets the Handshake
Complete signal.