### PR TITLE
recovery: pseudo code update for changes in #4421

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1806,14 +1806,15 @@ Invoked when DetectAndRemoveLostPackets deems packets lost.
 
 ~~~
 OnPacketsLost(lost_packets):
-  time_of_last_in_flight_packet = 0
+  latest_in_flight_lost = 0
   // Remove lost packets from bytes_in_flight.
   for lost_packet in lost_packets:
     if lost_packet.in_flight:
       bytes_in_flight -= lost_packet.sent_bytes
-      time_of_last_in_flight_packet = max(time_of_last_in_flight_packet, lost_packet.time_sent)
-  if (time_of_last_in_flight_packet != 0):
-    OnCongestionEvent(time_of_last_in_flight_packet)
+      latest_in_flight_lost = max(latest_in_flight_lost, lost_packet.time_sent)
+  // Congestion event if any in-flight packets were lost 
+  if (latest_in_flight_lost != 0):
+    OnCongestionEvent(latest_in_flight_lost)
 
   // Reset the congestion window if the loss of these
   // packets indicates persistent congestion.

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1811,7 +1811,8 @@ OnPacketsLost(lost_packets):
   for lost_packet in lost_packets:
     if lost_packet.in_flight:
       bytes_in_flight -= lost_packet.sent_bytes
-      latest_in_flight_lost = max(latest_in_flight_lost, lost_packet.time_sent)
+      latest_in_flight_lost =
+        max(latest_in_flight_lost, lost_packet.time_sent)
   // Congestion event if any in-flight packets were lost 
   if (latest_in_flight_lost != 0):
     OnCongestionEvent(latest_in_flight_lost)

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1813,7 +1813,7 @@ OnPacketsLost(lost_packets):
       bytes_in_flight -= lost_packet.sent_bytes
       latest_in_flight_lost =
         max(latest_in_flight_lost, lost_packet.time_sent)
-  // Congestion event if any in-flight packets were lost 
+  // Congestion event if in-flight packets were lost
   if (latest_in_flight_lost != 0):
     OnCongestionEvent(latest_in_flight_lost)
 


### PR DESCRIPTION
I changed the pseudo code such that the function InPersistentCongestion gets all lost packets sent after the first RTT sample, not only those that count as in flight.