### PR TITLE
Fix readme link to contributing guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,4 +55,4 @@ instructions](https://github.com/martinthomson/i-d-template/blob/main/doc/SETUP.
 ## Contributing
 
 See our
-[guidelines for contribution](https://github.com/quicwg/base-drafts/blob/main/CONTRIBUTING.md).
+[guidelines for contribution](https://github.com/quicwg/base-drafts/blob/master/CONTRIBUTING.md).


### PR DESCRIPTION
Hello all!

It seems that 094b7958 updated references for the template dependency by changing `master` to `main` in links pointing to its repository. But in doing so, the link to your repository's `CONTRIBUTING.md` guidelines file was changed as well, while the `main` branch does not exist, `master` is the correct one. This fixes this minor detail.

Cheers,
Paul.