### PR TITLE
Rewrite text on timing leaks for key generation

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1636,13 +1636,13 @@ in the network.  In this case, the Key Phase bit alone can be used to select
 keys.
 
 An endpoint MAY allow a period of approximately the Probe Timeout (PTO; see
-{{QUIC-RECOVERY}}) after receiving a packet that uses the new key generation
-before it creates the next set of packet protection keys.  These updated keys
-MAY replace the previous keys at that time.  With the caveat that PTO is a
+{{QUIC-RECOVERY}}) after promoting the next set of receive keys to be current
+before it creates the subsequent set of packet protection keys. These updated
+keys MAY replace the previous keys at that time. With the caveat that PTO is a
 subjective measure - that is, a peer could have a different view of the RTT -
 this time is expected to be long enough that any reordered packets would be
 declared lost by a peer even if they were acknowledged and short enough to
-allow for subsequent key updates.
+allow a peer to initiate further key updates.
 
 Endpoints need to allow for the possibility that a peer might not be able to
 decrypt packets that initiate a key update during the period when it retains old

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1584,7 +1584,7 @@ Key Phase bit.
 Endpoints are generally expected to have current and next receive packet
 protection keys available. For a short period after a key update completes, up
 to three times the PTO, endpoints MAY defer generation of the next set of
-receive packet protection keys and use old keys instead. This allows endpoints
+receive packet protection keys. This allows endpoints
 to retain only two sets of receive keys; see {{old-keys-recv}}.
 
 Once generated, the next set of packet protection keys SHOULD be retained, even

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1583,7 +1583,7 @@ Key Phase bit.
 
 Endpoints are generally expected to have current and next receive packet
 protection keys available. For a short period after a key update completes, up
-to three times the PTO, endpoints MAY defer generation of the next set of
+to the PTO, endpoints MAY defer generation of the next set of
 receive packet protection keys. This allows endpoints
 to retain only two sets of receive keys; see {{old-keys-recv}}.
 

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1576,12 +1576,16 @@ remove packet protection, and results in all packets with an invalid Key Phase
 bit being rejected.
 
 The process of creating new packet protection keys for receiving packets could
-reveal that a key update has occurred.  An endpoint MAY perform this process as
-part of packet processing, but this creates a timing signal that can be used by
-an attacker to learn when key updates happen and thus the value of the Key Phase
-bit in certain packets.  Endpoints MAY instead defer the creation of the next
-set of receive packet protection keys until some time after a key update
-completes, up to three times the PTO; see {{old-keys-recv}}.
+reveal that a key update has occurred. An endpoint MAY generate new keys as
+part of packet processing, but this creates a timing signal that could be used
+by an attacker to learn when key updates happen and thus leak the value of the
+Key Phase bit.
+
+Endpoints are generally expected to have current and next receive packet
+protection keys available. For a short period after a key update completes, up
+to three times the PTO, endpoints MAY defer generation of the next set of
+receive packet protection keys and use old keys instead. This allows endpoints
+to retain only two sets of receive keys; see {{old-keys-recv}}.
 
 Once generated, the next set of packet protection keys SHOULD be retained, even
 if the packet that was received was subsequently discarded.  Packets containing


### PR DESCRIPTION
Some of this is just forward reference, but it does need a little more
context.

Also, there was a missing word.

Closes #4498.