### PR TITLE
Restore missing field

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1398,6 +1398,7 @@ Retry Pseudo-Packet {
   DCID Len (8),
   Destination Connection ID (0..160),
   SCID Len (8),
+  Source Connection ID (0..160),
   Retry Token (..),
 }
 ~~~


### PR DESCRIPTION
This was a copy-paste error that it seems we never fixed.

Closes #4094.