### PR TITLE
Fix conflicting error codes

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -2001,16 +2001,12 @@ secrets.
 
 # IANA Considerations
 
-This document does not create any new IANA registries, but it registers the
-values in the following registries:
+This document registers the quic_transport_parameters extension found in
+{{quic_parameters}} in the TLS ExtensionType Values Registry
+{{!TLS-REGISTRIES=RFC8447}}.
 
-* TLS ExtensionType Values Registry {{!TLS-REGISTRIES=RFC8447}} - IANA is to
-  register the quic_transport_parameters extension found in {{quic_parameters}}.
-  The Recommended column is to be marked Yes.  The TLS 1.3 Column is to include
-  CH and EE.
-
-* QUIC Transport Error Codes Registry {{QUIC-TRANSPORT}} - IANA is to register
-  the KEY_UPDATE_ERROR (0xe), as described in {{key-update-error}}.
+The Recommended column is to be marked Yes. The TLS 1.3 Column is to include CH
+and EE.
 
 
 --- back

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -6310,7 +6310,12 @@ CRYPTO_BUFFER_EXCEEDED (0xd):
 
 : An endpoint has received more data in CRYPTO frames than it can buffer.
 
-AEAD_LIMIT_REACHED (0xe):
+KEY_UPDATE_ERROR (0xe):
+
+: An endpoint detected errors in performing key updates; see Section 6 of
+  {{QUIC-TLS}}.
+
+AEAD_LIMIT_REACHED (0xf):
 
 : An endpoint has reached the confidentiality or integrity limit for the AEAD
   algorithm used by the given connection.
@@ -7332,6 +7337,8 @@ The initial contents of this registry are shown in {{iana-error-table}}.
 | 0xb   | INVALID_TOKEN             | Invalid Token Received        | {{error-codes}} |
 | 0xc   | APPLICATION_ERROR         | Application error             | {{error-codes}} |
 | 0xd   | CRYPTO_BUFFER_EXCEEDED    | CRYPTO data buffer overflowed | {{error-codes}} |
+| 0xe   | KEY_UPDATE_ERROR          | Invalid packet protection update | {{error-codes}} |
+| 0xf   | AEAD_LIMIT_REACHED        | Excessive use of packet protection keys | {{error-codes}} |
 {: #iana-error-table title="Initial QUIC Transport Error Codes Entries"}
 
 


### PR DESCRIPTION
I guess technically we could have let both of these stand and used the
same error code for both conditions, but that seems unnecessary.  Moving
the AEAD limit seems easier.

Closes #4087.