### PR TITLE
Use FRAME_ENCODING_ERROR for stream limits >2^60

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -970,7 +970,7 @@ If a max_streams transport parameter or MAX_STREAMS frame is received with a
 value greater than 2^60, this would allow a maximum stream ID that cannot be
 expressed as a variable-length integer; see {{integer-encoding}}.
 If either is received, the connection MUST be closed immediately with a
-connection error of type STREAM_LIMIT_ERROR; see {{immediate-close}}.
+connection error of type FRAME_ENCODING_ERROR; see {{immediate-close}}.
 
 Endpoints MUST NOT exceed the limit set by their peer.  An endpoint that
 receives a frame with a stream ID exceeding the limit it has sent MUST treat


### PR DESCRIPTION
This is an error that can be detected in frame parsing without
additional context.

Closes #3781.