### PR TITLE
No RTT samples, no persistent congestion

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1589,7 +1589,7 @@ Invoked when DetectAndRemoveLostPackets deems packets lost.
    InPersistentCongestion(largest_lost):
      // Persistent congestion cannot be declared on the
      // first RTT sample.
-     if (is first rtt sample):
+     if (is first RTT sample):
        return false
      pto = smoothed_rtt + max(4 * rttvar, kGranularity) +
        max_ack_delay

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -843,10 +843,10 @@ The RECOMMENDED value for kPersistentCongestionThreshold is 3, which is
 approximately equivalent to two TLPs before an RTO in TCP.
 
 The persistent congestion period SHOULD NOT start until there is at
-least one RTT sample.  Prior to an RTT sample, the duration cannot be correctly
-calculated.  Waiting for one RTT sample also avoids spuriously declaring
-persistent congestion when the initial RTT is larger than the actual RTT,
-leading to an insufficient number of PTOs.
+least one RTT sample.  Prior to an RTT sample, the duration cannot be
+correctly calculated.  Waiting for one RTT sample also avoids spuriously
+declaring persistent congestion when the initial RTT is larger than the
+actual RTT, leading to an insufficient number of PTOs.
 
 This duration is computed as follows:
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -842,6 +842,9 @@ congestion, as TCP does with a Retransmission Timeout (RTO) {{?RFC5681}}.
 The RECOMMENDED value for kPersistentCongestionThreshold is 3, which is
 approximately equivalent to two TLPs before an RTO in TCP.
 
+Persistent congestion can not be determined until there is at least one RTT
+sample since smoothed_rtt and rttvar have unknown values.
+
 This duration is computed as follows:
 
 ~~~

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1586,7 +1586,7 @@ Invoked when an ACK frame with an ECN section is received from the peer.
 Invoked when DetectAndRemoveLostPackets deems packets lost.
 
 ~~~
-   InPersistentCongestion(lost_packets):
+   InPersistentCongestion(largest_lost):
      // Persistent congestion cannot be declared on the
      // first RTT sample.
      if (is first rtt sample):
@@ -1595,9 +1595,9 @@ Invoked when DetectAndRemoveLostPackets deems packets lost.
        max_ack_delay
      congestion_period = pto * kPersistentCongestionThreshold
      // Determine if all packets in the time period before the
-     // largest newly lost packet, including the edges, are
-     // marked lost
-     return AreAllPacketsLost(lost_packets, congestion_period)
+     // largest newly lost packet, including the edges and
+     // across all packet number spaces, are marked lost.
+     return AreAllPacketsLost(largest_lost, congestion_period)
 
    OnPacketsLost(lost_packets):
      // Remove lost packets from bytes_in_flight.
@@ -1606,7 +1606,7 @@ Invoked when DetectAndRemoveLostPackets deems packets lost.
      CongestionEvent(lost_packets.largest().time_sent)
 
      // Collapse congestion window if persistent congestion
-     if (InPersistentCongestion(lost_packets)):
+     if (InPersistentCongestion(lost_packets.largest())):
        congestion_window = kMinimumWindow
 ~~~
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -846,7 +846,7 @@ The persistent congestion period SHOULD NOT start until there is at
 least one RTT sample.  Prior to an RTT sample, the duration cannot be
 correctly calculated.  Waiting for one RTT sample also avoids spuriously
 declaring persistent congestion when the initial RTT is larger than the
-actual RTT, leading to an insufficient number of PTOs.
+actual RTT.
 
 This duration is computed as follows:
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1216,6 +1216,7 @@ OnAckReceived(ack, pn_space):
   if (newly_acked_packets.largest().packet_number ==
           ack.largest_acked &&
       IncludesAckEliciting(newly_acked_packets)):
+    has_prior_rtt_sample
     latest_rtt =
       now - sent_packets[pn_space][ack.largest_acked].time_sent
     ack_delay = 0
@@ -1587,6 +1588,10 @@ Invoked when DetectAndRemoveLostPackets deems packets lost.
 
 ~~~
    InPersistentCongestion(lost_packets):
+     // Persistent congestion cannot be declared on the
+     // first RTT sample.
+     if (has prior rtt sample):
+       return
      pto = smoothed_rtt + max(4 * rttvar, kGranularity) +
        max_ack_delay
      congestion_period = pto * kPersistentCongestionThreshold

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1216,7 +1216,6 @@ OnAckReceived(ack, pn_space):
   if (newly_acked_packets.largest().packet_number ==
           ack.largest_acked &&
       IncludesAckEliciting(newly_acked_packets)):
-    has_prior_rtt_sample
     latest_rtt =
       now - sent_packets[pn_space][ack.largest_acked].time_sent
     ack_delay = 0

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1590,8 +1590,8 @@ Invoked when DetectAndRemoveLostPackets deems packets lost.
    InPersistentCongestion(lost_packets):
      // Persistent congestion cannot be declared on the
      // first RTT sample.
-     if (has prior rtt sample):
-       return
+     if (is first rtt sample):
+       return false
      pto = smoothed_rtt + max(4 * rttvar, kGranularity) +
        max_ack_delay
      congestion_period = pto * kPersistentCongestionThreshold

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -842,8 +842,9 @@ congestion, as TCP does with a Retransmission Timeout (RTO) {{?RFC5681}}.
 The RECOMMENDED value for kPersistentCongestionThreshold is 3, which is
 approximately equivalent to two TLPs before an RTO in TCP.
 
-Persistent congestion can not be determined until there is at least one RTT
-sample since smoothed_rtt and rttvar have unknown values.
+The persistent congestion period SHOULD NOT start until there is at
+least one RTT sample, both because the length of the period is unknown and
+the PTO may be excessively conservative.
 
 This duration is computed as follows:
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -843,8 +843,10 @@ The RECOMMENDED value for kPersistentCongestionThreshold is 3, which is
 approximately equivalent to two TLPs before an RTO in TCP.
 
 The persistent congestion period SHOULD NOT start until there is at
-least one RTT sample, both because the length of the period is unknown and
-the PTO may be excessively conservative.
+least one RTT sample.  Prior to an RTT sample, the duration cannot be correctly
+calculated.  Waiting for one RTT sample also avoids spuriously declaring
+persistent congestion when the initial RTT is larger than the actual RTT,
+leading to an insufficient number of PTOs.
 
 This duration is computed as follows:
 


### PR DESCRIPTION
Fixes #3875

Adds a SHOULD NOT and clarifies that persistent congestion is across PN spaces.

I was thinking that this is how it would be implemented, but I suspect this'll end up as a design change.