### PR TITLE
Maximum datagram size of 1200 is a requirement

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4074,15 +4074,15 @@ datagram size includes one or more QUIC packet headers and protected payloads,
 but not the UDP or IP headers.
 
 The maximum datagram size is defined as the largest size of UDP payload that can
-be sent across a network path using a single UDP datagram.
+be sent across a network path using a single UDP datagram.  QUIC MUST NOT be
+used if the network path cannot support a maximum datagram size of at least 1200
+bytes.
 
-QUIC depends upon a minimum IP packet size of at least 1280 bytes.  This is the
-IPv6 minimum size ({{?IPv6=RFC8200}}) and is also supported by most modern IPv4
+QUIC assumes a minimum IP packet size of at least 1280 bytes.  This is the IPv6
+minimum size ({{?IPv6=RFC8200}}) and is also supported by most modern IPv4
 networks.  Assuming the minimum IP header size of 40 bytes for IPv6 and 20 bytes
 for IPv4 and a UDP header size of 8 bytes, this results in a maximum datagram
 size of 1232 bytes for IPv6 and 1252 bytes for IPv4.
-
-The maximum datagram size MUST be at least 1200 bytes.
 
 Any maximum datagram size larger than 1200 bytes can be discovered using Path
 Maximum Transmission Unit Discovery (PMTUD; see {{pmtud}}) or Datagram

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4082,7 +4082,8 @@ QUIC assumes a minimum IP packet size of at least 1280 bytes.  This is the IPv6
 minimum size ({{?IPv6=RFC8200}}) and is also supported by most modern IPv4
 networks.  Assuming the minimum IP header size of 40 bytes for IPv6 and 20 bytes
 for IPv4 and a UDP header size of 8 bytes, this results in a maximum datagram
-size of 1232 bytes for IPv6 and 1252 bytes for IPv4.
+size of 1232 bytes for IPv6 and 1252 bytes for IPv4. Thus, modern IPv4
+and all IPv6 network paths will be able to support QUIC.
 
 Any maximum datagram size larger than 1200 bytes can be discovered using Path
 Maximum Transmission Unit Discovery (PMTUD; see {{pmtud}}) or Datagram


### PR DESCRIPTION
On endpoints.

Closes #4271.