### PR TITLE
Mixing connection IDs is OK

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3192,8 +3192,8 @@ packets at the same encryption level.
 
 Receivers MAY route based on the information in the first packet contained in a
 UDP datagram.  Senders MUST NOT coalesce QUIC packets for different connections
-into a single UDP datagram.  Receivers SHOULD ignore any subsequent packets with
-a different Destination Connection ID than the first packet in the datagram.
+into a single UDP datagram.  Receivers SHOULD ignore any subsequent packets for
+a different connection than the first packet in the datagram.
 
 Every QUIC packet that is coalesced into a single UDP datagram is separate and
 complete.  The receiver of coalesced QUIC packets MUST individually process each


### PR DESCRIPTION
This is a loosening of the recommendation regarding mixed connection IDs while coalescing.  This says that receivers shouldn't route individual packets to different connections if they are coalesced.  (I note that it would be enough to permit them to discard packets for different connections, but a recommendation to apply good sense is also good.)

This isn't as strong as might seem theoretically necessary, but we determined it to be OK.  We can only coalesce during the handshake, so linkability concerns are moot as addresses are assumed to be stable.  With linkability concerns addressed, there was no need to provide any strong requirement that stacks provide the same connection ID for every coalesced packet.

Closes #3800.