### PR TITLE
Datagram size, not packet size

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4055,12 +4055,13 @@ MUST disable ECN if validation later fails.
 # Datagram Size {#datagram-size}
 
 A UDP datagram can include one or more QUIC packets. The datagram size refers to
-the total UDP payload size of a single UDP datagram carrying QUIC packets. That
-is, the datagram size includes includes the QUIC headers and protected payload,
-but not the UDP or IP headers.
+the total UDP payload size of a single UDP datagram carrying QUIC packets. The
+datagram size includes includes the QUIC headers and protected payload, but not
+the UDP or IP headers.
 
 The maximum datagram size is defined as the largest size of UDP payload that can
-be sent across a network path using a single UDP datagram.
+be sent across a network path using a single UDP datagram.  The maximum datagram
+size MUST be at least 1200 bytes.
 
 QUIC depends upon a minimum IP packet size of at least 1280 bytes.  This is the
 IPv6 minimum size ({{?IPv6=RFC8200}}) and is also supported by most modern IPv4
@@ -4188,7 +4189,7 @@ size. The MIN_PLPMTU is the same as the BASE_PLPMTU.
 
 QUIC endpoints implementing DPLPMTUD maintain a DPLPMTUD Maximum Packet Size
 (MPS, Section 4.4 of {{!DPLPMTUD}}) for each combination of local and remote IP
-addresses.
+addresses.  This corresponds to the maximum datagram size.
 
 
 ### DPLPMTUD and Initial Connectivity

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4056,8 +4056,8 @@ MUST disable ECN if validation later fails.
 
 A UDP datagram can include one or more QUIC packets. The datagram size refers to
 the total UDP payload size of a single UDP datagram carrying QUIC packets. The
-datagram size includes includes one or more QUIC packet headers and the
-protected payloads, but not the UDP or IP headers.
+datagram size includes one or more QUIC packet headers and protected payloads,
+but not the UDP or IP headers.
 
 The maximum datagram size is defined as the largest size of UDP payload that can
 be sent across a network path using a single UDP datagram.  The maximum datagram
@@ -4065,8 +4065,9 @@ size MUST be at least 1200 bytes.
 
 QUIC depends upon a minimum IP packet size of at least 1280 bytes.  This is the
 IPv6 minimum size ({{?IPv6=RFC8200}}) and is also supported by most modern IPv4
-networks.  Assuming the minimum IP header size, this results in a maximum
-datagram size of 1232 bytes for IPv6 and 1252 bytes for IPv4.
+networks.  Assuming the minimum IP header size of 40 bytes for IPv6 and 20 bytes
+for IPv4 and a UDP header size of 8 bytes, this results in a maximum datagram
+size of 1232 bytes for IPv6 and 1252 bytes for IPv4.
 
 Any maximum datagram size larger than 1200 bytes can be discovered using Path
 Maximum Transmission Unit Discovery (PMTUD; see {{pmtud}}) or Datagram
@@ -4111,11 +4112,11 @@ address of the client; see {{address-validation}}.
 ## Path Maximum Transmission Unit
 
 The Path Maximum Transmission Unit (PMTU) is the maximum size of the entire IP
-packet including the IP header, UDP header, and UDP payload.  The UDP payload
-includes one or more QUIC packet headers, the protected payloads, and any
-authentication fields.  The PMTU can depend on path characteristics, and can
-therefore change over time.  The largest UDP payload an endpoint sends at any
-given time is referred to as the endpoint's maximum datagram size.
+packet including the IP header, UDP header, and UDP payload. The UDP payload
+includes one or more QUIC packet headers and protected payloads. The PMTU can
+depend on path characteristics, and can therefore change over time. The largest
+UDP payload an endpoint sends at any given time is referred to as the endpoint's
+maximum datagram size.
 
 An endpoint SHOULD use DPLPMTUD ({{dplpmtud}}) or PMTUD ({{pmtud}}) to determine
 whether the path to a destination will support a desired maximum datagram size

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -182,7 +182,8 @@ This document describes the core QUIC protocol and is structured as follows:
   - {{packets-frames}} describes concepts related to packets and frames,
   - {{packetization}} defines models for the transmission, retransmission, and
     acknowledgement of data, and
-  - {{packet-size}} specifies rules for managing the size of packets.
+  - {{datagram-size}} specifies rules for managing the size of datagrams
+    carrying QUIC packets.
 
 * Finally, encoding details of QUIC protocol elements are described in:
   - {{versions}} (Versions),
@@ -4051,38 +4052,41 @@ Network routing and path elements can however change mid-connection; an endpoint
 MUST disable ECN if validation later fails.
 
 
-# Packet Size {#packet-size}
+# Datagram Size {#datagram-size}
 
-The QUIC packet size includes the QUIC header and protected payload, but not the
-UDP or IP headers.
+A UDP datagram can include one or more QUIC packets. The datagram size refers to
+the total UDP payload size of a single UDP datagram carrying QUIC packets. That
+is, the datagram size includes includes the QUIC headers and protected payload,
+but not the UDP or IP headers.
+
+The maximum datagram size is defined as the largest size of UDP payload that can
+be sent across a network path using a single UDP datagram.
 
 QUIC depends upon a minimum IP packet size of at least 1280 bytes.  This is the
 IPv6 minimum size ({{?IPv6=RFC8200}}) and is also supported by most modern IPv4
-networks.  Assuming the minimum IP header size, this results in a QUIC maximum
-packet size of 1232 bytes for IPv6 and 1252 bytes for IPv4.
+networks.  Assuming the minimum IP header size, this results in a maximum
+datagram size of 1232 bytes for IPv6 and 1252 bytes for IPv4.
 
-The QUIC maximum packet size is the largest size of QUIC packet that can be sent
-across a network path using a single packet. Any maximum packet size larger than
-1200 bytes can be discovered using Path Maximum Transmission Unit Discovery
-(PMTUD; see {{pmtud}}) or Datagram Packetization Layer PMTU Discovery (DPLPMTUD;
-see {{dplpmtud}}).
+Any maximum datagram size larger than 1200 bytes can be discovered using Path
+Maximum Transmission Unit Discovery (PMTUD; see {{pmtud}}) or Datagram
+Packetization Layer PMTU Discovery (DPLPMTUD; see {{dplpmtud}}).
 
 Enforcement of the max_udp_payload_size transport parameter
 ({{transport-parameter-definitions}}) might act as an additional limit on the
-maximum packet size. A sender can avoid exceeding this limit, once the value is
-known.  However, prior to learning the value of the transport parameter,
-endpoints risk datagrams being lost if they send packets larger than the
-smallest allowed maximum packet size of 1200 bytes.
+maximum datagram size. A sender can avoid exceeding this limit, once the value
+is known.  However, prior to learning the value of the transport parameter,
+endpoints risk datagrams being lost if they send datagrams larger than the
+smallest allowed maximum datagram size of 1200 bytes.
 
 UDP datagrams MUST NOT be fragmented at the IP layer.  In IPv4
 ({{!IPv4=RFC0791}}), the DF bit MUST be set if possible, to prevent
 fragmentation on the path.
 
 
-## Initial Packet Size {#initial-size}
+## Initial Datagram Size {#initial-size}
 
 A client MUST expand the payload of all UDP datagrams carrying Initial packets
-to at least the smallest allowed maximum packet size (1200 bytes) by adding
+to at least the smallest allowed maximum datagram size (1200 bytes) by adding
 PADDING frames to the Initial packet or by coalescing the Initial packet; see
 {{packet-coalesce}}.  Sending a UDP datagram of this size ensures that the
 network path from the client to the server supports a reasonable Path Maximum
@@ -4094,7 +4098,7 @@ Datagrams containing Initial packets MAY exceed 1200 bytes if the client
 believes that the network path and peer both support the size that it chooses.
 
 A server MUST discard an Initial packet that is carried in a UDP datagram with a
-payload that is less than the smallest allowed maximum packet size of 1200
+payload that is smaller than the smallest allowed maximum datagram size of 1200
 bytes.  A server MAY also immediately close the connection by sending a
 CONNECTION_CLOSE frame with an error code of PROTOCOL_VIOLATION; see
 {{immediate-close-hs}}.
@@ -4107,33 +4111,34 @@ address of the client; see {{address-validation}}.
 
 The Path Maximum Transmission Unit (PMTU) is the maximum size of the entire IP
 packet including the IP header, UDP header, and UDP payload.  The UDP payload
-includes the QUIC packet header, protected payload, and any authentication
-fields.  The PMTU can depend on path characteristics, and can therefore change
-over time.  The largest UDP payload an endpoint sends at any given time is
-referred to as the endpoint's maximum packet size.
+includes QUIC packet headers, protected payload, and any authentication fields.
+The PMTU can depend on path characteristics, and can therefore change over time.
+The largest UDP payload an endpoint sends at any given time is referred to as
+the endpoint's maximum datagram size.
 
 An endpoint SHOULD use DPLPMTUD ({{dplpmtud}}) or PMTUD ({{pmtud}}) to determine
-whether the path to a destination will support a desired maximum packet size
+whether the path to a destination will support a desired maximum datagram size
 without fragmentation.  In the absence of these mechanisms, QUIC endpoints
-SHOULD NOT send IP packets larger than the smallest allowed maximum packet size.
+SHOULD NOT send datagrams larger than the smallest allowed maximum datagram
+size.
 
-Both DPLPMTUD and PMTUD send IP packets that are larger than the current maximum
-packet size, referred to as PMTU probes.  All QUIC packets that are not sent in
-a PMTU probe SHOULD be sized to fit within the maximum packet size to avoid the
-packet being fragmented or dropped ({{?RFC8085}}).
+Both DPLPMTUD and PMTUD send datagrams that are larger than the current maximum
+datagram size, referred to as PMTU probes.  All QUIC packets that are not sent
+in a PMTU probe SHOULD be sized to fit within the maximum datagram size to avoid
+the datagram being fragmented or dropped ({{?RFC8085}}).
 
 If a QUIC endpoint determines that the PMTU between any pair of local and remote
-IP addresses has fallen below the smallest allowed maximum packet size of 1200
+IP addresses has fallen below the smallest allowed maximum datagram size of 1200
 bytes, it MUST immediately cease sending QUIC packets, except for those in PMTU
 probes or those containing CONNECTION_CLOSE frames, on the affected path.  An
 endpoint MAY terminate the connection if an alternative path cannot be found.
 
 Each pair of local and remote addresses could have a different PMTU.  QUIC
 implementations that implement any kind of PMTU discovery therefore SHOULD
-maintain a maximum packet size for each combination of local and remote IP
+maintain a maximum datagram size for each combination of local and remote IP
 addresses.
 
-A QUIC implementation MAY be more conservative in computing the maximum packet
+A QUIC implementation MAY be more conservative in computing the maximum datagram
 size to allow for unknown tunnel overheads or IP header options/extensions.
 
 
@@ -4141,13 +4146,13 @@ size to allow for unknown tunnel overheads or IP header options/extensions.
 
 Path Maximum Transmission Unit Discovery (PMTUD; {{!RFC1191}}, {{!RFC8201}})
 relies on reception of ICMP messages (e.g., IPv6 Packet Too Big messages) that
-indicate when a packet is dropped because it is larger than the local router
+indicate when an IP packet is dropped because it is larger than the local router
 MTU. DPLPMTUD can also optionally use these messages.  This use of ICMP messages
 is potentially vulnerable to off-path attacks that successfully guess the
 addresses used on the path and reduce the PMTU to a bandwidth-inefficient value.
 
 An endpoint MUST ignore an ICMP message that claims the PMTU has decreased below
-the minimum QUIC packet size.
+QUIC's smallest allowed maximum datagram size.
 
 The requirements for generating ICMP ({{?RFC1812}}, {{?RFC4443}}) state that the
 quoted packet should contain as much of the original packet as possible without
@@ -4165,7 +4170,7 @@ an active QUIC session.  The endpoint SHOULD ignore all ICMP messages that fail
 validation.
 
 An endpoint MUST NOT increase PMTU based on ICMP messages; see Section 3, clause
-6 of {{!DPLPMTUD}}.  Any reduction in the QUIC maximum packet size in response
+6 of {{!DPLPMTUD}}.  Any reduction in QUIC's maximum datagram size in response
 to ICMP messages MAY be provisional until QUIC's loss detection algorithm
 determines that the quoted packet has actually been lost.
 
@@ -4177,24 +4182,25 @@ relies on tracking loss or acknowledgment of QUIC packets that are carried in
 PMTU probes.  PMTU probes for DPLPMTUD that use the PADDING frame implement
 "Probing using padding data", as defined in Section 4.1 of {{!DPLPMTUD}}.
 
-Endpoints SHOULD set the initial value of BASE_PMTU (see Section 5.1 of
-{{!DPLPMTUD}}) to be consistent with the minimum QUIC packet size. The
-MIN_PLPMTU is the same as the BASE_PMTU.
+Endpoints SHOULD set the initial value of BASE_PLPMTU (Section 5.1 of
+{{!DPLPMTUD}}) to be consistent with QUIC's smallest allowed maximum datagram
+size. The MIN_PLPMTU is the same as the BASE_PLPMTU.
 
-QUIC endpoints implementing DPLPMTUD maintain a maximum packet size (DPLPMTUD
-MPS) for each combination of local and remote IP addresses.
+QUIC endpoints implementing DPLPMTUD maintain a DPLPMTUD Maximum Packet Size
+(MPS, Section 4.4 of {{!DPLPMTUD}}) for each combination of local and remote IP
+addresses.
 
 
 ### DPLPMTUD and Initial Connectivity
 
-From the perspective of DPLPMTUD, QUIC is an acknowledged packetization layer
-(PL). A sender can therefore enter the DPLPMTUD BASE state when the QUIC
-connection handshake has been completed.
+From the perspective of DPLPMTUD, QUIC is an acknowledged Packetization Layer
+(PL). A QUIC sender can therefore enter the DPLPMTUD BASE state (Section 5.2 of
+{{!DPLPMTUD}}) when the QUIC connection handshake has been completed.
 
 
-### Validating the QUIC Path with DPLPMTUD
+### Validating the Network Path with DPLPMTUD
 
-QUIC provides an acknowledged PL, therefore a sender does not implement the
+QUIC provides an acknowledged PL, therefore a sender does not implement a
 DPLPMTUD CONFIRMATION_TIMER while in the SEARCH_COMPLETE state; see Section
 5.2 of {{!DPLPMTUD}}.
 
@@ -4215,10 +4221,10 @@ apply if these messages are used by DPLPMTUD.
 
 PMTU probes are ack-eliciting packets.
 
-Endpoints could limit the content of PMTU probes to PING and PADDING frames as
-packets that are larger than the current maximum packet size are more likely to
-be dropped by the network.   Loss of a QUIC packet that is carried in a PMTU
-probe is therefore not a reliable indication of congestion and SHOULD NOT
+Endpoints could limit the content of PMTU probes to PING and PADDING frames,
+since packets that are larger than the current maximum datagram size are more
+likely to be dropped by the network.  Loss of a QUIC packet that is carried in a
+PMTU probe is therefore not a reliable indication of congestion and SHOULD NOT
 trigger a congestion control reaction; see Section 3, Bullet 7 of {{!DPLPMTUD}}.
 However, PMTU probes consume congestion window, which could delay subsequent
 transmission by an application.
@@ -5110,7 +5116,7 @@ max_udp_payload_size (0x03):
 
 : This limit does act as an additional constraint on datagram size in the same
   way as the path MTU, but it is a property of the endpoint and not the path;
-  see {{packet-size}}.  It is expected that this is the space an endpoint
+  see {{datagram-size}}.  It is expected that this is the space an endpoint
   dedicates to holding incoming packets.
 
 initial_max_data (0x04):

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4060,14 +4060,15 @@ datagram size includes one or more QUIC packet headers and protected payloads,
 but not the UDP or IP headers.
 
 The maximum datagram size is defined as the largest size of UDP payload that can
-be sent across a network path using a single UDP datagram.  The maximum datagram
-size MUST be at least 1200 bytes.
+be sent across a network path using a single UDP datagram.
 
 QUIC depends upon a minimum IP packet size of at least 1280 bytes.  This is the
 IPv6 minimum size ({{?IPv6=RFC8200}}) and is also supported by most modern IPv4
 networks.  Assuming the minimum IP header size of 40 bytes for IPv6 and 20 bytes
 for IPv4 and a UDP header size of 8 bytes, this results in a maximum datagram
 size of 1232 bytes for IPv6 and 1252 bytes for IPv4.
+
+The maximum datagram size MUST be at least 1200 bytes.
 
 Any maximum datagram size larger than 1200 bytes can be discovered using Path
 Maximum Transmission Unit Discovery (PMTUD; see {{pmtud}}) or Datagram

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4056,8 +4056,8 @@ MUST disable ECN if validation later fails.
 
 A UDP datagram can include one or more QUIC packets. The datagram size refers to
 the total UDP payload size of a single UDP datagram carrying QUIC packets. The
-datagram size includes includes the QUIC headers and protected payload, but not
-the UDP or IP headers.
+datagram size includes includes one or more QUIC packet headers and the
+protected payloads, but not the UDP or IP headers.
 
 The maximum datagram size is defined as the largest size of UDP payload that can
 be sent across a network path using a single UDP datagram.  The maximum datagram
@@ -4112,10 +4112,10 @@ address of the client; see {{address-validation}}.
 
 The Path Maximum Transmission Unit (PMTU) is the maximum size of the entire IP
 packet including the IP header, UDP header, and UDP payload.  The UDP payload
-includes QUIC packet headers, protected payload, and any authentication fields.
-The PMTU can depend on path characteristics, and can therefore change over time.
-The largest UDP payload an endpoint sends at any given time is referred to as
-the endpoint's maximum datagram size.
+includes one or more QUIC packet headers, the protected payloads, and any
+authentication fields.  The PMTU can depend on path characteristics, and can
+therefore change over time.  The largest UDP payload an endpoint sends at any
+given time is referred to as the endpoint's maximum datagram size.
 
 An endpoint SHOULD use DPLPMTUD ({{dplpmtud}}) or PMTUD ({{pmtud}}) to determine
 whether the path to a destination will support a desired maximum datagram size
@@ -4201,9 +4201,9 @@ From the perspective of DPLPMTUD, QUIC is an acknowledged Packetization Layer
 
 ### Validating the Network Path with DPLPMTUD
 
-QUIC provides an acknowledged PL, therefore a sender does not implement a
-DPLPMTUD CONFIRMATION_TIMER while in the SEARCH_COMPLETE state; see Section
-5.2 of {{!DPLPMTUD}}.
+QUIC is an acknowledged PL, therefore a QUIC sender does not implement a
+DPLPMTUD CONFIRMATION_TIMER while in the SEARCH_COMPLETE state; see Section 5.2
+of {{!DPLPMTUD}}.
 
 
 ### Handling of ICMP Messages by DPLPMTUD


### PR DESCRIPTION
Addresses #4196.

@gloinul points out in #4196 that we use `maximum packet size` in the transport draft and `max_datagram_size` in the recovery draft. In reading carefully, I realized that `maximum packet size` in the transport draft was actually historical, and `maximum datagram size` is the more appropriate term.

This is an entirely editorial PR, and it's largely simple changes, despite the fact that it looks a bit big. It is a bit subtle though. Sorry about that.