### PR TITLE
Application can reset stream or close connection even if no error occurs.

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1595,9 +1595,11 @@ sent, and receipt MAY be treated as an error of type H3_FRAME_UNEXPECTED.
 # Error Handling {#errors}
 
 QUIC allows the application to abruptly terminate (reset) individual streams or
-the entire connection when an error is encountered.  These are referred to as
-"stream errors" or "connection errors" and are described in more detail in
-{{QUIC-TRANSPORT}}.
+the entire connection, see Sections 2.4 and 5.3 of {{QUIC-TRANSPORT}}.  The
+cause for this is referred to as a "stream error" or "connection error" (see
+Section 11 of {{QUIC-TRANSPORT}}) and has an associated error code, but does not
+necessarily have to be an error.  For example, a stream can be reset if the
+requested resource is no longer needed.
 
 An endpoint MAY choose to treat a stream error as a connection error under
 certain circumstances.  Implementations need to consider the impact on

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1598,8 +1598,8 @@ QUIC allows the application to abruptly terminate (reset) individual streams or
 the entire connection; see Sections 2.4 and 5.3 of {{QUIC-TRANSPORT}}.  These
 are referred to as "stream errors" or "connection errors" (see Section 11 of
 {{QUIC-TRANSPORT}}) and have associated error codes, but do not necessarily
-have to be errors.  For example, a stream can be reset if the requested resource
-is no longer needed.
+indicate a problem with the connection or either implementation.  For example, a
+stream can be reset if the requested resource is no longer needed.
 
 An endpoint MAY choose to treat a stream error as a connection error under
 certain circumstances.  Implementations need to consider the impact on

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1595,8 +1595,8 @@ sent, and receipt MAY be treated as an error of type H3_FRAME_UNEXPECTED.
 # Error Handling {#errors}
 
 QUIC allows the application to abruptly terminate (reset) individual streams or
-the entire connection, see Sections 2.4 and 5.3 of {{QUIC-TRANSPORT}}.  The
-cause for this is referred to as a "stream error" or "connection error" (see
+the entire connection; see Sections 2.4 and 5.3 of {{QUIC-TRANSPORT}}.  This
+is referred to as a "stream error" or "connection error" (see
 Section 11 of {{QUIC-TRANSPORT}}) and has an associated error code, but does not
 necessarily have to be an error.  For example, a stream can be reset if the
 requested resource is no longer needed.

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1595,11 +1595,11 @@ sent, and receipt MAY be treated as an error of type H3_FRAME_UNEXPECTED.
 # Error Handling {#errors}
 
 QUIC allows the application to abruptly terminate (reset) individual streams or
-the entire connection; see Sections 2.4 and 5.3 of {{QUIC-TRANSPORT}}.  This
-is referred to as a "stream error" or "connection error" (see
-Section 11 of {{QUIC-TRANSPORT}}) and has an associated error code, but does not
-necessarily have to be an error.  For example, a stream can be reset if the
-requested resource is no longer needed.
+the entire connection; see Sections 2.4 and 5.3 of {{QUIC-TRANSPORT}}.  These
+are referred to as "stream errors" or "connection errors" (see Section 11 of
+{{QUIC-TRANSPORT}}) and have an associated error code, but do not necessarily
+have to be errors.  For example, a stream can be reset if the requested resource
+is no longer needed.
 
 An endpoint MAY choose to treat a stream error as a connection error under
 certain circumstances.  Implementations need to consider the impact on

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1597,7 +1597,7 @@ sent, and receipt MAY be treated as an error of type H3_FRAME_UNEXPECTED.
 QUIC allows the application to abruptly terminate (reset) individual streams or
 the entire connection; see Sections 2.4 and 5.3 of {{QUIC-TRANSPORT}}.  These
 are referred to as "stream errors" or "connection errors" (see Section 11 of
-{{QUIC-TRANSPORT}}) and have an associated error code, but do not necessarily
+{{QUIC-TRANSPORT}}) and have associated error codes, but do not necessarily
 have to be errors.  For example, a stream can be reset if the requested resource
 is no longer needed.
 


### PR DESCRIPTION
The application may reset a stream, for example, when a browser tab is
closed or when the pushed resource is found in cache.  It might close
the connection when the application is closed.  These are not errors per
se, even though the term "stream error" and "connection error" is used
for these events, and they have an associated "error code".