### PR TITLE
Server SHOULD send full-sized datagrams until the path is validated

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -669,7 +669,7 @@ unacknowledged CRYPTO data earlier than the PTO expiry, subject to the address
 validation limits in Section 8.1 of {{QUIC-TRANSPORT}}. Doing so at most once
 for each connection is adequate to quickly recover from a single packet loss.
 Endpoints that do not back off from retransmitting packets in response to
-unauthenticated data risks creating an infinite exchange of packets.
+unauthenticated data risk creating an infinite exchange of packets.
 
 Endpoints can also use coalesced packets (see Section 12.2 of
 {{QUIC-TRANSPORT}}) to ensure that each datagram elicits at least one

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -663,9 +663,10 @@ in Initial packets, or the client's estimated RTT is too small. When a
 client receives Handshake or 1-RTT packets prior to obtaining Handshake keys,
 it may assume some or all of the server's Initial packets were lost.
 
-To speed up handshake completion under these conditions, an endpoint MAY send
-a packet containing unacknowledged CRYPTO data earlier than the PTO expiry,
-subject to the address validation limits in Section 8.1 of {{QUIC-TRANSPORT}}.
+To speed up handshake completion under these conditions, an endpoint MAY, for a
+limited number of occasions per each connection, send a packet containing
+unacknowledged CRYPTO data earlier than the PTO expiry, subject to the address
+validation limits in Section 8.1 of {{QUIC-TRANSPORT}}.
 
 Endpoints can also use coalesced packets (see Section 12.2 of
 {{QUIC-TRANSPORT}}) to ensure that each datagram elicits at least one

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -668,6 +668,8 @@ limited number of occasions per each connection, send a packet containing
 unacknowledged CRYPTO data earlier than the PTO expiry, subject to the address
 validation limits in Section 8.1 of {{QUIC-TRANSPORT}}. Doing so at most once
 for each connection is adequate to quickly recover from a single packet loss.
+Endpoints that do not back off from retransmitting packets in response to
+unauthenticated data risks creating an infinite exchange of packets.
 
 Endpoints can also use coalesced packets (see Section 12.2 of
 {{QUIC-TRANSPORT}}) to ensure that each datagram elicits at least one

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -668,7 +668,7 @@ limited number of occasions per each connection, send a packet containing
 unacknowledged CRYPTO data earlier than the PTO expiry, subject to the address
 validation limits in Section 8.1 of {{QUIC-TRANSPORT}}. Doing so at most once
 for each connection is adequate to quickly recover from a single packet loss.
-Endpoints that do not back off from retransmitting packets in response to
+Endpoints that do not cease retransmitting packets in response to
 unauthenticated data risk creating an infinite exchange of packets.
 
 Endpoints can also use coalesced packets (see Section 12.2 of

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -667,7 +667,7 @@ To speed up handshake completion under these conditions, an endpoint MAY, for a
 limited number of occasions per each connection, send a packet containing
 unacknowledged CRYPTO data earlier than the PTO expiry, subject to the address
 validation limits in Section 8.1 of {{QUIC-TRANSPORT}}. Doing so at most once
-for each connection will be adequate to accommodate common loss scenarios.
+for each connection is adequate to quickly recover from a single packet loss.
 
 Endpoints can also use coalesced packets (see Section 12.2 of
 {{QUIC-TRANSPORT}}) to ensure that each datagram elicits at least one

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -666,7 +666,8 @@ it may assume some or all of the server's Initial packets were lost.
 To speed up handshake completion under these conditions, an endpoint MAY, for a
 limited number of occasions per each connection, send a packet containing
 unacknowledged CRYPTO data earlier than the PTO expiry, subject to the address
-validation limits in Section 8.1 of {{QUIC-TRANSPORT}}.
+validation limits in Section 8.1 of {{QUIC-TRANSPORT}}. Doing so at most once
+for each connection will be adequate to accommodate common loss scenarios.
 
 Endpoints can also use coalesced packets (see Section 12.2 of
 {{QUIC-TRANSPORT}}) to ensure that each datagram elicits at least one

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4101,9 +4101,9 @@ bytes.  A server MAY also immediately close the connection by sending a
 CONNECTION_CLOSE frame with an error code of PROTOCOL_VIOLATION; see
 {{immediate-close-hs}}.
 
-Until the server validates the client address, it MUST limit the
-the number of bytes it sends and SHOULD pad Initial packets; see
-{{address-validation}}.
+The server MUST also limit the number of bytes it sends before validating the
+address of the client, and additionally SHOULD pad the Initial packets that it
+sends; see {{address-validation}}.
 
 
 ## Path Maximum Transmission Unit

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1943,8 +1943,8 @@ the client during connection establishment with a Retry packet (see
 {{validate-retry}}) or in a previous connection using the NEW_TOKEN frame (see
 {{validate-future}}).
 
-Until the path is validated, a server SHOULD pad the Initial, Handshake, 1-RTT
-packets it sends so that their UDP payload size will be at least 1200 bytes.
+Until the path is validated, a server SHOULD pad all packets it sends, other
+than Retry, so that their UDP payload size will be at least 1200 bytes.
 Doing so guarantees that the handshake would make progress only when the path is
 capable of handling QUIC traffic; see {{packet-size}}.
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4101,7 +4101,7 @@ bytes.  A server MAY also immediately close the connection by sending a
 CONNECTION_CLOSE frame with an error code of PROTOCOL_VIOLATION; see
 {{immediate-close-hs}}.
 
-Until the server validates the client address, a server MUST also limit the
+Until the server validates the client address, it MUST limit the
 the number of bytes it sends and SHOULD pad the Initial packets; see
 {{address-validation}}.
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1920,12 +1920,14 @@ that are uniquely attributed to a single connection. This includes datagrams
 that contain packets that are successfully processed and datagrams that contain
 packets that are all discarded.
 
-Clients MUST and servers SHOULD ensure that UDP datagrams containing Initial
-packets have UDP payloads of at least 1200 bytes, adding PADDING frames as
-necessary.  A client that sends padded datagrams allows the server to send more
-data prior to completing address validation.  Endpoints sending UDP datagrams of
-at least 1200 bytes ensures that the handshake progresses only if the path is
-capable of handling QUIC traffic; see {{packet-size}}.
+Clients MUST ensure that UDP datagrams containing Initial packets have UDP
+payloads of at least 1200 bytes, adding PADDING frames as necessary.  Servers
+MUST ensure that UDP datagrams containing Initial packets carrying CRYPTO frames
+have UDP payloads of at least 1200 bytes.  A client that sends padded datagrams
+allows the server to send more data prior to completing address validation.
+Endpoints sending UDP datagrams of at least 1200 bytes ensures that the
+handshake progresses only if the path is capable of handling QUIC traffic; see
+{{packet-size}}.
 
 Loss of an Initial or Handshake packet from the server can cause a deadlock if
 the client does not send additional Initial or Handshake packets. A deadlock
@@ -4086,24 +4088,28 @@ fragmentation on the path.
 A client MUST expand the payload of all UDP datagrams carrying Initial packets
 to at least the smallest allowed maximum packet size (1200 bytes) by adding
 PADDING frames to the Initial packet or by coalescing the Initial packet; see
-{{packet-coalesce}}.  Sending a UDP datagram of this size ensures that the
-network path from the client to the server supports a reasonable Path Maximum
-Transmission Unit (PMTU).  This also helps reduce the amplitude of amplification
-attacks caused by server responses toward an unverified client address; see
+{{packet-coalesce}}.  Similarly, a server MUST expand the payload of all UDP
+datagrams carrying Initial packets that contain CRYPTO frames.  Sending UDP
+datagrams of this size ensures that the network path supports a reasonable Path Maximum Transmission Unit (PMTU), in both directions.  Additionally, a client
+padding Initial packets helps reduce the amplitude of amplification attacks
+caused by server responses toward an unverified client address; see
 {{address-validation}}.
 
-Datagrams containing Initial packets MAY exceed 1200 bytes if the client
+Datagrams containing Initial packets MAY exceed 1200 bytes if the endpoint
 believes that the network path and peer both support the size that it chooses.
 
 A server MUST discard an Initial packet that is carried in a UDP datagram with a
 payload that is less than the smallest allowed maximum packet size of 1200
 bytes.  A server MAY also immediately close the connection by sending a
 CONNECTION_CLOSE frame with an error code of PROTOCOL_VIOLATION; see
-{{immediate-close-hs}}.
+{{immediate-close-hs}}.  When a client receives an Initial packet containing a
+CRYPTO frame that is carried in a UDP datagram with a payload that is less than
+1200 bytes, that client MAY close the connection by sending a CONNECTION_CLOSE
+frame.
 
 The server MUST also limit the number of bytes it sends before validating the
-address of the client, and additionally SHOULD pad the Initial packets that it
-sends; see {{address-validation}}.
+address of the client, and MUST pad the Initial packets carrying CRYPTO frames
+that it sends; see {{address-validation}}.
 
 
 ## Path Maximum Transmission Unit

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4086,10 +4086,11 @@ to at least the smallest allowed maximum packet size (1200 bytes) by adding
 PADDING frames to the Initial packet or by coalescing the Initial packet; see
 {{packet-coalesce}}.  Similarly, a server MUST expand the payload of all UDP
 datagrams carrying ack-eliciting Initial packets to at least the smallest
-allowed maximum packet size (1200 bytes).  Sending UDP datagrams of this size ensures that the network path supports a reasonable Path Maximum Transmission Unit
-(PMTU), in both directions.  Additionally, a client that expands Initial packets
-helps reduce the amplitude of amplification attacks caused by server responses
-toward an unverified client address; see {{address-validation}}.
+allowed maximum packet size (1200 bytes).  Sending UDP datagrams of this size
+ensures that the network path supports a reasonable Path Maximum Transmission
+Unit (PMTU), in both directions.  Additionally, a client that expands Initial
+packets helps reduce the amplitude of amplification attacks caused by server
+responses toward an unverified client address; see {{address-validation}}.
 
 Datagrams containing Initial packets MAY exceed 1200 bytes if the sender
 believes that the network path and peer both support the size that it chooses.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4108,8 +4108,7 @@ that is carried in a UDP datagram with a payload that is less than 1200 bytes,
 that client MAY close the connection by sending a CONNECTION_CLOSE frame.
 
 The server MUST also limit the number of bytes it sends before validating the
-address of the client, and MUST pad ack-eliciting Initial packets that it sends;
-see {{address-validation}}.
+address of the client; see {{address-validation}}.
 
 
 ## Path Maximum Transmission Unit

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1923,7 +1923,7 @@ packets that are all discarded.
 Clients MUST and servers SHOULD ensure that UDP datagrams containing Initial
 packets have UDP payloads of at least 1200 bytes, adding PADDING frames as
 necessary.  A client that sends padded datagrams allows the server to send more
-data prior to completing address validation.  Endpoints using UDP datagrams of
+data prior to completing address validation.  Endpoints sending UDP datagrams of
 at least 1200 bytes ensures that the handshake progresses only if the path is
 capable of handling QUIC traffic; see {{packet-size}}.
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1943,10 +1943,10 @@ the client during connection establishment with a Retry packet (see
 {{validate-retry}}) or in a previous connection using the NEW_TOKEN frame (see
 {{validate-future}}).
 
-Until the client address is validated, a server SHOULD ensure that all packets
-it sends, with the exception of Retry packets, have a UDP payload size of at
-least 1200 bytes. Doing so ensures that the handshake progresses only if the
-path is capable of handling QUIC traffic; see {{packet-size}}.
+Until the client address is validated, servers SHOULD ensure that UDP datagrams
+containing Initial packets have UDP payloads of at least 1200 bytes.  Doing so
+ensures that the handshake progresses only if the path is capable of handling
+QUIC traffic; see {{packet-size}}.
 
 In addition to sending limits imposed prior to address validation, servers are
 also constrained in what they can send by the limits set by the congestion
@@ -4105,7 +4105,7 @@ CONNECTION_CLOSE frame with an error code of PROTOCOL_VIOLATION; see
 {{immediate-close-hs}}.
 
 Until the server validates the client address, a server MUST also limit the
-the number of bytes it sends and SHOULD pad the packets; see
+the number of bytes it sends and SHOULD pad the Initial packets; see
 {{address-validation}}.
 
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1920,10 +1920,12 @@ that are uniquely attributed to a single connection. This includes datagrams
 that contain packets that are successfully processed and datagrams that contain
 packets that are all discarded.
 
-Clients MUST ensure that UDP datagrams containing Initial packets have UDP
-payloads of at least 1200 bytes, adding PADDING frames as necessary.
-A client that sends padded datagrams allows the server to
-send more data prior to completing address validation.
+Clients MUST and servers SHOULD ensure that UDP datagrams containing Initial
+packets have UDP payloads of at least 1200 bytes, adding PADDING frames as
+necessary.  A client that sends padded datagrams allows the server to send more
+data prior to completing address validation.  Endpoints using UDP datagrams of
+at least 1200 bytes ensures that the handshake progresses only if the path is
+capable of handling QUIC traffic; see {{packet-size}}.
 
 Loss of an Initial or Handshake packet from the server can cause a deadlock if
 the client does not send additional Initial or Handshake packets. A deadlock
@@ -1942,11 +1944,6 @@ address validation prior to completing the handshake. This token is delivered to
 the client during connection establishment with a Retry packet (see
 {{validate-retry}}) or in a previous connection using the NEW_TOKEN frame (see
 {{validate-future}}).
-
-Until the client address is validated, servers SHOULD ensure that UDP datagrams
-containing Initial packets have UDP payloads of at least 1200 bytes.  Doing so
-ensures that the handshake progresses only if the path is capable of handling
-QUIC traffic; see {{packet-size}}.
 
 In addition to sending limits imposed prior to address validation, servers are
 also constrained in what they can send by the limits set by the congestion

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4104,8 +4104,9 @@ bytes.  A server MAY also immediately close the connection by sending a
 CONNECTION_CLOSE frame with an error code of PROTOCOL_VIOLATION; see
 {{immediate-close-hs}}.
 
-The server MUST also limit the number of bytes it sends before validating the
-address of the client; see {{address-validation}}.
+Until the server validates the client address, a server MUST also limit the
+the number of bytes it sends and SHOULD pad the packets; see
+{{address-validation}}.
 
 
 ## Path Maximum Transmission Unit

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4096,7 +4096,7 @@ Initial packets helps reduce the amplitude of amplification attacks caused by
 server responses toward an unverified client address; see
 {{address-validation}}.
 
-Datagrams containing Initial packets MAY exceed 1200 bytes if the endpoint
+Datagrams containing Initial packets MAY exceed 1200 bytes if the sender
 believes that the network path and peer both support the size that it chooses.
 
 A server MUST discard an Initial packet that is carried in a UDP datagram with a

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1922,11 +1922,11 @@ packets that are all discarded.
 
 Clients MUST ensure that UDP datagrams containing Initial packets have UDP
 payloads of at least 1200 bytes, adding PADDING frames as necessary.  Servers
-MUST ensure that UDP datagrams containing Initial packets carrying CRYPTO frames
-have UDP payloads of at least 1200 bytes.  A client that sends padded datagrams
-allows the server to send more data prior to completing address validation.
-Endpoints sending UDP datagrams of at least 1200 bytes ensures that the
-handshake progresses only if the path is capable of handling QUIC traffic; see
+MUST ensure that UDP datagrams containing ack-eliciting Initial packets have UDP
+payloads of at least 1200 bytes.  A client that sends padded datagrams allows
+the server to send more data prior to completing address validation.  Endpoints
+sending UDP datagrams of at least 1200 bytes ensures that the handshake
+progresses only if the path is capable of handling QUIC traffic; see
 {{packet-size}}.
 
 Loss of an Initial or Handshake packet from the server can cause a deadlock if
@@ -4089,11 +4089,11 @@ A client MUST expand the payload of all UDP datagrams carrying Initial packets
 to at least the smallest allowed maximum packet size (1200 bytes) by adding
 PADDING frames to the Initial packet or by coalescing the Initial packet; see
 {{packet-coalesce}}.  Similarly, a server MUST expand the payload of all UDP
-datagrams carrying Initial packets that contain CRYPTO frames.  Sending UDP
-datagrams of this size ensures that the network path supports a reasonable Path
-Maximum Transmission Unit (PMTU), in both directions.  Additionally, a client
-padding Initial packets helps reduce the amplitude of amplification attacks
-caused by server responses toward an unverified client address; see
+datagrams carrying ack-eliciting Initial packets.  Sending UDP datagrams of this
+size ensures that the network path supports a reasonable Path Maximum
+Transmission Unit (PMTU), in both directions.  Additionally, a client padding
+Initial packets helps reduce the amplitude of amplification attacks caused by
+server responses toward an unverified client address; see
 {{address-validation}}.
 
 Datagrams containing Initial packets MAY exceed 1200 bytes if the endpoint
@@ -4103,14 +4103,13 @@ A server MUST discard an Initial packet that is carried in a UDP datagram with a
 payload that is less than the smallest allowed maximum packet size of 1200
 bytes.  A server MAY also immediately close the connection by sending a
 CONNECTION_CLOSE frame with an error code of PROTOCOL_VIOLATION; see
-{{immediate-close-hs}}.  When a client receives an Initial packet containing a
-CRYPTO frame that is carried in a UDP datagram with a payload that is less than
-1200 bytes, that client MAY close the connection by sending a CONNECTION_CLOSE
-frame.
+{{immediate-close-hs}}.  When a client receives an ack-eliciting Initial packet
+that is carried in a UDP datagram with a payload that is less than 1200 bytes,
+that client MAY close the connection by sending a CONNECTION_CLOSE frame.
 
 The server MUST also limit the number of bytes it sends before validating the
-address of the client, and MUST pad the Initial packets carrying CRYPTO frames
-that it sends; see {{address-validation}}.
+address of the client, and MUST pad ack-eliciting Initial packets that it sends;
+see {{address-validation}}.
 
 
 ## Path Maximum Transmission Unit

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1946,7 +1946,7 @@ the client during connection establishment with a Retry packet (see
 Until the path is validated, a server SHOULD pad the Initial, Handshake, 1-RTT
 packets it sends so that their UDP payload size will be at least 1200 bytes.
 Doing so guarantees that the handshake would make progress only when the path is
-capable of handling QUIC traffic (see {{packet-size}}).
+capable of handling QUIC traffic; see {{packet-size}}.
 
 In addition to sending limits imposed prior to address validation, servers are
 also constrained in what they can send by the limits set by the congestion

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1943,10 +1943,10 @@ the client during connection establishment with a Retry packet (see
 {{validate-retry}}) or in a previous connection using the NEW_TOKEN frame (see
 {{validate-future}}).
 
-Until the path is validated, a server SHOULD pad all packets it sends, other
-than Retry, so that their UDP payload size will be at least 1200 bytes.
-Doing so guarantees that the handshake would make progress only when the path is
-capable of handling QUIC traffic; see {{packet-size}}.
+Until the client address is validated, a server SHOULD ensure that all
+packets it sends, with the exception of Retry packets, have a UDP payload
+size of at least 1200 bytes. Doing so ensures that the handshake progresses
+only if the path is capable of handling QUIC traffic; see {{packet-size}}.
 
 In addition to sending limits imposed prior to address validation, servers are
 also constrained in what they can send by the limits set by the congestion

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4090,7 +4090,8 @@ to at least the smallest allowed maximum packet size (1200 bytes) by adding
 PADDING frames to the Initial packet or by coalescing the Initial packet; see
 {{packet-coalesce}}.  Similarly, a server MUST expand the payload of all UDP
 datagrams carrying Initial packets that contain CRYPTO frames.  Sending UDP
-datagrams of this size ensures that the network path supports a reasonable Path Maximum Transmission Unit (PMTU), in both directions.  Additionally, a client
+datagrams of this size ensures that the network path supports a reasonable Path
+Maximum Transmission Unit (PMTU), in both directions.  Additionally, a client
 padding Initial packets helps reduce the amplitude of amplification attacks
 caused by server responses toward an unverified client address; see
 {{address-validation}}.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1943,10 +1943,10 @@ the client during connection establishment with a Retry packet (see
 {{validate-retry}}) or in a previous connection using the NEW_TOKEN frame (see
 {{validate-future}}).
 
-Until the client address is validated, a server SHOULD ensure that all
-packets it sends, with the exception of Retry packets, have a UDP payload
-size of at least 1200 bytes. Doing so ensures that the handshake progresses
-only if the path is capable of handling QUIC traffic; see {{packet-size}}.
+Until the client address is validated, a server SHOULD ensure that all packets
+it sends, with the exception of Retry packets, have a UDP payload size of at
+least 1200 bytes. Doing so ensures that the handshake progresses only if the
+path is capable of handling QUIC traffic; see {{packet-size}}.
 
 In addition to sending limits imposed prior to address validation, servers are
 also constrained in what they can send by the limits set by the congestion

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1921,13 +1921,9 @@ that contain packets that are successfully processed and datagrams that contain
 packets that are all discarded.
 
 Clients MUST ensure that UDP datagrams containing Initial packets have UDP
-payloads of at least 1200 bytes, adding PADDING frames as necessary.  Servers
-MUST ensure that UDP datagrams containing ack-eliciting Initial packets have UDP
-payloads of at least 1200 bytes.  A client that sends padded datagrams allows
-the server to send more data prior to completing address validation.  Endpoints
-sending UDP datagrams of at least 1200 bytes ensures that the handshake
-progresses only if the path is capable of handling QUIC traffic; see
-{{packet-size}}.
+payloads of at least 1200 bytes, adding PADDING frames as necessary.
+A client that sends padded datagrams allows the server to
+send more data prior to completing address validation.
 
 Loss of an Initial or Handshake packet from the server can cause a deadlock if
 the client does not send additional Initial or Handshake packets. A deadlock

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4085,12 +4085,11 @@ A client MUST expand the payload of all UDP datagrams carrying Initial packets
 to at least the smallest allowed maximum packet size (1200 bytes) by adding
 PADDING frames to the Initial packet or by coalescing the Initial packet; see
 {{packet-coalesce}}.  Similarly, a server MUST expand the payload of all UDP
-datagrams carrying ack-eliciting Initial packets.  Sending UDP datagrams of this
-size ensures that the network path supports a reasonable Path Maximum
-Transmission Unit (PMTU), in both directions.  Additionally, a client padding
-Initial packets helps reduce the amplitude of amplification attacks caused by
-server responses toward an unverified client address; see
-{{address-validation}}.
+datagrams carrying ack-eliciting Initial packets to at least the smallest
+allowed maximum packet size (1200 bytes).  Sending UDP datagrams of this size ensures that the network path supports a reasonable Path Maximum Transmission Unit
+(PMTU), in both directions.  Additionally, a client that expands Initial packets
+helps reduce the amplitude of amplification attacks caused by server responses
+toward an unverified client address; see {{address-validation}}.
 
 Datagrams containing Initial packets MAY exceed 1200 bytes if the sender
 believes that the network path and peer both support the size that it chooses.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4102,7 +4102,7 @@ CONNECTION_CLOSE frame with an error code of PROTOCOL_VIOLATION; see
 {{immediate-close-hs}}.
 
 Until the server validates the client address, it MUST limit the
-the number of bytes it sends and SHOULD pad the Initial packets; see
+the number of bytes it sends and SHOULD pad Initial packets; see
 {{address-validation}}.
 
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1943,6 +1943,11 @@ the client during connection establishment with a Retry packet (see
 {{validate-retry}}) or in a previous connection using the NEW_TOKEN frame (see
 {{validate-future}}).
 
+Until the path is validated, a server SHOULD pad the Initial, Handshake, 1-RTT
+packets it sends so that their UDP payload size will be at least 1200 bytes.
+Doing so guarantees that the handshake would make progress only when the path is
+capable of handling QUIC traffic (see {{packet-size}}).
+
 In addition to sending limits imposed prior to address validation, servers are
 also constrained in what they can send by the limits set by the congestion
 controller.  Clients are only constrained by the congestion controller.


### PR DESCRIPTION
Closes #4183.

The recommendation is written so that it would prevent the two failure modes discussed in the issue:
* client and server doing ping-pong due to only the tail of the server-sent packets reaching the client
* the connection getting stuck after the handshake is complete, when Initial and Handshake packets will be small (particularly when TLS session tickets are used)