### PR TITLE
Update initial congestion window on MTU decrease

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -751,11 +751,10 @@ twice the maximum datagram size. This follows the analysis and recommendations
 in {{?RFC6928}}, increasing the byte limit to account for the smaller 8 byte
 overhead of UDP compared to the 20 byte overhead for TCP.
 
-If the maximum datagram size is decreased in order to complete the handshake,
-the initial congestion window SHOULD be recalculated with the new smaller size
-and the congestion window SHOULD be set to the smaller initial congestion
-window. This avoids overly large initial congestion windows.  The initial
-window is not recalculated at any other time.
+If the maximum datagram size changes during the connection, the initial
+congestion window SHOULD be recalculated with the new size.  If the maximum
+datagram size is decreased in order to complete the handshake, the
+congestion window SHOULD be set to the new initial congestion window.
 
 Prior to validating the client's address, the server can be further limited by
 the anti-amplification limit as specified in Section 8.1 of {{QUIC-TRANSPORT}}.

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -751,6 +751,11 @@ twice the maximum datagram size. This follows the analysis and recommendations
 in {{?RFC6928}}, increasing the byte limit to account for the smaller 8 byte
 overhead of UDP compared to the 20 byte overhead for TCP.
 
+If the maximum datagram size is decreased in order to complete the handshake,
+the initial congestion window SHOULD be recalculated with the new smaller size.
+This avoids overly large initial congestion windows.  The initial window is
+not recalculated at any other time.
+
 Prior to validating the client's address, the server can be further limited by
 the anti-amplification limit as specified in Section 8.1 of {{QUIC-TRANSPORT}}.
 Though the anti-amplification limit can prevent the congestion window from

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -752,9 +752,10 @@ in {{?RFC6928}}, increasing the byte limit to account for the smaller 8 byte
 overhead of UDP compared to the 20 byte overhead for TCP.
 
 If the maximum datagram size is decreased in order to complete the handshake,
-the initial congestion window SHOULD be recalculated with the new smaller size.
-This avoids overly large initial congestion windows.  The initial window is
-not recalculated at any other time.
+the initial congestion window SHOULD be recalculated with the new smaller size
+and the congestion window SHOULD be set to the smaller initial congestion
+window. This avoids overly large initial congestion windows.  The initial
+window is not recalculated at any other time.
 
 Prior to validating the client's address, the server can be further limited by
 the anti-amplification limit as specified in Section 8.1 of {{QUIC-TRANSPORT}}.


### PR DESCRIPTION
Fixes #3997 by specifying that IW should be updated if the max packet size decreases in order to complete the handshake.