### PR TITLE
Use kGranularity in persistent congestion

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -845,7 +845,7 @@ approximately equivalent to two TLPs before an RTO in TCP.
 This duration is computed as follows:
 
 ~~~
-(smoothed_rtt + 4 * rttvar + max_ack_delay) *
+(smoothed_rtt + max(4 * rttvar, kGranularity) + max_ack_delay) *
     kPersistentCongestionThreshold
 ~~~
 


### PR DESCRIPTION
This aligns the calculation with the PTO calculation, which is what persistent congestion is based off.

Fixes #3899