### PR TITLE
Use `L` to represent any type of length

### DIFF
--- a/draft-ietf-quic-invariants.md
+++ b/draft-ietf-quic-invariants.md
@@ -137,12 +137,12 @@ x (A..B):
   a minimum of zero bits and B can be omitted to indicate no set upper limit;
   values in this format always end on an byte boundary
 
-x (?) = C:
+x (L) = C:
 : Indicates that x has a fixed value of C
 
-x (E) ...:
+x (L) ...:
 : Indicates that x is repeated zero or more times (and that each instance is
-  length E)
+  length L)
 
 This document uses network byte order (that is, big endian) values.  Fields
 are placed starting from the high-order bits of each byte.

--- a/draft-ietf-quic-invariants.md
+++ b/draft-ietf-quic-invariants.md
@@ -138,7 +138,7 @@ x (A..B):
   values in this format always end on an byte boundary
 
 x (L) = C:
-: Indicates that x has a fixed value of C
+: Indicates that x, with a length described by L, has a fixed value of C
 
 x (L) ...:
 : Indicates that x is repeated zero or more times (and that each instance is

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -306,20 +306,20 @@ x (A..B):
   a minimum of zero bits and B can be omitted to indicate no set upper limit;
   values in this format always end on an byte boundary
 
-x (?) = C:
+x (L) = C:
 : Indicates that x has a fixed value of C with the length described by
-  ?, as above
+  L, which can use any of the three length forms above
 
-x (?) = C..D:
+x (L) = C..D:
 : Indicates that x has a value in the range from C to D, inclusive,
-  with the length described by ?, as above
+  with the length described by L, as above
 
-\[x (E)\]:
-: Indicates that x is optional (and has length of E)
+\[x (L)\]:
+: Indicates that x is optional (and has length of L)
 
-x (E) ...:
+x (L) ...:
 : Indicates that x is repeated zero or more times (and that each instance is
-  length E)
+  length L)
 
 This document uses network byte order (that is, big endian) values.  Fields
 are placed starting from the high-order bits of each byte.


### PR DESCRIPTION
As suggested by Éric.

Closes #4540.