### PR TITLE
Idempotent is not the standard for 0-RTT

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1289,7 +1289,8 @@ that is in use.
 An application protocol that uses QUIC MUST include a profile that defines
 acceptable use of 0-RTT; otherwise, 0-RTT can only be used to carry QUIC frames
 that do not carry application data. For example, a profile for HTTP is
-described in {{?HTTP-REPLAY=RFC8740}}.
+described in {{?HTTP-REPLAY=RFC8470}} and used for HTTP/3; see Section 10.9 of
+{{QUIC-HTTP}}.
 
 Though replaying packets might result in additional connection attempts, the
 effect of processing replayed frames that do not carry application data is

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -741,7 +741,7 @@ the server has sent a NEW_TOKEN frame; see Section 8.1 of {{QUIC-TRANSPORT}}.
 ### Accepting and Rejecting 0-RTT
 
 A server accepts 0-RTT by sending an early_data extension in the
-EncryptedExtensions (see Section 4.2.10 of {{!TLS13}}).  The server then
+EncryptedExtensions; see Section 4.2.10 of {{!TLS13}}.  The server then
 processes and acknowledges the 0-RTT packets that it receives.
 
 A server rejects 0-RTT by sending the EncryptedExtensions without an early_data

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1276,10 +1276,30 @@ If 0-RTT keys are available (see {{enable-0rtt}}), the lack of replay protection
 means that restrictions on their use are necessary to avoid replay attacks on
 the protocol.
 
-A client MUST only use 0-RTT keys to protect data that is idempotent.  A client
-MAY wish to apply additional restrictions on what data it sends prior to the
-completion of the TLS handshake.  A client otherwise treats 0-RTT keys as
-equivalent to 1-RTT keys, except that it MUST NOT send ACKs with 0-RTT keys.
+Of the frames defined in {{QUIC-TRANSPORT}}, only the STREAM frame is
+potentially unsafe for use with 0-RTT as it carries application data.
+Application data that is received in 0-RTT could cause an application at the
+server to process the data multiple times rather than just once. Additional
+actions taken by a server as a result of processing replayed application data
+could have unwanted consequences. A client therefore MUST only use 0-RTT for
+application data that is permitted by the application that is in use.
+
+An application protocol that uses QUIC MUST include a profile that defines
+acceptable use of 0-RTT; otherwise, 0-RTT can only be used to carry QUIC frames
+that do not carry application data. For example, a profile for HTTP is
+described in {{?HTTP-REPLAY=RFC8740}}.
+
+Though replaying packets might result in additional connection attempts, the
+effect of processing replayed frames that do not carry application data is
+limited to changing the state of the affected connection. A TLS handshake
+cannot be successfully completed using replayed packets.
+
+A client MAY wish to apply additional restrictions on what data it sends prior
+to the completion of the TLS handshake.
+
+A client otherwise treats 0-RTT keys as equivalent to 1-RTT keys, except that
+it cannot send certain frames with 0-RTT keys; see Section 12.5 of
+{{QUIC-TRANSPORT}}.
 
 A client that receives an indication that its 0-RTT data has been accepted by a
 server can send 0-RTT data until it receives all of the server's handshake

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1283,8 +1283,8 @@ carry application data.  Application data that is received in 0-RTT could cause
 an application at the server to process the data multiple times rather than
 just once. Additional actions taken by a server as a result of processing
 replayed application data could have unwanted consequences. A client therefore
-MUST only use 0-RTT for application data that is permitted by the application
-that is in use.
+MUST NOT use 0-RTT for application data unless specifically
+requested by the application that is in use.
 
 An application protocol that uses QUIC MUST include a profile that defines
 acceptable use of 0-RTT; otherwise, 0-RTT can only be used to carry QUIC frames

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -195,7 +195,8 @@ TLS provides two basic handshake modes of interest to QUIC:
  * A 0-RTT handshake, in which the client uses information it has previously
    learned about the server to send Application Data immediately.  This
    Application Data can be replayed by an attacker so 0-RTT is not suitable for
-   carrying instructions that might initiate any non-idempotent action.
+   carrying instructions that might initiate any action that could cause
+   unwanted effects if replayed.
 
 A simplified TLS handshake with 0-RTT application data is shown in {{tls-full}}.
 

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1276,13 +1276,14 @@ If 0-RTT keys are available (see {{enable-0rtt}}), the lack of replay protection
 means that restrictions on their use are necessary to avoid replay attacks on
 the protocol.
 
-Of the frames defined in {{QUIC-TRANSPORT}}, only the STREAM frame is
-potentially unsafe for use with 0-RTT as it carries application data.
-Application data that is received in 0-RTT could cause an application at the
-server to process the data multiple times rather than just once. Additional
-actions taken by a server as a result of processing replayed application data
-could have unwanted consequences. A client therefore MUST only use 0-RTT for
-application data that is permitted by the application that is in use.
+Of the frames defined in {{QUIC-TRANSPORT}}, the STREAM, RESET_STREAM, and
+CONNECTION_CLOSE frames are potentially unsafe for use with 0-RTT as they can
+carry application data.  Application data that is received in 0-RTT could cause
+an application at the server to process the data multiple times rather than
+just once. Additional actions taken by a server as a result of processing
+replayed application data could have unwanted consequences. A client therefore
+MUST only use 0-RTT for application data that is permitted by the application
+that is in use.
 
 An application protocol that uses QUIC MUST include a profile that defines
 acceptable use of 0-RTT; otherwise, 0-RTT can only be used to carry QUIC frames

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1277,7 +1277,7 @@ means that restrictions on their use are necessary to avoid replay attacks on
 the protocol.
 
 Of the frames defined in {{QUIC-TRANSPORT}}, the STREAM, RESET_STREAM, and
-CONNECTION_CLOSE frames are potentially unsafe for use with 0-RTT as they can
+CONNECTION_CLOSE frames are potentially unsafe for use with 0-RTT as they
 carry application data.  Application data that is received in 0-RTT could cause
 an application at the server to process the data multiple times rather than
 just once. Additional actions taken by a server as a result of processing


### PR DESCRIPTION
This captures the outcome of an older analysis I did.  Basically, if a replay is attempted, you get a new connection attempt.  Only the application data that is processed at that time is a risk.

Also, all protocols need a profile that describes how to use 0-RTT, otherwise it can only be used for QUIC things.  Like NEW_CONNECTION_ID (I'm struggling to think of anything else that might reasonably go here).

Closes #4393.