### PR TITLE
WIP: Begin lightly abstracting over the use of UDP as the underlying transport

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2755,10 +2755,10 @@ detrimental effect on performance.
 A connection will time out if no packets are sent or received for a period
 longer than the time negotiated using the max_idle_timeout transport parameter;
 see {{termination}}.  However, state in middleboxes might time out earlier than
-that.  Though REQ-5 in {{?RFC4787}} recommends a 2 minute timeout interval,
-experience shows that sending packets every 30 seconds is necessary to prevent
-the majority of middleboxes from losing state for underlying-transport flows
-{{?GATEWAY=DOI.10.1145/1879141.1879174}}.
+that.  For example, though REQ-5 in {{?RFC4787}} recommends a 2 minute timeout
+interval for UDP mappings, experience shows that sending packets every 30
+seconds is necessary to prevent the majority of middleboxes from losing state
+for UDP flows {{?GATEWAY=DOI.10.1145/1879141.1879174}}.
 
 
 ## Immediate Close {#immediate-close}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3232,18 +3232,16 @@ after a connection is established and 1-RTT keys are available; see
 
 ## Underlying Transport Protocol {#underlying-transport-protocol}
 
-The underlying protocol is the protocol with which QUIC packet are sent.
+The underlying protocol is the protocol over which QUIC packets are sent.
 
 This protocol SHOULD NOT have automatic retransmission, ordering, congestion
 control, or other such mechanisms that would overlap with those provided by QUIC
 and therefore not actually enhance the overall quality of service.  This
 protocol SHOULD be message-oriented.
 
-The underlying protocol MUST contain both a source and destination address:
-while the underlying protocol is free to route datagrams by whichever means it
-chooses, and futhermore a source address isn't strictly necessary to route a
-datagram, the QUIC implementation needs to be able to inspect both addresses for
-to implement connection migration.
+The underlying protocol MUST contain both a source and destination address,
+as the QUIC implementation needs to be able to inspect both addresses in
+order to support connection migration.
 
 An underlying datagram MUST correspond to a single IP packet, if it is sent over
 IP.  That means IP fragmentation MUST NOT be used.  When using IPv4
@@ -4030,9 +4028,8 @@ later time in the connection.
 
 # Packet Size {#packet-size}
 
-The QUIC packet size is just the total size of the QUIC header and protected
-payload. It follows that the sizes of any other headers that are part of the
-underlying datagram and associated with underlying protocols are not counted.
+The QUIC packet size includes the QUIC header and protected payload, but not the
+headers of any underlying protocol.
 
 QUIC depends upon a minimum IP packet size of at least 1280 bytes.  This is the
 IPv6 minimum size ({{?IPv6=RFC8200}}) and is also supported by most modern IPv4

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2554,15 +2554,16 @@ those paths to be linked by entities other than the peer.
 
 A client might wish to reduce linkability by employing a new connection ID and
 source address when sending traffic after a period of inactivity.  (In
-conventional situations using UDP, the client cannot freely vary the IP address,
-but can much more readily change the UDP port.  Since an address for QUIC when
-using UDP is the tuple of the IP address and UDP port, changing the source port
-along constitutes changing the QUIC address.) So changing the address from which
-it sends packets at the same time might cause the packet to appear as a
-connection migration.  This ensures that the mechanisms that support migration
-are exercised even for clients that do not experience NAT rebindings or genuine
-migrations.  Changing port number can cause a peer to reset its congestion state
-(see {{migration-cc}}), so the port SHOULD only be changed infrequently.
+conventional situations using UDP, the client may not always be able to freely
+vary the IP address, but can much more readily change the UDP port.  Since an
+address for QUIC when using UDP is the tuple of the IP address and UDP port,
+changing the source port along constitutes changing the QUIC address.) So
+changing the address from which it sends packets at the same time might cause
+the packet to appear as a connection migration.  This ensures that the
+mechanisms that support migration are exercised even for clients that do not
+experience NAT rebindings or genuine migrations.  Changing port number can cause
+a peer to reset its congestion state (see {{migration-cc}}), so the port SHOULD
+only be changed infrequently.
 
 An endpoint that exhausts available connection IDs cannot probe new paths or
 initiate migration, nor can it respond to probes or attempts by its peer to


### PR DESCRIPTION
Based on recent mailing list feedback that this might possibly be OK, I
decided to take a crack at reducing the "hard coding" of UDP in the
spirit of other RFCs which strive to be agnostic to the underlying
protocol.

Due to the controversy over this, I imposed these constraints on myself
to try to be as conservative as possible.

- Absolutely no design changes on things which are already standardized,
  just editorial changes, and very simple extrapolation of the existing
  design. (I never ever considered the former at this time, just
  documenting this for posterity.

- Anything that is not UDP (over IP) is deemed experimental. The size
  limitations I figure may not make sense for other transports / during
  other experiments, so I call that out.

- When UDP was mentioned in some interesting way that generalized (e.g.
  something that separately mentions IP address and UDP port), I provide
  the general language (plain "address", but also provide the UDP common
  case as before so no specificity is lost.

The purpose of this exercise is *not* to get QUIC over UDP "more ready
for production", as that would slow down the WG for little gain, but
rather to call out the dependencies that currently do exist so as to be
sure there is no unintentional coupling. I fully leave to others to
decide what coupling is intenional or unintentional, and whether
anything at all is cause for concern.

----

In this first commit, I just audited all the occurrence of "UDP". If
this looks good, I would then go back and likewise scan for "port"
"IPv4", and "IPv6".

My one regret is that in keeping the line length the same, I made the
diff more complicated than it would otherwise be. Do you all have a
process for that?

Progress towards issue #4061.