### PR TITLE
Packet number encoding appendix

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -7411,7 +7411,7 @@ The EncodePacketNumber function takes two arguments:
 
 * full_pn is the full packet number of the packet being sent.
 * largest_acked is the largest packet number which has been acknowledged by the
-  recipient in the current packet number space, if any
+  peer in the current packet number space, if any
 
 ~~~
 EncodePacketNumber(full_pn, largest_acked):
@@ -7433,7 +7433,7 @@ EncodePacketNumber(full_pn, largest_acked):
 For example, if an endpoint has received an acknowledgment for packet 0xabe8bc
 and is sending a packet with a number of 0xac5c02, there are 29,519 (0x734f)
 outstanding packets.  In order to represent at least twice this range (59,038
-packets, or 0xe69e), 16 bits will be required.
+packets, or 0xe69e), 16 bits are required.
 
 In the same state, sending a packet with a number of 0xace8fe uses the 24-bit
 encoding, because at least 18 bits are required to represent twice the range

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -7430,10 +7430,14 @@ EncodePacketNumber(full_pn, largest_acked):
 ~~~
 {: #alg-encode-pn title="Sample Packet Number Encoding Algorithm"}
 
-For example, if an endpoint has received an acknowledgment for packet 0xabe8bc,
-sending a packet with a number of 0xac5c02 requires a packet number encoding
-with 16 bits or more; whereas the 24-bit packet number encoding is needed to
-send a packet with a number of 0xace8fe.
+For example, if an endpoint has received an acknowledgment for packet 0xabe8bc
+and is sending a packet with a number of 0xac5c02, there are 29,519 (0x734f)
+outstanding packets.  In order to represent at least twice this range (59,038
+packets, or 0xe69e), 16 bits will be required.
+
+In the same state, sending a packet with a number of 0xace8fe uses the 24-bit
+encoding, because at least 18 bits are required to represent twice the range
+(131,182 packets, or 0x2006e).
 
 # Sample Packet Number Decoding Algorithm {#sample-packet-number-decoding}
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4383,9 +4383,12 @@ sent.  A peer receiving the packet will then correctly decode the packet number,
 unless the packet is delayed in transit such that it arrives after many
 higher-numbered packets have been received.  An endpoint SHOULD use a large
 enough packet number encoding to allow the packet number to be recovered even if
-the packet arrives after packets that are sent afterwards.  Pseudo-code and
-examples for packet number encoding can be found in
-{{sample-packet-number-encoding}}.
+the packet arrives after packets that are sent afterwards.
+
+As a result, the size of the packet number encoding is at least one bit more
+than the base-2 logarithm of the number of contiguous unacknowledged packet
+numbers, including the new packet.  Pseudo-code and examples for packet number
+encoding can be found in {{sample-packet-number-encoding}}.
 
 At a receiver, protection of the packet number is removed prior to recovering
 the full packet number. The full packet number is then reconstructed based on
@@ -7427,8 +7430,8 @@ EncodePacketNumber(full_pn, largest_acked):
   min_bits = log(num_unacked, 2) + 1
   num_bytes = ceil(min_bits / 8)
 
-  // Encode the integer value and truncate to the 
-  // num_bytes least-significant bytes.
+  // Encode the integer value and truncate to
+  // the num_bytes least-significant bytes.
   return encode(full_pn, num_bytes)
 ~~~
 {: #alg-encode-pn title="Sample Packet Number Encoding Algorithm"}

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -7427,9 +7427,9 @@ EncodePacketNumber(full_pn, largest_acked):
   min_bits = log(num_unacked, 2) + 1
   num_bytes = ceil(min_bits / 8)
 
-  // Return the value after truncating the full packet number
-  // to num_bytes least-significant bytes
-  return truncate(full_pn, num_bytes)
+  // Encode the integer value and truncate to the 
+  // num_bytes least-significant bytes.
+  return encode(full_pn, num_bytes)
 ~~~
 {: #alg-encode-pn title="Sample Packet Number Encoding Algorithm"}
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -7411,7 +7411,7 @@ The EncodePacketNumber function takes two arguments:
 
 * full_pn is the full packet number of the packet being sent.
 * largest_acked is the largest packet number which has been acknowledged by the
-  peer in the current packet number space, if any
+  peer in the current packet number space, if any.
 
 ~~~
 EncodePacketNumber(full_pn, largest_acked):

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -7415,18 +7415,21 @@ The EncodePacketNumber function takes two arguments:
 
 ~~~
 EncodePacketNumber(full_pn, largest_acked):
-  // If no packets in the current space have been
-  // acknowledged, the full packet number is used.
-  if largest_acked is None:
-    return full_pn
 
   // The number of bits must be at least one more
   // than the base-2 logarithm of the number of contiguous
   // unacknowledged packet numbers, including the new packet.
-  num_unacked = full_pn - largest_acked
+  if largest_acked is None:
+    num_unacked = full_pn + 1
+  else:
+    num_unacked = full_pn - largest_acked
+
   min_bits = log(num_unacked, 2) + 1
   num_bytes = ceil(min_bits / 8)
-  return full_pn[-num_bytes:]
+
+  // Return the value after truncating the full packet number
+  // to num_bytes least-significant bytes
+  return truncate(full_pn, num_bytes)
 ~~~
 {: #alg-encode-pn title="Sample Packet Number Encoding Algorithm"}
 


### PR DESCRIPTION
Fixes #4301.

I took some liberties with data types here, but... pseudocode.  I do wonder if the slice notation is sufficiently clear; I was hesitant to just do bit-shifts and masks because the number of bytes returned is key.  An alternative would be simply to return the number of bytes, I suppose.