### PR TITLE
Fixing recovery pseudocode

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1154,7 +1154,8 @@ Pseudocode for OnPacketSent follows:
      if (ack_eliciting):
        time_of_last_ack_eliciting_packet[pn_space] = now()
      OnPacketSentCC(sent_bytes)
-     sent_packets[pn_space][packet_number].sent_bytes = sent_bytes
+     sent_packets[pn_space][packet_number].sent_bytes =
+       sent_bytes
      SetLossDetectionTimer()
 ~~~
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1541,7 +1541,8 @@ newly acked_packets from sent_packets.
       congestion_window += acked_packet.sent_bytes
     else:
       // Congestion avoidance.
-      congestion_window += max_datagram_size * acked_packet.sent_bytes
+      congestion_window += 
+        max_datagram_size * acked_packet.sent_bytes
         / congestion_window
 ~~~
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1512,24 +1512,30 @@ newly acked_packets from sent_packets.
    InCongestionRecovery(sent_time):
      return sent_time <= congestion_recovery_start_time
 
-   OnPacketsAcked(acked_packets):
-     for packet in acked_packets:
-       // Remove from bytes_in_flight.
-       bytes_in_flight -= packet.sent_bytes
-       if (InCongestionRecovery(packet.time_sent)):
-         // Do not increase congestion window in recovery period.
-         return
-       if (IsAppOrFlowControlLimited()):
-         // Do not increase congestion_window if application
-         // limited or flow control limited.
-         return
-       if (congestion_window < ssthresh):
-         // Slow start.
-         congestion_window += packet.sent_bytes
-         return
-       // Congestion avoidance.
-       congestion_window += max_datagram_size * acked_packet.sent_bytes
-           / congestion_window
+  OnPacketsAcked(acked_packets):
+    for acked_packet in acked_packets:
+      OnPacketAcked(acked_packet)
+
+  OnPacketAcked(packet):
+    // Remove from bytes_in_flight.
+    bytes_in_flight -= packet.sent_bytes
+
+    // Do not increase congestion_window if application
+    // limited or flow control limited.
+    if (IsAppOrFlowControlLimited())
+        return
+
+    // Do not increase congestion window in recovery period.
+    if (InCongestionRecovery(packet.time_sent)):
+        return
+
+    if (congestion_window < ssthresh):
+        // Slow start.
+        congestion_window += packet.sent_bytes
+    else:
+        // Congestion avoidance.
+        congestion_window += max_datagram_size * acked_packet.sent_bytes
+            / congestion_window
 ~~~
 
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1203,7 +1203,7 @@ OnAckReceived(ack, pn_space):
           ack.largest_acked &&
       IncludesAckEliciting(newly_acked_packets)):
     latest_rtt =
-      now - sent_packets[pn_space][ack.largest_acked].time_sent
+      now() - sent_packets[pn_space][ack.largest_acked].time_sent
     ack_delay = 0
     if (pn_space == ApplicationData):
       ack_delay = ack.ack_delay

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1515,8 +1515,8 @@ Invoked from loss detection's OnAckReceived and is supplied with the
 newly acked_packets from sent_packets.
 
 ~~~
-   InCongestionRecovery(sent_time):
-     return sent_time <= congestion_recovery_start_time
+  InCongestionRecovery(sent_time):
+    return sent_time <= congestion_recovery_start_time
 
   OnPacketsAcked(acked_packets):
     for acked_packet in acked_packets:
@@ -1529,19 +1529,19 @@ newly acked_packets from sent_packets.
     // Do not increase congestion_window if application
     // limited or flow control limited.
     if (IsAppOrFlowControlLimited())
-        return
+      return
 
     // Do not increase congestion window in recovery period.
     if (InCongestionRecovery(acked_packet.time_sent)):
-        return
+      return
 
     if (congestion_window < ssthresh):
-        // Slow start.
-        congestion_window += acked_packet.sent_bytes
+      // Slow start.
+      congestion_window += acked_packet.sent_bytes
     else:
-        // Congestion avoidance.
-        congestion_window += max_datagram_size * acked_packet.sent_bytes
-            / congestion_window
+      // Congestion avoidance.
+      congestion_window += max_datagram_size * acked_packet.sent_bytes
+        / congestion_window
 ~~~
 
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1182,6 +1182,12 @@ When an ACK frame is received, it may newly acknowledge any number of packets.
 Pseudocode for OnAckReceived and UpdateRtt follow:
 
 ~~~
+IncludesAckEliciting(packets):
+  for packet in packets:
+    if (packet.ack_eliciting):
+      return true
+  return false
+
 OnAckReceived(ack, pn_space):
   if (largest_acked_packet[pn_space] == infinite):
     largest_acked_packet[pn_space] = ack.largest_acked

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1541,7 +1541,7 @@ newly acked_packets from sent_packets.
       congestion_window += acked_packet.sent_bytes
     else:
       // Congestion avoidance.
-      congestion_window += 
+      congestion_window +=
         max_datagram_size * acked_packet.sent_bytes
         / congestion_window
 ~~~

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1154,7 +1154,7 @@ Pseudocode for OnPacketSent follows:
      if (ack_eliciting):
        time_of_last_ack_eliciting_packet[pn_space] = now()
      OnPacketSentCC(sent_bytes)
-     sent_packets[pn_space][packet_number].size = sent_bytes
+     sent_packets[pn_space][packet_number].sent_bytes = sent_bytes
      SetLossDetectionTimer()
 ~~~
 
@@ -1515,7 +1515,7 @@ newly acked_packets from sent_packets.
    OnPacketsAcked(acked_packets):
      for packet in acked_packets:
        // Remove from bytes_in_flight.
-       bytes_in_flight -= packet.size
+       bytes_in_flight -= packet.sent_bytes
        if (InCongestionRecovery(packet.time_sent)):
          // Do not increase congestion window in recovery period.
          return
@@ -1525,10 +1525,10 @@ newly acked_packets from sent_packets.
          return
        if (congestion_window < ssthresh):
          // Slow start.
-         congestion_window += packet.size
+         congestion_window += packet.sent_bytes
          return
        // Congestion avoidance.
-       congestion_window += max_datagram_size * acked_packet.size
+       congestion_window += max_datagram_size * acked_packet.sent_bytes
            / congestion_window
 ~~~
 
@@ -1584,7 +1584,7 @@ Invoked when DetectAndRemoveLostPackets deems packets lost.
    OnPacketsLost(lost_packets):
      // Remove lost packets from bytes_in_flight.
      for lost_packet in lost_packets:
-       bytes_in_flight -= lost_packet.size
+       bytes_in_flight -= lost_packet.sent_bytes
      CongestionEvent(lost_packets.largest().time_sent)
 
      // Collapse congestion window if persistent congestion

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1522,9 +1522,9 @@ newly acked_packets from sent_packets.
     for acked_packet in acked_packets:
       OnPacketAcked(acked_packet)
 
-  OnPacketAcked(packet):
+  OnPacketAcked(acked_packet):
     // Remove from bytes_in_flight.
-    bytes_in_flight -= packet.sent_bytes
+    bytes_in_flight -= acked_packet.sent_bytes
 
     // Do not increase congestion_window if application
     // limited or flow control limited.
@@ -1532,12 +1532,12 @@ newly acked_packets from sent_packets.
         return
 
     // Do not increase congestion window in recovery period.
-    if (InCongestionRecovery(packet.time_sent)):
+    if (InCongestionRecovery(acked_packet.time_sent)):
         return
 
     if (congestion_window < ssthresh):
         // Slow start.
-        congestion_window += packet.sent_bytes
+        congestion_window += acked_packet.sent_bytes
     else:
         // Congestion avoidance.
         congestion_window += max_datagram_size * acked_packet.sent_bytes


### PR DESCRIPTION
- Fixing trivial syntax errors.
- Adding comments for unused variables or defined-later.
- 6d43abd changes `return` to `continue` to make sense. (need to check by reviewers)