### PR TITLE
Changelogs for -30

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -2493,6 +2493,13 @@ what might be a temporary or intermittent error.
 > **RFC Editor's Note:**  Please remove this section prior to publication of a
 > final version of this document.
 
+## Since draft-ietf-quic-http-29
+
+- Require a connection error if a reserved frame type that corresponds to a
+  frame in HTTP/2 is received (#3991, #3993)
+- Require a connection error if a reserved setting that corresponds to a
+  setting in HTTP/2 is received (#3954, #3955)
+
 ## Since draft-ietf-quic-http-28
 
 - CANCEL_PUSH is recommended even when the stream is reset (#3698, #3700)

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -1619,6 +1619,10 @@ return encoderBuffer, prefixBuffer + streamBuffer
 > **RFC Editor's Note:** Please remove this section prior to publication of a
 > final version of this document.
 
+## Since draft-ietf-quic-qpack-16
+
+Editorial changes only
+
 ## Since draft-ietf-quic-qpack-15
 
 No changes

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1793,6 +1793,20 @@ OnPacketNumberSpaceDiscarded(pn_space):
 
 Issue and pull request numbers are listed with a leading octothorp.
 
+## Since draft-ietf-quic-recovery-29
+
+- Allow caching of packets that can't be decrypted, by allowing the reported
+  acknowledgment delay to exceed max_ack_delay prior to confirming the
+  handshake (#3821, #3980, #4035, #3874)
+- Persistent congestion cannot include packets sent before the first RTT
+  sample for the path (#3875, #3889)
+- Recommend reset of min_rtt in persistent congestion (#3927, #3975)
+- Persistent congestion is independent of packet number space (#3939, #3961)
+- Only limit bursts to the initial window without information about the path
+  (#3892, #3936)
+- Add normative requirements for increasing and reducing the congestion
+  window (#3944, #3978, #3997, #3998)
+
 ## Since draft-ietf-quic-recovery-28
 
 - Refactored pseudocode to correct PTO calculation (#3564, #3674, #3681)

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -2467,6 +2467,12 @@ larger advantage in forging packets than the target of 2^-57.
 
 Issue and pull request numbers are listed with a leading octothorp.
 
+## Since draft-ietf-quic-tls-29
+
+- Updated limits on packet protection (#3788, #3789)
+- Allow for packet processing to continue while waiting for TLS to provide
+  keys (#3821, #3874)
+
 ## Since draft-ietf-quic-tls-28
 
 - Defined limits on the number of packets that can be protected with a single

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -7414,6 +7414,27 @@ incurred.
 
 Issue and pull request numbers are listed with a leading octothorp.
 
+## Since draft-ietf-quic-transport-29
+
+- Require the same connection ID on coalesced packets (#3800, #3930)
+- Allow caching of packets that can't be decrypted, by allowing the reported
+  acknowledgment delay to exceed max_ack_delay prior to confirming the
+  handshake (#3821, #3980, #4035, #3874)
+- Allow connection ID to be used for address validation (#3834, #3924)
+- Required protocol operations are no longer directed at implementations, but
+  are features provided to application protocols (#3838, #3935)
+- Narrow requirements for reset of congestion state on path change (#3842,
+  #3945)
+- Add a three times amplification limit for sending of CONNECTION_CLOSE with
+  reduced state (#3845, #3864)
+- Change error code for invalid RETIRE_CONNECTION_ID frames (#3860, #3861)
+- Recommend retention of state for lost packets to allow for late arrival and
+  avoid unnecessary retransmission (#3956, #3957)
+- Allow a server to reject connections if a client reuses packet numbers after
+  Retry (#3989, #3990)
+- Limit recommendation for immediate acknowledgment to when ack-eliciting
+  packets are reordered (#4001, #4000)
+
 ## Since draft-ietf-quic-transport-28
 
 - Made SERVER_BUSY error (0x2) more generic, now CONNECTION_REFUSED (#3709,


### PR DESCRIPTION
Note that -invariants has a change here, but I don't think that it's worth adding a changelog.

This is everything @MikeBishop.  HTTP only had two, QPACK had none.