### PR TITLE
ack_delay in the first Handshake and 1RTT packet

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -363,12 +363,15 @@ When adjusting an RTT sample using peer-reported acknowledgement delays, an
 endpoint:
 
 - MUST ignore the ACK Delay field of the ACK frame for packets sent in the
-  Initial and Handshake packet number space, except for the first ACK frame
-  received in Handshake.
+  Initial packet number space.
+
+- MUST ignore the ACK Delay field of the ACK frame for packets sent in the
+  Handshake packet number space, unless the ACK frame only acknowledges
+  packets sent prior to the peer having decryption keys.
 
 - MUST use the lesser of the value reported in ACK Delay field of the ACK frame
-  and the peer's max_ack_delay transport parameter, unless it's the first ACK
-  frame received for Handshake or ApplicationData.
+  and the peer's max_ack_delay transport parameter, unless the ACK frame only
+  acknowledges packets sent prior to the peer having decryption keys.
 
 - MUST NOT apply the adjustment if the resulting RTT sample is smaller than the
   min_rtt.  This limits the underestimation that a misreporting peer can cause

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -348,11 +348,11 @@ latency at the peer or loss of previous ACK frames.  Any delays beyond the
 peer's max_ack_delay are therefore considered effectively part of path delay and
 incorporated into the smoothed_rtt estimate.
 
-The first ACK frame in the Handshake and ApplicationData packet number spaces can
-be greatly delayed due to a lack of decryption keys at the time they're received.
-For these two ACK frames, the max_ack_delay MAY be ignored if the sender chooses.
-Note that if there are no prior RTT samples, ignoring max_ack_delay has no
-impact.
+The first ACK frame in the Handshake and ApplicationData packet number spaces
+can be greatly delayed due to a lack of decryption keys at the time they're
+received. For these two ACK frames, the max_ack_delay MAY be ignored if the
+sender chooses. If the delayed ACK frame is the first RTT sample, ignoring
+max_ack_delay has no impact.
 
 When adjusting an RTT sample using peer-reported acknowledgement delays, an
 endpoint:

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -348,14 +348,22 @@ latency at the peer or loss of previous ACK frames.  Any delays beyond the
 peer's max_ack_delay are therefore considered effectively part of path delay and
 incorporated into the smoothed_rtt estimate.
 
+The first ACK frame in the Handshake and ApplicationData packet number spaces can
+be greatly delayed due to a lack of decryption keys at the time they're received.
+For these two ACK frames, the max_ack_delay MAY be ignored if the sender chooses.
+Note that if there are no prior RTT samples, ignoring max_ack_delay has no
+impact.
+
 When adjusting an RTT sample using peer-reported acknowledgement delays, an
 endpoint:
 
 - MUST ignore the ACK Delay field of the ACK frame for packets sent in the
-  Initial and Handshake packet number space.
+  Initial and Handshake packet number space, except for the first ACK frame
+  received in Handshake.
 
 - MUST use the lesser of the value reported in ACK Delay field of the ACK frame
-  and the peer's max_ack_delay transport parameter.
+  and the peer's max_ack_delay transport parameter, unless it's the first ACK
+  frame received for Handshake or ApplicationData.
 
 - MUST NOT apply the adjustment if the resulting RTT sample is smaller than the
   min_rtt.  This limits the underestimation that a misreporting peer can cause

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -348,11 +348,16 @@ latency at the peer or loss of previous ACK frames.  Any delays beyond the
 peer's max_ack_delay are therefore considered effectively part of path delay and
 incorporated into the smoothed_rtt estimate.
 
-The first ACK frame in the Handshake and ApplicationData packet number spaces
-can be greatly delayed due to a lack of decryption keys at the time they're
-received. For these two ACK frames, the max_ack_delay MAY be ignored if the
-sender chooses. If the delayed ACK frame is the first RTT sample, ignoring
-max_ack_delay has no impact.
+ACK frames in the Handshake and ApplicationData packet number spaces are
+delayed when the receiver lacks the decryption keys to process them immediately
+and instead sends an ACK frame after the keys become available. For ACK frames
+which only acknowledge packets sent prior to the receiver having the decryption
+keys, the max_ack_delay MAY be ignored. Note that if the delayed ACK frame
+is the first RTT sample, ignoring max_ack_delay has no impact.
+
+The server can receive 1-RTT packets containing ACK frames before the decryption
+keys are available. If the packet is buffered and later processed, the server
+MAY reduce the measured RTT by the amount of time the packet was buffered.
 
 When adjusting an RTT sample using peer-reported acknowledgement delays, an
 endpoint:

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -349,11 +349,11 @@ peer's max_ack_delay are therefore considered effectively part of path delay and
 incorporated into the smoothed_rtt estimate.
 
 ACK frames in the Handshake and ApplicationData packet number spaces are
-delayed when the receiver lacks the decryption keys to process them immediately
-and instead sends an ACK frame after the keys become available. For ACK frames
-which only acknowledge packets sent prior to the receiver having the decryption
-keys, the max_ack_delay MAY be ignored. Note that if the delayed ACK frame
-is the first RTT sample, ignoring max_ack_delay has no impact.
+delayed when the receiver lacks the decryption keys to process packets
+immediately and instead sends an ACK frame after the keys become available.
+For ACK frames which only acknowledge packets sent prior to the receiver having
+the decryption keys, the max_ack_delay MAY be ignored. Note that if the delayed
+ACK frame is the first RTT sample, ignoring max_ack_delay has no impact.
 
 The server can receive 1-RTT packets containing ACK frames before the decryption
 keys are available. If the packet is buffered and later processed, the server

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3688,11 +3688,11 @@ to adjust for any intentional delays, which is important for getting a better
 estimate of the path RTT when acknowledgments are delayed.  A packet might be
 held in the OS kernel or elsewhere on the host before being processed.  An
 endpoint MUST NOT include delays that it does not control when populating the
-ACK Delay field in an ACK frame.
+ACK Delay field in an ACK frame, but endpoints SHOULD include delays caused
+by lack of available decryption keys.
 
-Since the acknowledgement delay is not used for Initial and Handshake
-packets, the ACK Delay field in acknowledgements for those packet types
-SHOULD be set to 0.
+Since the acknowledgement delay is not used for Initial packets, the ACK Delay
+field in Initial acknowledgements SHOULD be set to 0.
 
 ### ACK Frames and Packet Protection
 


### PR DESCRIPTION
Clarifies that ack_delay includes anytime the packets were buffered and undecryptable, as well as allowing senders to better use those first ACKs if they choose.

Fixes #3980 