### PR TITLE
Prohibit reading 1-RTT before handshake complete

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1255,7 +1255,7 @@ handshake messages from a client, it is missing assurances on the client state:
 - Any received 0-RTT data that the server responds to might be due to a replay
   attack.
 
-Therefore, the server's use of 1-RTT keys MUST be limited to sending data before
+Therefore, the server's use of 1-RTT keys is limited to sending data before
 the handshake is complete.  A server MUST NOT process incoming 1-RTT protected
 packets before the TLS handshake is complete.  Because sending acknowledgments
 indicates that all frames in a packet have been processed, a server cannot send
@@ -1279,6 +1279,10 @@ acknowledged.  This enables immediate server processing for those packets.
 A server could receive packets protected with 0-RTT keys prior to receiving a
 TLS ClientHello.  The server MAY retain these packets for later decryption in
 anticipation of receiving a ClientHello.
+
+A client generally receives 1-RTT keys at the same time as the handshake
+completes.  However, a client also MUST NOT process incoming 1-RTT protected
+packets before the TLS handshake is complete.
 
 
 ## Retry Packet Integrity {#retry-integrity}

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1255,8 +1255,8 @@ handshake messages from a client, it is missing assurances on the client state:
 - Any received 0-RTT data that the server responds to might be due to a replay
   attack.
 
-Therefore, the server's use of 1-RTT keys is limited to sending data before
-the handshake is complete.  A server MUST NOT process incoming 1-RTT protected
+Therefore, the server's use of 1-RTT keys before the handshake is complete is
+limited to sending data.  A server MUST NOT process incoming 1-RTT protected
 packets before the TLS handshake is complete.  Because sending acknowledgments
 indicates that all frames in a packet have been processed, a server cannot send
 acknowledgments for 1-RTT packets until the TLS handshake is complete.  Received

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1281,8 +1281,8 @@ TLS ClientHello.  The server MAY retain these packets for later decryption in
 anticipation of receiving a ClientHello.
 
 A client generally receives 1-RTT keys at the same time as the handshake
-completes.  However, a client also MUST NOT process incoming 1-RTT protected
-packets before the TLS handshake is complete.
+completes.  Even if it has 1-RTT secrets, a client also MUST NOT process
+incoming 1-RTT protected packets before the TLS handshake is complete.
 
 
 ## Retry Packet Integrity {#retry-integrity}

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1281,7 +1281,7 @@ TLS ClientHello.  The server MAY retain these packets for later decryption in
 anticipation of receiving a ClientHello.
 
 A client generally receives 1-RTT keys at the same time as the handshake
-completes.  Even if it has 1-RTT secrets, a client also MUST NOT process
+completes.  Even if it has 1-RTT secrets, a client MUST NOT process
 incoming 1-RTT protected packets before the TLS handshake is complete.
 
 


### PR DESCRIPTION
This was never explicit for the client as it is usually not possible.

Closes #3855 in a way that perhaps was not anticipated.