### PR TITLE
Behavior around key availability delays during handshake

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -532,7 +532,7 @@ delay sending an acknowledgement.
 
 When the PTO is armed for Initial or Handshake packet number spaces, the
 max_ack_delay in the PTO period computation is set to 0, since the peer is
-expected to acknowledge these packets immediately; see 13.2.1 of
+expected to not delay these packets intentionally; see 13.2.1 of
 {{QUIC-TRANSPORT}}.
 
 The PTO period MUST be at least kGranularity, to avoid the timer expiring

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -527,12 +527,17 @@ no ack-eliciting packets in flight, the PTO is set from that moment.
 
 When setting the PTO timer, the ApplicationData packet number space (Section
 4.1.1 of {{QUIC-TLS}}) MUST be ignored until the handshake completes. Not arming
-the PTO for ApplicationData prevents a client from retransmitting a 0-RTT packet
-on a PTO expiration before confirming that the server is able to decrypt 0-RTT
-packets, and prevents a server from sending a 1-RTT packet on a PTO expiration
-before the client obtains the keys to decrypt the 1-RTT packet (Section 4.1.4 of
-{{QUIC-TLS}}) or before the server obtains the keys to process an
-acknowledgement.
+the PTO for ApplicationData prevents unnecessary transmissions on a PTO
+expiration, such as:
+
+* an endpoint sending probe packets before obtaining the keys to process an
+  acknowledgement,
+
+* a client sending 0-RTT probe packets before confirming that the server is able
+  to decrypt 0-RTT packets, or
+
+* a server sending 1-RTT probe packets before the client obtains the keys to
+  decrypt 1-RTT packets (Section 4.1.4 of {{QUIC-TLS}}).
 
 When ack-eliciting packets in multiple packet number spaces are in flight,
 the timer MUST be set for the packet number space with the earliest timeout.

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -530,9 +530,9 @@ When setting the PTO timer, the ApplicationData packet number space (Section
 arming the PTO timer on ApplicationData prevents an endpoint from retransmitting
 data in packets when the peer might not yet have the keys necessary to process
 them or when the endpoint does not yet have the keys necessary to process their
-acknowledgements. For instance, this can happen when a client retransmits data
+acknowledgements. For instance, this could happen if a client retransmitted data
 sent in 0-RTT packets to the server before confirming that the server is able to
-decrypt 0-RTT packets. Or it can happen when a server retransmits data sent in
+decrypt 0-RTT packets. Or it could happen if a server retransmitted data sent in
 1-RTT packets while the client verifies the server's certificate and therefore
 cannot read 1-RTT packets yet.
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -351,7 +351,7 @@ max_ack_delay, avoiding unnecessary inflation of the RTT estimate.
 Note however that a large acknowledgement delay can result in a substantially
 inflated smoothed_rtt, if there is either an error in the peer's reporting of
 the acknowledgement delay or in the endpoint's min_rtt estimate.  Therefore,
-prior to handshake confirmation, an endpoint can ignore RTT samples if adjusting
+prior to handshake confirmation, an endpoint MAY ignore RTT samples if adjusting
 the RTT sample for acknowledgement delay causes the sample to be less than the
 min_rtt.
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -370,7 +370,7 @@ endpoint:
 
 - MAY ignore the acknowledgement delay for Initial packets,
 
-- SHOULD ignore the peer's max_ack_delay until the handshake is confirmed,
+- MAY ignore the peer's max_ack_delay until the handshake is confirmed,
 
 - MUST use the lesser of the acknowledgement delay and the peer's max_ack_delay
   after the handshake is confirmed,

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -373,7 +373,7 @@ Additionaly, an endpoint might postpone the processing of acknowledgements when
 the corresponding decryption keys are not immediately available. For example, a
 client might receive an acknowledgement for a 0-RTT packet that it cannot
 decrypt because 1-RTT packet protection keys are not yet available to it. In
-such cases, an endpoint SHOULD ignore such local delays in its round-trip time
+such cases, an endpoint SHOULD ignore such local delays in its RTT
 sample until the handshake is confirmed.
 
 smoothed_rtt and rttvar are computed as follows, similar to {{?RFC6298}}.

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -365,12 +365,14 @@ estimate.
 Therefore, when adjusting an RTT sample using peer-reported acknowledgement
 delays, an endpoint:
 
-- MAY ignore the acknowledgement delay for Initial packets,
+- MAY ignore the acknowledgement delay for Initial packets, since these
+  acknowledgements are not delayed by the peer (Section 13.2.1 of
+  {{QUIC-TRANSPORT}});
 
-- SHOULD ignore the peer's max_ack_delay until the handshake is confirmed,
+- SHOULD ignore the peer's max_ack_delay until the handshake is confirmed;
 
 - MUST use the lesser of the acknowledgement delay and the peer's max_ack_delay
-  after the handshake is confirmed,
+  after the handshake is confirmed; and
 
 - MUST NOT subtract the acknowledgement delay from the RTT sample if the
   resulting value is smaller than the min_rtt.  This limits the underestimation

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -348,12 +348,12 @@ acknowledgement delays are likely to be non-repeating and limited to the
 handshake. The endpoint can therefore use them without limiting them to the
 max_ack_delay, avoiding unnecessary inflation of the RTT estimate.
 
-Note that a large acknowledgement delay that is not limited to the peer's
-max_ack_delay can result in a substantially inflated smoothed_rtt, if there is
-either an error in the peer's reporting of the acknowledgement delay or in the
-endpoint's min_rtt estimate.  Therefore, prior to handshake confirmation, an
-endpoint can ignore RTT samples if adjusting the RTT sample for acknowledgement
-delay causes the sample to be less than the min_rtt.
+Note however that a large acknowledgement delay can result in a substantially
+inflated smoothed_rtt, if there is either an error in the peer's reporting of
+the acknowledgement delay or in the endpoint's min_rtt estimate.  Therefore,
+prior to handshake confirmation, an endpoint can ignore RTT samples if adjusting
+the RTT sample for acknowledgement delay causes the sample to be less than the
+min_rtt.
 
 After the handshake is confirmed, any acknowledgement delays reported by the
 peer that are greater than the peer's max_ack_delay are attributed to

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -526,10 +526,10 @@ packet in the correct packet number space. When the PTO expires and there are
 no ack-eliciting packets in flight, the PTO is set from that moment.
 
 When setting the PTO timer, the ApplicationData packet number space (Section
-4.1.1 of {{QUIC-TLS}}) MUST be ignored until the handshake completes. Not arming
-the PTO timer on ApplicationData prevents an endpoint from retransmitting data
-in packets when the peer might not yet have the keys necessary to process them
-or when the endpoint does not yet have the keys necessary to process their
+4.1.1 of {{QUIC-TLS}}) MUST be ignored until the handshake is confirmed. Not
+arming the PTO timer on ApplicationData prevents an endpoint from retransmitting
+data in packets when the peer might not yet have the keys necessary to process
+them or when the endpoint does not yet have the keys necessary to process their
 acknowledgements. For instance, this can happen when a client retransmits data
 sent in 0-RTT packets to the server before confirming that the server is able to
 decrypt 0-RTT packets. Or it can happen when a server retransmits data sent in

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -340,16 +340,20 @@ The calculation of smoothed_rtt uses path latency after adjusting RTT samples
 for acknowledgement delays. These delays are computed using the ACK Delay
 field of the ACK frame as described in Section 19.3 of {{QUIC-TRANSPORT}}.
 
-When 0-RTT or 1-RTT ack-eliciting packets are received, a peer MUST NOT delay
-acknowledging them any longer than the period it advertised in the max_ack_delay
-transport parameter (Section 18.2 of {{QUIC-TRANSPORT}}), with the following
-exception.  Prior to handshake confirmation, the peer might not have the packet
-protection keys for these packets when they are received. It might therefore
-buffer them and acknowledge them when the requisite keys become available.
+A peer MUST immediately acknowledge all ack-eliciting Initial packets.
 
-Since the peer might report large acknowledgement delays, the endpoint MAY
-ignore max_ack_delay until the handshake is confirmed (Section 4.1.2 of
-{{QUIC-TLS}}). Since these acknowledgement delays, when they occur, are
+Prior to handshake confirmation, a peer might not have the packet protection
+keys for Handshake, 0-RTT, or 1-RTT packets when they are received. It might
+therefore buffer them and acknowledge them when the requisite keys become
+available. When this is not the case, the peer MUST immediately acknowledge all
+ack-eliciting Handshake packets, and MUST NOT delay acknowledgement of
+ack-eliciting 0-RTT, or 1-RTT packets for any longer than the period that it
+advertised in the max_ack_delay transport parameter (Section 18.2 of
+{{QUIC-TRANSPORT}}).
+
+Since the peer might report large acknowledgement delays during the handshake,
+the endpoint MAY ignore max_ack_delay until the handshake is confirmed (Section
+4.1.2 of {{QUIC-TLS}}). Since these acknowledgement delays, when they occur, are
 measurable and limited to the handshake, the endpoint can use them without
 limiting them to the max_ack_delay and avoid unnecessarily inflating the
 smoothed_rtt estimate.

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -407,6 +407,13 @@ rttvar_sample = abs(smoothed_rtt - adjusted_rtt)
 rttvar = 3/4 * rttvar + 1/4 * rttvar_sample
 ~~~
 
+An endpoint might postpone the processing of acknowledgements when the
+corresponding decryption keys are not immediately available. For example, a
+client might receive an acknowledgement for a 0-RTT packet that it cannot
+decrypt because 1-RTT packet protection keys are not yet available to it. In
+such cases, an endpoint can ignore such local delays in its round-trip time
+sample until the handshake is confirmed.
+
 
 # Loss Detection {#loss-detection}
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -387,9 +387,9 @@ default values.
 On subsequent RTT samples, smoothed_rtt and rttvar evolve as follows:
 
 ~~~
-ack_delay = decoded acknowledgement delay from ACK frame
+ack_delay = decoded ACK Delay field from ACK frame
 if (handshake confirmed):
-    ack_delay = min(ack_delay, max_ack_delay)
+  ack_delay = min(ack_delay, max_ack_delay)
 adjusted_rtt = latest_rtt
 if (min_rtt + ack_delay < latest_rtt):
   adjusted_rtt = latest_rtt - ack_delay
@@ -1284,7 +1284,7 @@ UpdateRtt(ack_delay):
 
   // min_rtt ignores acknowledgment delay.
   min_rtt = min(min_rtt, latest_rtt)
-  // Limit ack_delay to max_ack_delay after handshake confirmation.
+  // Apply max_ack_delay after handshake confirmation.
   if (handshake confirmed):
     ack_delay = min(ack_delay, max_ack_delay)
   // Adjust for acknowledgment delay if plausible.

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -540,7 +540,8 @@ expiration, such as:
   decrypt 1-RTT packets (Section 4.1.4 of {{QUIC-TLS}}).
 
 When ack-eliciting packets in multiple packet number spaces are in flight,
-the timer MUST be set for the packet number space with the earliest timeout.
+the timer MUST be set to the earlier value of the Initial and Handshake packet
+number spaces.
 
 When a PTO timer expires, the PTO backoff MUST be increased, resulting in the
 PTO period being set to twice its current value. The PTO backoff factor is reset

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -353,10 +353,10 @@ advertised in the max_ack_delay transport parameter (Section 18.2 of
 
 Since the peer might report large acknowledgement delays during the handshake,
 the endpoint MAY ignore max_ack_delay until the handshake is confirmed (Section
-4.1.2 of {{QUIC-TLS}}). Since these acknowledgement delays, when they occur, are
-measurable and limited to the handshake, the endpoint can use them without
-limiting them to the max_ack_delay and avoid unnecessarily inflating the
-smoothed_rtt estimate.
+4.1.2 of {{QUIC-TLS}}). Since these large acknowledgement delays, when they
+occur, are likely to be non-repeating and limited to the handshake, the endpoint
+can use them without limiting them to the max_ack_delay and avoid unnecessarily
+inflating the smoothed_rtt estimate.
 
 After the handshake is confirmed, any acknowledgement delays reported by the
 peer that are greater than its max_ack_delay are attributed to unintentional but
@@ -368,10 +368,9 @@ smoothed_rtt estimate.
 When adjusting an RTT sample using peer-reported acknowledgement delays, an
 endpoint:
 
-- MAY ignore the ACK Delay field of the ACK frame for packets sent in the
-  Initial packet number space.
+- MAY ignore the acknowledgement delay for Initial packets,
 
-- MAY ignore the peer's max_ack_delay until the handshake is confirmed,
+- SHOULD ignore the peer's max_ack_delay until the handshake is confirmed,
 
 - MUST use the lesser of the acknowledgement delay and the peer's max_ack_delay
   after the handshake is confirmed,

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -340,18 +340,19 @@ The calculation of smoothed_rtt uses path latency after adjusting RTT samples
 for acknowledgement delays. These delays are computed using the ACK Delay
 field of the ACK frame as described in Section 19.3 of {{QUIC-TRANSPORT}}.
 
-When 0-RTT or 1-RTT ack-eliciting packets are received, a peer does not delay
+When 0-RTT or 1-RTT ack-eliciting packets are received, a peer MUST NOT delay
 acknowledging them any longer than the period it advertised in the max_ack_delay
-transport parameter; see Section 18.2 of {{QUIC-TRANSPORT}}.
+transport parameter (Section 18.2 of {{QUIC-TRANSPORT}}), with the following
+exception.  Prior to handshake confirmation, the peer might not have the packet
+protection keys for these packets when they are received. It might therefore
+buffer them and acknowledge them when the requisite keys become available.
 
-However, an endpoint MAY ignore max_ack_delay until the handshake is confirmed
-(Section 4.1.2 of {{QUIC-TLS}}). Prior to handshake confirmation, the peer's
-reported acknowledgement delays might exceed the peer's max_ack_delay because it
-might buffer undecryptable packets and acknowledge them when the requisite keys
-become available to it. Since these delays, when they occur, are measurable and
-limited to the handshake, the endpoint can use the delays without limiting them
-to the max_ack_delay and avoid unnecessarily inflating the smoothed_rtt
-estimate.
+Since the peer might report large acknowledgement delays, the endpoint MAY
+ignore max_ack_delay until the handshake is confirmed (Section 4.1.2 of
+{{QUIC-TLS}}). Since these acknowledgement delays, when they occur, are
+measurable and limited to the handshake, the endpoint can use them without
+limiting them to the max_ack_delay and avoid unnecessarily inflating the
+smoothed_rtt estimate.
 
 After the handshake is confirmed, any acknowledgement delays reported by the
 peer that are greater than its max_ack_delay are attributed to unintentional but

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -525,14 +525,17 @@ set based on the latest RTT information and for the last sent ack-eliciting
 packet in the correct packet number space. When the PTO expires and there are
 no ack-eliciting packets in flight, the PTO is set from that moment.
 
+When setting the PTO timer, the ApplicationData packet number space (Section
+4.1.1 of {{QUIC-TLS}}) MUST be ignored until the handshake completes. Not arming
+the PTO for ApplicationData prevents a client from retransmitting a 0-RTT packet
+on a PTO expiration before confirming that the server is able to decrypt 0-RTT
+packets, and prevents a server from sending a 1-RTT packet on a PTO expiration
+before the client obtains the keys to decrypt the 1-RTT packet (Section 4.1.4 of
+{{QUIC-TLS}}) or before the server obtains the keys to process an
+acknowledgement.
+
 When ack-eliciting packets in multiple packet number spaces are in flight,
-the timer MUST be set for the packet number space with the earliest timeout,
-with one exception. The Application Data packet number space (Section 4.1.1
-of {{QUIC-TLS}}) MUST be ignored until the handshake completes. Not arming
-the PTO for Application Data prevents a client from retransmitting a 0-RTT
-packet on a PTO expiration before confirming that the server is able to
-decrypt 0-RTT packets, and prevents a server from sending a 1-RTT packet on
-a PTO expiration before it has the keys to process an acknowledgement.
+the timer MUST be set for the packet number space with the earliest timeout.
 
 When a PTO timer expires, the PTO backoff MUST be increased, resulting in the
 PTO period being set to twice its current value. The PTO backoff factor is reset

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -348,6 +348,11 @@ acknowledgement delays are likely to be non-repeating and limited to the
 handshake. The endpoint can therefore use them without limiting them to the
 max_ack_delay, avoiding unnecessary inflation of the RTT estimate.
 
+Ignoring max_ack_delay at the beginning of the connection can lead to a
+substantially inflated smoothed_rtt. Therefore, prior to handshake confirmation,
+an endpoint MAY ignore RTT samples if subtracting the acknowledgement delay
+causes the sample to be less than the min_rtt.
+
 After the handshake is confirmed, any acknowledgement delays reported by the
 peer that are greater than the peer's max_ack_delay are attributed to
 unintentional but potentially repeating delays, such as scheduler latency at the

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -534,7 +534,7 @@ acknowledgments. This occurs when the client sends 0-RTT packets as the server
 might not accept 0-RTT and the client will not have 1-RTT keys for processing
 acknowledgments until the handshake completes. This occurs for 1-RTT packets as
 either endpoint might not have the ability to read until the handshake is
-complete or confirmed.
+complete.
 
 When ack-eliciting packets in multiple packet number spaces are in flight,
 the timer MUST be set to the earlier value of the Initial and Handshake packet

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -369,6 +369,13 @@ endpoint:
   is smaller than the min_rtt.  This limits the underestimation of the
   smoothed_rtt because of a misreporting peer.
 
+Additionaly, an endpoint might postpone the processing of acknowledgements when
+the corresponding decryption keys are not immediately available. For example, a
+client might receive an acknowledgement for a 0-RTT packet that it cannot
+decrypt because 1-RTT packet protection keys are not yet available to it. In
+such cases, an endpoint SHOULD ignore such local delays in its round-trip time
+sample until the handshake is confirmed.
+
 smoothed_rtt and rttvar are computed as follows, similar to {{?RFC6298}}.
 
 When there are no samples for a network path, and on the first RTT sample for
@@ -397,14 +404,6 @@ smoothed_rtt = 7/8 * smoothed_rtt + 1/8 * adjusted_rtt
 rttvar_sample = abs(smoothed_rtt - adjusted_rtt)
 rttvar = 3/4 * rttvar + 1/4 * rttvar_sample
 ~~~
-
-An endpoint might postpone the processing of acknowledgements when the
-corresponding decryption keys are not immediately available. For example, a
-client might receive an acknowledgement for a 0-RTT packet that it cannot
-decrypt because 1-RTT packet protection keys are not yet available to it. In
-such cases, an endpoint SHOULD ignore such local delays in its round-trip time
-sample until the handshake is confirmed.
-
 
 # Loss Detection {#loss-detection}
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -526,15 +526,15 @@ packet in the correct packet number space. When the PTO expires and there are
 no ack-eliciting packets in flight, the PTO is set from that moment.
 
 When setting the PTO timer, the ApplicationData packet number space (Section
-4.1.1 of {{QUIC-TLS}}) MUST be ignored until the handshake completes. PTO is not
-armed because issues other than packet loss might prevent an endpoint from
-receiving an acknowledgement. A receiver might lack the keys necessary to
-process packets, or the sender might lack the keys necessary to process
-acknowledgments. This occurs when the client sends 0-RTT packets as the server
-might not accept 0-RTT and the client will not have 1-RTT keys for processing
-acknowledgments until the handshake completes. This occurs for 1-RTT packets as
-either endpoint might not have the ability to read until the handshake is
-complete.
+4.1.1 of {{QUIC-TLS}}) MUST be ignored until the handshake completes. Not arming
+the PTO timer on ApplicationData prevents an endpoint from retransmitting data
+in packets when the peer might not yet have the keys necessary to process them
+or when the endpoint does not yet have the keys necessary to process their
+acknowledgements. For instance, this can happen when a client retransmits data
+sent in 0-RTT packets to the server before confirming that the server is able to
+decrypt 0-RTT packets. Or it can happen when a server retransmits data sent in
+1-RTT packets while the client verifies the server's certificate and therefore
+cannot read 1-RTT packets yet.
 
 When ack-eliciting packets in multiple packet number spaces are in flight,
 the timer MUST be set to the earlier value of the Initial and Handshake packet

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -526,18 +526,15 @@ packet in the correct packet number space. When the PTO expires and there are
 no ack-eliciting packets in flight, the PTO is set from that moment.
 
 When setting the PTO timer, the ApplicationData packet number space (Section
-4.1.1 of {{QUIC-TLS}}) MUST be ignored until the handshake completes. Not arming
-the PTO for ApplicationData prevents unnecessary transmissions on a PTO
-expiration, such as:
-
-* an endpoint sending probe packets before obtaining the keys to process an
-  acknowledgement,
-
-* a client sending 0-RTT probe packets before confirming that the server is able
-  to decrypt 0-RTT packets, or
-
-* a server sending 1-RTT probe packets before the client obtains the keys to
-  decrypt 1-RTT packets (Section 4.1.4 of {{QUIC-TLS}}).
+4.1.1 of {{QUIC-TLS}}) MUST be ignored until the handshake completes. PTO is not
+armed because issues other than packet loss might prevent an endpoint from
+receiving an acknowledgement. A receiver might lack the keys necessary to
+process packets, or the sender might lack the keys necessary to process
+acknowledgments. This occurs when the client sends 0-RTT packets as the server
+might not accept 0-RTT and the client will not have 1-RTT keys for processing
+acknowledgments until the handshake completes. This occurs for 1-RTT packets as
+either endpoint might not have the ability to read until the handshake is
+complete or confirmed.
 
 When ack-eliciting packets in multiple packet number spaces are in flight,
 the timer MUST be set to the earlier value of the Initial and Handshake packet

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -342,18 +342,18 @@ field of the ACK frame as described in Section 19.3 of {{QUIC-TRANSPORT}}.
 
 As the peer might report acknowledgement delays that are larger than the peer's
 max_ack_delay during the handshake (Section 13.2.1 of {{QUIC-TRANSPORT}}), the
-endpoint MAY ignore max_ack_delay until the handshake is confirmed (Section
+endpoint SHOULD ignore max_ack_delay until the handshake is confirmed (Section
 4.1.2 of {{QUIC-TLS}}). Since these large acknowledgement delays, when they
 occur, are likely to be non-repeating and limited to the handshake, the endpoint
 can use them without limiting them to the max_ack_delay and avoid unnecessarily
 inflating the smoothed_rtt estimate.
 
 After the handshake is confirmed, any acknowledgement delays reported by the
-peer that are greater than its max_ack_delay are attributed to unintentional but
-potentially repeating delays, such as scheduler latency at the peer or loss of
-previous acknowledgements. Any delays beyond the peer's max_ack_delay are
-therefore considered effectively part of path delay and incorporated into the
-smoothed_rtt estimate.
+peer that are greater than the peer's max_ack_delay are attributed to
+unintentional but potentially repeating delays, such as scheduler latency at the
+peer or loss of previous acknowledgements. Therefore, these extra delays are
+considered effectively part of path delay and incorporated into the smoothed_rtt
+estimate.
 
 When adjusting an RTT sample using peer-reported acknowledgement delays, an
 endpoint:

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -346,13 +346,13 @@ endpoint SHOULD ignore max_ack_delay until the handshake is confirmed (Section
 4.1.2 of {{QUIC-TLS}}). Since these large acknowledgement delays, when they
 occur, are likely to be non-repeating and limited to the handshake, the endpoint
 can use them without limiting them to the max_ack_delay and avoid unnecessarily
-inflating the smoothed_rtt estimate.
+inflating the RTT estimate.
 
 After the handshake is confirmed, any acknowledgement delays reported by the
 peer that are greater than the peer's max_ack_delay are attributed to
 unintentional but potentially repeating delays, such as scheduler latency at the
 peer or loss of previous acknowledgements. Therefore, these extra delays are
-considered effectively part of path delay and incorporated into the smoothed_rtt
+considered effectively part of path delay and incorporated into the RTT
 estimate.
 
 When adjusting an RTT sample using peer-reported acknowledgement delays, an
@@ -394,7 +394,7 @@ default values.
 On subsequent RTT samples, smoothed_rtt and rttvar evolve as follows:
 
 ~~~
-ack_delay = decoded ACK Delay field from ACK frame
+ack_delay = decoded acknowledgement delay from ACK frame
 if (handshake confirmed):
   ack_delay = min(ack_delay, max_ack_delay)
 adjusted_rtt = latest_rtt
@@ -1249,8 +1249,9 @@ OnAckReceived(ack, pn_space):
   if (newly_acked_packets.empty()):
     return
 
-  // If the largest acknowledged is newly acked and
-  // at least one ack-eliciting was newly acked, update the RTT.
+  // Update the RTT if the largest acknowledged is newly acked
+  // and at least one ack-eliciting was newly acked.
+
   if (newly_acked_packets.largest().packet_number ==
           ack.largest_acked &&
       IncludesAckEliciting(newly_acked_packets)):

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -365,16 +365,16 @@ endpoint:
 - MUST use the lesser of the acknowledgement delay and the peer's max_ack_delay
   after the handshake is confirmed,
 
-- MUST NOT apply the adjustments above if the resulting round-trip time sample
-  is smaller than the min_rtt.  This limits the underestimation of the
-  smoothed_rtt because of a misreporting peer.
+- MUST NOT apply the adjustments above if the resulting RTT sample is smaller
+  than the min_rtt.  This limits the underestimation of the smoothed_rtt because
+  of a misreporting peer.
 
 Additionaly, an endpoint might postpone the processing of acknowledgements when
 the corresponding decryption keys are not immediately available. For example, a
 client might receive an acknowledgement for a 0-RTT packet that it cannot
 decrypt because 1-RTT packet protection keys are not yet available to it. In
-such cases, an endpoint SHOULD ignore such local delays in its RTT
-sample until the handshake is confirmed.
+such cases, an endpoint SHOULD ignore such local delays in its RTT sample until
+the handshake is confirmed.
 
 smoothed_rtt and rttvar are computed as follows, similar to {{?RFC6298}}.
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -348,10 +348,12 @@ acknowledgement delays are likely to be non-repeating and limited to the
 handshake. The endpoint can therefore use them without limiting them to the
 max_ack_delay, avoiding unnecessary inflation of the RTT estimate.
 
-Ignoring max_ack_delay at the beginning of the connection can lead to a
-substantially inflated smoothed_rtt. Therefore, prior to handshake confirmation,
-an endpoint MAY ignore RTT samples if subtracting the acknowledgement delay
-causes the sample to be less than the min_rtt.
+Note that a large acknowledgement delay that is not limited to the peer's
+max_ack_delay can result in a substantially inflated smoothed_rtt, if there is
+either an error in the peer's reporting of the acknowledgement delay or in the
+endpoint's min_rtt estimate.  Therefore, prior to handshake confirmation, an
+endpoint can ignore RTT samples if adjusting the RTT sample for acknowledgement
+delay causes the sample to be less than the min_rtt.
 
 After the handshake is confirmed, any acknowledgement delays reported by the
 peer that are greater than the peer's max_ack_delay are attributed to

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -344,14 +344,14 @@ When 0-RTT or 1-RTT ack-eliciting packets are received, a peer does not delay
 acknowledging them any longer than the period it advertised in the max_ack_delay
 transport parameter; see Section 18.2 of {{QUIC-TRANSPORT}}.
 
-However, an endpoint SHOULD use ignore max_ack_delay until the handshake is
-confirmed (Section 4.1.2 of {{QUIC-TLS}}). Prior to handshake confirmation, the
-peer's reported acknowledgement delays might exceed the peer's max_ack_delay
-because it might buffer undecryptable packets and acknowledge them when the
-requisite keys become available to it. Since these delays, when they occur, are
-measurable and limited to the handshake, the endpoint can use the delays without
-limiting them to the max_ack_delay and avoid unnecessarily inflating the
-smoothed_rtt estimate.
+However, an endpoint MAY ignore max_ack_delay until the handshake is confirmed
+(Section 4.1.2 of {{QUIC-TLS}}). Prior to handshake confirmation, the peer's
+reported acknowledgement delays might exceed the peer's max_ack_delay because it
+might buffer undecryptable packets and acknowledge them when the requisite keys
+become available to it. Since these delays, when they occur, are measurable and
+limited to the handshake, the endpoint can use the delays without limiting them
+to the max_ack_delay and avoid unnecessarily inflating the smoothed_rtt
+estimate.
 
 After the handshake is confirmed, any acknowledgement delays reported by the
 peer that are greater than its max_ack_delay are attributed to unintentional but
@@ -363,10 +363,10 @@ smoothed_rtt estimate.
 When adjusting an RTT sample using peer-reported acknowledgement delays, an
 endpoint:
 
-- MUST ignore the ACK Delay field of the ACK frame for packets sent in the
-  Initial and Handshake packet number space.
+- MAY ignore the ACK Delay field of the ACK frame for packets sent in the
+  Initial packet number space.
 
-- MUST ignore the peer's max_ack_delay until the handshake is confirmed,
+- MAY ignore the peer's max_ack_delay until the handshake is confirmed,
 
 - MUST use the lesser of the acknowledgement delay and the peer's max_ack_delay
   after the handshake is confirmed,
@@ -1254,10 +1254,7 @@ OnAckReceived(ack, pn_space):
       IncludesAckEliciting(newly_acked_packets)):
     latest_rtt =
       now() - newly_acked_packets.largest().time_sent
-    ack_delay = 0
-    if (pn_space == ApplicationData):
-      ack_delay = ack.ack_delay
-    UpdateRtt(ack_delay)
+    UpdateRtt(ack.ack_delay)
 
   // Process ECN information if present.
   if (ACK frame contains ECN information):

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -351,7 +351,7 @@ ack-eliciting 0-RTT, or 1-RTT packets for any longer than the period that it
 advertised in the max_ack_delay transport parameter (Section 18.2 of
 {{QUIC-TRANSPORT}}).
 
-Since the peer might report large acknowledgement delays during the handshake,
+As the peer might report large acknowledgement delays during the handshake,
 the endpoint MAY ignore max_ack_delay until the handshake is confirmed (Section
 4.1.2 of {{QUIC-TLS}}). Since these large acknowledgement delays, when they
 occur, are likely to be non-repeating and limited to the handshake, the endpoint
@@ -411,7 +411,7 @@ An endpoint might postpone the processing of acknowledgements when the
 corresponding decryption keys are not immediately available. For example, a
 client might receive an acknowledgement for a 0-RTT packet that it cannot
 decrypt because 1-RTT packet protection keys are not yet available to it. In
-such cases, an endpoint can ignore such local delays in its round-trip time
+such cases, an endpoint SHOULD ignore such local delays in its round-trip time
 sample until the handshake is confirmed.
 
 

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -504,8 +504,7 @@ generating these keys, an endpoint SHOULD buffer received packets marked as
 protected by the keys being generated, and process them once those keys become
 available.  If the keys are generated asynchronously, an endpoint MAY continue
 responding to the received packets that were processable while waiting for TLS
-to provide these keys.  >>>>>>> allow endpoints to generate traffic keys
-asynchronously, write down the expectations in relation
+to provide these keys.
 
 TLS provides QUIC with three items as a new encryption level becomes available:
 

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -499,9 +499,13 @@ handshake, new data is requested from TLS after providing received data.
 ### Encryption Level Changes
 
 As keys at a given encryption level become available to TLS, TLS indicates to
-QUIC that reading or writing keys at that encryption level are available.  These
-events are not asynchronous; they always occur immediately after TLS is provided
-with new handshake bytes, or after TLS produces handshake bytes.
+QUIC that reading or writing keys at that encryption level are available.  While
+generating these keys, an endpoint SHOULD buffer received packets marked as
+protected by the keys being generated, and process them once those keys become
+available.  If the keys are generated asynchronously, an endpoint MAY continue
+responding to the received packets that were processable while waiting for TLS
+to provide these keys.  >>>>>>> allow endpoints to generate traffic keys
+asynchronously, write down the expectations in relation
 
 TLS provides QUIC with three items as a new encryption level becomes available:
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3530,10 +3530,18 @@ communicated using the max_ack_delay transport parameter; see
 contract: an endpoint promises to never intentionally delay acknowledgments of
 an ack-eliciting packet by more than the indicated value. If it does, any excess
 accrues to the RTT estimate and could result in spurious or delayed
-retransmissions from the peer. For Initial and Handshake packets, a
-max_ack_delay of 0 is used. The sender uses the receiver's max_ack_delay value
+retransmissions from the peer. A sender uses the receiver's max_ack_delay value
 in determining timeouts for timer-based retransmission, as detailed in Section
 6.2 of {{QUIC-RECOVERY}}.
+
+An endpoint MUST immediately acknowledge all ack-eliciting Initial and Handshake
+packets and MUST NOT delay acknowledgement of ack-eliciting 0-RTT, or 1-RTT
+packets for any longer than the period that it advertised in the max_ack_delay
+transport parameter (Section 18.2 of {{QUIC-TRANSPORT}}), with the following
+exception. Prior to handshake confirmation, an endpoint might not have packet
+protection keys for decrypting Handshake, 0-RTT, or 1-RTT packets when they are
+received. It might therefore buffer them and acknowledge them when the requisite
+keys become available.
 
 Since packets containing only ACK frames are not congestion controlled, an
 endpoint MUST NOT send more than one such packet in response to receiving an
@@ -3690,6 +3698,11 @@ held in the OS kernel or elsewhere on the host before being processed.  An
 endpoint MUST NOT include delays that it does not control when populating the
 ACK Delay field in an ACK frame, but endpoints SHOULD include buffering delays
 caused by unavailability of decryption keys.
+
+When the measured acknowledgement delay is larger than its max_ack_delay, an
+endpoint SHOULD report the measured delay. This information is especially useful
+during the handshake when delays might be large; see
+{{sending-acknowledgements}}.
 
 ### ACK Frames and Packet Protection
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3691,11 +3691,13 @@ packet with the largest packet number is received and the time an acknowledgment
 is sent.  The endpoint encodes this acknowledgement delay in the ACK Delay field
 of an ACK frame; see {{frame-ack}}.  This allows the receiver of the ACK frame
 to adjust for any intentional delays, which is important for getting a better
-estimate of the path RTT when acknowledgments are delayed.  A packet might be
-held in the OS kernel or elsewhere on the host before being processed.  An
-endpoint MUST NOT include delays that it does not control when populating the
-ACK Delay field in an ACK frame, but endpoints SHOULD include buffering delays
-caused by unavailability of decryption keys.
+estimate of the path RTT when acknowledgments are delayed.
+
+A packet might be held in the OS kernel or elsewhere on the host before being
+processed.  An endpoint MUST NOT include delays that it does not control when
+populating the ACK Delay field in an ACK frame. However, endpoints SHOULD
+include buffering delays caused by unavailability of decryption keys, since
+these delays can be large and are likely to be non-repeating.
 
 When the measured acknowledgement delay is larger than its max_ack_delay, an
 endpoint SHOULD report the measured delay. This information is especially useful

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3688,11 +3688,8 @@ to adjust for any intentional delays, which is important for getting a better
 estimate of the path RTT when acknowledgments are delayed.  A packet might be
 held in the OS kernel or elsewhere on the host before being processed.  An
 endpoint MUST NOT include delays that it does not control when populating the
-ACK Delay field in an ACK frame.
-
-Since the acknowledgement delay is not used for Initial and Handshake
-packets, the ACK Delay field in acknowledgements for those packet types
-SHOULD be set to 0.
+ACK Delay field in an ACK frame, but endpoints SHOULD include buffering delays
+caused by unavailability of decryption keys.
 
 ### ACK Frames and Packet Protection
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3537,7 +3537,7 @@ in determining timeouts for timer-based retransmission, as detailed in Section
 An endpoint MUST immediately acknowledge all ack-eliciting Initial and Handshake
 packets and MUST NOT delay acknowledgement of ack-eliciting 0-RTT, or 1-RTT
 packets for any longer than the period that it advertised in the max_ack_delay
-transport parameter (Section 18.2 of {{QUIC-TRANSPORT}}), with the following
+transport parameter ({{transport-parameter-definitions}}), with the following
 exception. Prior to handshake confirmation, an endpoint might not have packet
 protection keys for decrypting Handshake, 0-RTT, or 1-RTT packets when they are
 received. It might therefore buffer them and acknowledge them when the requisite

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3534,14 +3534,12 @@ retransmissions from the peer. A sender uses the receiver's max_ack_delay value
 in determining timeouts for timer-based retransmission, as detailed in Section
 6.2 of {{QUIC-RECOVERY}}.
 
-An endpoint MUST immediately acknowledge all ack-eliciting Initial and Handshake
-packets and MUST NOT delay acknowledgement of ack-eliciting 0-RTT, or 1-RTT
-packets for any longer than the period that it advertised in the max_ack_delay
-transport parameter ({{transport-parameter-definitions}}), with the following
-exception. Prior to handshake confirmation, an endpoint might not have packet
-protection keys for decrypting Handshake, 0-RTT, or 1-RTT packets when they are
-received. It might therefore buffer them and acknowledge them when the requisite
-keys become available.
+An endpoint MUST acknowledge all ack-eliciting Initial and Handshake packets
+immediately and all ack-eliciting 0-RTT and 1-RTT packets within its advertised
+max_ack_delay, with the following exception. Prior to handshake confirmation, an
+endpoint might not have packet protection keys for decrypting Handshake, 0-RTT,
+or 1-RTT packets when they are received. It might therefore buffer them and
+acknowledge them when the requisite keys become available.
 
 Since packets containing only ACK frames are not congestion controlled, an
 endpoint MUST NOT send more than one such packet in response to receiving an


### PR DESCRIPTION
As pointed out in #3821, the drafts assume that the traffic keys are generated synchronously. But that's not what we see in the wild. In fact, clients often need to spend time while verifying the certificate, and some if not most of the clients do receive and send QUIC packets while they do so.

This PR acknowledges the existence of such implementation, recommending them to buffer the undecryptable packets while they calculate the next key, to prevent loss events that would kill the slow start. It also allows endpoints to postpone arming the PTO timer when it knows that the peer is going to send a handshake message.

Closes #3821.
Closes #3980.
Closes #4035.