### PR TITLE
receivers cannot enforce datagram padding (though they may drop)

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4085,7 +4085,7 @@ UDP datagrams MUST NOT be fragmented at the IP layer.  In IPv4
 ({{!IPv4=RFC0791}}), the DF bit MUST be set if possible, to prevent
 fragmentation on the path.
 
-Datagrams are required to be padded under some conditions.  However, the
+Datagrams are required to be a minimum size under some conditions.  However, the
 size of the datagram is not authenticated.  Therefore, an endpoint MUST NOT
 close a connection when it receives a datagram that does not meet size
 constraints, though the endpoint MAY discard such datagrams.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4087,9 +4087,10 @@ fragmentation on the path.
 
 Even though datagrams with certain properties are required to be padded, the
 size of the datagram is not authenticated, and endpoints might send coalesced
-packets after the handshake is confirmed.  Therefore, an endpoint MUST NOT close
-a connection when it receives a datagram that does not meet the padding
-requirements, though the endpoint MAY discard such datagrams.
+packets after the handshake is confirmed (see {{packet-coalesce}}).  Therefore,
+an endpoint MUST NOT close a connection when it receives a datagram that does
+not meet the padding requirements, though the endpoint MAY discard such
+datagrams.
 
 
 ## Initial Datagram Size {#initial-size}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4087,7 +4087,7 @@ fragmentation on the path.
 
 Even though datagrams with certain properties are required to be padded, the
 size of the datagram is not authenticated, and endpoints might send coalesced
-packets after the handshake is confirmed (see {{packet-coalesce}}).  Therefore,
+packets after the handshake is confirmed; see {{packet-coalesce}}.  Therefore,
 an endpoint MUST NOT close a connection when it receives a datagram that does
 not meet the padding requirements, though the endpoint MAY discard such
 datagrams.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4085,6 +4085,12 @@ UDP datagrams MUST NOT be fragmented at the IP layer.  In IPv4
 ({{!IPv4=RFC0791}}), the DF bit MUST be set if possible, to prevent
 fragmentation on the path.
 
+Even though datagrams with certain properties are required to be padded, the
+size of the datagram is not authenticated, and endpoints might send coalesced
+packets after the handshake is confirmed.  Therefore, an endpoint MUST NOT close
+a connection when it receives a datagram that does not meet the padding
+requirements, though the endpoint MAY discard such datagrams.
+
 
 ## Initial Datagram Size {#initial-size}
 
@@ -4106,9 +4112,7 @@ A server MUST discard an Initial packet that is carried in a UDP datagram with a
 payload that is smaller than the smallest allowed maximum datagram size of 1200
 bytes.  A server MAY also immediately close the connection by sending a
 CONNECTION_CLOSE frame with an error code of PROTOCOL_VIOLATION; see
-{{immediate-close-hs}}.  When a client receives an ack-eliciting Initial packet
-that is carried in a UDP datagram with a payload that is less than 1200 bytes,
-that client MAY close the connection by sending a CONNECTION_CLOSE frame.
+{{immediate-close-hs}}.
 
 The server MUST also limit the number of bytes it sends before validating the
 address of the client; see {{address-validation}}.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4085,7 +4085,7 @@ UDP datagrams MUST NOT be fragmented at the IP layer.  In IPv4
 ({{!IPv4=RFC0791}}), the DF bit MUST be set if possible, to prevent
 fragmentation on the path.
 
-Even though datagrams with certain properties are required to be padded, the
+Datagrams are required to be padded under some conditions.  However, the
 size of the datagram is not authenticated, and endpoints might send coalesced
 packets after the handshake is confirmed; see {{packet-coalesce}}.  Therefore,
 an endpoint MUST NOT close a connection when it receives a datagram that does

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4089,7 +4089,7 @@ Datagrams are required to be padded under some conditions.  However, the
 size of the datagram is not authenticated, and endpoints might send coalesced
 packets after the handshake is confirmed; see {{packet-coalesce}}.  Therefore,
 an endpoint MUST NOT close a connection when it receives a datagram that does
-not meet the padding requirements, though the endpoint MAY discard such
+not meet size constraints, though the endpoint MAY discard such
 datagrams.
 
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4086,11 +4086,9 @@ UDP datagrams MUST NOT be fragmented at the IP layer.  In IPv4
 fragmentation on the path.
 
 Datagrams are required to be padded under some conditions.  However, the
-size of the datagram is not authenticated, and endpoints might send coalesced
-packets after the handshake is confirmed; see {{packet-coalesce}}.  Therefore,
-an endpoint MUST NOT close a connection when it receives a datagram that does
-not meet size constraints, though the endpoint MAY discard such
-datagrams.
+size of the datagram is not authenticated.  Therefore, an endpoint MUST NOT
+close a connection when it receives a datagram that does not meet size
+constraints, though the endpoint MAY discard such datagrams.
 
 
 ## Initial Datagram Size {#initial-size}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4085,8 +4085,8 @@ UDP datagrams MUST NOT be fragmented at the IP layer.  In IPv4
 ({{!IPv4=RFC0791}}), the DF bit MUST be set if possible, to prevent
 fragmentation on the path.
 
-Datagrams are required to be a minimum size under some conditions.  However, the
-size of the datagram is not authenticated.  Therefore, an endpoint MUST NOT
+Datagrams are required to be of a minimum size under some conditions.  However,
+the size of the datagram is not authenticated.  Therefore, an endpoint MUST NOT
 close a connection when it receives a datagram that does not meet size
 constraints, though the endpoint MAY discard such datagrams.
 


### PR DESCRIPTION
Closes #4253, by adding generic "MUST NOT close, MAY discard packets" rule.