### PR TITLE
STOP_SENDING carries information too

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1282,13 +1282,13 @@ If 0-RTT keys are available (see {{enable-0rtt}}), the lack of replay protection
 means that restrictions on their use are necessary to avoid replay attacks on
 the protocol.
 
-Of the frames defined in {{QUIC-TRANSPORT}}, the STREAM, RESET_STREAM, and
-CONNECTION_CLOSE frames are potentially unsafe for use with 0-RTT as they
-carry application data.  Application data that is received in 0-RTT could cause
-an application at the server to process the data multiple times rather than
-just once. Additional actions taken by a server as a result of processing
-replayed application data could have unwanted consequences. A client therefore
-MUST NOT use 0-RTT for application data unless specifically
+Of the frames defined in {{QUIC-TRANSPORT}}, the STREAM, RESET_STREAM,
+STOP_SENDING, and CONNECTION_CLOSE frames are potentially unsafe for use with
+0-RTT as they carry application data. Application data that is received in
+0-RTT could cause an application at the server to process the data multiple
+times rather than just once. Additional actions taken by a server as a result
+of processing replayed application data could have unwanted consequences. A
+client therefore MUST NOT use 0-RTT for application data unless specifically
 requested by the application that is in use.
 
 An application protocol that uses QUIC MUST include a profile that defines


### PR DESCRIPTION
So it could be unsafe for use in 0-RTT.

Closes #4494.