### PR TITLE
Consistency tweak to persistent congestion definition

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -997,8 +997,8 @@ congestion without depending on PTO expiration.
 A sender establishes persistent congestion after the receipt of an
 acknowledgement if two packets that are ack-eliciting are declared lost, and:
 
-* all packets, across all packet number spaces, sent between the send times of
-  these two packets are declared lost;
+* across all packet number spaces, none of the packets sent between the send
+  times of these two packets are acknowledged;
 
 * the duration between the send times of these two packets exceeds the
   persistent congestion duration ({{pc-duration}}); and


### PR DESCRIPTION
Persistent congestion means that no packets between two ack-eliciting packets was received by the peer. This was codified as all packets between those boundary packets being lost.

However, non-ack-eliciting packets can be often never declared as lost, since loss declaration requires a packet to be in-flight (https://quicwg.org/base-drafts/draft-ietf-quic-recovery.html#section-6.1). What we really want to say is that none of the packets between these boundary packets were acknowledged. This PR makes this change.

Note that the example below the definition already follows this; packets in between the boundary packets are noted as "not acknowledged" rather than marked as lost.

(Problem also noted here: https://github.com/quicwg/base-drafts/pull/4434#issuecomment-742966423)
