### PR TITLE
http editorial fix: Fix the value of MAX_PUSH_ID Frame Type

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1583,7 +1583,7 @@ sending MAX_PUSH_ID frames as the server fulfills or cancels server pushes.
 
 ~~~~~~~~~~  drawing
 MAX_PUSH_ID Frame {
-  Type (i) = 0x1,
+  Type (i) = 0xD,
   Length (i),
   Push ID (i),
 }


### PR DESCRIPTION
I found an erratum for the value of MAX_PUSH_ID Frame Type in the draft. The value must be `0xD` (https://github.com/quicwg/base-drafts/blob/master/draft-ietf-quic-http.md#frame-types-iana-frames).