### PR TITLE
[HTTP/3] [editorial] Fix SETTINGS_MAX_FIELD_SECTION_SIZE usage.

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1819,14 +1819,14 @@ to buffer the entire header field section.  Since there is no hard limit to the
 size of a field section, some endpoints could be forced to commit a large amount
 of available memory for header fields.
 
-An endpoint can use the SETTINGS_MAX_HEADER_LIST_SIZE ({{settings-parameters}})
-setting to advise peers of limits that might apply on the size of field
-sections. This setting is only advisory, so endpoints MAY choose to send field
-sections that exceed this limit and risk having the request or response being
-treated as malformed.  This setting is specific to a connection, so any request
-or response could encounter a hop with a lower, unknown limit.  An intermediary
-can attempt to avoid this problem by passing on values presented by different
-peers, but they are not obligated to do so.
+An endpoint can use the SETTINGS_MAX_FIELD_SECTION_SIZE
+({{settings-parameters}}) setting to advise peers of limits that might apply on
+the size of field sections. This setting is only advisory, so endpoints MAY
+choose to send field sections that exceed this limit and risk having the request
+or response being treated as malformed.  This setting is specific to a
+connection, so any request or response could encounter a hop with a lower,
+unknown limit.  An intermediary can attempt to avoid this problem by passing on
+values presented by different peers, but they are not obligated to do so.
 
 A server that receives a larger field section than it is willing to handle can
 send an HTTP 431 (Request Header Fields Too Large) status code {{?RFC6585}}.  A
@@ -2331,8 +2331,9 @@ SETTINGS_MAX_FRAME_SIZE:
 : This setting has no equivalent in HTTP/3.  Specifying it in the SETTINGS frame
   is an error.
 
-SETTINGS_MAX_FIELD_SECTION_SIZE:
-: See {{settings-parameters}}.
+SETTINGS_MAX_HEADER_LIST_SIZE:
+: This setting identifier has been renamed SETTINGS_MAX_FIELD_SECTION_SIZE.  See
+  {{settings-parameters}}.
 
 In HTTP/3, setting values are variable-length integers (6, 14, 30, or 62 bits
 long) rather than fixed-length 32-bit fields as in HTTP/2.  This will often


### PR DESCRIPTION
Replace SETTINGS_MAX_HEADER_LIST_SIZE with
SETTINGS_MAX_FIELD_SECTION_SIZE in one last place.

Add comment to HTTP/2 identifier mapping section about rename.