### PR TITLE
Nits in TLS Section 5.7

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1316,7 +1316,7 @@ Note:
   receives all server handshake messages.
 
 
-## Receiving Out-of-Order Protected Frames {#pre-hs-protected}
+## Receiving Out-of-Order Protected Packets {#pre-hs-protected}
 
 Due to reordering and loss, protected packets might be received by an endpoint
 before the final TLS handshake messages are received.  A client will be unable

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1331,7 +1331,7 @@ handshake messages from a client, it is missing assurances on the client state:
   pre-shared key and validated the client's pre-shared key binder; see Section
   4.2.11 of {{!TLS13}}.
 
-- The client has not demonstrated liveness, unless a RETRY packet was used.
+- The client has not demonstrated liveness, unless a Retry packet was used.
 
 - Any received 0-RTT data that the server responds to might be due to a replay
   attack.

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1331,7 +1331,9 @@ handshake messages from a client, it is missing assurances on the client state:
   pre-shared key and validated the client's pre-shared key binder; see Section
   4.2.11 of {{!TLS13}}.
 
-- The client has not demonstrated liveness, unless a Retry packet was used.
+- The client has not demonstrated liveness, unless the server has validated the
+  client's address with a Retry packet or other means; see Section 8.1 of
+  [QUIC-TRANSPORT].
 
 - Any received 0-RTT data that the server responds to might be due to a replay
   attack.


### PR DESCRIPTION
Three minor changes here; separate if needed:
- The section title refers to frames, but the content discusses packets
- The text refers to a RETRY packet; packet types are not shouting-case
- Retry is not the only way to verify liveness prior to handshake completion (e.g. Connection ID on packets with a multi-round-trip handshake); reference to address validation for more context