### PR TITLE
Document why one might want to pad ACKS

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4097,12 +4097,10 @@ toward an unverified client address; see {{address-validation}}.
 
 Similarly, a server MUST expand the payload of all UDP datagrams carrying
 ack-eliciting Initial packets to at least the smallest allowed maximum datagram
-size of 1200 bytes.  Unexpanded Initial packets extend the peer's idle timeout,
-even if the path is not capable of carrying the full MTU, so servers can choose
-to expand ACK-only packets to at least 1200 bytes and clients can choose not to
-extend the idle timeout upon receipt of a non-ack-eliciting packet less than
-1200 bytes. Sending UDP datagrams of this size ensures that the network path
-supports a reasonable Path Maximum Transmission Unit (PMTU), in both directions.
+size of 1200 bytes.  Note that unexpanded Initial packets extend the peer's
+idle timeout, even if the path is not capable of carrying the full MTU.
+Sending UDP datagrams of this size ensures that the network path supports a
+reasonable Path Maximum Transmission Unit (PMTU), in both directions.
 
 Datagrams containing Initial packets MAY exceed 1200 bytes if the sender
 believes that the network path and peer both support the size that it chooses.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4091,13 +4091,18 @@ fragmentation on the path.
 A client MUST expand the payload of all UDP datagrams carrying Initial packets
 to at least the smallest allowed maximum datagram size of 1200 bytes by adding
 PADDING frames to the Initial packet or by coalescing the Initial packet; see
-{{packet-coalesce}}.  Similarly, a server MUST expand the payload of all UDP
-datagrams carrying ack-eliciting Initial packets to at least the smallest
-allowed maximum datagram size of 1200 bytes.  Sending UDP datagrams of this size
-ensures that the network path supports a reasonable Path Maximum Transmission
-Unit (PMTU), in both directions.  Additionally, a client that expands Initial
-packets helps reduce the amplitude of amplification attacks caused by server
-responses toward an unverified client address; see {{address-validation}}.
+{{packet-coalesce}}. Additionally, a client that expands Initial packets helps
+reduce the amplitude of amplification attacks caused by server responses
+toward an unverified client address; see {{address-validation}}.
+
+Similarly, a server MUST expand the payload of all UDP datagrams carrying
+ack-eliciting Initial packets to at least the smallest allowed maximum datagram
+size of 1200 bytes.  Unexpanded Initial packets extend the peer's idle timeout,
+even if the path is not capable of carrying the full MTU, so servers can choose
+to expand ACK-only packets to at least 1200 bytes and clients can choose not to
+extend the idle timeout upon receipt of a non-ack-eliciting packet less than
+1200 bytes. Sending UDP datagrams of this size ensures that the network path
+supports a reasonable Path Maximum Transmission Unit (PMTU), in both directions.
 
 Datagrams containing Initial packets MAY exceed 1200 bytes if the sender
 believes that the network path and peer both support the size that it chooses.


### PR DESCRIPTION
...or alter the idle timeout behavior when unpadded ACK-only packets are received.

Fixes #4183 