### PR TITLE
Prohibit using old keys for sending

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1557,9 +1557,8 @@ keys in addition to these might improve performance, but this is not essential.
 
 ## Sending with Updated Keys {#old-keys-send}
 
-An endpoint always sends packets that are protected with the newest keys.  Keys
-used for packet protection can be discarded immediately after switching to newer
-keys.
+An endpoint never sends packets that are protected with old keys. Keys used for
+protecting packets can be discarded immediately after switching to newer keys.
 
 Packets with higher packet numbers MUST be protected with either the same or
 newer packet protection keys than packets with lower packet numbers.  An

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1557,8 +1557,9 @@ keys in addition to these might improve performance, but this is not essential.
 
 ## Sending with Updated Keys {#old-keys-send}
 
-An endpoint never sends packets that are protected with old keys. Keys used for
-protecting packets can be discarded immediately after switching to newer keys.
+An endpoint never sends packets that are protected with old keys.  Only the
+current keys are used.  Keys used for protecting packets can be discarded
+immediately after switching to newer keys.
 
 Packets with higher packet numbers MUST be protected with either the same or
 newer packet protection keys than packets with lower packet numbers.  An


### PR DESCRIPTION
In this context, "newer" was confusing as the code permits the creation
of the next set of packet protection keys when switching over.  As the
goal of the text was to ensure that old keys not be used, using that
formulation avoids any confusion that might be caused from not having a
reference against which to decide which is "newer".

Closes #4199.