### PR TITLE
TLS: improve check for unconsumed data on encryption level changes

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -441,10 +441,9 @@ network, it proceeds as follows:
 
 - If the packet is from a new encryption level, it is saved for later processing
   by TLS.  Once TLS moves to receiving from this encryption level, saved data
-  can be provided to TLS.  When providing data from any new encryption level to
-  TLS, if there is data from a previous encryption level that TLS has not
-  consumed, this MUST be treated as a connection error of type
-  PROTOCOL_VIOLATION.
+  can be provided to TLS.  When TLS provides keys for a higher encryption level,
+  if there is data from a previous encryption level that TLS has not consumed,
+  this MUST be treated as a connection error of type PROTOCOL_VIOLATION.
 
 Each time that TLS is provided with new data, new handshake bytes are requested
 from TLS.  TLS might not provide any bytes if the handshake messages it has


### PR DESCRIPTION
This check really is triggered by TLS providing new keys, not QUIC delivering data on a higher encryption level.

Otherwise, in the case where no session ticket is sent, this condition would go undetected for unconsumed data at the Handshake encryption level.