### PR TITLE
transport 19.7: better wordings for new_token

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -5739,15 +5739,15 @@ Token Length:
 Token:
 
 : An opaque blob that the client may use with a future Initial packet. The token
-  MUST NOT be empty.  An endpoint MUST treat receipt of a NEW_TOKEN frame with
+  MUST NOT be empty.  A client MUST treat receipt of a NEW_TOKEN frame with
   an empty Token field as a connection error of type FRAME_ENCODING_ERROR.
 
-An endpoint might receive multiple NEW_TOKEN frames that contain the same token
+A client might receive multiple NEW_TOKEN frames that contain the same token
 value if packets containing the frame are incorrectly determined to be lost.
-Endpoints are responsible for discarding duplicate values, which might be used
+Clients are responsible for discarding duplicate values, which might be used
 to link connection attempts; see {{validate-future}}.
 
-Clients MUST NOT send NEW_TOKEN frames.  Servers MUST treat receipt of a
+Clients MUST NOT send NEW_TOKEN frames.  A server MUST treat receipt of a
 NEW_TOKEN frame as a connection error of type PROTOCOL_VIOLATION.
 
 


### PR DESCRIPTION
Since only servers can send NEW_TOKEN, using "client" is clearer. "Servers MUST treat" is used only here, so it is changed into "A server MUST treat".