### PR TITLE
Add some MUSTs to congestion control

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -767,20 +767,20 @@ While in slow start, QUIC increases the congestion window by the
 number of bytes acknowledged when each acknowledgment is processed, resulting
 in exponential growth of the congestion window.
 
-QUIC exits slow start upon loss or upon increase in the ECN-CE counter.
-When slow start is exited, the congestion window halves and the slow start
-threshold is set to the new congestion window.  QUIC re-enters slow start
-any time the congestion window is less than the slow start threshold,
-which only occurs after persistent congestion is declared.
+QUIC MUST exit slow start and enter congestion avoidance upon loss or upon
+increase in the ECN-CE counter. When slow start is exited, the congestion
+window halves and the slow start threshold is set to the new congestion
+window.  QUIC re-enters slow start any time the congestion window is less
+than the slow start threshold, which only occurs after persistent congestion
+is declared.
 
 ## Congestion Avoidance
 
-Slow start exits to congestion avoidance.  Congestion avoidance uses an
-Additive Increase Multiplicative Decrease (AIMD) approach that increases
-the congestion window by one maximum packet size per congestion window
-acknowledged.  When a loss or ECN-CE marking is detected, NewReno halves
-the congestion window, sets the slow start threshold to the new
-congestion window, and then enters the recovery period.
+Congestion avoidance uses an Additive Increase Multiplicative Decrease (AIMD)
+approach that MUST increase the congestion window by one maximum packet size
+per congestion window acknowledged.  When a loss or ECN-CE marking is
+detected, the congestion window MUST be halved and the slow start threshold
+MUST be set to the new congestion window.
 
 ## Recovery Period
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -763,8 +763,8 @@ The RECOMMENDED value is 2 * max_datagram_size.
 
 ## Slow Start
 
-While in slow start, a sender increases the congestion window by the number of
-bytes acknowledged when each acknowledgment is processed, resulting in
+While in slow start, a NewReno sender increases the congestion window by the
+number of bytes acknowledged when each acknowledgment is processed, resulting in
 exponential growth of the congestion window.
 
 A sender MUST exit slow start and enter recovery when a loss is detected or when
@@ -784,9 +784,9 @@ detected or when the ECN-CE counter reported by the peer increases.
 
 ## Recovery Period
 
-A sender enters the recovery period when it detects loss or an ECN-CE mark is
-received. A recovery period ends when a packet sent during the recovery period
-is acknowledged.
+A NewReno sender enters the recovery period when it detects loss or an ECN-CE
+mark is received. A recovery period ends when a packet sent during the recovery
+period is acknowledged.
 
 A sender that is already in a recovery period stays in it and does not re-enter
 it.

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -777,10 +777,10 @@ is declared.
 ## Congestion Avoidance
 
 Congestion avoidance uses an Additive Increase Multiplicative Decrease (AIMD)
-approach that MUST increase the congestion window by one maximum packet size
-per congestion window acknowledged.  When a loss or ECN-CE marking is
-detected, the congestion window MUST be halved and the slow start threshold
-MUST be set to the new congestion window.
+approach that typically and at most increases the congestion window by one
+maximum packet size per congestion window acknowledged.  When a loss or
+ECN-CE marking is detected, the congestion window MUST be halved and the
+slow start threshold MUST be set to the new congestion window.
 
 ## Recovery Period
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -791,20 +791,18 @@ period is acknowledged.
 On entering a recovery period, a sender MUST set the slow start threshold to
 half the value of the congestion window at the moment that loss is detected. The
 congestion window MUST be set to the reduced value of the slow start threshold
-before exiting the recovery period. Implementations MAY set the congestion
-window immediately on entering a recovery period or use other mechanisms, such
-as Proportional Rate Reduction ({{?PRR=RFC6937}}), to reduce it more gradually.
+before exiting the recovery period.
+
+Implementations MAY set the congestion window immediately on entering a recovery
+period or use other mechanisms, such as Proportional Rate Reduction
+({{?PRR=RFC6937}}), to reduce it more gradually. If the congestion window is
+reduced immediately, a single packet can be sent prior to reduction.  This speeds
+up loss recovery if the data in the lost packet is retransmitted and is similar
+to TCP as described in Section 5 of {{?RFC6675}}.
 
 The recovery period aims to limit congestion window reduction to once per round
 trip. Therefore during recovery, the congestion window remains unchanged
 irrespective of new losses or increases in the ECN-CE counter.
-
-When entering a recovery period, a single packet MAY be sent even if bytes in
-flight now exceeds the recently reduced congestion window.  This speeds up loss
-recovery if the data in the lost packet is retransmitted and is similar to TCP
-as described in Section 5 of {{?RFC6675}}.  If further packets are lost while
-the sender is in recovery, sending any packets in response MUST obey the
-congestion window limit.
 
 ## Ignoring Loss of Undecryptable Packets
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -788,18 +788,12 @@ A NewReno sender enters the recovery period when it detects loss or an ECN-CE
 mark is received. A recovery period ends when a packet sent during the recovery
 period is acknowledged.
 
-A sender that is already in a recovery period stays in it and does not re-enter
-it.
-
-On entering recovery, a sender MUST do the following:
-
-* set the slow start threshold to half the value of the congestion window at the
-  moment that loss is detected, and
-
-* set the congestion window to the new value of the slow start
-  threshold. Implementations MAY set the congestion window immediately on
-  detecting loss or use other mechanisms, such as Proportional Rate Reduction
-  ({{?RFC6937}}), to reduce it over the recovery period.
+On entering a recovery period, a sender MUST set the slow start threshold to
+half the value of the congestion window at the moment that loss is detected. The
+congestion window MUST be set to the reduced value of the slow start threshold
+before exiting the recovery period. Implementations MAY set the congestion
+window immediately on entering a recovery period or use other mechanisms, such
+as Proportional Rate Reduction ({{?PRR=RFC6937}}), to reduce it more gradually.
 
 The recovery period aims to limit congestion window reduction to once per round
 trip. Therefore during recovery, the congestion window remains unchanged

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1000,9 +1000,10 @@ limits and so no advantage is gained by doing so.
 
 Endpoints choose the congestion controller that they use. Congestion controllers
 respond to reports of ECN-CE by reducing their rate, but the response may vary.
-Markings can be treated as equivalent to loss ({{?RFC3168}}), but other responses
-can be specified, such as ({{?RFC8511}}) or ({{?RFC8311}}). Failure to correctly
-respond to information about ECN markings is therefore difficult to detect.
+Markings can be treated as equivalent to loss ({{?RFC3168}}), but other
+responses can be specified, such as ({{?RFC8511}}) or ({{?RFC8311}}). Failure to
+correctly respond to information about ECN markings is therefore difficult to
+detect.
 
 
 # IANA Considerations

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -777,10 +777,11 @@ is declared.
 ## Congestion Avoidance
 
 Congestion avoidance uses an Additive Increase Multiplicative Decrease (AIMD)
-approach that typically and at most increases the congestion window by one
-maximum packet size per congestion window acknowledged.  When a loss or
-ECN-CE marking is detected, the congestion window MUST be halved and the
-slow start threshold MUST be set to the new congestion window.
+approach that typically increases the congestion window by one maximum packet
+size per congestion window acknowledged, and MUST NOT increase the congestion
+window faster.  When a loss or ECN-CE marking is detected, the congestion
+window MUST be halved and the slow start threshold MUST be set to the new
+congestion window.
 
 ## Recovery Period
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -763,42 +763,50 @@ The RECOMMENDED value is 2 * max_datagram_size.
 
 ## Slow Start
 
-While in slow start, QUIC increases the congestion window by the
-number of bytes acknowledged when each acknowledgment is processed, resulting
-in exponential growth of the congestion window.
+While in slow start, a sender increases the congestion window by the number of
+bytes acknowledged when each acknowledgment is processed, resulting in
+exponential growth of the congestion window.
 
-QUIC MUST exit slow start and enter congestion avoidance upon loss or upon
-increase in the ECN-CE counter. When slow start is exited, the congestion
-window halves and the slow start threshold is set to the new congestion
-window.  QUIC re-enters slow start any time the congestion window is less
-than the slow start threshold, which only occurs after persistent congestion
-is declared.
+A sender MUST exit slow start and enter recovery when a loss is detected or when
+the ECN-CE counter reported by the peer increases.
+
+A sender re-enters slow start any time the congestion window is less than the
+slow start threshold, which only occurs after persistent congestion is declared.
 
 ## Congestion Avoidance
 
-NewReno congestion avoidance uses an Additive Increase Multiplicative Decrease
-(AIMD) approach that typically increases the congestion window by one maximum
-datagram size per congestion window acknowledged, and MUST NOT increase the
-congestion window faster.  When a loss or ECN-CE marking is detected, the sender
-MUST reduce the congestion window. NewReno halves the congestion window, sets
-the slow start threshold to the new congestion window, and then enters the
-recovery period.
+A NewReno sender in congestion avoidance uses an Additive Increase
+Multiplicative Decrease (AIMD) approach that MUST increase the congestion window
+by no more than one maximum datagram size per congestion window acknowledged.
+
+A sender MUST exit congestion avoidance and enter recovery when a loss is
+detected or when the ECN-CE counter reported by the peer increases.
 
 ## Recovery Period
 
-A recovery period is entered when loss or ECN-CE marking of a packet is
-detected in congestion avoidance after the congestion window and slow start
-threshold have been decreased.  A recovery period ends when a packet sent
-during the recovery period is acknowledged.  This is slightly different from
-TCP's definition of recovery, which ends when the lost packet that started
-recovery is acknowledged.
+A sender enters the recovery period when it detects loss or an ECN-CE mark is
+received. A recovery period ends when a packet sent during the recovery period
+is acknowledged.
+
+A sender that is already in a recovery period stays in it and does not re-enter
+it.
+
+On entering recovery, a sender MUST do the following:
+
+* set the slow start threshold to half the value of the congestion window at the
+  moment that loss is detected, and
+
+* set the congestion window to the new value of the slow start
+  threshold. Implementations MAY set the congestion window immediately on
+  detecting loss or use other mechanisms, such as Proportional Rate Reduction
+  ({{?RFC6937}}), to reduce it over the recovery period.
 
 The recovery period aims to limit congestion window reduction to once per round
 trip. Therefore during recovery, the congestion window remains unchanged
 irrespective of new losses or increases in the ECN-CE counter.
 
-When entering recovery, a single packet MAY be sent even if bytes in flight
-now exceeds the recently reduced congestion window.  This speeds up loss
+When entering a recovery period, a single packet MAY be sent even if bytes in
+flight now exceeds the recently reduced congestion window.  This speeds up loss
 recovery if the data in the lost packet is retransmitted and is similar to TCP
 as described in Section 5 of {{?RFC6675}}.  If further packets are lost while
 the sender is in recovery, sending any packets in response MUST obey the

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -776,11 +776,11 @@ is declared.
 
 ## Congestion Avoidance
 
-Congestion avoidance uses an Additive Increase Multiplicative Decrease (AIMD)
-approach that typically increases the congestion window by one maximum datagram
-size per congestion window acknowledged, and MUST NOT increase the congestion
-window faster.  When a loss or ECN-CE marking is detected, the sender MUST
-reduce the congestion window. NewReno halves the congestion window, sets the
+NewReno congestion avoidance uses an Additive Increase Multiplicative Decrease
+(AIMD) approach that typically increases the congestion window by one maximum
+datagram size per congestion window acknowledged, and MUST NOT increase the
+congestion window faster.  When a loss or ECN-CE marking is detected, the sender
+MUST reduce the congestion window. NewReno halves the congestion window, sets the
 slow start threshold to the new congestion window, and then enters the recovery
 period.
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -780,8 +780,9 @@ Congestion avoidance uses an Additive Increase Multiplicative Decrease (AIMD)
 approach that typically increases the congestion window by one maximum datagram
 size per congestion window acknowledged, and MUST NOT increase the congestion
 window faster.  When a loss or ECN-CE marking is detected, the sender MUST
-reduce the congestion window. NewReno halves the congestion window, sets the slow start
-threshold to the new congestion window, and then enters the recovery period.
+reduce the congestion window. NewReno halves the congestion window, sets the
+slow start threshold to the new congestion window, and then enters the recovery
+period.
 
 ## Recovery Period
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -777,7 +777,7 @@ is declared.
 ## Congestion Avoidance
 
 Congestion avoidance uses an Additive Increase Multiplicative Decrease (AIMD)
-approach that typically increases the congestion window by one maximum packet
+approach that typically increases the congestion window by one maximum datagram
 size per congestion window acknowledged, and MUST NOT increase the congestion
 window faster.  When a loss or ECN-CE marking is detected, the sender MUST
 reduce the cwnd. NewReno halves the congestion window, sets the slow start

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -780,7 +780,7 @@ Congestion avoidance uses an Additive Increase Multiplicative Decrease (AIMD)
 approach that typically increases the congestion window by one maximum datagram
 size per congestion window acknowledged, and MUST NOT increase the congestion
 window faster.  When a loss or ECN-CE marking is detected, the sender MUST
-reduce the cwnd. NewReno halves the congestion window, sets the slow start
+reduce the congestion window. NewReno halves the congestion window, sets the slow start
 threshold to the new congestion window, and then enters the recovery period.
 [RFC8511] specifies an alternate cwnd reduction.
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -780,9 +780,9 @@ NewReno congestion avoidance uses an Additive Increase Multiplicative Decrease
 (AIMD) approach that typically increases the congestion window by one maximum
 datagram size per congestion window acknowledged, and MUST NOT increase the
 congestion window faster.  When a loss or ECN-CE marking is detected, the sender
-MUST reduce the congestion window. NewReno halves the congestion window, sets the
-slow start threshold to the new congestion window, and then enters the recovery
-period.
+MUST reduce the congestion window. NewReno halves the congestion window, sets
+the slow start threshold to the new congestion window, and then enters the
+recovery period.
 
 ## Recovery Period
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -796,7 +796,7 @@ before exiting the recovery period.
 Implementations MAY set the congestion window immediately on entering a recovery
 period or use other mechanisms, such as Proportional Rate Reduction
 ({{?PRR=RFC6937}}), to reduce it more gradually. If the congestion window is
-reduced immediately, a single packet can be sent prior to reduction.  This speeds
+reduced immediately, a single packet can be sent prior to reduction. This speeds
 up loss recovery if the data in the lost packet is retransmitted and is similar
 to TCP as described in Section 5 of {{?RFC6675}}.
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -782,7 +782,6 @@ size per congestion window acknowledged, and MUST NOT increase the congestion
 window faster.  When a loss or ECN-CE marking is detected, the sender MUST
 reduce the congestion window. NewReno halves the congestion window, sets the slow start
 threshold to the new congestion window, and then enters the recovery period.
-[RFC8511] specifies an alternate cwnd reduction.
 
 ## Recovery Period
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -779,9 +779,10 @@ is declared.
 Congestion avoidance uses an Additive Increase Multiplicative Decrease (AIMD)
 approach that typically increases the congestion window by one maximum packet
 size per congestion window acknowledged, and MUST NOT increase the congestion
-window faster.  When a loss or ECN-CE marking is detected, the congestion
-window MUST be halved and the slow start threshold MUST be set to the new
-congestion window.
+window faster.  When a loss or ECN-CE marking is detected, the sender MUST
+reduce the cwnd. NewReno halves the congestion window, sets the slow start
+threshold to the new congestion window, and then enters the recovery period.
+[RFC8511] specifies an alternate cwnd reduction.
 
 ## Recovery Period
 
@@ -997,11 +998,11 @@ Reporting additional ECN-CE markings will cause a sender to reduce their sending
 rate, which is similar in effect to advertising reduced connection flow control
 limits and so no advantage is gained by doing so.
 
-Endpoints choose the congestion controller that they use.  Though congestion
-controllers generally treat reports of ECN-CE markings as equivalent to loss
-({{?RFC8311}}), the exact response for each controller could be different.
-Failure to correctly respond to information about ECN markings is therefore
-difficult to detect.
+Endpoints choose the congestion controller that they use. Congestion controllers
+respond to reports of ECN-CE by reducing their rate, but the response may vary.
+Markings can be treated as equivalent to loss ({{?RFC3168}}), but other responses
+can be specified, such as ({{?RFC8511}}) or ({{?RFC8311}}). Failure to correctly
+respond to information about ECN markings is therefore difficult to detect.
 
 
 # IANA Considerations

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1001,9 +1001,7 @@ limits and so no advantage is gained by doing so.
 Endpoints choose the congestion controller that they use. Congestion controllers
 respond to reports of ECN-CE by reducing their rate, but the response may vary.
 Markings can be treated as equivalent to loss ({{?RFC3168}}), but other
-responses can be specified, such as ({{?RFC8511}}) or ({{?RFC8311}}). Failure to
-correctly respond to information about ECN markings is therefore difficult to
-detect.
+responses can be specified, such as ({{?RFC8511}}) or ({{?RFC8311}}).
 
 
 # IANA Considerations


### PR DESCRIPTION
Fixes #3944

Includes some changes suggested in #3992(see below)

ISSUE:
/When a loss or ECN-CE marking is detected, NewReno halves the 
congestion window, sets the slow start threshold to the new congestion 
window, and then enters the recovery period./
- The requirement is that TCP needs to reduce after CE, The RFC series 
does not now say it needs to halve, it could for example follow the 
reduction method specified in RFC8511. e.g. /When a loss or ECN-CE 
marking is detected, the sender must reduce the cwnd. NewReno halves the 
congestion window, sets the slow start threshold to the new congestion 
window, and then enters the recovery period. [RFC8511] specifies an 
alternate cwnd reduction./

ISSUE:
Similar comment in 8.3:
/Though congestion controllers generally treat reports of ECN-CE 
markings as equivalent to loss [RFC8311], the exact response for each 
controller could be different. /
- This does not seem correct. Could I suggest:
/Congestion controllers respond to reports of ECN-CE by reducing their 
rate. Markings can be treated as equivalent to loss [RFC3168], but other 
responses can be specified (e.g. [RFC8511]) [RFC8311]. /