### PR TITLE
Use brackets for empty arrays

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1544,7 +1544,7 @@ Pseudocode for DetectAndRemoveLostPackets follows:
 DetectAndRemoveLostPackets(pn_space):
   assert(largest_acked_packet[pn_space] != infinite)
   loss_time[pn_space] = 0
-  lost_packets = {}
+  lost_packets = []
   loss_delay = kTimeThreshold * max(latest_rtt, smoothed_rtt)
 
   // Minimum time of kGranularity before packets are deemed lost.
@@ -1760,7 +1760,7 @@ OnPacketsLost(lost_packets):
   // packets indicates persistent congestion.
   // Only consider packets sent after getting an RTT sample.
   assert(first_rtt_sample != 0)
-  pc_lost = {}
+  pc_lost = []
   for lost in lost_packets:
     if lost.time_sent > first_rtt_sample:
       pc_lost.insert(lost)


### PR DESCRIPTION
The curlies were fine, but we use brackets already for:

```
for pn_space in [ Initial, Handshake, ApplicationData ]:
```

So this is arguably more consistent.