### PR TITLE
Migration can be unpermitted

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2329,7 +2329,7 @@ verifies ECN capability as described in {{ecn}}.
 Receiving a packet from a new peer address containing a non-probing frame
 indicates that the peer has migrated to that address.
 
-If the recipient permits the migration, an endpoint MUST send subsequent packets
+If the recipient permits the migration, it MUST send subsequent packets
 to the new peer address and MUST initiate path validation ({{migrate-validate}})
 to verify the peer's ownership of the address if validation is not already
 underway.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2334,9 +2334,10 @@ to the new peer address and MUST initiate path validation ({{migrate-validate}})
 to verify the peer's ownership of the address if validation is not already
 underway.
 
-An endpoint only changes the address that it sends packets to in response to the
-highest-numbered non-probing packet. This ensures that an endpoint does not send
-packets to an old peer address in the case that it receives reordered packets.
+An endpoint only changes the address to which it sends packets in response to
+the highest-numbered non-probing packet. This ensures that an endpoint does not
+send packets to an old peer address in the case that it receives reordered
+packets.
 
 An endpoint MAY send data to an unvalidated peer address, but it MUST protect
 against potential attacks as described in {{address-spoofing}} and

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2329,14 +2329,14 @@ verifies ECN capability as described in {{ecn}}.
 Receiving a packet from a new peer address containing a non-probing frame
 indicates that the peer has migrated to that address.
 
+If the recipient permits the migration, an endpoint MUST send subsequent packets
+to the new peer address and MUST initiate path validation ({{migrate-validate}})
+to verify the peer's ownership of the address if validation is not already
+underway.
+
 An endpoint only changes the address that it sends packets to in response to the
 highest-numbered non-probing packet. This ensures that an endpoint does not send
 packets to an old peer address in the case that it receives reordered packets.
-
-In response to such a packet, an endpoint MUST send subsequent packets to the
-new peer address and MUST initiate path validation ({{migrate-validate}}) to
-verify the peer's ownership of the address if validation is not already
-underway.
 
 An endpoint MAY send data to an unvalidated peer address, but it MUST protect
 against potential attacks as described in {{address-spoofing}} and


### PR DESCRIPTION
Reading over the text in the sections @ekr commented on, it feels like the heart of the conflict is this:

- Some sections say that servers don't migrate in this version of QUIC.
- This section speaks generically about what an implementation MUST do if the peer migrates, suggesting clients have to obey them if the server does migrate.

Additionally, we've discussed mitigations to other issues (e.g. #3765) in which a server might consider certain probes/migrations unacceptable and simply not respond to them.  That possibility isn't currently discussed in the text.

The solution to both appears to be the same:  Condition the MUST on acceptance of the migration.  If the migration is somehow unacceptable (the remote address violates some deployment-specific rule, or the migration is prohibited by this version of QUIC) these requirements simply don't attach.  The recipient *doesn't* change where they're sending packets or validate the new address.  That might mean the connection fails rather than migrating, but that's the price you pay.

I think this is editorial, because it acknowledges a carve-out in the MUST that we've always implicitly used to accommodate other text in the doc.

Fixes #4063.