### PR TITLE
Don't DoS the IANA registry server

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -2100,8 +2100,6 @@ Each code of the format `0x1f * N + 0x21` for non-negative integer values of N
 (that is, 0x21, 0x40, ..., through 0x3FFFFFFFFFFFFFFE) MUST NOT be assigned by
 IANA and MUST NOT appear in the listing of assigned values.
 
-The previous paragraph will be included as a note on the IANA registry page.
-
 ### Settings Parameters {#iana-settings}
 
 This document establishes a registry for HTTP/3 settings.  The "HTTP/3 Settings"
@@ -2143,8 +2141,6 @@ The entries in {{iana-setting-table}} are registered by this document.
 Each code of the format `0x1f * N + 0x21` for non-negative integer values of N
 (that is, 0x21, 0x40, ..., through 0x3ffffffffffffffe) MUST NOT be assigned by
 IANA and MUST NOT appear in the listing of assigned values.
-
-The previous paragraph will be included as a note on the IANA registry page.
 
 ### Error Codes {#iana-error-codes}
 
@@ -2202,8 +2198,6 @@ Each code of the format `0x1f * N + 0x21` for non-negative integer values of N
 (that is, 0x21, 0x40, ..., through 0x3ffffffffffffffe) MUST NOT be assigned by
 IANA and MUST NOT appear in the listing of assigned values.
 
-The previous paragraph will be included as a note on the IANA registry page.
-
 ### Stream Types {#iana-stream-types}
 
 This document establishes a registry for HTTP/3 unidirectional stream types. The
@@ -2239,8 +2233,6 @@ The entries in the following table are registered by this document.
 Each code of the format `0x1f * N + 0x21` for non-negative integer values of N
 (that is, 0x21, 0x40, ..., through 0x3ffffffffffffffe) MUST NOT be assigned by
 IANA and MUST NOT appear in the listing of assigned values.
-
-The previous paragraph will be included as a note on the IANA registry page.
 
 
 --- back

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -2096,9 +2096,11 @@ The entries in {{iana-frame-table}} are registered by this document.
 | ---------------- | ------ | -------------------------- |
 {: #iana-frame-table title="Initial HTTP/3 Frame Types"}
 
-Additionally, each code of the format `0x1f * N + 0x21` for non-negative integer
-values of N (that is, 0x21, 0x40, ..., through 0x3FFFFFFFFFFFFFFE) MUST
-NOT be assigned by IANA.
+Each code of the format `0x1f * N + 0x21` for non-negative integer values of N
+(that is, 0x21, 0x40, ..., through 0x3FFFFFFFFFFFFFFE) MUST NOT be assigned by
+IANA and MUST NOT appear in the listing of assigned values.
+
+The previous paragraph will be included as a note on the IANA registry page.
 
 ### Settings Parameters {#iana-settings}
 
@@ -2138,9 +2140,11 @@ The entries in {{iana-setting-table}} are registered by this document.
 | ---------------------------- | ------ | ------------------------- | --------- |
 {: #iana-setting-table title="Initial HTTP/3 Settings"}
 
-Additionally, each code of the format `0x1f * N + 0x21` for non-negative integer
-values of N (that is, 0x21, 0x40, ..., through 0x3ffffffffffffffe) MUST NOT be
-assigned by IANA.
+Each code of the format `0x1f * N + 0x21` for non-negative integer values of N
+(that is, 0x21, 0x40, ..., through 0x3ffffffffffffffe) MUST NOT be assigned by
+IANA and MUST NOT appear in the listing of assigned values.
+
+The previous paragraph will be included as a note on the IANA registry page.
 
 ### Error Codes {#iana-error-codes}
 
@@ -2194,9 +2198,11 @@ Required policy to avoid collisions with HTTP/2 error codes.
 | --------------------------------- | ---------- | ---------------------------------------- | ---------------------- |
 {: #iana-error-table title="Initial HTTP/3 Error Codes"}
 
-Additionally, each code of the format `0x1f * N + 0x21` for non-negative integer
-values of N (that is, 0x21, 0x40, ..., through 0x3ffffffffffffffe) MUST NOT be
-assigned by IANA.
+Each code of the format `0x1f * N + 0x21` for non-negative integer values of N
+(that is, 0x21, 0x40, ..., through 0x3ffffffffffffffe) MUST NOT be assigned by
+IANA and MUST NOT appear in the listing of assigned values.
+
+The previous paragraph will be included as a note on the IANA registry page.
 
 ### Stream Types {#iana-stream-types}
 
@@ -2230,9 +2236,12 @@ The entries in the following table are registered by this document.
 | Push Stream      |  0x01  | {{server-push}}            | Server |
 | ---------------- | ------ | -------------------------- | ------ |
 
-Additionally, each code of the format `0x1f * N + 0x21` for non-negative integer
-values of N (that is, 0x21, 0x40, ..., through 0x3ffffffffffffffe) MUST NOT be
-assigned by IANA.
+Each code of the format `0x1f * N + 0x21` for non-negative integer values of N
+(that is, 0x21, 0x40, ..., through 0x3ffffffffffffffe) MUST NOT be assigned by
+IANA and MUST NOT appear in the listing of assigned values.
+
+The previous paragraph will be included as a note on the IANA registry page.
+
 
 --- back
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -7402,8 +7402,9 @@ The initial contents of this registry are shown in {{iana-tp-table}}.
 | 0x10 | retry_source_connection_id  | {{transport-parameter-definitions}} |
 {: #iana-tp-table title="Initial QUIC Transport Parameters Entries"}
 
-Additionally, each value of the format `31 * N + 27` for integer values of N
-(that is, 27, 58, 89, ...) are reserved and MUST NOT be assigned by IANA.
+Each value of the format `31 * N + 27` for integer values of N (that is, 27, 58,
+89, ...) are reserved; these values MUST NOT be assigned by IANA and MUST NOT
+appear in the listing of assigned values.
 
 
 ## QUIC Frame Types Registry {#iana-frames}


### PR DESCRIPTION
IANA's review wanted to know whether the 148 quadrillion GREASE values should be listed on the registry page as Reserved, and what note should be present if not.

They should not, lest it be challenging to actually download the registry page within the lifetime of the human race.  This rewords the restriction and clarifies that the restriction should be the note.

Fixes #4372.