### PR TITLE
fixing OnAckReceived of recovery draft

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1210,7 +1210,7 @@ OnAckReceived(ack, pn_space):
           ack.largest_acked &&
       IncludesAckEliciting(newly_acked_packets)):
     latest_rtt =
-      now() - sent_packets[pn_space][ack.largest_acked].time_sent
+      now() - newly_acked_packets.largest().time_sent
     ack_delay = 0
     if (pn_space == ApplicationData):
       ack_delay = ack.ack_delay


### PR DESCRIPTION
In `OnAckReceived`, `sent_packets[pn_space][ack.largest_acked]` is not available since it was already removed by `DetectAndRemoveAckedPackets`. `newly_acked_packets.largest()` should be used instead.