### PR TITLE
Rework flow of Push ID

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -799,16 +799,16 @@ indicated request.  This trades off network usage against a potential latency
 gain.  HTTP/3 server push is similar to what is described in HTTP/2 {{?HTTP2}},
 but uses different mechanisms.
 
-Each server push is identified by a unique Push ID, which is used to refer to
-the push in various contexts throughout the lifetime of the connection.
+Each server push is assigned a unique Push ID by the server which is used to
+refer to the push in various contexts throughout the lifetime of the connection.
 
 The Push ID space begins at zero, and ends at a maximum value set by the
-MAX_PUSH_ID frame; see {{frame-max-push-id}}.  Server push is only enabled on a
-connection when a client sends a MAX_PUSH_ID frame.  A client sends additional
-MAX_PUSH_ID frames to control the number of pushes that a server can promise.  A
-server SHOULD use Push IDs sequentially.  A client MUST treat receipt of a push
-stream with a Push ID that is greater than the maximum Push ID as a connection
-error of type H3_ID_ERROR.
+MAX_PUSH_ID frame; see {{frame-max-push-id}}.  In particular, a server is not
+able to push until after the client sends a MAX_PUSH_ID frame.  A client sends
+additional MAX_PUSH_ID frames to control the number of pushes that a server can
+promise.  A server SHOULD use Push IDs sequentially, beginning from zero.  A
+client MUST treat receipt of a push stream with a Push ID that is greater than
+the maximum Push ID as a connection error of type H3_ID_ERROR.
 
 The Push ID is used in one or more PUSH_PROMISE frames ({{frame-push-promise}})
 that carry the header section of the request message.  These frames are sent on

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -805,10 +805,10 @@ refer to the push in various contexts throughout the lifetime of the connection.
 The Push ID space begins at zero, and ends at a maximum value set by the
 MAX_PUSH_ID frame; see {{frame-max-push-id}}.  In particular, a server is not
 able to push until after the client sends a MAX_PUSH_ID frame.  A client sends
-additional MAX_PUSH_ID frames to control the number of pushes that a server can
-promise.  A server SHOULD use Push IDs sequentially, beginning from zero.  A
-client MUST treat receipt of a push stream with a Push ID that is greater than
-the maximum Push ID as a connection error of type H3_ID_ERROR.
+MAX_PUSH_ID frames to control the number of pushes that a server can promise.  A
+server SHOULD use Push IDs sequentially, beginning from zero.  A client MUST
+treat receipt of a push stream with a Push ID that is greater than the maximum
+Push ID as a connection error of type H3_ID_ERROR.
 
 The Push ID is used in one or more PUSH_PROMISE frames ({{frame-push-promise}})
 that carry the header section of the request message.  These frames are sent on

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -816,7 +816,7 @@ the request stream which generated the push.  This allows the server push to be
 associated with a client request.  When the same Push ID is promised on multiple
 request streams, the decompressed request field sections MUST contain the same
 fields in the same order, and both the name and the value in each field MUST be
-exact matches.
+identical.
 
 The Push ID is then included with the push stream that ultimately fulfills
 those promises; see {{push-streams}}.  The push stream identifies the Push ID of

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -818,7 +818,7 @@ request streams, the decompressed request field sections MUST contain the same
 fields in the same order, and both the name and the value in each field MUST be
 exact matches.
 
-The Push ID is then included with the push stream which ultimately fulfills
+The Push ID is then included with the push stream that ultimately fulfills
 those promises; see {{push-streams}}.  The push stream identifies the Push ID of
 the promise that it fulfills, then contains a response to the promised request
 as described in {{request-response}}.

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -799,7 +799,7 @@ indicated request.  This trades off network usage against a potential latency
 gain.  HTTP/3 server push is similar to what is described in HTTP/2 {{?HTTP2}},
 but uses different mechanisms.
 
-Each server push is assigned a unique Push ID by the server which is used to
+Each server push is assigned a unique Push ID by the server.  The Push ID is used to
 refer to the push in various contexts throughout the lifetime of the connection.
 
 The Push ID space begins at zero, and ends at a maximum value set by the

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -807,8 +807,9 @@ indicated request.  This trades off network usage against a potential latency
 gain.  HTTP/3 server push is similar to what is described in HTTP/2 {{?HTTP2}},
 but uses different mechanisms.
 
-Each server push is assigned a unique Push ID by the server.  The Push ID is used to
-refer to the push in various contexts throughout the lifetime of the connection.
+Each server push is assigned a unique Push ID by the server.  The Push ID is
+used to refer to the push in various contexts throughout the lifetime of the
+connection.
 
 The Push ID space begins at zero, and ends at a maximum value set by the
 MAX_PUSH_ID frame; see {{frame-max-push-id}}.  In particular, a server is not


### PR DESCRIPTION
The Push ID text was divided up between the definitions of various frames and sprinkled into the description of Server Push.  This rearranges a bit to give a "lifecycle" of a Push ID.  I'd really like to have a separate subsection for Push IDs, but they're fundamental enough to knowing how Server Push works in HTTP/3 that I don't feel like I can do that without moving most of the section to more subsections.

No normative changes here, just some moved text and a little bit of new prose.