### PR TITLE
Add Handshake Confirmed to the TLS interface

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -570,7 +570,11 @@ Install 1-RTT keys
 
                                               Handshake Received
                                               Handshake Complete
+                                             Handshake Confirmed
                                            Install rx 1-RTT keys
+                     <--------------- 1-RTT
+                           (HANDSHAKE_DONE)
+Handshake Confirmed
 ~~~
 {: #exchange-summary title="Interaction Summary between QUIC and TLS"}
 


### PR DESCRIPTION
Though this doesn't really need to be shown here to illustrate the
interface between the stack components, the state is defined in this
section, so it makes sense to show it.  For completeness, if nothing
else (or is it confirmedness?).

Originally raised in #4480.