### PR TITLE
Three times PTOs allows PTO to expire

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2707,8 +2707,8 @@ ensures that connections are not closed after new activity is initiated.
 
 To avoid excessively small idle timeout periods, endpoints MUST increase the
 idle timeout period to be at least three times the current Probe Timeout (PTO).
-This allows for multiple PTOs to expire prior to idle timeout, allowing for at
-least one packet to be lost prior to idle timeout.
+This allows for multiple PTOs to expire prior to idle timeout, ensuring a single
+packet loss event cannot cause an idle timeout.
 
 
 ### Liveness Testing

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2222,8 +2222,7 @@ defined in {{QUIC-RECOVERY}} is RECOMMENDED.  That is:
 ~~~
 
 This timeout allows for multiple PTOs to expire prior to failing path
-validation, allowing for at least one path validation to be lost before
-declaring failure.
+validation, ensuring one packet loss does not cause path validation failure.
 
 Note that the endpoint might receive packets containing other frames on the new
 path, but a PATH_RESPONSE frame with appropriate data is required for path
@@ -2708,7 +2707,7 @@ ensures that connections are not closed after new activity is initiated.
 To avoid excessively small idle timeout periods, endpoints MUST increase the
 idle timeout period to be at least three times the current Probe Timeout (PTO).
 This allows for multiple PTOs to expire prior to idle timeout, allowing for at
-least one path packet to be lost timing out the connection.
+least one packet to be lost prior to idle timeout.
 
 
 ### Liveness Testing

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2707,8 +2707,8 @@ ensures that connections are not closed after new activity is initiated.
 
 To avoid excessively small idle timeout periods, endpoints MUST increase the
 idle timeout period to be at least three times the current Probe Timeout (PTO).
-This allows for multiple PTOs to expire prior to idle timeout, ensuring a single
-packet loss event cannot cause an idle timeout.
+This allows for multiple PTOs to expire prior to idle timeout, ensuring the idle
+timeout does not expire as a result of a single packet loss.
 
 
 ### Liveness Testing

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2221,6 +2221,10 @@ defined in {{QUIC-RECOVERY}} is RECOMMENDED.  That is:
    validation_timeout = max(3*PTO, 6*kInitialRtt)
 ~~~
 
+This timeout allows for multiple PTOs to expire prior to failing path
+validation, allowing for at least one path validation to be lost before
+declaring failure.
+
 Note that the endpoint might receive packets containing other frames on the new
 path, but a PATH_RESPONSE frame with appropriate data is required for path
 validation to succeed.
@@ -2703,6 +2707,8 @@ ensures that connections are not closed after new activity is initiated.
 
 To avoid excessively small idle timeout periods, endpoints MUST increase the
 idle timeout period to be at least three times the current Probe Timeout (PTO).
+This allows for multiple PTOs to expire prior to idle timeout, allowing for at
+least one path packet to be lost timing out the connection.
 
 
 ### Liveness Testing

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2222,7 +2222,8 @@ defined in {{QUIC-RECOVERY}} is RECOMMENDED.  That is:
 ~~~
 
 This timeout allows for multiple PTOs to expire prior to failing path
-validation, ensuring one packet loss does not cause path validation failure.
+validation, so that loss of a single PATH_CHALLENGE or PATH_RESPONSE frame
+does not cause path validation failure.
 
 Note that the endpoint might receive packets containing other frames on the new
 path, but a PATH_RESPONSE frame with appropriate data is required for path


### PR DESCRIPTION
I believe these two cases are both 3*PTO to allow the PTO to expire at least once before declaring path validation failure and idle timeout.

Fixes #3987

Closes #4071 