### PR TITLE
Add 'time' to latest_in_flight_lost

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1811,16 +1811,16 @@ Invoked when DetectAndRemoveLostPackets deems packets lost.
 
 ~~~
 OnPacketsLost(lost_packets):
-  latest_time_of_in_flight_lost = 0
+  time_of_latest_in_flight_loss = 0
   // Remove lost packets from bytes_in_flight.
   for lost_packet in lost_packets:
     if lost_packet.in_flight:
       bytes_in_flight -= lost_packet.sent_bytes
-      latest_time_of_in_flight_lost =
-        max(latest_time_of_in_flight_lost, lost_packet.time_sent)
+      time_of_latest_in_flight_loss =
+        max(time_of_latest_in_flight_loss, lost_packet.time_sent)
   // Congestion event if in-flight packets were lost
-  if (latest_time_of_in_flight_lost != 0):
-    OnCongestionEvent(latest_time_of_in_flight_lost)
+  if (time_of_latest_in_flight_loss != 0):
+    OnCongestionEvent(time_of_latest_in_flight_loss)
 
   // Reset the congestion window if the loss of these
   // packets indicates persistent congestion.

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1811,16 +1811,16 @@ Invoked when DetectAndRemoveLostPackets deems packets lost.
 
 ~~~
 OnPacketsLost(lost_packets):
-  latest_in_flight_lost = 0
+  latest_time_of_in_flight_lost = 0
   // Remove lost packets from bytes_in_flight.
   for lost_packet in lost_packets:
     if lost_packet.in_flight:
       bytes_in_flight -= lost_packet.sent_bytes
-      latest_in_flight_lost =
-        max(latest_in_flight_lost, lost_packet.time_sent)
+      latest_time_of_in_flight_lost =
+        max(latest_time_of_in_flight_lost, lost_packet.time_sent)
   // Congestion event if in-flight packets were lost
-  if (latest_in_flight_lost != 0):
-    OnCongestionEvent(latest_in_flight_lost)
+  if (latest_time_of_in_flight_lost != 0):
+    OnCongestionEvent(latest_time_of_in_flight_lost)
 
   // Reset the congestion window if the loss of these
   // packets indicates persistent congestion.

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1811,16 +1811,16 @@ Invoked when DetectAndRemoveLostPackets deems packets lost.
 
 ~~~
 OnPacketsLost(lost_packets):
-  time_of_latest_in_flight_loss = 0
+  sent_time_of_last_loss = 0
   // Remove lost packets from bytes_in_flight.
   for lost_packet in lost_packets:
     if lost_packet.in_flight:
       bytes_in_flight -= lost_packet.sent_bytes
-      time_of_latest_in_flight_loss =
-        max(time_of_latest_in_flight_loss, lost_packet.time_sent)
+      sent_time_of_last_loss =
+        max(sent_time_of_last_loss, lost_packet.time_sent)
   // Congestion event if in-flight packets were lost
-  if (time_of_latest_in_flight_loss != 0):
-    OnCongestionEvent(time_of_latest_in_flight_loss)
+  if (sent_time_of_last_loss != 0):
+    OnCongestionEvent(sent_time_of_last_loss)
 
   // Reset the congestion window if the loss of these
   // packets indicates persistent congestion.


### PR DESCRIPTION
I'm not sure this is the best name, but I think adding 'time' to the variable makes this easier to read, particularly since the variable is initialized to 0, which is not really a time.

Follow-up to #4426