### PR TITLE
Apply the 3x amplification-limit to migration too

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1895,12 +1895,11 @@ on its own.
 
 The primary defense against amplification attack is verifying that an endpoint
 is able to receive packets at the transport address that it claims.  An endpoint
-that responds to packets received from a new address limits the data it sends
-to that address until the peer address is validated.  Prior to validating the
-peer's address, endpoints MUST NOT send datagrams toward that address
-whose total payload exceeds three times the amount of data received from
-that address.  This
-limit on the size of responses is known as the anti-amplification limit.
+that responds to packets received from a new address limits the data it sends to
+that address until the peer address is validated.  Prior to validating the
+peer's address, endpoints MUST NOT send datagrams toward that address whose
+total payload exceeds three times the amount of data received from that address.
+This limit on the size of responses is known as the anti-amplification limit.
 
 Address validation is performed both during connection establishment (see
 {{validate-handshake}}) and during connection migration (see
@@ -1915,9 +1914,9 @@ confirms that the client received the Initial packet from the server.  Once the
 server has successfully processed a Handshake packet from the client, it can
 consider the client address to have been validated.
 
-Additionally, a server MAY consider the client address validated if the
-client uses a connection ID chosen by the server and the connection ID contains
-at least 64 bits of entropy.
+Additionally, a server MAY consider the client address validated if the client
+uses a connection ID chosen by the server and the connection ID contains at
+least 64 bits of entropy.
 
 Prior to validating the client address, servers MUST NOT send more than three
 times as many bytes as the number of bytes they have received.  This limits the
@@ -2221,11 +2220,11 @@ from the endpoint to the peer can be used for QUIC; see {{datagram-size}}.
 If an endpoint is unable to expand the datagram payload to 1200 bytes, no
 padding is necessary.  However, this means that the path MTU will not be
 validated.  To ensure that the path MTU is large enough, the endpoint MUST
-perform a second path validation by sending a PATH_CHALLENGE frame in a
-datagram of at least 1200 bytes.  This additional validation can be
-performed after a PATH_RESPONSE is successfully received or when enough
-bytes have been received on the path that sending the larger datagram will
-not result in exceeding the anti-amplification limit.
+perform a second path validation by sending a PATH_CHALLENGE frame in a datagram
+of at least 1200 bytes.  This additional validation can be performed after a
+PATH_RESPONSE is successfully received or when enough bytes have been received
+on the path that sending the larger datagram will not result in exceeding the
+anti-amplification limit.
 
 
 ### Path Validation Responses
@@ -2244,10 +2243,9 @@ enable an attack on migration; see {{off-path-forward}}.
 An endpoint MUST expand datagrams that contain a PATH_RESPONSE frame to at
 least the smallest allowed maximum datagram size of 1200 bytes. This verifies
 that the path is able to carry datagrams of this size in both directions.
-However, an endpoint MUST NOT expand the datagram containing the
-PATH_RESPONSE if it is constrained by an anti-amplification limit.  This
-will only occur if the PATH_CHALLENGE was not sent in an expanded
-datagram.
+However, an endpoint MUST NOT expand the datagram containing the PATH_RESPONSE
+if it is constrained by an anti-amplification limit.  This will only occur if
+the PATH_CHALLENGE was not sent in an expanded datagram.
 
 An endpoint MUST NOT send more than one PATH_RESPONSE frame in response to one
 PATH_CHALLENGE frame; see {{retransmission-of-information}}.  The peer is

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -6538,8 +6538,8 @@ Note:
 
 : The anti-amplification limit only applies when an endpoint responds to packets
   received from an unvalidated address. The anti-amplification limit does not
-  apply to clients when establishing a new connection or when initiating path
-  migration.
+  apply to clients when establishing a new connection or when initiating
+  connection migration.
 
 
 #### Server-Side DoS

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1894,12 +1894,12 @@ use the server to send more data toward the victim than it would be able to send
 on its own.
 
 The primary defense against amplification attack is verifying that an endpoint
-is able to receive packets at the transport address that it claims. An endpoint
-that responds to packets received on a new path limits the data is sends on
-that path until the peer address is validated. Prior to validating the peer's
-address, endpoints MUST NOT send data toward that address that exceeds three
-times the amount of data received from that address.  This three times limit on
-the size of responses is known as the anti-amplification limit.
+is able to receive packets at the transport address that it claims.  An endpoint
+that responds to packets received from a new address limits the data it sends
+to that address until the peer address is validated.  Prior to validating the
+peer's address, endpoints MUST NOT send data toward that address that exceeds
+three times the amount of data received from that address.  This three times
+limit on the size of responses is known as the anti-amplification limit.
 
 Address validation is performed both during connection establishment (see
 {{validate-handshake}}) and during connection migration (see
@@ -6919,6 +6919,13 @@ attacker can observe packets.
 Prior to address validation, endpoints are limited in what they are able to
 send.  Endpoints cannot send data toward an unvalidated address in excesss of
 three times the data received from that address.
+
+Note:
+
+: The three times anti-amplification limit only applies when sending in
+  response to packets received from an unvalidated address. The
+  anti-amplification limit does not apply to clients that establish a new
+  connection or when path migration is initiated.
 
 
 #### Server-Side DoS

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2260,6 +2260,9 @@ additional validation can be performed after a PATH_RESPONSE is successfully
 received or when enough bytes have been received on the path that sending the
 larger datagram will not result in exceeding the anti-amplification limit.
 
+Unlike other cases where datagrams are expanded, endpoints MUST NOT discard
+datagrams that appear to be too small when they contain PATH_CHALLENGE or
+PATH_RESPONSE.
 
 ### Path Validation Responses
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2219,10 +2219,12 @@ from the endpoint to the peer can be used for QUIC; see {{datagram-size}}.
 
 If an endpoint is unable to expand the datagram payload to 1200 bytes, no
 padding is necessary.  However, this means that the path MTU will not be
-validated.  The endpoint MUST perform a second path validation with a datagram
-of at least 1200 bytes once a PATH_RESPONSE is successfully received or when
-enough bytes have been received on the path that sending the larger datagram
-will not result in exceeding the anti-amplification limit.
+validated.  To ensure that the path MTU is large enough, the endpoint MUST
+perform a second path validation by sending a PATH_CHALLENGE frame in a
+datagram of at least 1200 bytes.  This additional validation can be
+performed after a PATH_RESPONSE is successfully received or when enough
+bytes have been received on the path that sending the larger datagram will
+not result in exceeding the anti-amplification limit.
 
 
 ### Path Validation Responses

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2132,7 +2132,7 @@ Tokens sent in NEW_TOKEN frames MUST include information that allows the server
 to verify that the client IP address has not changed from when the token was
 issued. Servers can use tokens from NEW_TOKEN in deciding not to send a Retry
 packet, even if the client address has changed. If the client IP address has
-changed, the server MUST adhere to the anti-amplification limits; see
+changed, the server MUST adhere to the anti-amplification limit; see
 {{address-validation}}.  Note that in the presence of NAT, this requirement
 might be insufficient to protect other hosts that share the NAT from
 amplification attack.
@@ -2243,7 +2243,7 @@ least the smallest allowed maximum datagram size of 1200 bytes. This verifies
 that the path is able to carry datagrams of this size in both directions.
 However, an endpoint MUST NOT expand the PATH_RESPONSE if it is constrained
 by an anti-amplification limit.  This will only occur if the PATH_CHALLENGE
-is not send in an expanded packet.
+was not sent in an expanded packet.
 
 An endpoint MUST NOT send more than one PATH_RESPONSE frame in response to one
 PATH_CHALLENGE frame; see {{retransmission-of-information}}.  The peer is

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2709,9 +2709,7 @@ might also occur because the client's access network used a different NAT
 binding for the server's preferred address.
 
 Servers SHOULD initiate path validation to the client's new address upon
-receiving a probe packet from a different address.  Before the client address
-is validated, servers MUST NOT send to the address more than three times the
-number of bytes that have been received; see {{address-validation}}.
+receiving a probe packet from a different address; see {{address-validation}}.
 
 A client that migrates to a new address SHOULD use a preferred address from the
 same address family for the server.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2707,8 +2707,8 @@ binding for the server's preferred address.
 
 Servers SHOULD initiate path validation to the client's new address upon
 receiving a probe packet from a different address.  Before the client address
-is validated, servers MUST NOT send more data on the path than three times the
-number of bytes received on the path; see {{address-validation}}.
+is validated, servers MUST NOT send to the address more than three times the
+number of bytes that have been received; see {{address-validation}}.
 
 A client that migrates to a new address SHOULD use a preferred address from the
 same address family for the server.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1921,7 +1921,7 @@ generates more or larger packets in response to that packet, the attacker can
 use the server to send more data toward the victim than it would be able to send
 on its own.
 
-The primary defense against amplification attack is verifying that a peer is
+The primary defense against amplification attacks is verifying that a peer is
 able to receive packets at the transport address that it claims.  Therefore,
 after receiving packets from an address that is not yet validated, an endpoint
 MUST limit the amount of data it sends to the unvalidated address to three times

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2261,7 +2261,7 @@ PATH_CHALLENGE was sent.
 If the PATH_CHALLENGE frame was sent in a datagram that was not expanded to at
 least 1200 bytes, an endpoint can regard the address as valid for the purposes
 of sending more than three times the amount of data that has been received.
-However, the path MTU is not validated so the endpoint SHOULD initiate another
+However, the path MTU is not validated so the endpoint MUST initiate another
 path validation to verify that the path MTU is sufficient.
 
 Receipt of an acknowledgment for a packet containing a PATH_CHALLENGE frame is

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2314,7 +2314,7 @@ paths are available, an endpoint can wait for a new path to become available or
 close the connection.  An endpoint that has no valid network path to its peer
 MAY signal this using the NO_VIABLE_PATH connection error, noting that this is
 only possible if the network path exists but does not support the required
-MTU {{datagram-size}}.
+MTU ({{datagram-size}}).
 
 A path validation might be abandoned for other reasons besides
 failure. Primarily, this happens if a connection migration to a new path is

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1897,8 +1897,9 @@ The primary defense against amplification attack is verifying that an endpoint
 is able to receive packets at the transport address that it claims.  An endpoint
 that responds to packets received from a new address limits the data it sends
 to that address until the peer address is validated.  Prior to validating the
-peer's address, endpoints MUST NOT send data toward that address that exceeds
-three times the amount of data received from that address.  This three times
+peer's address, endpoints MUST NOT send datagrams toward that address
+whose total payload exceeds three times the amount of data received from
+that address.  This
 limit on the size of responses is known as the anti-amplification limit.
 
 Address validation is performed both during connection establishment (see
@@ -2243,9 +2244,10 @@ enable an attack on migration; see {{off-path-forward}}.
 An endpoint MUST expand datagrams that contain a PATH_RESPONSE frame to at
 least the smallest allowed maximum datagram size of 1200 bytes. This verifies
 that the path is able to carry datagrams of this size in both directions.
-However, an endpoint MUST NOT expand the PATH_RESPONSE if it is constrained
-by an anti-amplification limit.  This will only occur if the PATH_CHALLENGE
-was not sent in an expanded packet.
+However, an endpoint MUST NOT expand the datagram containing the
+PATH_RESPONSE if it is constrained by an anti-amplification limit.  This
+will only occur if the PATH_CHALLENGE was not sent in an expanded
+datagram.
 
 An endpoint MUST NOT send more than one PATH_RESPONSE frame in response to one
 PATH_CHALLENGE frame; see {{retransmission-of-information}}.  The peer is


### PR DESCRIPTION
This touches a lot of places in the document, but I think that the changes are all manageable in scope.

The major change here is a move to a uniform 3x limit on sending
packets toward unvalidated addresses.  Specifically, this applies when
the packets are sent in response to another packet.  In practice, this
means that only servers are affected by this.

The consequence of this change is that PATH_CHALLENGE won't always be
padded, as previously agreed.  That also means that PATH_RESPONSE might
not be as well (if the client migrates, it can send PATH_CHALLENGE in
that packet; though we require that to be padded, we specifically don't
require enforcement, so...).  Address validation using this packet
works, but this doesn't also provide MTU validation.  To fix that, I
have recommended that a second validation be performed when the address
is valid, or there are enough bytes available that the
anti-amplification limit is not a barrier.

The nice part about this is that unifies the response.  We no longer
have weird carve-outs for rate limiting or minimum congestion window
(both of which I removed as part of this).

Closes #4257.