### PR TITLE
Reorder and introduce Security Considerations

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -6421,11 +6421,10 @@ the CONNECTION_CLOSE frame with a type of 0x1d ({{frame-connection-close}}).
 
 # Security Considerations
 
-The goal of QUIC is to provide a secure transport connection.  However,
-third-parties and malicious peers are able to disrupt the connection in
-various ways.  {{security-properties}} presents an in-depth overview
-of the security properties QUIC attempts to provide; subsequent sections
-discuss the mitigations QUIC employs against various types of attacks.
+The goal of QUIC is to provide a secure transport connection.
+{{security-properties}} provides an overview of those properties; subsequent
+sections discuss constraints and caveats regarding these properties, including
+descriptions of known attacks and countermeasures.
 
 ## Overview of Security Properties {#security-properties}
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -6421,6 +6421,12 @@ the CONNECTION_CLOSE frame with a type of 0x1d ({{frame-connection-close}}).
 
 # Security Considerations
 
+The goal of QUIC is to provide a secure transport connection.  However,
+third-parties and malicious peers are able to disrupt the connection in
+various ways.  {{security-properties}} presents an in-depth overview
+of the security properties QUIC attempts to provide; subsequent sections
+discuss the mitigations QUIC employs against various types of attacks.
+
 ## Overview of Security Properties {#security-properties}
 
 A complete security analysis of QUIC is outside the scope of this document.


### PR DESCRIPTION
It may be useful to review the commits separately; the first commit reorders sections without modifying text, while the second commit contains a new paragraph added to the beginning of the section.

Fixes #4304.