### PR TITLE
Handle unset Maximum Push ID

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -824,8 +824,9 @@ MAX_PUSH_ID frame; see {{frame-max-push-id}}.  In particular, a server is not
 able to push until after the client sends a MAX_PUSH_ID frame.  A client sends
 MAX_PUSH_ID frames to control the number of pushes that a server can promise.  A
 server SHOULD use Push IDs sequentially, beginning from zero.  A client MUST
-treat receipt of a push stream with a Push ID that is greater than the maximum
-Push ID as a connection error of type H3_ID_ERROR.
+treat receipt of a push stream as a connection error of type H3_ID_ERROR when no
+MAX_PUSH_ID frame has been sent or when the stream references a Push ID that is
+greater than the maximum Push ID.
 
 The Push ID is used in one or more PUSH_PROMISE frames ({{frame-push-promise}})
 that carry the header section of the request message.  These frames are sent on


### PR DESCRIPTION
Fixes #4052.  Probably editorial since this is what was previously intended, but still touching a MUST.