### PR TITLE
fix wrong stream type used in sending state stream secion

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -538,7 +538,7 @@ allocating a stream ID to a stream until it sends the first STREAM frame and
 enters this state, which can allow for better stream prioritization.
 
 The sending part of a bidirectional stream initiated by a peer (type 0 for a
-server, type 1 for a client) starts in the "Ready" state when the receiving part
+client, type 1 for a server) starts in the "Ready" state when the receiving part
 is created.
 
 In the "Send" state, an endpoint transmits - and retransmits as necessary -


### PR DESCRIPTION
type 0 is for a client initiated stream and type 1 is for a server initiated stream