### PR TITLE
Use "domain name", not "DNS name"

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -370,9 +370,10 @@ QUIC transport versions with HTTP/3 MAY be defined by future specifications.
 
 QUIC version 1 uses TLS version 1.3 or greater as its handshake protocol.
 HTTP/3 clients MUST support a mechanism to indicate the target host to the
-server during the TLS handshake.  If the server is identified by a DNS name,
-clients MUST send the Server Name Indication (SNI; {{!RFC6066}}) TLS extension
-unless an alternative mechanism to indicate the target host is used.
+server during the TLS handshake.  If the server is identified by a domain name
+({{?DNS-TERMS=RFC8499}}), clients MUST send the Server Name Indication (SNI;
+{{!RFC6066}}) TLS extension unless an alternative mechanism to indicate the
+target host is used.
 
 QUIC connections are established as described in {{QUIC-TRANSPORT}}. During
 connection establishment, HTTP/3 support is indicated by selecting the ALPN


### PR DESCRIPTION
To align with "official" terminology in RFC 8499.  Cite that.