### PR TITLE
IANA: split change controller and contact

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -2000,8 +2000,8 @@ policy documented in Section 22.1 of {{QUIC-TRANSPORT}}.  These registries all
 include the common set of fields listed in Section 22.1.1 of {{QUIC-TRANSPORT}}.
 
 The initial allocations in these registries created in this document are all
-assigned permanent status and list as contact both the IETF and the HTTP working
-group (ietf-http-wg@w3.org).
+assigned permanent status and list a change controller of the IETF and a contact
+of the HTTP working group (ietf-http-wg@w3.org).
 
 ### Frame Types {#iana-frames}
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -7178,6 +7178,9 @@ Specification:
 Date:
 : The date of last update to the registration.
 
+Change Controller:
+: The entity that is responsible for the definition of the registration.
+
 Contact:
 : Contact details for the registrant.
 
@@ -7262,8 +7265,9 @@ for a frame type ({{iana-frames}}) of 61 could be requested.
 
 All registrations made by Standards Track publications MUST be permanent.
 
-All registrations in this document are assigned a permanent status and list as
-contact the IETF (quic@ietf.org).
+All registrations in this document are assigned a permanent status and list a
+change controller of the IETF and a contact of the QUIC working group
+(quic@ietf.org).
 
 
 ## QUIC Transport Parameter Registry {#iana-transport-parameters}


### PR DESCRIPTION
At @gloinul's suggestion this adds a "change controller" field to
registries and splits between a change controller (IETF) and contact
(QUIC WG).

Not really sure if this is worth a design label...

Closes #4230.