### PR TITLE
Closing and draining tidy

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2835,10 +2835,10 @@ send further packets, which could result in a constant exchange of
 CONNECTION_CLOSE frames until either endpoint exits the closing state.
 
 An endpoint MAY transition from the closing state to the draining state if it
-receives a CONNECTION_CLOSE frame or stateless reset, either of which indicate
-that the peer is also closing or draining.  The draining state SHOULD end when
-the closing state would have ended.  In other words, the endpoint uses the
-same end time, but cease retransmission of the closing packet.
+receives a CONNECTION_CLOSE frame, which indicates that the peer is also
+closing or draining. In this case, the draining state SHOULD end when the
+closing state would have ended. In other words, the endpoint uses the same end
+time, but cease retransmission of the closing packet.
 
 
 ### Immediate Close During the Handshake {#immediate-close-hs}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2755,14 +2755,13 @@ These states SHOULD persist for at least three times the current Probe Timeout
 Disposing of connection state prior to exiting the closing or draining state
 could cause delayed or reordered packets to generate an unnecessary stateless
 reset. Endpoints that have some alternative means to ensure that late-arriving
-packets on the connection do not induce a response, such as those that are able
+packets do not induce a response, such as those that are able
 to close the UDP socket, MAY end these states earlier to allow
 for faster resource recovery.  Servers that retain an open socket for accepting
 new connections SHOULD NOT end the closing or draining states early.
 
 Once the closing or draining state ends, an endpoint SHOULD discard all
-connection state.  This results in new packets on the connection being handled
-generically.  For instance, an endpoint MAY send a stateless reset in response
+connection state.  An endpoint MAY send a stateless reset in response
 to any further incoming packets.
 
 
@@ -2807,13 +2806,10 @@ Note:
   connection. Retransmitting the final packet requires less state.
 
 While in the closing state, an endpoint could receive packets from a new
-source address, indicating a connection migration; see {{migration}}. An
-endpoint that discards information about validated addresses might be used to
-create an amplification attack; see {{address-validation}}. To avoid being used
-for an amplication attack, an endpoint in the closing state MUST either discard
-packets received from unvalidated addresses or limit the cumulative size of
-packets it sends to unvalidated addresses to 3 times the size of packets it
-receives from the address.
+source address, possibly indicating a connection migration; see {{migration}}.
+An endpoint in the closing state MUST either discard packets received from
+unvalidated addresses or limit the cumulative size of packets it sends to
+unvalidated addresses to 3 times the size of packets it receives from the address.
 
 An endpoint is not expected to handle key updates when it is closing. A key
 update might prevent the endpoint from moving from the closing state to

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2740,12 +2740,12 @@ closing state; see {{closing}}. After receiving a CONNECTION_CLOSE frame,
 endpoints enter the draining state; see {{draining}}.
 
 An immediate close can be used after an application protocol has arranged to
-close a connection.  This might be after the application protocols negotiates a
-graceful shutdown.  The application protocol exchanges whatever messages that
-are needed to cause both endpoints to agree to close the connection, after which
-the application requests that the connection be closed.  When the application
-closes the connection, a CONNECTION_CLOSE frame with an appropriate error code
-will be used to signal closure.
+close a connection.  This might be after the application protocol negotiates a
+graceful shutdown.  The application protocol can exchange messages that
+are needed for both application endpoints to agree that the connection can be closed, after which
+the application requests that QUIC close the connection.  When QUIC consequently
+closes the connection, a CONNECTION_CLOSE frame with an application-supplied error code
+will be used to signal closure to the peer.
 
 The closing and draining connection states exist to ensure that connections
 close cleanly and that delayed or reordered packets are properly discarded.
@@ -2753,16 +2753,16 @@ These states SHOULD persist for at least three times the current Probe Timeout
 (PTO) interval as defined in {{QUIC-RECOVERY}}.
 
 Disposing of connection state prior to exiting the closing or draining state
-could cause could result in an generating unnecessary stateless reset in
-response to receiving a packet.  Endpoints that have some alternative means to
+could cause could result in an endpoint generating a stateless reset unnecessarily when
+it receives a late-arriving packet.  Endpoints that have some alternative means to
 ensure that late-arriving packets do not induce a response, such as those that
 are able to close the UDP socket, MAY end these states earlier to allow for
 faster resource recovery.  Servers that retain an open socket for accepting new
 connections SHOULD NOT end the closing or draining states early.
 
-Once the closing or draining state ends, an endpoint SHOULD discard all
-connection state.  An endpoint MAY send a stateless reset in response
-to any further incoming packets.
+Once its closing or draining state ends, an endpoint SHOULD discard all
+connection state.  The endpoint MAY send a stateless reset in response
+to any further incoming packets belonging to this connection.
 
 
 ### Closing Connection State {#closing}
@@ -2780,22 +2780,22 @@ state. For instance, an endpoint could wait for a progressively increasing
 number of received packets or amount of time before responding to received
 packets.
 
-The endpoint's selected connection ID and the QUIC version are sufficient
-information to identify packets for a closing connection; an endpoint MAY
+An endpoint's selected connection ID and the QUIC version are sufficient
+information to identify packets for a closing connection; the endpoint MAY
 discard all other connection state. An endpoint that is closing is not required
-to process the frames contained in packets. An endpoint MAY retain packet
+to process any received frame. An endpoint MAY retain packet
 protection keys for incoming packets to allow it to read and process a
 CONNECTION_CLOSE frame.
 
 An endpoint MAY drop packet protection keys when entering the closing state
-and send a packet containing a CONNECTION_CLOSE in response to any UDP datagram
+and send a packet containing a CONNECTION_CLOSE frame in response to any UDP datagram
 that is received. However, an endpoint that discards packet protection keys
 cannot identify and discard invalid packets. To avoid being used for an
 amplication attack, such endpoints MUST limit the cumulative size of packets
-containing a CONNECTION_CLOSE frame to 3 times the cumulative size of the
-packets that cause those packets to be sent. To minimize the state that an
+it sends to three times the cumulative size of the
+packets that are received and attributed to the connection. To minimize the state that an
 endpoint maintains for a closing connection, endpoints MAY send the exact same
-packet.
+packet in response to any received packet.
 
 Note:
 
@@ -2808,13 +2808,13 @@ Note:
 While in the closing state, an endpoint could receive packets from a new source
 address, possibly indicating a connection migration; see {{migration}}.  An
 endpoint in the closing state MUST either discard packets received from
-unvalidated addresses or limit the cumulative size of packets it sends to
-unvalidated addresses to 3 times the size of packets it receives from the
+an unvalidated address or limit the cumulative size of packets it sends to
+an unvalidated address to three times the size of packets it receives from that
 address.
 
-An endpoint is not expected to handle key updates when it is closing. A key
+An endpoint is not expected to handle key updates when it is closing (Section 6 of {{QUIC-TLS}}). A key
 update might prevent the endpoint from moving from the closing state to
-the draining state, but it otherwise has no impact.
+the draining state, as the endpoint will not be able to process subsequently received packets, but it otherwise has no impact.
 
 
 ### Draining Connection State {#draining}
@@ -2827,15 +2827,15 @@ is in the draining state.
 
 An endpoint that receives a CONNECTION_CLOSE frame MAY send a single packet
 containing a CONNECTION_CLOSE frame before entering the draining state, using a
-NO_ERROR code if appropriate.  An endpoint MUST NOT send further packets, which
-could result in a constant exchange of CONNECTION_CLOSE frames until either
-endpoint exits the closing state.
+NO_ERROR code if appropriate.  An endpoint MUST NOT send further packets. Doing so
+could result in a constant exchange of CONNECTION_CLOSE frames until one of the
+endpoints exits the closing state.
 
-An endpoint MAY transition from the closing state to the draining state if it
+An endpoint MAY enter the draining state from the closing state if it
 receives a CONNECTION_CLOSE frame, which indicates that the peer is also
 closing or draining. In this case, the draining state SHOULD end when the
 closing state would have ended. In other words, the endpoint uses the same end
-time, but ceases retransmission of the closing packet.
+time, but ceases transmission of any packets on this connection.
 
 
 ### Immediate Close During the Handshake {#immediate-close-hs}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2774,15 +2774,15 @@ endpoint can discard all other connection state. An endpoint MAY retain packet
 protection keys for incoming packets to allow it to read and process a
 CONNECTION_CLOSE frame.
 
-An endpoint MAY drop packet protection keys when entering the closing period
-({{draining}}) and send a packet containing a CONNECTION_CLOSE in response to
-any UDP datagram that is received. However, an endpoint without the packet
-protection keys cannot identify and discard invalid packets. To avoid being
-used for an amplication attack, such endpoints MUST limit the cumulative size
-of packets containing a CONNECTION_CLOSE frame to 3 times the cumulative size
-of the packets that cause those packets to be sent. To minimize the state that
-an endpoint maintains for a closing connection, endpoints MAY send the exact
-same packet.
+An endpoint MAY drop packet protection keys when starting the closing period
+and send a packet containing a CONNECTION_CLOSE in response to any UDP datagram
+that is received. However, an endpoint without the packet protection keys
+cannot identify and discard invalid packets. To avoid being used for an
+amplication attack, such endpoints MUST limit the cumulative size of packets
+containing a CONNECTION_CLOSE frame to 3 times the cumulative size of the
+packets that cause those packets to be sent. To minimize the state that an
+endpoint maintains for a closing connection, endpoints MAY send the exact same
+packet.
 
 Note:
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2741,11 +2741,11 @@ endpoints enter the draining state; see {{draining}}.
 
 An immediate close can be used after an application protocol has arranged to
 close a connection.  This might be after the application protocol negotiates a
-graceful shutdown.  The application protocol can exchange messages that
-are needed for both application endpoints to agree that the connection can be closed, after which
-the application requests that QUIC close the connection.  When QUIC consequently
-closes the connection, a CONNECTION_CLOSE frame with an application-supplied error code
-will be used to signal closure to the peer.
+graceful shutdown.  The application protocol can exchange messages that are
+needed for both application endpoints to agree that the connection can be
+closed, after which the application requests that QUIC close the connection.
+When QUIC consequently closes the connection, a CONNECTION_CLOSE frame with an
+application-supplied error code will be used to signal closure to the peer.
 
 The closing and draining connection states exist to ensure that connections
 close cleanly and that delayed or reordered packets are properly discarded.
@@ -2753,16 +2753,17 @@ These states SHOULD persist for at least three times the current Probe Timeout
 (PTO) interval as defined in {{QUIC-RECOVERY}}.
 
 Disposing of connection state prior to exiting the closing or draining state
-could cause could result in an endpoint generating a stateless reset unnecessarily when
-it receives a late-arriving packet.  Endpoints that have some alternative means to
-ensure that late-arriving packets do not induce a response, such as those that
-are able to close the UDP socket, MAY end these states earlier to allow for
-faster resource recovery.  Servers that retain an open socket for accepting new
-connections SHOULD NOT end the closing or draining states early.
+could cause could result in an endpoint generating a stateless reset
+unnecessarily when it receives a late-arriving packet.  Endpoints that have some
+alternative means to ensure that late-arriving packets do not induce a response,
+such as those that are able to close the UDP socket, MAY end these states
+earlier to allow for faster resource recovery.  Servers that retain an open
+socket for accepting new connections SHOULD NOT end the closing or draining
+states early.
 
 Once its closing or draining state ends, an endpoint SHOULD discard all
-connection state.  The endpoint MAY send a stateless reset in response
-to any further incoming packets belonging to this connection.
+connection state.  The endpoint MAY send a stateless reset in response to any
+further incoming packets belonging to this connection.
 
 
 ### Closing Connection State {#closing}
@@ -2783,19 +2784,18 @@ packets.
 An endpoint's selected connection ID and the QUIC version are sufficient
 information to identify packets for a closing connection; the endpoint MAY
 discard all other connection state. An endpoint that is closing is not required
-to process any received frame. An endpoint MAY retain packet
-protection keys for incoming packets to allow it to read and process a
-CONNECTION_CLOSE frame.
+to process any received frame. An endpoint MAY retain packet protection keys for
+incoming packets to allow it to read and process a CONNECTION_CLOSE frame.
 
-An endpoint MAY drop packet protection keys when entering the closing state
-and send a packet containing a CONNECTION_CLOSE frame in response to any UDP datagram
-that is received. However, an endpoint that discards packet protection keys
-cannot identify and discard invalid packets. To avoid being used for an
-amplication attack, such endpoints MUST limit the cumulative size of packets
-it sends to three times the cumulative size of the
-packets that are received and attributed to the connection. To minimize the state that an
-endpoint maintains for a closing connection, endpoints MAY send the exact same
-packet in response to any received packet.
+An endpoint MAY drop packet protection keys when entering the closing state and
+send a packet containing a CONNECTION_CLOSE frame in response to any UDP
+datagram that is received. However, an endpoint that discards packet protection
+keys cannot identify and discard invalid packets. To avoid being used for an
+amplication attack, such endpoints MUST limit the cumulative size of packets it
+sends to three times the cumulative size of the packets that are received and
+attributed to the connection. To minimize the state that an endpoint maintains
+for a closing connection, endpoints MAY send the exact same packet in response
+to any received packet.
 
 Note:
 
@@ -2807,14 +2807,15 @@ Note:
 
 While in the closing state, an endpoint could receive packets from a new source
 address, possibly indicating a connection migration; see {{migration}}.  An
-endpoint in the closing state MUST either discard packets received from
-an unvalidated address or limit the cumulative size of packets it sends to
-an unvalidated address to three times the size of packets it receives from that
+endpoint in the closing state MUST either discard packets received from an
+unvalidated address or limit the cumulative size of packets it sends to an
+unvalidated address to three times the size of packets it receives from that
 address.
 
-An endpoint is not expected to handle key updates when it is closing (Section 6 of {{QUIC-TLS}}). A key
-update might prevent the endpoint from moving from the closing state to
-the draining state, as the endpoint will not be able to process subsequently received packets, but it otherwise has no impact.
+An endpoint is not expected to handle key updates when it is closing (Section 6
+of {{QUIC-TLS}}). A key update might prevent the endpoint from moving from the
+closing state to the draining state, as the endpoint will not be able to process
+subsequently received packets, but it otherwise has no impact.
 
 
 ### Draining Connection State {#draining}
@@ -2827,15 +2828,15 @@ is in the draining state.
 
 An endpoint that receives a CONNECTION_CLOSE frame MAY send a single packet
 containing a CONNECTION_CLOSE frame before entering the draining state, using a
-NO_ERROR code if appropriate.  An endpoint MUST NOT send further packets. Doing so
-could result in a constant exchange of CONNECTION_CLOSE frames until one of the
-endpoints exits the closing state.
+NO_ERROR code if appropriate.  An endpoint MUST NOT send further packets. Doing
+so could result in a constant exchange of CONNECTION_CLOSE frames until one of
+the endpoints exits the closing state.
 
-An endpoint MAY enter the draining state from the closing state if it
-receives a CONNECTION_CLOSE frame, which indicates that the peer is also
-closing or draining. In this case, the draining state SHOULD end when the
-closing state would have ended. In other words, the endpoint uses the same end
-time, but ceases transmission of any packets on this connection.
+An endpoint MAY enter the draining state from the closing state if it receives a
+CONNECTION_CLOSE frame, which indicates that the peer is also closing or
+draining. In this case, the draining state SHOULD end when the closing state
+would have ended. In other words, the endpoint uses the same end time, but
+ceases transmission of any packets on this connection.
 
 
 ### Immediate Close During the Handshake {#immediate-close-hs}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2767,7 +2767,7 @@ to any further incoming packets.
 
 ### Closing Connection State {#closing}
 
-An endpoint enters a closing state after initiating an immediate close.
+An endpoint enters the closing state after initiating an immediate close.
 
 In the closing state, an endpoint retains only enough information to generate a
 packet containing a CONNECTION_CLOSE frame and to identify packets as belonging
@@ -2814,7 +2814,7 @@ address.
 
 An endpoint is not expected to handle key updates when it is closing. A key
 update might prevent the endpoint from moving from the closing state to
-draining, but it otherwise has no impact.
+the draining state, but it otherwise has no impact.
 
 
 ### Draining Connection State {#draining}
@@ -2827,7 +2827,7 @@ is in the draining state.
 
 An endpoint that receives a CONNECTION_CLOSE frame MAY send a single packet
 containing a CONNECTION_CLOSE frame before entering the draining state, using a
-CONNECTION_CLOSE frame and a NO_ERROR code if appropriate.  An endpoint MUST NOT
+NO_ERROR code if appropriate.  An endpoint MUST NOT
 send further packets, which could result in a constant exchange of
 CONNECTION_CLOSE frames until either endpoint exits the closing state.
 
@@ -2835,7 +2835,7 @@ An endpoint MAY transition from the closing state to the draining state if it
 receives a CONNECTION_CLOSE frame, which indicates that the peer is also
 closing or draining. In this case, the draining state SHOULD end when the
 closing state would have ended. In other words, the endpoint uses the same end
-time, but cease retransmission of the closing packet.
+time, but ceases retransmission of the closing packet.
 
 
 ### Immediate Close During the Handshake {#immediate-close-hs}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2827,9 +2827,9 @@ is in the draining state.
 
 An endpoint that receives a CONNECTION_CLOSE frame MAY send a single packet
 containing a CONNECTION_CLOSE frame before entering the draining state, using a
-NO_ERROR code if appropriate.  An endpoint MUST NOT
-send further packets, which could result in a constant exchange of
-CONNECTION_CLOSE frames until either endpoint exits the closing state.
+NO_ERROR code if appropriate.  An endpoint MUST NOT send further packets, which
+could result in a constant exchange of CONNECTION_CLOSE frames until either
+endpoint exits the closing state.
 
 An endpoint MAY transition from the closing state to the draining state if it
 receives a CONNECTION_CLOSE frame, which indicates that the peer is also

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2753,12 +2753,12 @@ These states SHOULD persist for at least three times the current Probe Timeout
 (PTO) interval as defined in {{QUIC-RECOVERY}}.
 
 Disposing of connection state prior to exiting the closing or draining state
-could cause delayed or reordered packets to generate an unnecessary stateless
-reset. Endpoints that have some alternative means to ensure that late-arriving
-packets do not induce a response, such as those that are able
-to close the UDP socket, MAY end these states earlier to allow
-for faster resource recovery.  Servers that retain an open socket for accepting
-new connections SHOULD NOT end the closing or draining states early.
+could cause could result in an generating unnecessary stateless reset in
+response to receiving a packet.  Endpoints that have some alternative means to
+ensure that late-arriving packets do not induce a response, such as those that
+are able to close the UDP socket, MAY end these states earlier to allow for
+faster resource recovery.  Servers that retain an open socket for accepting new
+connections SHOULD NOT end the closing or draining states early.
 
 Once the closing or draining state ends, an endpoint SHOULD discard all
 connection state.  An endpoint MAY send a stateless reset in response
@@ -2805,11 +2805,12 @@ Note:
   congestion control, which are not expected to be relevant for a closed
   connection. Retransmitting the final packet requires less state.
 
-While in the closing state, an endpoint could receive packets from a new
-source address, possibly indicating a connection migration; see {{migration}}.
-An endpoint in the closing state MUST either discard packets received from
+While in the closing state, an endpoint could receive packets from a new source
+address, possibly indicating a connection migration; see {{migration}}.  An
+endpoint in the closing state MUST either discard packets received from
 unvalidated addresses or limit the cumulative size of packets it sends to
-unvalidated addresses to 3 times the size of packets it receives from the address.
+unvalidated addresses to 3 times the size of packets it receives from the
+address.
 
 An endpoint is not expected to handle key updates when it is closing. A key
 update might prevent the endpoint from moving from the closing state to

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2752,7 +2752,7 @@ close cleanly and that delayed or reordered packets are properly discarded.
 These states SHOULD persist for at least three times the current Probe Timeout
 (PTO) interval as defined in {{QUIC-RECOVERY}}.
 
-Disposing of connection state prior to the exiting the closing or draining state
+Disposing of connection state prior to exiting the closing or draining state
 could cause delayed or reordered packets to generate an unnecessary stateless
 reset. Endpoints that have some alternative means to ensure that late-arriving
 packets on the connection do not induce a response, such as those that are able

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2752,11 +2752,23 @@ the application requests that the connection be closed.  When the application
 closes the connection, a CONNECTION_CLOSE frame with an appropriate error code
 will be used to signal closure.
 
+Disposing of connection state prior to the end of the closing or draining period
+could cause delayed or reordered packets to generate an unnecessary stateless
+reset. Endpoints that have some alternative means to ensure that late-arriving
+packets on the connection do not induce a response, such as those that are able
+to close the UDP socket, MAY use an abbreviated draining period to allow
+for faster resource recovery.  Servers that retain an open socket for accepting
+new connections SHOULD NOT exit the closing or draining period early.
+
+Once the closing or draining period has ended, an endpoint SHOULD discard all
+connection state.  This results in new packets on the connection being handled
+generically.  For instance, an endpoint MAY send a stateless reset in response
+to any further incoming packets.
+
 
 ### Closing Connection State {#closing}
 
-An endpoint enters a closing period after initiating an immediate close;
-{{immediate-close}}.
+An endpoint enters a closing period after initiating an immediate close.
 
 During the closing period, an endpoint that sends a CONNECTION_CLOSE frame
 SHOULD respond to any incoming packet that can be decrypted with another packet
@@ -2818,29 +2830,13 @@ An endpoint that receives a CONNECTION_CLOSE frame MAY send a single packet
 containing a CONNECTION_CLOSE frame before entering the draining state, using a
 CONNECTION_CLOSE frame and a NO_ERROR code if appropriate.  An endpoint MUST NOT
 send further packets, which could result in a constant exchange of
-CONNECTION_CLOSE frames until the closing period on either peer ended.
+CONNECTION_CLOSE frames until the closing period on either peer ends.
 
-An endpoint MAY transition from the closing period to the draining period if it
+An endpoint MAY transition from the closing state to the draining state if it
 receives a CONNECTION_CLOSE frame or stateless reset, either of which indicate
 that the peer is also closing or draining.  The draining period SHOULD end when
 the closing period would have ended.  In other words, the endpoint can use the
 same end time, but cease retransmission of the closing packet.
-
-
-### Terminal Connection State
-
-Disposing of connection state prior to the end of the closing or draining period
-could cause delayed or reordered packets to generate an unnecessary stateless
-reset. Endpoints that have some alternative means to ensure that late-arriving
-packets on the connection do not induce a response, such as those that are able
-to close the UDP socket, MAY use an abbreviated draining period to allow
-for faster resource recovery.  Servers that retain an open socket for accepting
-new connections SHOULD NOT exit the closing or draining period early.
-
-Once the closing or draining period has ended, an endpoint SHOULD discard all
-connection state.  This results in new packets on the connection being handled
-generically.  For instance, an endpoint MAY send a stateless reset in response
-to any further incoming packets.
 
 
 ### Immediate Close During the Handshake {#immediate-close-hs}


### PR DESCRIPTION
I took a careful look at the text here and found a few things:

1. There wasn't much redundancy, but there was a little.  Mostly the problem was scattering of content between two locations in the document.

2. The closing and draining states only apply to immediate close.

So I moved things up.  I trimmed the top-level immediate close text, and moved text specific to closing or draining to sections corresponding to each.

There were a few bits that could be cut, and a few that needed to be better aligned with existing text, but nothing major.  Most of this is unmodified text.

There are a few bits that I had to tweak.  I will add comments for those.

Closes #3907.