### PR TITLE
Transport calls these 4 bits Unused

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1409,7 +1409,7 @@ Retry Pseudo-Packet {
   Header Form (1) = 1,
   Fixed Bit (1) = 1,
   Long Packet Type (2) = 3,
-  Type-Specific Bits (4),
+  Unused (4),
   Version (32),
   DCID Len (8),
   Destination Connection ID (0..160),


### PR DESCRIPTION
So -tls should too.

Closes #4496.