### PR TITLE
Clarify HTTP/2 setting parameter reservation

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1397,7 +1397,8 @@ value the implementation selects.
 
 Setting identifiers which were used in HTTP/2 where there is no corresponding
 HTTP/3 setting have also been reserved ({{iana-settings}}). These settings MUST
-NOT be sent, and receipt MAY be treated as an error of type H3_SETTINGS_ERROR.
+NOT be sent, and their receipt MUST be treated as an error of type
+H3_SETTINGS_ERROR.
 
 Additional settings can be defined by extensions to HTTP/3; see {{extensions}}
 for more details.
@@ -2310,8 +2311,10 @@ frame of the control stream, and thereafter cannot change.  This eliminates many
 corner cases around synchronization of changes.
 
 Some transport-level options that HTTP/2 specifies via the SETTINGS frame are
-superseded by QUIC transport parameters in HTTP/3. The HTTP-level options that
-are retained in HTTP/3 have the same value as in HTTP/2.
+superseded by QUIC transport parameters in HTTP/3.  The HTTP-level options that
+are retained in HTTP/3 have the same value as in HTTP/2.  The superseded
+settings are reserved, and their receipt is an error.  See
+{{settings-parameters}} for discussion of both the retained and reserved values.
 
 Below is a listing of how each HTTP/2 SETTINGS parameter is mapped:
 
@@ -2342,8 +2345,7 @@ SETTINGS_MAX_FRAME_SIZE:
   HTTP/3 SETTINGS frame is an error.
 
 SETTINGS_MAX_HEADER_LIST_SIZE:
-: This setting identifier has been renamed SETTINGS_MAX_FIELD_SECTION_SIZE.  See
-  {{settings-parameters}}.
+: This setting identifier has been renamed SETTINGS_MAX_FIELD_SECTION_SIZE.
 
 In HTTP/3, setting values are variable-length integers (6, 14, 30, or 62 bits
 long) rather than fixed-length 32-bit fields as in HTTP/2.  This will often

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1395,6 +1395,10 @@ settings to have any meaning upon receipt.
 Because the setting has no defined meaning, the value of the setting can be any
 value the implementation selects.
 
+Setting identifiers which were used in HTTP/2 where there is no corresponding
+HTTP/3 setting have also been reserved ({{iana-settings}}). These settings MUST
+NOT be sent, and receipt MAY be treated as an error of type H3_SETTINGS_ERROR.
+
 Additional settings can be defined by extensions to HTTP/3; see {{extensions}}
 for more details.
 
@@ -2316,20 +2320,26 @@ SETTINGS_HEADER_TABLE_SIZE:
 
 SETTINGS_ENABLE_PUSH:
 : This is removed in favor of the MAX_PUSH_ID which provides a more granular
-  control over server push.
+  control over server push.  Specifying a setting with the identifier 0x2
+  (corresponding to the SETTINGS_ENABLE_PUSH parameter) in the HTTP/3 SETTINGS
+  frame is an error.
 
 SETTINGS_MAX_CONCURRENT_STREAMS:
 : QUIC controls the largest open Stream ID as part of its flow control logic.
-  Specifying SETTINGS_MAX_CONCURRENT_STREAMS in the SETTINGS frame is an error.
+  Specifying a setting with the identifier 0x3 (corresponding to the
+  SETTINGS_MAX_CONCURRENT_STREAMS parameter) in the HTTP/3 SETTINGS frame is an
+  error.
 
 SETTINGS_INITIAL_WINDOW_SIZE:
 : QUIC requires both stream and connection flow control window sizes to be
-  specified in the initial transport handshake.  Specifying
-  SETTINGS_INITIAL_WINDOW_SIZE in the SETTINGS frame is an error.
+  specified in the initial transport handshake.  Specifying a setting with the
+  identifier 0x4 (corresponding to the SETTINGS_INITIAL_WINDOW_SIZE parameter)
+  in the HTTP/3 SETTINGS frame is an error.
 
 SETTINGS_MAX_FRAME_SIZE:
-: This setting has no equivalent in HTTP/3.  Specifying it in the SETTINGS frame
-  is an error.
+: This setting has no equivalent in HTTP/3.  Specifying a setting with the
+  identifier 0x5 (corresponding to the SETTINGS_MAX_FRAME_SIZE parameter) in the
+  HTTP/3 SETTINGS frame is an error.
 
 SETTINGS_MAX_HEADER_LIST_SIZE:
 : This setting identifier has been renamed SETTINGS_MAX_FIELD_SECTION_SIZE.  See

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1398,7 +1398,7 @@ value the implementation selects.
 
 Setting identifiers which were used in HTTP/2 where there is no corresponding
 HTTP/3 setting have also been reserved ({{iana-settings}}). These settings MUST
-NOT be sent, and their receipt MUST be treated as an error of type
+NOT be sent, and their receipt MUST be treated as a connection error of type
 H3_SETTINGS_ERROR.
 
 Additional settings can be defined by extensions to HTTP/3; see {{extensions}}


### PR DESCRIPTION
Fixes #3954 by copying the language we already had for frame types and taking @martinthomson's suggestion from #3942.