### PR TITLE
Closure alerts are errors too

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -803,7 +803,7 @@ added to 0x100 to produce a QUIC error code from the range reserved for
 CRYPTO_ERROR. The resulting value is sent in a QUIC CONNECTION_CLOSE frame of
 type 0x1c.
 
-QUIC is only able to convey an alert level of "fatal". The only existing uses
+QUIC is only able to convey an alert level of "fatal". In TLS 1.3, the only existing uses
 for the "warning" level are to signal connection close; see Section 6.1 of
 {{!TLS13}}. As QUIC provides alternative mechanisms for connection termination
 and the TLS connection is only closed if an error is encountered, a QUIC

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -803,8 +803,11 @@ added to 0x100 to produce a QUIC error code from the range reserved for
 CRYPTO_ERROR. The resulting value is sent in a QUIC CONNECTION_CLOSE frame of
 type 0x1c.
 
-The alert level of all TLS alerts is "fatal"; a TLS stack MUST NOT generate
-alerts at the "warning" level.
+QUIC is only able to convey an alert level of "fatal". The only existing uses
+for the "warning" level are to signal connection close; see Section 6.1 of
+{{!TLS13}}. As QUIC provides alternative mechanisms for connection termination
+and the TLS connection is only closed if an error is encountered, a QUIC
+endpoint MUST treat any alert from TLS as if it were at the "fatal" level.
 
 QUIC permits the use of a generic code in place of a specific error code; see
 Section 11 of {{QUIC-TRANSPORT}}. For TLS alerts, this includes replacing any

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -803,11 +803,12 @@ added to 0x100 to produce a QUIC error code from the range reserved for
 CRYPTO_ERROR. The resulting value is sent in a QUIC CONNECTION_CLOSE frame of
 type 0x1c.
 
-QUIC is only able to convey an alert level of "fatal". In TLS 1.3, the only existing uses
-for the "warning" level are to signal connection close; see Section 6.1 of
-{{!TLS13}}. As QUIC provides alternative mechanisms for connection termination
-and the TLS connection is only closed if an error is encountered, a QUIC
-endpoint MUST treat any alert from TLS as if it were at the "fatal" level.
+QUIC is only able to convey an alert level of "fatal". In TLS 1.3, the only
+existing uses for the "warning" level are to signal connection close; see
+Section 6.1 of {{!TLS13}}. As QUIC provides alternative mechanisms for
+connection termination and the TLS connection is only closed if an error is
+encountered, a QUIC endpoint MUST treat any alert from TLS as if it were at the
+"fatal" level.
 
 QUIC permits the use of a generic code in place of a specific error code; see
 Section 11 of {{QUIC-TRANSPORT}}. For TLS alerts, this includes replacing any


### PR DESCRIPTION
This changes the shape of the requirement from one that proscribes the
behaviour of a TLS stack to the reaction of QUIC to a warning level
alert.  This recommends treating them as fatal as QUIC never
deliberately closes TLS.

This is a normative change that should have no practical effect on
implementations.

Closes #4485.