### PR TITLE
Loss epoch wording

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -194,13 +194,13 @@ not available.
 
 ## Clearer Loss Epoch
 
-QUIC starts a loss epoch when a packet is lost and ends one when any packet
-sent after the epoch starts is acknowledged.  TCP waits for the gap in the
-sequence number space to be filled, and so if a segment is lost multiple times
-in a row, the loss epoch may not end for several round trips. Because both
-should reduce their congestion windows only once per epoch, QUIC will do it
-once for every round trip that experiences loss, while TCP may only do it
-once across multiple round trips.
+QUIC starts a loss epoch when a packet is lost. The loss epoch ends when any
+packet sent after the start of the epoch is acknowledged.  TCP waits for the gap
+in the sequence number space to be filled, and so if a segment is lost multiple
+times in a row, the loss epoch may not end for several round trips. Because both
+should reduce their congestion windows only once per epoch, QUIC will do it once
+for every round trip that experiences loss, while TCP may only do it once across
+multiple round trips.
 
 ## No Reneging
 


### PR DESCRIPTION
Fixes #4324.

This isn't critical, but it's clearer and easier to parse.  All to the good.