### PR TITLE
Group 0-RTT sections

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -703,6 +703,11 @@ This information includes parameters that determine TLS state, as governed by
 information the application protocol might need; see {{app-0rtt}}.  This
 information determines how 0-RTT packets and their contents are formed.
 
+To ensure that the same information is available to both endpoints, information
+used to establish 0-RTT comes from the same connection and all information that
+might affect 0-RTT is retained.  Endpoints cannot selectively disregard
+information that might alter the sending or processing of 0-RTT.
+
 {{!TLS13}} sets a limit of 7 days on the time between the original connection
 and any attempt to use 0-RTT.  There are other constraints on 0-RTT usage,
 notably those caused by the potential exposure to replay attack; see {{replay}}.
@@ -713,7 +718,7 @@ notably those caused by the potential exposure to replay attack; see {{replay}}.
 To communicate their willingness to process 0-RTT data, servers send a
 NewSessionTicket message that contains the "early_data" extension with a
 max_early_data_size of 0xffffffff.  The TLS max_early_data_size parameter is not
-used in QUIC, the amount of data which the client can send in 0-RTT is
+used in QUIC.  The amount of data which the client can send in 0-RTT is
 controlled by the "initial_max_data" transport parameter supplied by the server.
 
 Servers MUST NOT send the "early_data" extension with a max_early_data_size set

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -703,10 +703,10 @@ This information includes parameters that determine TLS state, as governed by
 information the application protocol might need; see {{app-0rtt}}.  This
 information determines how 0-RTT packets and their contents are formed.
 
-To ensure that the same information is available to both endpoints, all information
-used to establish 0-RTT comes from the same connection.  Endpoints cannot
-selectively disregard information that might alter the sending or processing of
-0-RTT.
+To ensure that the same information is available to both endpoints, all
+information used to establish 0-RTT comes from the same connection.  Endpoints
+cannot selectively disregard information that might alter the sending or
+processing of 0-RTT.
 
 {{!TLS13}} sets a limit of 7 days on the time between the original connection
 and any attempt to use 0-RTT.  There are other constraints on 0-RTT usage,

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -703,7 +703,7 @@ This information includes parameters that determine TLS state, as governed by
 information the application protocol might need; see {{app-0rtt}}.  This
 information determines how 0-RTT packets and their contents are formed.
 
-To ensure that the same information is available to both endpoints, information
+To ensure that the same information is available to both endpoints, all information
 used to establish 0-RTT comes from the same connection.  Endpoints cannot
 selectively disregard information that might alter the sending or processing of
 0-RTT.

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -704,9 +704,9 @@ information the application protocol might need; see {{app-0rtt}}.  This
 information determines how 0-RTT packets and their contents are formed.
 
 To ensure that the same information is available to both endpoints, information
-used to establish 0-RTT comes from the same connection and all information that
-might affect 0-RTT is retained.  Endpoints cannot selectively disregard
-information that might alter the sending or processing of 0-RTT.
+used to establish 0-RTT comes from the same connection.  Endpoints cannot
+selectively disregard information that might alter the sending or processing of
+0-RTT.
 
 {{!TLS13}} sets a limit of 7 days on the time between the original connection
 and any attempt to use 0-RTT.  There are other constraints on 0-RTT usage,


### PR DESCRIPTION
This adds a short introductory section to the three sections that deal
with 0-RTT.  That might help contextualize and help contain the
spaghetti structure that this section seems to have.