### PR TITLE
State CS-PRNG requirements

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1993,9 +1993,9 @@ secrets.
 
 ## Randomness
 
-QUIC depends on the ability to generate secure random numbers, both directly for
-protocol values such as the connection ID, and transitively via TLS. See
-{{!RFC4086}} for guidance on secure random number generation.
+QUIC depends on endpoint being able to generate secure random numbers, both
+directly for protocol values such as the connection ID, and transitively via
+TLS. See {{!RFC4086}} for guidance on secure random number generation.
 
 
 # IANA Considerations

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1993,12 +1993,9 @@ secrets.
 
 ## Randomness
 
-TLS relies on a cryptographically secure pseudorandom number generator
-(CSPRNG) {{!RFC4086}} to produce random or unpredictable values. In addition
-to the uses in TLS, a source of unpredictable values is used in QUIC for a
-variety of protocol elements, including stateless reset messages, stateless
-reset tokens, and PATH_CHALLENGE frames. An endpoint that employs a weak
-CSPRNG forfeits many of the security properties that QUIC provides.
+QUIC depends on the ability to generate secure random numbers, both directly for
+protocol values such as the connection ID, and transitively via TLS. See
+{{!RFC4086}} for guidance on secure random number generation.
 
 
 # IANA Considerations

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1991,6 +1991,16 @@ New QUIC versions SHOULD define a new salt value used in calculating initial
 secrets.
 
 
+## Randomness
+
+TLS relies on a cryptographically secure pseudorandom number generator
+(CS-PRNG) {{!RFC4086}} to produce random or unpredictable values. In addition
+to the uses in TLS, a source of unpredictable values is used in QUIC for a
+variety of protocol elements, including stateless reset messages, stateless
+reset tokens, and PATH_CHALLENGE frames. An endpoint that employs a weak
+CS-PRNG forfeits many of the security properties that QUIC provides.
+
+
 # IANA Considerations
 
 This document registers the quic_transport_parameters extension found in

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1994,7 +1994,7 @@ secrets.
 ## Randomness
 
 TLS relies on a cryptographically secure pseudorandom number generator
-(CS-PRNG) {{!RFC4086}} to produce random or unpredictable values. In addition
+(CSPRNG) {{!RFC4086}} to produce random or unpredictable values. In addition
 to the uses in TLS, a source of unpredictable values is used in QUIC for a
 variety of protocol elements, including stateless reset messages, stateless
 reset tokens, and PATH_CHALLENGE frames. An endpoint that employs a weak

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1993,7 +1993,7 @@ secrets.
 
 ## Randomness
 
-QUIC depends on endpoint being able to generate secure random numbers, both
+QUIC depends on endpoints being able to generate secure random numbers, both
 directly for protocol values such as the connection ID, and transitively via
 TLS. See {{!RFC4086}} for guidance on secure random number generation.
 

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1998,7 +1998,7 @@ TLS relies on a cryptographically secure pseudorandom number generator
 to the uses in TLS, a source of unpredictable values is used in QUIC for a
 variety of protocol elements, including stateless reset messages, stateless
 reset tokens, and PATH_CHALLENGE frames. An endpoint that employs a weak
-CS-PRNG forfeits many of the security properties that QUIC provides.
+CSPRNG forfeits many of the security properties that QUIC provides.
 
 
 # IANA Considerations


### PR DESCRIPTION
I'm opposed to saying that values from a PRNG shouldn't be exposed.  But
we can at least say that we need a good CS-PRNG to get many of the
security properties claimed by the protocol.

Closes #4314.