### PR TITLE
When is the PTO armed from?

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -580,7 +580,7 @@ discarded, the PTO and loss detection timers MUST be reset, because discarding
 keys indicates forward progress and the loss detection timer might have been set
 for a now discarded packet number space.
 
-#### Before Server Address Validation
+#### Before Address Validation
 
 Until the server has validated the client's address on the path, the amount of
 data it can send is limited to three times the amount of data received,

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -520,11 +520,12 @@ A sender recomputes and may need to reset its PTO timer every time an
 ack-eliciting packet is sent or acknowledged, when the handshake is confirmed,
 or when Initial or Handshake keys are discarded. This ensures the PTO is always
 set based on the latest RTT information and for the last sent ack-eliciting
-packet in the correct packet number space.  A client could have received and
-acknowledged a Handshake packet, causing it to discard state for the Initial
-packet number space, but not sent any ack-eliciting Handshake packets.
-In this case, there are no ack-eliciting packets, so the PTO is set
-from the current time.
+packet in the correct packet number space. When the PTO is armed and there are
+no ack-eliciting packets in flight, the PTO is set from the current time.
+This occurs if a client's Initial packets are acknowledged or a client has
+received and acknowledged a Handshake packet, causing it to discard state for
+the Initial packet number space, but not sent any ack-eliciting Handshake
+packets.
 
 When ack-eliciting packets in multiple packet number spaces are in flight,
 the timer MUST be set for the packet number space with the earliest timeout,

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -520,7 +520,11 @@ A sender recomputes and may need to reset its PTO timer every time an
 ack-eliciting packet is sent or acknowledged, when the handshake is confirmed,
 or when Initial or Handshake keys are discarded. This ensures the PTO is always
 set based on the latest RTT information and for the last sent ack-eliciting
-packet in the correct packet number space.
+packet in the correct packet number space.  A client could have received and
+acknowledged a Handshake packet, causing it to discard state for the Initial
+packet number space, but not sent any ack-eliciting Handshake packets.
+In this case, there are no ack-eliciting packets, so the PTO is set
+from the current time.
 
 When ack-eliciting packets in multiple packet number spaces are in flight,
 the timer MUST be set for the packet number space with the earliest timeout,
@@ -595,11 +599,6 @@ Handshake or 1-RTT packets, and has not received a HANDSHAKE_DONE frame.
 If Handshake keys are available to the client, it MUST send a Handshake
 packet, and otherwise it MUST send an Initial packet in a UDP datagram of
 at least 1200 bytes.
-
-A client could have received and acknowledged a Handshake packet, causing it to
-discard state for the Initial packet number space, but not sent any
-ack-eliciting Handshake packets.  In this case, the PTO is set from the current
-time.
 
 ### Speeding Up Handshake Completion
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -592,7 +592,7 @@ client, it is the client's responsibility to send packets to unblock the server
 until it is certain that the server has finished its address validation
 (see Section 8 of {{QUIC-TRANSPORT}}).  That is, the client MUST set the
 probe timer if the client has not received an acknowledgement for one of its
-Handshake or 1-RTT packets, and has not received a HANDSHAKE_DONE frame,
+Handshake or 1-RTT packets and has not received a HANDSHAKE_DONE frame,
 even if there are no packets in flight. If Handshake keys are available to the
 client, it MUST send a Handshake packet, and otherwise it MUST send an Initial
 packet in a UDP datagram of at least 1200 bytes.

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -519,8 +519,8 @@ immediately.
 A sender recomputes and may need to reset its PTO timer every time an
 ack-eliciting packet is sent or acknowledged, when the handshake is confirmed,
 or when Initial or Handshake keys are discarded. This ensures the PTO is always
-set based on the latest RTT information and for the last sent packet in the
-correct packet number space.
+set based on the latest RTT information and for the last sent ack-eliciting
+packet in the correct packet number space.
 
 When ack-eliciting packets in multiple packet number spaces are in flight,
 the timer MUST be set for the packet number space with the earliest timeout,
@@ -576,7 +576,7 @@ discarded, the PTO and loss detection timers MUST be reset, because discarding
 keys indicates forward progress and the loss detection timer might have been set
 for a now discarded packet number space.
 
-#### Before Address Validation
+#### Before Server Address Validation
 
 Until the server has validated the client's address on the path, the amount of
 data it can send is limited to three times the amount of data received,

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -520,7 +520,7 @@ A sender recomputes and may need to reset its PTO timer every time an
 ack-eliciting packet is sent or acknowledged, when the handshake is confirmed,
 or when Initial or Handshake keys are discarded. This ensures the PTO is always
 set based on the latest RTT information and for the last sent ack-eliciting
-packet in the correct packet number space. When the PTO is armed and there are
+packet in the correct packet number space. When the PTO expires and there are
 no ack-eliciting packets in flight, the PTO is set from the current time.
 
 When ack-eliciting packets in multiple packet number spaces are in flight,

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -593,9 +593,9 @@ until it is certain that the server has finished its address validation
 (see Section 8 of {{QUIC-TRANSPORT}}).  That is, the client MUST set the
 probe timer if the client has not received an acknowledgement for one of its
 Handshake or 1-RTT packets and has not received a HANDSHAKE_DONE frame,
-even if there are no packets in flight. If Handshake keys are available to the
-client, it MUST send a Handshake packet, and otherwise it MUST send an Initial
-packet in a UDP datagram of at least 1200 bytes.
+even if there are no packets in flight. When the PTO fires, the client MUST
+send a Handshake packet if it has Handshake keys, otherwise it MUST
+send an Initial packet in a UDP datagram of at least 1200 bytes.
 
 ### Speeding Up Handshake Completion
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -521,7 +521,7 @@ ack-eliciting packet is sent or acknowledged, when the handshake is confirmed,
 or when Initial or Handshake keys are discarded. This ensures the PTO is always
 set based on the latest RTT information and for the last sent ack-eliciting
 packet in the correct packet number space. When the PTO expires and there are
-no ack-eliciting packets in flight, the PTO is set from the current time.
+no ack-eliciting packets in flight, the PTO is set from that moment.
 
 When ack-eliciting packets in multiple packet number spaces are in flight,
 the timer MUST be set for the packet number space with the earliest timeout,


### PR DESCRIPTION
I tried adding more text, but I think it made it more confusing, so I moved text up for the one case you set PTO from the current time.  Suggestions welcome.

Later updated to go back to using "current time" which @martinthomson didn't like in #3908.  It seems fairly clear to me, and the original fix doesn't work for the Initial packet number space, which is why we're back to current time.

Fixes #3831
Fixes #3962 