### PR TITLE
Strike confusing paragraph

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2402,9 +2402,6 @@ duplicate.  If the attacker is able to continue forwarding packets, it might be
 able to cause migration to a path via the attacker.  This places the attacker on
 path, giving it the ability to observe or drop all subsequent packets.
 
-Unlike the attack described in {{on-path-spoofing}}, the attacker can ensure
-that the new path is successfully validated.
-
 This style of attack relies on the attacker using a path that is approximately
 as fast as the direct path between endpoints.  The attack is more reliable if
 relatively few packets are sent or if packet loss coincides with the attempted


### PR DESCRIPTION
This text could be read to imply that an off-path attacker is more
capable than an on-path attacker, which is rarely true.  What it was
meant to point out was that it is easier to move traffic onto a path
that you are on.  What it fails to acknowledge is that it is also easier
to move traffic *off* a path that you are on.

In other words, the treatment of this in 21.12 is more thorough and we
don't need to talk about limitations.

Mike suggested that there is some duplication between this attack and
the more comprehensive analysis in 21.12.  That is true, but these serve
different purposes.  This is to describe attacks and the normative
requirements on endpoints necessary to avoid them.  The other section is
a thorough and hollistic analysis.  I couldn't see any truly
straightforward changes.  That doesn't mean that we won't find a way to
clean this up, or that it would be undesirable to have fewer words, but
I've not the time for that right now.

Closes #3841.