### PR TITLE
Don't refer to the Time Threshold Loss Detection Timer

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -613,7 +613,7 @@ idle timeout.
 The PTO timer MUST NOT be set if a timer is set for time threshold
 loss detection; see {{time-threshold}}.  A timer that is set for time
 threshold loss detection will expire earlier than the PTO timer
-in many cases and is less likely to spuriously retransmit data.
+in most cases and is less likely to spuriously retransmit data.
 
 ### Handshakes and New Paths {#pto-handshake}
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -612,8 +612,8 @@ idle timeout.
 
 The PTO timer MUST NOT be set if a timer is set for time threshold
 loss detection; see {{time-threshold}}.  A timer that is set for time
-threshold loss detection is expected to both expire earlier than
-the PTO timer and be less likely to spuriously retransmit data.
+threshold loss detection will expire earlier than the PTO timer
+in many cases and is less likely to spuriously retransmit data.
 
 ### Handshakes and New Paths {#pto-handshake}
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -610,10 +610,10 @@ in the Handshake packet number space.
 The total length of time over which consecutive PTOs expire is limited by the
 idle timeout.
 
-The probe timer MUST NOT be set if the time threshold ({{time-threshold}}) loss
-detection timer is set.  The time threshold loss detection timer is expected
-to both expire earlier than the PTO and be less likely to spuriously retransmit
-data.
+The PTO timer MUST NOT be set if a timer is set for time threshold
+({{time-threshold}}) loss detection.  Time threshold loss detection
+is expected to both expire earlier than the PTO and be less likely to
+spuriously retransmit data.
 
 ### Handshakes and New Paths {#pto-handshake}
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -611,7 +611,7 @@ The total length of time over which consecutive PTOs expire is limited by the
 idle timeout.
 
 The PTO timer MUST NOT be set if a timer is set for time threshold
-loss detection ({{time-threshold}}).  A timer that is set for time
+loss detection; see {{time-threshold}}.  A timer that is set for time
 threshold loss detection is expected to both expire earlier than
 the PTO timer and be less likely to spuriously retransmit data.
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -611,9 +611,9 @@ The total length of time over which consecutive PTOs expire is limited by the
 idle timeout.
 
 The PTO timer MUST NOT be set if a timer is set for time threshold
-({{time-threshold}}) loss detection.  Time threshold loss detection
-is expected to both expire earlier than the PTO and be less likely to
-spuriously retransmit data.
+loss detection ({{time-threshold}}).  A timer that is set for time
+threshold loss detection is expected to both expire earlier than
+the PTO timer and be less likely to spuriously retransmit data.
 
 ### Handshakes and New Paths {#pto-handshake}
 


### PR DESCRIPTION
That term doesn't appear above, so don't use it in the PTO section.

Fixes #4193