### PR TITLE
Rework section on persistent congestion

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -836,9 +836,8 @@ The persistent congestion duration is computed as follows:
     kPersistentCongestionThreshold
 ~~~
 
-Note that unlike the PTO computation in {{pto}}, this duration includes the
-max_ack_delay irrespective of the packet number spaces in which losses are
-established.
+Unlike the PTO computation in {{pto}}, this duration includes the max_ack_delay
+irrespective of the packet number spaces in which losses are established.
 
 This duration allows a sender to send enough packets, including some in response
 to PTO expiration, as TCP does with Tail Loss Probe ({{RACK}}), before

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -863,10 +863,12 @@ correctly calculated.  Waiting for one RTT sample also avoids spuriously
 declaring persistent congestion when the initial RTT is larger than the
 actual RTT.
 
-### Declaring Persistent Congestion
+### Establishing Persistent Congestion
 
-A sender declares persistent congestion on receiving an acknowledgement, if the
-following conditions are true:
+A sender establishes persistent congestion on receiving an acknowledgement, if
+the following conditions are true:
+
+* a prior RTT sample exists;
 
 * there are at least two ack-eliciting packets that are declared lost;
 
@@ -875,11 +877,16 @@ following conditions are true:
 
 * all packets sent between those times are declared lost.
 
+Before the first RTT sample, a sender arms its PTO timer based on the initial
+RTT ({{pto-handshake}}), which could be substantially larger than the actual
+RTT. Requiring a prior RTT sample prevents a sender from establishing persistent
+congestion with potentially too few probes.
+
 Since network congestion is not affected by packet number spaces, persistent
-congestion SHOULD be established across packet number spaces. A sender that does
-not have state for all packet number spaces or an implementation that cannot
-compare send times across packet number spaces MAY use state for just the packet
-number space that was acknowledged.
+congestion SHOULD consider packets sent across packet number spaces. A sender
+that does not have state for all packet number spaces or an implementation that
+cannot compare send times across packet number spaces MAY use state for just the
+packet number space that was acknowledged.
 
 When persistent congestion is declared, the sender's congestion window MUST be
 reduced to the minimum congestion window (kMinimumWindow).  This response of
@@ -889,8 +896,8 @@ similar to a sender's response on a Retransmission Timeout (RTO) in TCP
 
 ### Example
 
-The following example illustrates how persistent congestion can be
-established. Assume:
+The following example illustrates how a sender might establish persistent
+congestion. Assume:
 
 ~~~
 smoothed_rtt + max(4*rttvar, kGranularity) + max_ack_delay = 2
@@ -917,10 +924,10 @@ Packets 2 through 8 are declared lost when the acknowledgement for packet 9 is
 received at t = 12.2.
 
 The congestion period is calculated as the time between the oldest and newest
-lost packets: 8 - 1 = 7.  The duration for establishing persistent congestion
-is: 2 * 3 = 6.  Because the threshold was reached and because none of the
-packets between the oldest and the newest lost packets were acknowledged, the
-network is considered to have experienced persistent congestion.
+lost packets: 8 - 1 = 7.  The persistent congestion duration is: 2 * 3 = 6.
+Because the threshold was reached and because none of the packets between the
+oldest and the newest lost packets were acknowledged, the network is considered
+to have experienced persistent congestion.
 
 While this example shows the occurrence of PTOs, they are not required for
 persistent congestion to be established.

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -848,12 +848,14 @@ establishing persistent congestion, as TCP does with a Retransmission Timeout
 The RECOMMENDED value for kPersistentCongestionThreshold is 3, which is
 approximately equivalent to two TLPs before an RTO in TCP.
 
-This design uses an explicit duration instead of consecutive PTO events since
-the PTO timer is restarted every time an ack-eliciting packet is sent. An
-application that sends data with silence periods can restart the PTO timer every
-time it sends, potentially preventing the PTO timer from expiring for a long
-period of time. A consequence of this design is that persistent congestion can
-be established without the occurrence of any PTOs.
+This design does not use consecutive PTO events to establish persistent
+congestion, since a PTO expiration is controlled by application patterns in
+addition to network activity. For example, a sender that sends small amounts of
+data with silence periods between them restarts the PTO timer every time it
+sends, potentially preventing the PTO timer from expiring for a long period of
+time, even when no acknowledgments are being received. The use of a duration
+enables a sender to establish persistent congestion without depending on the
+occurrence of PTOs.
 
 The persistent congestion period SHOULD NOT start until there is at
 least one RTT sample.  Prior to an RTT sample, the duration cannot be

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -840,20 +840,20 @@ Note that unlike the PTO computation in {{pto}}, this duration includes the
 max_ack_delay irrespective of the packet number spaces in which losses are
 established.
 
-This duration is intended to allow a sender to use initial PTOs for aggressive
-probing, as TCP does with Tail Loss Probe (TLP; see {{RACK}}), before
+This duration allows a sender to send enough packets, including some in response
+to PTO expiration, as TCP does with Tail Loss Probe ({{RACK}}), before
 establishing persistent congestion, as TCP does with a Retransmission Timeout
-(RTO; see {{?RFC5681}}).
+({{?RFC5681}}).
 
 The RECOMMENDED value for kPersistentCongestionThreshold is 3, which is
 approximately equivalent to two TLPs before an RTO in TCP.
 
 This design uses an explicit duration instead of consecutive PTO events since
 the PTO timer is restarted every time an ack-eliciting packet is sent. An
-application that trickles data restarts the PTO timer repeatedly, preventing the
-PTO timer from expiring for a potentially long period of time. A consequence of
-this design is that persistent congestion can be established without the
-occurrence of any PTOs.
+application that sends data with silence periods can restart the PTO timer every
+time it sends, potentially preventing the PTO timer from expiring for a long
+period of time. A consequence of this design is that persistent congestion can
+be established without the occurrence of any PTOs.
 
 The persistent congestion period SHOULD NOT start until there is at
 least one RTT sample.  Prior to an RTT sample, the duration cannot be

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -826,15 +826,25 @@ packets.
 
 When an ACK frame is received that establishes loss of all in-flight packets
 sent over a long enough period of time, the network is considered to be
-experiencing persistent congestion.  Commonly, this can be established by
-consecutive PTOs, but since the PTO timer is reset when a new ack-eliciting
-packet is sent, an explicit duration must be used to account for those cases
-where PTOs do not occur or are substantially delayed. The rationale for this
-threshold is to enable a sender to use initial PTOs for aggressive probing, as
-TCP does with Tail Loss Probe (TLP; see {{RACK}}), before establishing
-persistent congestion, as TCP does with a Retransmission Timeout (RTO; see
-{{?RFC5681}}). The RECOMMENDED value for kPersistentCongestionThreshold is 3,
-which is approximately equivalent to two TLPs before an RTO in TCP.
+experiencing persistent congestion.
+
+A sender declares persistent congestion on receiving an acknowledgement that:
+
+- 
+
+While this can be established by consecutive PTOs, but since the PTO timer is
+reset when a new ack-eliciting packet is sent, an explicit duration must be used
+to account for those cases where PTOs do not occur or are substantially delayed.
+
+The rationale for this threshold is to enable a sender to use initial PTOs for
+aggressive probing, as TCP does with Tail Loss Probe (TLP; see {{RACK}}), before
+establishing persistent congestion, as TCP does with a Retransmission Timeout
+(RTO; see {{?RFC5681}}).
+
+The RECOMMENDED value for kPersistentCongestionThreshold is 3, which is
+approximately equivalent to two TLPs before an RTO in TCP.
+
+
 
 The persistent congestion period SHOULD NOT start until there is at
 least one RTT sample.  Prior to an RTT sample, the duration cannot be

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -827,7 +827,7 @@ packets.
 When a sender establishes loss of all in-flight packets sent over a long enough
 duration, the network is considered to be experiencing persistent congestion.
 
-### Duration {#duration}
+### Duration {#pc-duration}
 
 The persistent congestion duration is computed as follows:
 
@@ -868,8 +868,8 @@ following conditions are true:
 
 * there are at least two ack-eliciting packets that are declared lost;
 
-* the duration between the send times of these two packets exceeds the
-  persistent congestion duration ({{duration}}); and
+* the duration between the send times of these packets exceeds the
+  persistent congestion duration ({{pc-duration}}); and
 
 * all packets sent between those times are declared lost.
 
@@ -883,7 +883,7 @@ When persistent congestion is declared, the sender's congestion window MUST be
 reduced to the minimum congestion window (kMinimumWindow).  This response of
 collapsing the congestion window on persistent congestion is functionally
 similar to a sender's response on a Retransmission Timeout (RTO) in TCP
-({{RFC5681}}) after Tail Loss Probes (TLP; see {{RACK}}).
+({{RFC5681}}) after Tail Loss Probes ({{RACK}}).
 
 ### Example
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -839,8 +839,8 @@ The persistent congestion duration is computed as follows:
 Unlike the PTO computation in {{pto}}, this duration includes the max_ack_delay
 irrespective of the packet number spaces in which losses are established.
 
-This duration allows a sender to send enough packets, including some in response
-to PTO expiration, as TCP does with Tail Loss Probe ({{RACK}}), before
+This duration allows a sender to send as many packets, including some in
+response to PTO expiration, as TCP does with Tail Loss Probe ({{RACK}}), before
 establishing persistent congestion, as TCP does with a Retransmission Timeout
 ({{?RFC5681}}).
 
@@ -848,27 +848,25 @@ The RECOMMENDED value for kPersistentCongestionThreshold is 3, which is
 approximately equivalent to two TLPs before an RTO in TCP.
 
 This design does not use consecutive PTO events to establish persistent
-congestion, since a PTO expiration is controlled by application patterns in
-addition to network activity. For example, a sender that sends small amounts of
-data with silence periods between them restarts the PTO timer every time it
-sends, potentially preventing the PTO timer from expiring for a long period of
-time, even when no acknowledgments are being received. The use of a duration
-enables a sender to establish persistent congestion without depending on the
-occurrence of PTOs.
+congestion, since application patterns impact PTO expirations. For example, a
+sender that sends small amounts of data with silence periods between them
+restarts the PTO timer every time it sends, potentially preventing the PTO timer
+from expiring for a long period of time, even when no acknowledgments are being
+received. The use of a duration enables a sender to establish persistent
+congestion without depending on the occurrence of PTOs.
 
 ### Establishing Persistent Congestion
 
-A sender establishes persistent congestion on receiving an acknowledgement, if
-the following conditions are true:
+A sender establishes persistent congestion on receiving an acknowledgement if at
+least two ack-eliciting packets are declared lost, and:
 
-* there are at least two ack-eliciting packets that are declared lost;
+* a prior RTT sample existed when both packets were sent;
 
-* a prior RTT sample existed at the time these packets were sent;
-
-* the duration between the send times of these packets exceeds the
+* the duration between the send times of these two packets exceeds the
   persistent congestion duration ({{pc-duration}}); and
 
-* all packets sent between those times are declared lost.
+* all packets, across all packet number spaces, sent between those two send
+  times are declared lost.
 
 The persistent congestion period SHOULD NOT start until there is at least one
 RTT sample. Before the first RTT sample, a sender arms its PTO timer based on
@@ -883,10 +881,8 @@ cannot compare send times across packet number spaces MAY use state for just the
 packet number space that was acknowledged.
 
 When persistent congestion is declared, the sender's congestion window MUST be
-reduced to the minimum congestion window (kMinimumWindow).  This response of
-collapsing the congestion window on persistent congestion is functionally
-similar to a sender's response on a Retransmission Timeout (RTO) in TCP
-({{RFC5681}}) after Tail Loss Probes ({{RACK}}).
+reduced to the minimum congestion window (kMinimumWindow), similar to a TCP
+sender's response on an RTO ({{RFC5681}}).
 
 ### Example
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -853,7 +853,7 @@ sender that sends small amounts of data with silence periods between them
 restarts the PTO timer every time it sends, potentially preventing the PTO timer
 from expiring for a long period of time, even when no acknowledgments are being
 received. The use of a duration enables a sender to establish persistent
-congestion without depending on the occurrence of PTOs.
+congestion without depending on PTO expiration.
 
 ### Establishing Persistent Congestion
 
@@ -919,8 +919,8 @@ Because the threshold was reached and because none of the packets between the
 oldest and the newest lost packets were acknowledged, the network is considered
 to have experienced persistent congestion.
 
-While this example shows the occurrence of PTOs, they are not required for
-persistent congestion to be established.
+While this example shows PTO expiration, they are not required for persistent
+congestion to be established.
 
 
 ## Pacing {#pacing}

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -857,30 +857,25 @@ time, even when no acknowledgments are being received. The use of a duration
 enables a sender to establish persistent congestion without depending on the
 occurrence of PTOs.
 
-The persistent congestion period SHOULD NOT start until there is at
-least one RTT sample.  Prior to an RTT sample, the duration cannot be
-correctly calculated.  Waiting for one RTT sample also avoids spuriously
-declaring persistent congestion when the initial RTT is larger than the
-actual RTT.
-
 ### Establishing Persistent Congestion
 
 A sender establishes persistent congestion on receiving an acknowledgement, if
 the following conditions are true:
 
-* a prior RTT sample exists;
-
 * there are at least two ack-eliciting packets that are declared lost;
+
+* a prior RTT sample existed at the time these packets were sent;
 
 * the duration between the send times of these packets exceeds the
   persistent congestion duration ({{pc-duration}}); and
 
 * all packets sent between those times are declared lost.
 
-Before the first RTT sample, a sender arms its PTO timer based on the initial
-RTT ({{pto-handshake}}), which could be substantially larger than the actual
-RTT. Requiring a prior RTT sample prevents a sender from establishing persistent
-congestion with potentially too few probes.
+The persistent congestion period SHOULD NOT start until there is at least one
+RTT sample. Before the first RTT sample, a sender arms its PTO timer based on
+the initial RTT ({{pto-handshake}}), which could be substantially larger than
+the actual RTT. Requiring a prior RTT sample prevents a sender from establishing
+persistent congestion with potentially too few probes.
 
 Since network congestion is not affected by packet number spaces, persistent
 congestion SHOULD consider packets sent across packet number spaces. A sender

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -824,27 +824,36 @@ packets.
 
 ## Persistent Congestion {#persistent-congestion}
 
-When an ACK frame is received that establishes loss of all in-flight packets
-sent over a long enough period of time, the network is considered to be
-experiencing persistent congestion.
+When a sender establishes loss of all in-flight packets sent over a long enough
+duration, the network is considered to be experiencing persistent congestion.
 
-A sender declares persistent congestion on receiving an acknowledgement that:
+### Duration {#duration}
 
-- 
+The persistent congestion duration is computed as follows:
 
-While this can be established by consecutive PTOs, but since the PTO timer is
-reset when a new ack-eliciting packet is sent, an explicit duration must be used
-to account for those cases where PTOs do not occur or are substantially delayed.
+~~~
+(smoothed_rtt + max(4*rttvar, kGranularity) + max_ack_delay) *
+    kPersistentCongestionThreshold
+~~~
 
-The rationale for this threshold is to enable a sender to use initial PTOs for
-aggressive probing, as TCP does with Tail Loss Probe (TLP; see {{RACK}}), before
+Note that unlike the PTO computation in {{pto}}, this duration includes the
+max_ack_delay irrespective of the packet number spaces in which losses are
+established.
+
+This duration is intended to allow a sender to use initial PTOs for aggressive
+probing, as TCP does with Tail Loss Probe (TLP; see {{RACK}}), before
 establishing persistent congestion, as TCP does with a Retransmission Timeout
 (RTO; see {{?RFC5681}}).
 
 The RECOMMENDED value for kPersistentCongestionThreshold is 3, which is
 approximately equivalent to two TLPs before an RTO in TCP.
 
-
+This design uses an explicit duration instead of consecutive PTO events since
+the PTO timer is restarted every time an ack-eliciting packet is sent. An
+application that trickles data restarts the PTO timer repeatedly, preventing the
+PTO timer from expiring for a potentially long period of time. A consequence of
+this design is that persistent congestion can be established without the
+occurrence of any PTOs.
 
 The persistent congestion period SHOULD NOT start until there is at
 least one RTT sample.  Prior to an RTT sample, the duration cannot be
@@ -852,16 +861,31 @@ correctly calculated.  Waiting for one RTT sample also avoids spuriously
 declaring persistent congestion when the initial RTT is larger than the
 actual RTT.
 
-This duration is computed as follows:
+### Declaring Persistent Congestion
 
-~~~
-(smoothed_rtt + max(4*rttvar, kGranularity) + max_ack_delay) *
-    kPersistentCongestionThreshold
-~~~
+A sender declares persistent congestion on receiving an acknowledgement, if the
+following conditions are true:
 
-Unlike the PTO computation in {{pto}}, persistent congestion includes the
-max_ack_delay irrespective of the packet number spaces in which losses are
-established.
+* there are at least two ack-eliciting packets that are declared lost;
+
+* the duration between the send times of these two packets exceeds the
+  persistent congestion duration ({{duration}}); and
+
+* all packets sent between those times are declared lost.
+
+Since network congestion is not affected by packet number spaces, persistent
+congestion SHOULD be established across packet number spaces. A sender that does
+not have state for all packet number spaces or an implementation that cannot
+compare send times across packet number spaces MAY use state for just the packet
+number space that was acknowledged.
+
+When persistent congestion is declared, the sender's congestion window MUST be
+reduced to the minimum congestion window (kMinimumWindow).  This response of
+collapsing the congestion window on persistent congestion is functionally
+similar to a sender's response on a Retransmission Timeout (RTO) in TCP
+({{RFC5681}}) after Tail Loss Probes (TLP; see {{RACK}}).
+
+### Example
 
 The following example illustrates how persistent congestion can be
 established. Assume:
@@ -899,11 +923,6 @@ network is considered to have experienced persistent congestion.
 While this example shows the occurrence of PTOs, they are not required for
 persistent congestion to be established.
 
-When persistent congestion is established, the sender's congestion window MUST
-be reduced to the minimum congestion window (kMinimumWindow).  This response of
-collapsing the congestion window on persistent congestion is functionally
-similar to a sender's response on a Retransmission Timeout (RTO) in TCP
-({{RFC5681}}) after Tail Loss Probes (TLP; see {{RACK}}).
 
 ## Pacing {#pacing}
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -839,10 +839,9 @@ The persistent congestion duration is computed as follows:
 Unlike the PTO computation in {{pto}}, this duration includes the max_ack_delay
 irrespective of the packet number spaces in which losses are established.
 
-This duration allows a sender to send as many packets, including some in
-response to PTO expiration, as TCP does with Tail Loss Probe ({{RACK}}), before
-establishing persistent congestion, as TCP does with a Retransmission Timeout
-({{?RFC5681}}).
+This duration allows a sender to send as many packets before establishing
+persistent congestion, including some in response to PTO expiration, as TCP does
+with Tail Loss Probes ({{RACK}}) and a Retransmission Timeout ({{?RFC5681}}).
 
 The RECOMMENDED value for kPersistentCongestionThreshold is 3, which is
 approximately equivalent to two TLPs before an RTO in TCP.
@@ -860,13 +859,13 @@ congestion without depending on PTO expiration.
 A sender establishes persistent congestion on receiving an acknowledgement if at
 least two ack-eliciting packets are declared lost, and:
 
-* a prior RTT sample existed when both packets were sent;
+* all packets, across all packet number spaces, sent between these two send
+  times are declared lost;
 
 * the duration between the send times of these two packets exceeds the
   persistent congestion duration ({{pc-duration}}); and
 
-* all packets, across all packet number spaces, sent between those two send
-  times are declared lost.
+* a prior RTT sample existed when both packets were sent.
 
 The persistent congestion period SHOULD NOT start until there is at least one
 RTT sample. Before the first RTT sample, a sender arms its PTO timer based on


### PR DESCRIPTION
I started with trying to do small fixes, but quickly found that restructuring a bit and clarifying the details of what the sender was precisely supposed to do was the better than trying to be terse. 

This adds a couple of normatives, which may be unnecessary, and I'm happy to take suggestions on those.

Closes #3937.
Closes #3939.
Closes #3940.
Closes #3941.