### PR TITLE
Hyphenate 8-byte overhead

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -830,7 +830,7 @@ an initial value.  Endpoints SHOULD use an initial congestion window of 10 times
 the maximum datagram size (max_datagram_size), limited to the larger of 14720
 bytes or twice the maximum datagram size. This follows the analysis and
 recommendations in {{?RFC6928}}, increasing the byte limit to account for the
-smaller 8 byte overhead of UDP compared to the 20 byte overhead for TCP.
+smaller 8-byte overhead of UDP compared to the 20-byte overhead for TCP.
 
 If the maximum datagram size changes during the connection, the initial
 congestion window SHOULD be recalculated with the new size.  If the maximum


### PR DESCRIPTION
and the 20-byte overhead too.

(If this is superseded, that's cool.  Low hanging fruit...)

Closes #4592.