### PR TITLE
recovery: persistent congestion and ack-eliciting

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -993,15 +993,16 @@ A sender establishes persistent congestion after the receipt of an
 acknowledgement if at least two ack-eliciting packets are declared lost, and:
 
 * all packets, across all packet number spaces, sent between the send times of
-  these two packets are declared lost;
+  two ack-eliciting packets are declared lost;
 
 * the duration between the send times of these two packets exceeds the
   persistent congestion duration ({{pc-duration}}); and
 
 * a prior RTT sample existed when both packets were sent.
 
-The two packets to consider need to be ack-eliciting, because otherwise a sender
-cannot expect to receive an acknowledgement after a specific time.
+These two packets MUST be ack-eliciting, since a receiver is required to
+acknowledge only ack-eliciting packets within its maximum ack delay; see Section
+13.2 of {{QUIC-TRANSPORT}}.
 
 The persistent congestion period SHOULD NOT start until there is at least one
 RTT sample. Before the first RTT sample, a sender arms its PTO timer based on

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -950,9 +950,8 @@ packets.
 
 ## Persistent Congestion {#persistent-congestion}
 
-When a sender establishes loss of all ack-eliciting packets sent over a long
-enough duration, the network is considered to be experiencing persistent
-congestion.
+When a sender establishes loss of all packets sent over a long enough duration,
+the network is considered to be experiencing persistent congestion.
 
 ### Duration {#pc-duration}
 
@@ -990,16 +989,19 @@ congestion without depending on PTO expiration.
 
 ### Establishing Persistent Congestion
 
-A sender establishes persistent congestion on receiving an acknowledgement if at
-least two ack-eliciting packets are declared lost, and:
+A sender establishes persistent congestion after the receipt of an
+acknowledgement if at least two ack-eliciting packets are declared lost, and:
 
-* all packets, across all packet number spaces, sent between these two send
-  times are declared lost;
+* all packets, across all packet number spaces, sent between the send times of
+  these two packets are declared lost;
 
 * the duration between the send times of these two packets exceeds the
   persistent congestion duration ({{pc-duration}}); and
 
 * a prior RTT sample existed when both packets were sent.
+
+The two packets to consider need to be ack-eliciting, because otherwise a sender
+cannot expect to receive an acknowledgement after a specific time.
 
 The persistent congestion period SHOULD NOT start until there is at least one
 RTT sample. Before the first RTT sample, a sender arms its PTO timer based on


### PR DESCRIPTION
Removes the word ack-eliciting in the descriptive text to persistent congestion. It also contains minor text changes in the following of that section.

Fixes #4413.
Closes #4420.