### PR TITLE
minimum valid packet size is an example

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3056,9 +3056,9 @@ An endpoint MUST NOT send a stateless reset that is three times or more larger
 than the packet it receives to avoid being used for amplification.
 {{reset-looping}} describes additional limits on stateless reset size.
 
-Endpoints MUST discard packets that are too small to be valid QUIC packets.
-With the set of AEAD functions defined in {{QUIC-TLS}}, packets that are smaller
-than 21 bytes are never valid.
+Endpoints MUST discard packets that are too small to be valid QUIC packets.  To
+give an example, with the set of AEAD functions defined in {{QUIC-TLS}}, short
+header packets that are smaller than 21 bytes are never valid.
 
 Endpoints MUST send stateless reset packets formatted as a packet with a short
 header.  However, endpoints MUST treat any packet ending in a valid stateless


### PR DESCRIPTION
Minimum packet size varies between the packet types (and other things like the length of CID being used). Therefore, the sentence is merely providing an example, and should be stated as such.

Closes #4395, ~~though I am not sure if 21 is the correct number~~.