### PR TITLE
More about authenticating Version Negotiation

### DIFF
--- a/draft-ietf-quic-invariants.md
+++ b/draft-ietf-quic-invariants.md
@@ -299,7 +299,7 @@ Supported Version fields, or a truncated Supported Version.
 
 Version Negotiation packets do not use integrity or confidentiality protection.
 Specific QUIC versions might include protocol elements that allow endpoints to
-detect when the set of supported versions is modified or corrupted.
+detect modification or corruption in the set of supported versions.
 
 An endpoint MUST include the value from the Source Connection ID field of the
 packet it receives in the Destination Connection ID field.  The value for Source

--- a/draft-ietf-quic-invariants.md
+++ b/draft-ietf-quic-invariants.md
@@ -334,8 +334,8 @@ requires that middleboxes retain state for every connection ID they see.
 
 The Version Negotiation packet described in this document is not
 integrity-protected; it only has modest protection against insertion by off-path
-attackers.  QUIC versions that use Version Negotiation packets MUST define a
-mechanism that authenticates the values it contains.
+attackers.  A QUIC version that uses a Version Negotiation packet MUST define a
+mechanism to verify authenticate the values the packet contains.
 
 
 # IANA Considerations

--- a/draft-ietf-quic-invariants.md
+++ b/draft-ietf-quic-invariants.md
@@ -335,7 +335,7 @@ requires that middleboxes retain state for every connection ID they see.
 The Version Negotiation packet described in this document is not
 integrity-protected; it only has modest protection against insertion by off-path
 attackers.  A QUIC version that uses a Version Negotiation packet MUST define a
-mechanism to verify authenticate the values the packet contains.
+mechanism to authenticate the values the packet contains.
 
 
 # IANA Considerations

--- a/draft-ietf-quic-invariants.md
+++ b/draft-ietf-quic-invariants.md
@@ -334,8 +334,8 @@ requires that middleboxes retain state for every connection ID they see.
 
 The Version Negotiation packet described in this document is not
 integrity-protected; it only has modest protection against insertion by off-path
-attackers.  A QUIC version that uses a Version Negotiation packet MUST define a
-mechanism to authenticate the values the packet contains.
+attackers.  An endpoint MUST authenticate the contents of a Version Negotiation
+packet if it attempts a different QUIC version as a result.
 
 
 # IANA Considerations

--- a/draft-ietf-quic-invariants.md
+++ b/draft-ietf-quic-invariants.md
@@ -298,8 +298,8 @@ contains no other fields.  An endpoint MUST ignore a packet that contains no
 Supported Version fields, or a truncated Supported Version.
 
 Version Negotiation packets do not use integrity or confidentiality protection.
-Specific QUIC versions define mechanisms to authenticate the packet as part of
-the connection establishment process.
+Specific QUIC versions might include protocol elements that allow endpoints to
+detect when the set of supported versions is modified or corrupted.
 
 An endpoint MUST include the value from the Source Connection ID field of the
 packet it receives in the Destination Connection ID field.  The value for Source
@@ -334,8 +334,8 @@ requires that middleboxes retain state for every connection ID they see.
 
 The Version Negotiation packet described in this document is not
 integrity-protected; it only has modest protection against insertion by off-path
-attackers.  QUIC versions MUST define a mechanism that authenticates the values
-it contains.
+attackers.  QUIC versions that use Version Negotiation packets MUST define a
+mechanism that authenticates the values it contains.
 
 
 # IANA Considerations


### PR DESCRIPTION
This clarifies that it is a mechanism in the target QUIC version that
authenticates the information.

This also lifts the strong requirement on authenticating the contents of
Version Negotiation.  QUIC version 1 does not do this and so does not
comply with this requirement.  The intent was always that only
information that is used needs to be authenticated in this way.

(This is a tiny bit of evasion as Version Negotiation is used in QUIC
version 1 as a signal that a version is not supported, which results in
clients abandoning connections.)

Closes #3828.