### PR TITLE
[qpack] remove nameIndex from pseudocode

### DIFF
--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -1580,7 +1580,7 @@ for line in field_lines:
   if dynamicIndex is None:
     # Could not index it, literal
     if dynamicNameIndex is not None:
-      # encode literal with dynamic name, possibly above base
+      # Encode literal with dynamic name, possibly above base
       encodeDynamicLiteral(streamBuffer, dynamicNameIndex,
                            base, line)
       requiredInsertCount = max(requiredInsertCount,

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -1579,13 +1579,15 @@ for line in field_lines:
 
   if dynamicIndex is None:
     # Could not index it, literal
-    if nameIndex is None or isStaticName:
-      # Encodes a literal with a static name or literal name
-      encodeLiteral(streamBuffer, nameIndex, line)
-    else:
+    if dynamicNameIndex is not None:
       # encode literal with dynamic name, possibly above base
-      encodeDynamicLiteral(streamBuffer, nameIndex, base, line)
-      requiredInsertCount = max(requiredInsertCount, nameIndex)
+      encodeDynamicLiteral(streamBuffer, dynamicNameIndex,
+                           base, line)
+      requiredInsertCount = max(requiredInsertCount,
+                                dynamicNameIndex)
+    else:
+      # Encodes a literal with a static name or literal name
+      encodeLiteral(streamBuffer, staticNameIndex, line)
   else:
     # Dynamic index reference
     assert(dynamicIndex is not None)


### PR DESCRIPTION
It was split to dynamicNameIndex and staticNameIndex earlier but was still used.

Fixes: #4067