### PR TITLE
Clarify header protection sampling

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1216,6 +1216,20 @@ packet's bytes, with unprotected header fields as its header and the encrypted
 payload, output of the {{!AEAD}} encryption process (see {{aead}}), as its
 payload.
 
+Note that the header protection sampling actually operates on the ciphertext
+only, so the process can be expressed relative to the beginning of the
+encrypted payload as well. The following pseudocode shows how this can be
+achieved, for both short-header and long-header packets:
+
+~~~
+sample_offset = 4 - len(packet_number)
+
+sample = ciphertext[sample_offset..sample_offset+sample_length]
+~~~
+
+where `ciphertext` is the encrypted payload, result of the {{!AEAD}} function
+for the original packet payload, as described in {{aead}}.
+
 
 ### AES-Based Header Protection {#hp-aes}
 

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1211,6 +1211,11 @@ if packet_type == Initial:
 sample = packet[sample_offset..sample_offset+sample_length]
 ~~~
 
+In both above pseudocodes, `packet` designates the entire partially protected
+packet's bytes, with unprotected header fields as its header and the encrypted
+payload, output of the {{!AEAD}} encryption process (see {{aead}}), as its
+payload.
+
 
 ### AES-Based Header Protection {#hp-aes}
 


### PR DESCRIPTION
Hello gentlemen!

The header protection sampling (HPS) is quite simple, as it is just selecting 16 bytes out of the encrypted payload, but we think the current description is really confusing.

Indeed, section 5.4.2 explains the process with pseudocodes computing an offset relative to the beginning of an entire packet which payload is the encrypted one. However, when applying the AEAD function, one cannot do it in-place, so additional allocation must be reserved in any case. Therefore, one most probably has access to the encrypted payload separately from the unprotected packet, headers and payload.

Thus, this PR proposes two things, split in different commits:
 * Clearly and explicitly specify the two already-existing pseudocodes sample from an entire packet.
 * Add another pseudocode explaining how the sampling can be achieved for both short-header and long-header packets.

We have not changed or removed any existing content however, as we believe this draft could use some more explanations and clarifications here and there, rather than less with confusing elements, even if it means a bit of duplication.

Please tell us if there is any form of typo, wrong wording, grammatical issue or just general mistake, especially concerning the new pseudocode.

Hope this helps.
Cheers,
Paul.