### PR TITLE
May use 64+bit CIDs as address validation

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1877,7 +1877,7 @@ endpoints.  In particular, receipt of a packet protected with Handshake keys
 confirms that the client received the Initial packet from the server.  Once the
 server has successfully processed a Handshake packet from the client, it can
 consider the client address to have been validated.  Servers MAY treat the
-receipt of a server generated destination connection ID with at least 64 bits
+receipt of a packet using a server generated destination connection ID with at least 64 bits
 of entropy as address validation.
 
 Prior to validating the client address, servers MUST NOT send more than three

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1876,9 +1876,11 @@ Connection establishment implicitly provides address validation for both
 endpoints.  In particular, receipt of a packet protected with Handshake keys
 confirms that the client received the Initial packet from the server.  Once the
 server has successfully processed a Handshake packet from the client, it can
-consider the client address to have been validated.  Servers MAY treat the
-receipt of a packet using a server-generated destination connection ID with
-at least 64 bits of entropy as address validation.
+consider the client address to have been validated.
+
+Additionally, a server MAY consider the client address valididated if the
+client uses a connection ID chosen by the server and the connection ID contains
+at least 64 bits of entropy.
 
 Prior to validating the client address, servers MUST NOT send more than three
 times as many bytes as the number of bytes they have received.  This limits the

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1876,7 +1876,9 @@ Connection establishment implicitly provides address validation for both
 endpoints.  In particular, receipt of a packet protected with Handshake keys
 confirms that the client received the Initial packet from the server.  Once the
 server has successfully processed a Handshake packet from the client, it can
-consider the client address to have been validated.
+consider the client address to have been validated.  Servers MAY treat the
+receipt of a server generated destination connection ID with at least 64 bits
+of entropy as address validation.
 
 Prior to validating the client address, servers MUST NOT send more than three
 times as many bytes as the number of bytes they have received.  This limits the

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1877,8 +1877,8 @@ endpoints.  In particular, receipt of a packet protected with Handshake keys
 confirms that the client received the Initial packet from the server.  Once the
 server has successfully processed a Handshake packet from the client, it can
 consider the client address to have been validated.  Servers MAY treat the
-receipt of a packet using a server generated destination connection ID with at least 64 bits
-of entropy as address validation.
+receipt of a packet using a server generated destination connection ID with
+at least 64 bits of entropy as address validation.
 
 Prior to validating the client address, servers MUST NOT send more than three
 times as many bytes as the number of bytes they have received.  This limits the

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1877,7 +1877,7 @@ endpoints.  In particular, receipt of a packet protected with Handshake keys
 confirms that the client received the Initial packet from the server.  Once the
 server has successfully processed a Handshake packet from the client, it can
 consider the client address to have been validated.  Servers MAY treat the
-receipt of a packet using a server generated destination connection ID with
+receipt of a packet using a server-generated destination connection ID with
 at least 64 bits of entropy as address validation.
 
 Prior to validating the client address, servers MUST NOT send more than three


### PR DESCRIPTION
I'm not sure this changes anything in practice, since the client can't rely on it and the server could already do this, but explicitly saying it seems preferable.

Fixes #3834