### PR TITLE
Byte counting at Congestion avoidance

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1506,7 +1506,7 @@ ssthresh:
   acknowledged.
 
 bytes_acked:
-:  Number of bytes acknowledged which have not yet been used to increment
+: Number of bytes acknowledged which have not yet been used to increment
   the congestion window during congestion avoidance.
 
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1506,8 +1506,8 @@ ssthresh:
   acknowledged.
 
 bytes_acked:
-: Records number of bytes acked and used during congestion
-  avoidance, for incrementing the congestion window.
+: Records number of bytes acked, and used for incrementing
+  the congestion window during congestion avoidance.
 
 
 ## Initialization

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1506,7 +1506,7 @@ ssthresh:
   acknowledged.
 
 bytes_acked:
-: Records number of bytes acked, and used for incrementing
+:  Number of bytes acknowledged which have not yet been used to increment
   the congestion window during congestion avoidance.
 
 


### PR DESCRIPTION
There is an issue in current congestion avoidance pseudocode
when `max_datagram_size * acked_packet.sent_bytes < congestion_window`
cwnd increment effectively becomes zero, especially because most
implementations use integer operation to calculate cwnd.

This happens when `acked_packet.sent_bytes` is a small value or
`congestion_window` is very big. It may lead to too conservative
cwnd growth during congestion avoidance.

To fix the issue, I propose to use a TCP ABC style cwnd growth
during congestion avoidance: https://www.rfc-editor.org/rfc/rfc3465.html#section-2.1

Basically it stores accumulated acked bytes in a new
variable `bytes_acked` and increase cwnd by `max_datagram_size` when
`bytes_acked` reaches to cwnd.