### PR TITLE
This "this" was just confusing

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -2754,8 +2754,9 @@ setting IPv6 flow labels.
 The IPv6 flow label SHOULD be a pseudo-random function of the source and
 destination addresses, source and destination UDP ports, and the Destination
 Connection ID field.  The flow label generation MUST be designed to minimize the
-chances of linkability with a previously used flow label, as this would enable
-correlating activity on multiple paths; see {{migration-linkability}}.
+chances of linkability with a previously used flow label, as a stable flow
+label would enable correlating activity on multiple paths; see
+{{migration-linkability}}.
 
 A possible implementation is to compute the flow label as a cryptographic hash
 function of the source and destination addresses, source and destination


### PR DESCRIPTION
The text was probably backwards, but rather than invert it, remove the
indirect reference to the subject of the claim and be explicit.

Closes #4515.