### PR TITLE
Persistent congestion pseudocode to match text

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1517,7 +1517,7 @@ variables as follows:
    bytes_in_flight = 0
    congestion_recovery_start_time = 0
    ssthresh = infinite
-   first_rtt_sample = never
+   first_rtt_sample = 0
    for pn_space in [ Initial, Handshake, ApplicationData ]:
      ecn_ce_counters[pn_space] = 0
 ~~~
@@ -1551,7 +1551,7 @@ newly acked_packets from sent_packets.
     // Remove from bytes_in_flight.
     bytes_in_flight -= acked_packet.sent_bytes
 
-    if (first_rtt_sample is never):
+    if (first_rtt_sample == 0):
       first_rtt_sample = now()
 
     // Do not increase congestion_window if application
@@ -1621,7 +1621,7 @@ Invoked when DetectAndRemoveLostPackets deems packets lost.
 
      // Only look for persistent congestion if the period
      // starts after getting the first RTT sample.
-     assert(first_rtt_sample is not never)
+     assert(first_rtt_sample != 0)
      if (largest_lost.time_sent - pc_period > first_rtt_sample):
        return false
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1631,6 +1631,8 @@ InPersistentCongestion(lost_packets):
 
   // Find the duration of the largest contiguous set of lost
   // packets that starts and ends with an ack-eliciting packet.
+  // Note: Indexing pc_lost by time_sent rather than packet
+  // number might simplify implementation.
   pc_duration = FindLargestLossPeriod(pc_lost)
 
   // Declare persistent congestion if these packets span

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1629,16 +1629,15 @@ InPersistentCongestion(lost_packets):
     if lost.time_sent <= first_rtt_sample:
       pc_lost.remove(lost)
 
-  // Find the largest contiguous set of lost packets that
-  // starts and ends with an ack-eliciting packet.
-  (first, last) = FindLargestContiguousLoss(pc_lost)
+  // Find the duration of the largest contiguous set of lost
+  // packets that starts and ends with an ack-eliciting packet.
+  pc_duration = FindLargestLossPeriod(pc_lost)
 
   // Declare persistent congestion if these packets span
   // a period longer than the persistent congestion period.
   pto = smoothed_rtt + max(4 * rttvar, kGranularity) +
     max_ack_delay
-  pc_period = pto * kPersistentCongestionThreshold
-  return (last.time_sent - first.time_sent) > pc_period
+  return pc_duration > pto * kPersistentCongestionThreshold
 
 OnPacketsLost(lost_packets):
   // Remove lost packets from bytes_in_flight.

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1621,7 +1621,7 @@ Invoked when DetectAndRemoveLostPackets deems packets lost.
 ~~~
 InPersistentCongestion(lost_packets):
   // Consider lost packets across all packet number spaces.
-  pc_lost += lost_packets
+  pc_lost.append(lost_packets)
 
   // Disregard packets sent prior to getting an RTT sample.
   assert(first_rtt_sample != 0)


### PR DESCRIPTION
This adds a new variable `first_rtt_sample` that records when the first
RTT was recorded.  This variable is used to avoid declaring persistent
congestion based on packets that were sent prior to this time.

Note that I removed the lame check in `InPersistentCongestion`.  This
avoids the implication that you need to propagate a signal that says
"this is the first RTT sample" all the way from the ACK handling code.
That signal is now propagated using the new variable.

Closes #3972.