### PR TITLE
Minor editorial: Not necessarily ack-eliciting

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -950,9 +950,8 @@ packets.
 
 ## Persistent Congestion {#persistent-congestion}
 
-When a sender establishes loss of all ack-eliciting packets sent over a long
-enough duration, the network is considered to be experiencing persistent
-congestion.
+When a sender establishes a long enough period of complete packet loss, the
+network is considered to be experiencing persistent congestion.
 
 ### Duration {#pc-duration}
 


### PR DESCRIPTION
#4414 tried to fix this descriptive text, but I think it missed the nuance in the mechanism below, which looks at loss of _all_ packets between two ack-eliciting packets.

This PR tries to fix the text to be correct without precisely describing the mechanism.