### PR TITLE
Reserve just one value for standards action

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -7271,10 +7271,12 @@ New uses of codepoints from QUIC registries SHOULD use a randomly selected
 codepoint that excludes both existing allocations and the first unallocated
 codepoint in the selected space.  Requests for multiple codepoints MAY use a
 contiguous range.  This minimizes the risk that differing semantics are
-attributed to the same codepoint by different implementations.  Use of the first
-codepoint in a range is intended for use by specifications that are developed
-through the standards process {{?STD=RFC2026}} and its allocation MUST be
-negotiated with IANA before use.
+attributed to the same codepoint by different implementations.
+
+Use of the first available codepoint in a range is reserved for use by
+specifications that are developed through the standards process
+{{?STD=RFC2026}}; the early codepoint assignment process
+{{!EARLY-ASSIGN=RFC7120}} can be used for these values.
 
 For codepoints that are encoded in variable-length integers
 ({{integer-encoding}}), such as frame types, codepoints that encode to four or

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -7273,10 +7273,10 @@ codepoint in the selected space.  Requests for multiple codepoints MAY use a
 contiguous range.  This minimizes the risk that differing semantics are
 attributed to the same codepoint by different implementations.
 
-Use of the first available codepoint in a range is reserved for use by
-specifications that are developed through the standards process
-{{?STD=RFC2026}}; the early codepoint assignment process
-{{!EARLY-ASSIGN=RFC7120}} can be used for these values.
+Use of the first available codepoint in a range is reserved for allocation using
+the Standards Action policy; see Section 4.9 of {{!RFC8126}}.  The early
+codepoint assignment process {{!EARLY-ASSIGN=RFC7120}} can be used for these
+values.
 
 For codepoints that are encoded in variable-length integers
 ({{integer-encoding}}), such as frame types, codepoints that encode to four or
@@ -7284,9 +7284,8 @@ eight bytes (that is, values 2^14 and above) SHOULD be used unless the usage is
 especially sensitive to having a longer encoding.
 
 Applications to register codepoints in QUIC registries MAY include a codepoint
-as part of the registration.  IANA MUST allocate the selected codepoint unless
-that codepoint is already assigned or the codepoint is the first unallocated
-codepoint in the registry.
+as part of the registration.  IANA MUST allocate the selected codepoint if the
+codepoint is unassigned and the requirements of the registration policy are met.
 
 
 ### Reclaiming Provisional Codepoints


### PR DESCRIPTION
And cite RFC 7120 for how that can be assigned.

Closes #4378.