### PR TITLE
Two idle timeout corrections

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2712,8 +2712,11 @@ An implementation of QUIC might provide applications with an option to defer an
 idle timeout.  This facility could be used when the application wishes to avoid
 losing state that has been associated with an open connection, but does not
 expect to exchange application data for some time.  With this option, an
-endpoint could send a PING frame periodically to defer an idle timeout; see
-{{frame-ping}}.
+endpoint could send a PING frame ({{frame-ping}}) periodically, which will cause
+the peer to restart its idle timeout period.  Sending a packet containing a PING
+frame also restarts the idle timeout for the endpoint if this is the first
+ack-eliciting packet sent since receiving a packet or when an acknowledgment is
+received.
 
 Application protocols that use QUIC SHOULD provide guidance on when deferring an
 idle timeout is appropriate.  Unnecessary sending of PING frames could have a

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2692,8 +2692,8 @@ idle timeout period to be at least three times the current Probe Timeout (PTO).
 ### Liveness Testing
 
 An endpoint that sends packets close to the effective timeout risks having
-them be discarded at the peer, since the peer might enter its draining state
-before these packets arrive.
+them be discarded at the peer, since the idle timeout period might have expired
+at the peer before these packets arrive.
 
 An endpoint can send a PING or another ack-eliciting frame to test the
 connection for liveness if the peer could time out soon, such as within a PTO;

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2715,8 +2715,9 @@ expect to exchange application data for some time.  With this option, an
 endpoint could send a PING frame ({{frame-ping}}) periodically, which will cause
 the peer to restart its idle timeout period.  Sending a packet containing a PING
 frame also restarts the idle timeout for the endpoint if this is the first
-ack-eliciting packet sent since receiving a packet.  The idle time also restarts
-when an acknowledgment for the packet is received.
+ack-eliciting packet sent since receiving a packet.  Sending a PING frame causes
+the peer to respond with an acknowledgment, which also restarts the idle
+timeout.
 
 Application protocols that use QUIC SHOULD provide guidance on when deferring an
 idle timeout is appropriate.  Unnecessary sending of PING frames could have a

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2715,8 +2715,8 @@ expect to exchange application data for some time.  With this option, an
 endpoint could send a PING frame ({{frame-ping}}) periodically, which will cause
 the peer to restart its idle timeout period.  Sending a packet containing a PING
 frame also restarts the idle timeout for the endpoint if this is the first
-ack-eliciting packet sent since receiving a packet or when an acknowledgment is
-received.
+ack-eliciting packet sent since receiving a packet.  The idle time also restarts
+when an acknowledgment for the packet is received.
 
 Application protocols that use QUIC SHOULD provide guidance on when deferring an
 idle timeout is appropriate.  Unnecessary sending of PING frames could have a

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2714,10 +2714,10 @@ losing state that has been associated with an open connection, but does not
 expect to exchange application data for some time.  With this option, an
 endpoint could send a PING frame ({{frame-ping}}) periodically, which will cause
 the peer to restart its idle timeout period.  Sending a packet containing a PING
-frame also restarts the idle timeout for the endpoint if this is the first
+frame restarts the idle timeout for this endpoint also if this is the first
 ack-eliciting packet sent since receiving a packet.  Sending a PING frame causes
 the peer to respond with an acknowledgment, which also restarts the idle
-timeout.
+timeout for the endpoint.
 
 Application protocols that use QUIC SHOULD provide guidance on when deferring an
 idle timeout is appropriate.  Unnecessary sending of PING frames could have a


### PR DESCRIPTION
Idle timeout doesn't enter the draining period.

Sending PING will reset both idle timeouts for both endpoints.

Closes #3798.
Closes #3844.