### PR TITLE
Emphasize still talking about sending

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1165,10 +1165,11 @@ desired. They MAY also be sent on connections where no data is currently being
 transferred. Endpoints MUST NOT consider these streams to have any meaning upon
 receipt.
 
-The payload and length of the stream are selected in any manner the
-implementation chooses.  Implementations MAY terminate these streams cleanly, or
-MAY abruptly terminate them.  When terminating abruptly, the error code
-H3_NO_ERROR or a reserved error code ({{http-error-codes}}) SHOULD be used.
+The payload and length of the stream are selected in any manner the sending
+implementation chooses.  When sending a reserved stream type, the implementation
+MAY either terminate the stream cleanly or reset it.  When resetting the stream,
+the error code H3_NO_ERROR or a reserved error code ({{http-error-codes}})
+SHOULD be used.
 
 
 # HTTP Framing Layer {#http-framing-layer}

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1168,8 +1168,8 @@ receipt.
 The payload and length of the stream are selected in any manner the sending
 implementation chooses.  When sending a reserved stream type, the implementation
 MAY either terminate the stream cleanly or reset it.  When resetting the stream,
-the error code H3_NO_ERROR or a reserved error code ({{http-error-codes}})
-SHOULD be used.
+either the H3_NO_ERROR error code or a reserved error code
+({{http-error-codes}}) SHOULD be used.
 
 
 # HTTP Framing Layer {#http-framing-layer}


### PR DESCRIPTION
I totally misread this passage, so let's make it more emphatic which side of the stream we're talking about.  Fixes #3933.