### PR TITLE
Attempt to define slow start/congestion avoidance

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -783,13 +783,15 @@ The congestion controller is in congestion avoidance any time the congestion
 window is at or above the slow start threshold.
 
 Congestion avoidance uses an Additive Increase Multiplicative Decrease (AIMD)
-approach that increases the congestion window by one maximum packet size per
-congestion window acknowledged.
+approach that increases the congestion window by one maximum datagram size per
+congestion window acknowledged. A congestion controller MUST NOT increase the
+congestion window by more than this amount.
 
 When first entering congestion avoidance, when a packet is declared lost, or
-when the ECN-CE count is increased, the congestion controller halves the
-congestion window, reduces the slow start threshold to the resulting size, and
-enters the recovery period.
+when the ECN-CE count is increased, the congestion controller described in this
+document halves the congestion window, reduces the slow start threshold to the
+resulting size, and enters the recovery period. A congestion controller MUST
+reduce the congestion window when a loss or ECN-CE marking is detected.
 
 ## Recovery Period
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -764,7 +764,8 @@ The RECOMMENDED value is 2 * max_datagram_size.
 ## Slow Start
 
 The congestion controller is in slow start any time the congestion window is
-below the slow start threshold.  The congestion controller begins in slow start.
+below the slow start threshold.  The congestion controller begins in slow start
+because the slow start threshold is initialized to an infinite value.
 
 While the congestion controller is in slow start, the congestion window
 increases by the number of bytes acknowledged when each acknowledgment is

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -763,24 +763,33 @@ The RECOMMENDED value is 2 * max_datagram_size.
 
 ## Slow Start
 
-While in slow start, QUIC increases the congestion window by the
-number of bytes acknowledged when each acknowledgment is processed, resulting
-in exponential growth of the congestion window.
+The congestion controller is in slow start any time the congestion window is
+below the slow start threshold.  The congestion controller begins in slow start.
 
-QUIC exits slow start upon loss or upon increase in the ECN-CE counter.
-When slow start is exited, the congestion window halves and the slow start
-threshold is set to the new congestion window.  QUIC re-enters slow start
-any time the congestion window is less than the slow start threshold,
-which only occurs after persistent congestion is declared.
+While the congestion controller is in slow start, the congestion window
+increases by the number of bytes acknowledged when each acknowledgment is
+processed.  This results in exponential growth of the congestion window.
+
+The congestion controller exits slow start and enters congestion avoidance when
+a packet is lost or when the ECN-CE count increases.
+
+The congestion controller re-enters slow start any time the congestion window is
+less than the slow start threshold, which only occurs after persistent
+congestion is declared.
 
 ## Congestion Avoidance
 
-Slow start exits to congestion avoidance.  Congestion avoidance uses an
-Additive Increase Multiplicative Decrease (AIMD) approach that increases
-the congestion window by one maximum packet size per congestion window
-acknowledged.  When a loss or ECN-CE marking is detected, NewReno halves
-the congestion window, sets the slow start threshold to the new
-congestion window, and then enters the recovery period.
+The congestion controller is in congestion avoidance any time the congestion
+window is at or above the slow start threshold.
+
+Congestion avoidance uses an Additive Increase Multiplicative Decrease (AIMD)
+approach that increases the congestion window by one maximum packet size per
+congestion window acknowledged.
+
+When first entering congestion avoidance, when a packet is declared lost, or
+when the ECN-CE count is detected, the congestion controller halves the
+congestion window, reduces the slow start threshold to the resulting size, and
+enters the recovery period.
 
 ## Recovery Period
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -787,7 +787,7 @@ approach that increases the congestion window by one maximum packet size per
 congestion window acknowledged.
 
 When first entering congestion avoidance, when a packet is declared lost, or
-when the ECN-CE count is detected, the congestion controller halves the
+when the ECN-CE count is increased, the congestion controller halves the
 congestion window, reduces the slow start threshold to the resulting size, and
 enters the recovery period.
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -788,13 +788,16 @@ approach that increases the congestion window by one maximum datagram size per
 congestion window acknowledged. A congestion controller MUST NOT increase the
 congestion window by more than this amount.
 
-When first entering congestion avoidance, when a packet is declared lost, or
-when the ECN-CE count is increased, the congestion controller described in this
-document halves the congestion window, reduces the slow start threshold to the
-resulting size, and enters the recovery period. A congestion controller MUST
-reduce the congestion window when a loss or ECN-CE marking is detected.
+The congestion controller described in this document, when not in the
+recovery period ({{recovery}}), MUST take the following steps when first
+entering congestion avoidance, when a packet is declared lost, or when
+the ECN-CE count is increased:
 
-## Recovery Period
+* halve the congestion window,
+* set the slow start threshold to the size of the reduced congestion window, and
+* enter the recovery period.
+
+## Recovery Period {#recovery}
 
 A recovery period is entered when loss or ECN-CE marking of a packet is
 detected in congestion avoidance after the congestion window and slow start

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -818,20 +818,20 @@ The RECOMMENDED value is 2 * max_datagram_size.
 
 ## Slow Start
 
-The congestion controller is in slow start any time the congestion window is
-below the slow start threshold.  The congestion controller begins in slow start
-because the slow start threshold is initialized to an infinite value.
+A NewReno sender is in slow start any time the congestion window is below the
+slow start threshold. A sender begins in slow start because the slow start
+threshold is initialized to an infinite value.
 
-While the congestion controller is in slow start, a NewReno sender increases the
-congestion window by the number of bytes acknowledged when each acknowledgment is
-processed.  This results in exponential growth of the congestion window.
+While a sender is in slow start, the congestion window increases by the number
+of bytes acknowledged when each acknowledgment is processed. This results in
+exponential growth of the congestion window.
 
 A sender exits slow start and enters congestion avoidance when a packet is lost
 or when the ECN-CE count increases.
 
-The congestion controller re-enters slow start any time the congestion window is
-less than the slow start threshold, which only occurs after persistent
-congestion is declared.
+A sender re-enters slow start any time the congestion window is less than the
+slow start threshold, which only occurs after persistent congestion is
+declared.
 
 ## Congestion Avoidance
 
@@ -840,13 +840,12 @@ above the slow start threshold.
 
 Congestion avoidance uses an Additive Increase Multiplicative Decrease (AIMD)
 approach that increases the congestion window by one maximum datagram size per
-congestion window acknowledged. A congestion controller MUST NOT increase the
-congestion window by more than this amount.
+congestion window acknowledged. A sender MUST NOT increase the congestion
+window by more than this amount.
 
-The congestion controller described in this document, when not in the recovery
-period ({{recovery-period}}), MUST take the following steps when first entering
-congestion avoidance, when a packet is declared lost, or when the ECN-CE count
-is increased:
+A NewReno sender, when not in the recovery period ({{recovery-period}}), MUST
+take the following steps when first entering congestion avoidance, when a
+packet is declared lost, or when the ECN-CE count is increased:
 
 * halve the congestion window,
 * set the slow start threshold to the size of the reduced congestion window, and


### PR DESCRIPTION
This essentially rewrites these small sections.

The definitions are new.  The text on how the congestion window
increases is just tweaked.  The reaction to loss is moved to the
congestion avoidance section, to avoid repetition.

Closes #3982.