### PR TITLE
Clearer explanation of caveat on discarding packets

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1167,7 +1167,8 @@ expected keys are available.
 
 Invalid packets without packet protection, such as Initial, Retry, or Version
 Negotiation, MAY be discarded.  An endpoint MUST generate a connection error if
-it commits changes to state before discovering an error.
+processing of the contents of these packets prior to discovering an error
+results in changes to the state of a connection that cannot be reverted.
 
 
 ### Client Packet Handling {#client-pkt-handling}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1168,7 +1168,7 @@ expected keys are available.
 Invalid packets without packet protection, such as Initial, Retry, or Version
 Negotiation, MAY be discarded.  An endpoint MUST generate a connection error if
 processing of the contents of these packets prior to discovering an error
-results in changes to the state of a connection that cannot be reverted.
+resulted in changes to the state of a connection that cannot be reverted.
 
 
 ### Client Packet Handling {#client-pkt-handling}


### PR DESCRIPTION
Those packets that are not authenticated can be discarded, but only if
processing them has no permanent effect on existing state.  This
attempts to explain that.

Closes #3836.