### PR TITLE
Pseudocode for persistent congestion is too hard

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1707,10 +1707,11 @@ OnPacketsLost(lost_packets):
   // packets indicates persistent congestion.
   // Disregard packets sent prior to getting an RTT sample.
   assert(first_rtt_sample != 0)
-  for lost in lost_packets:
+  pc_lost = lost_packets
+  for lost in pc_lost:
     if lost.time_sent <= first_rtt_sample:
-      lost_packets.remove(lost)
-  if (InPersistentCongestion(lost_packets)):
+      pc_lost.remove(lost)
+  if (InPersistentCongestion(pc_lost)):
     congestion_window = kMinimumWindow
     congestion_recovery_start_time = 0
 ~~~

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1749,7 +1749,7 @@ OnPacketsLost(lost_packets):
 
   // Reset the congestion window if the loss of these
   // packets indicates persistent congestion.
-  // Disregard packets sent prior to getting an RTT sample.
+  // Only consider packets sent after getting an RTT sample.
   assert(first_rtt_sample != 0)
   pc_lost = {}
   for lost in lost_packets:

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1751,7 +1751,7 @@ OnPacketsLost(lost_packets):
   // packets indicates persistent congestion.
   // Disregard packets sent prior to getting an RTT sample.
   assert(first_rtt_sample != 0)
-  pc_lost = []
+  pc_lost = {}
   for lost in lost_packets:
     if lost.time_sent > first_rtt_sample:
       pc_lost.insert(lost)

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1690,27 +1690,17 @@ ProcessECN(ack, pn_space):
 Invoked when DetectAndRemoveLostPackets deems packets lost.
 
 ~~~
-InPersistentCongestion(largest_lost):
-  // Persistent congestion cannot be declared on the
-  // first RTT sample.
-  if (is first RTT sample):
-    return false
-  pto = smoothed_rtt + max(4 * rttvar, kGranularity) +
-    max_ack_delay
-  congestion_period = pto * kPersistentCongestionThreshold
-  // Determine if all packets in the time period before the
-  // largest newly lost packet, including the edges and
-  // across all packet number spaces, are marked lost.
-  return AreAllPacketsLost(largest_lost, congestion_period)
-
 OnPacketsLost(lost_packets):
   // Remove lost packets from bytes_in_flight.
   for lost_packet in lost_packets:
     bytes_in_flight -= lost_packet.sent_bytes
   OnCongestionEvent(lost_packets.largest().time_sent)
-  // Collapse congestion window if persistent congestion
-  if (InPersistentCongestion(lost_packets.largest())):
+  // Reset the congestion window if the loss of these
+  // packets indicates persistent congestion.
+  if (InPersistentCongestion(lost_packets)):
     congestion_window = kMinimumWindow
+    ssthresh = infinite
+    congestion_recovery_start_time = 0
 ~~~
 
 ## Upon dropping Initial or Handshake keys

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1699,7 +1699,6 @@ OnPacketsLost(lost_packets):
   // packets indicates persistent congestion.
   if (InPersistentCongestion(lost_packets)):
     congestion_window = kMinimumWindow
-    ssthresh = infinite
     congestion_recovery_start_time = 0
 ~~~
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1751,10 +1751,10 @@ OnPacketsLost(lost_packets):
   // packets indicates persistent congestion.
   // Disregard packets sent prior to getting an RTT sample.
   assert(first_rtt_sample != 0)
-  pc_lost = lost_packets
-  for lost in pc_lost:
-    if lost.time_sent <= first_rtt_sample:
-      pc_lost.remove(lost)
+  pc_lost = []
+  for lost in lost_packets:
+    if lost.time_sent > first_rtt_sample:
+      pc_lost.insert(lost)
   if (InPersistentCongestion(pc_lost)):
     congestion_window = kMinimumWindow
     congestion_recovery_start_time = 0


### PR DESCRIPTION
This removes that function, relying instead on comments and the
definition in text (which people have noted is now very clear).

I have also reset a couple of extra variables in this case.  It is
important to catch all of these because if you don't you get poor
outcomes.

The only question I have is regarding bytes in flight.  I think that we
need to keep tracking those bytes, or the overall accounting gets messy.
That is what our implementation does anyway.

Closes #4010.
Closes #3972.