### PR TITLE
Don't apply PTO backoff twice in GetPtoTimeAndSpace()

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1316,8 +1316,8 @@ GetPtoTimeAndSpace():
       // Skip Application Data until handshake complete.
       if (handshake is not complete):
         return pto_timeout, pto_space
-      // Include max_ack_delay and backoff for Application Data.
-      duration += max_ack_delay * (2 ^ pto_count)
+      // Include max_ack_delay for Application Data.
+      duration += max_ack_delay
 
     t = time_of_last_ack_eliciting_packet[space] + duration
     if (t < pto_timeout):


### PR DESCRIPTION
From the recovery draft pseudo-code:
```
GetPtoTimeAndSpace():
  duration = (smoothed_rtt + max(4 * rttvar, kGranularity))
      * (2 ^ pto_count)
```

then later:
```
      duration += max_ack_delay * (2 ^ pto_count)
```

so `pto_count` seems to be applied twice to `duration`, which I think is
a mistake.