### PR TITLE
Describe inputs to TLS more clearly

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -502,18 +502,17 @@ As keys at a given encryption level become available to TLS, TLS indicates to
 QUIC that reading or writing keys at that encryption level are available.
 
 The events that cause new keys to be available are not asynchronous; they
-always occur immediately after TLS is provided with inputs. Inputs are either
-new handshake bytes or new instructions. The two instructions that this
-document relies upon are the initial signal to start the handshake and - if the
-TLS implementation depends on certificate validation being performed externally
-- an indication that the certificate chain of a peer has been accepted or
-rejected.
+always occur after TLS is provided with inputs. TLS only provides new keys
+after being initialized (by a client) or after being provided with new
+handshake data.
 
-While waiting for TLS processing, including certificate validation, to
-complete, an endpoint SHOULD buffer received packets if they might be processed
-using keys that aren't yet available. These packets can be processed once keys
-are provided by TLS. An endpoint MAY continue to respond to packets that could
-be processed.
+However, a TLS implementation could perform some of its processing
+asynchronously. In particular, the process of validating a certificate can take
+some time. While waiting for TLS processing to complete, an endpoint SHOULD
+buffer received packets if they might be processed using keys that aren't yet
+available. These packets can be processed once keys are provided by TLS. An
+endpoint MAY continue to respond to packets that can be processed during this
+time.
 
 After processing inputs, TLS might produce handshake bytes, keys for new
 encryption levels, or both.

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -505,14 +505,15 @@ The events that cause new keys to be available are not asynchronous; they
 always occur immediately after TLS is provided with inputs. Inputs are either
 new handshake bytes or new instructions. The two instructions that this
 document relies upon are the initial signal to start the handshake and - if the
-TLS implementation allows asynchronous certificate validation - an indication
-that the certificate chain of a peer has been accepted or rejected.
+TLS implementation depends on certificate validation being performed externally
+- an indication that the certificate chain of a peer has been accepted or
+rejected.
 
-While waiting for TLS processing, including asynchronous certificate
-validation, to complete, an endpoint SHOULD buffer received packets if they
-might be processed using keys that aren't yet available. These packets can be
-processed once keys are provided by TLS. An endpoint MAY continue to respond to
-packets that could be processed.
+While waiting for TLS processing, including certificate validation, to
+complete, an endpoint SHOULD buffer received packets if they might be processed
+using keys that aren't yet available. These packets can be processed once keys
+are provided by TLS. An endpoint MAY continue to respond to packets that could
+be processed.
 
 After processing inputs, TLS might produce handshake bytes, keys for new
 encryption levels, or both.

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -501,17 +501,16 @@ handshake, new data is requested from TLS after providing received data.
 As keys at a given encryption level become available to TLS, TLS indicates to
 QUIC that reading or writing keys at that encryption level are available.
 
-The events that cause new keys to be available are not asynchronous; they
-always occur after TLS is provided with inputs. TLS only provides new keys
-after being initialized (by a client) or after being provided with new
-handshake data.
+The availability of new keys is always a result of providing inputs to TLS.  TLS
+only provides new keys after being initialized (by a client) or when provided
+with new handshake data.
 
 However, a TLS implementation could perform some of its processing
 asynchronously. In particular, the process of validating a certificate can take
 some time. While waiting for TLS processing to complete, an endpoint SHOULD
 buffer received packets if they might be processed using keys that aren't yet
 available. These packets can be processed once keys are provided by TLS. An
-endpoint MAY continue to respond to packets that can be processed during this
+endpoint SHOULD continue to respond to packets that can be processed during this
 time.
 
 After processing inputs, TLS might produce handshake bytes, keys for new

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -499,9 +499,17 @@ handshake, new data is requested from TLS after providing received data.
 ### Encryption Level Changes
 
 As keys at a given encryption level become available to TLS, TLS indicates to
-QUIC that reading or writing keys at that encryption level are available.  These
-events are not asynchronous; they always occur immediately after TLS is provided
-with new handshake bytes, or after TLS produces handshake bytes.
+QUIC that reading or writing keys at that encryption level are available.
+
+The events that cause new keys to be available are not asynchronous; they
+always occur immediately after TLS is provided with inputs. Inputs are either
+new handshake bytes or new instructions. The two instructions that this
+document relies upon are the initial signal to start the handshake and - if the
+TLS implementation allows asynchronous certificate validation - an indication
+that the certificate chain of a peer has been accepted or rejected.
+
+After processing inputs, TLS might produce handshake bytes, keys for new
+encryption levels, or both.
 
 TLS provides QUIC with three items as a new encryption level becomes available:
 
@@ -512,8 +520,8 @@ TLS provides QUIC with three items as a new encryption level becomes available:
 * A Key Derivation Function (KDF)
 
 These values are based on the values that TLS negotiates and are used by QUIC to
-generate packet and header protection keys (see {{packet-protection}} and
-{{header-protect}}).
+generate packet and header protection keys; see {{packet-protection}} and
+{{header-protect}}.
 
 If 0-RTT is possible, it is ready after the client sends a TLS ClientHello
 message or the server receives that message.  After providing a QUIC client with


### PR DESCRIPTION
This clarifies the TLS interface by explaining that TLS only generates
outputs (handshake bytes or keying material) in response to inputs.
Previously, the only inputs we acknowledged were the handshake bytes,
but this recognizes two more: the signal from the client to start
handshaking, and - for async validation - a signal that a certificate is
OK or not.

Closes #3873.