### PR TITLE
handling of KeyUpdate in other epochs are specified in RFC 8446, do not override

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1424,7 +1424,8 @@ without needing to receive the first packet that triggered the change.  An
 endpoint that notices a changed Key Phase bit updates keys and decrypts the
 packet that contains the changed value.
 
-This mechanism replaces the TLS KeyUpdate message.  Endpoints MUST NOT send a
+This mechanism replaces the key update mechanism of TLS, which relies on
+KeyUpdate messages sent using 1-RTT encryption keys.  Endpoints MUST NOT send a
 TLS KeyUpdate message.  Endpoints MUST treat the receipt of a TLS KeyUpdate
 message in a 1-RTT packet as a connection error of type 0x10a, equivalent to a
 fatal TLS alert of unexpected_message (see {{tls-errors}}).

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1428,7 +1428,7 @@ This mechanism replaces the key update mechanism of TLS, which relies on
 KeyUpdate messages sent using 1-RTT encryption keys.  Endpoints MUST NOT send a
 TLS KeyUpdate message.  Endpoints MUST treat the receipt of a TLS KeyUpdate
 message in a 1-RTT packet as a connection error of type 0x10a, equivalent to a
-fatal TLS alert of unexpected_message (see {{tls-errors}}).
+fatal TLS alert of unexpected_message; see {{tls-errors}}.
 
 {{ex-key-update}} shows a key update process, where the initial set of keys used
 (identified with @M) are replaced by updated keys (identified with @N).  The

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1426,8 +1426,8 @@ packet that contains the changed value.
 
 This mechanism replaces the TLS KeyUpdate message.  Endpoints MUST NOT send a
 TLS KeyUpdate message.  Endpoints MUST treat the receipt of a TLS KeyUpdate
-message as a connection error of type 0x10a, equivalent to a fatal TLS alert of
-unexpected_message (see {{tls-errors}}).
+message in a 1-RTT packet as a connection error of type 0x10a, equivalent to a
+fatal TLS alert of unexpected_message (see {{tls-errors}}).
 
 {{ex-key-update}} shows a key update process, where the initial set of keys used
 (identified with @M) are replaced by updated keys (identified with @N).  The


### PR DESCRIPTION
QUIC-TLS defines some "adjustments"(https://quicwg.org/base-drafts/draft-ietf-quic-tls.html#name-quic-specific-adjustments-t) to TLS 1.3.

As they are adjustments, we are updating TLS only when necessary. However, discussion in #4410 seems to have revealed one corner case that is ambiguous. This PR addresses that problem.

To be specific, TLS 1.3 defines the necessary action when an endpoint receives KeyUpdate message in epochs other than 1-RTT. However, current statement in QUIC-TLS can be read as if it is updating that. This PR makes it clear that the "adjustment" applies to only when the use of KeyUpdate is permitted by TLS 1.3 but not in QUIC-TLS.

Closes #4410.