### PR TITLE
Remove Peer Creates transition to Ready

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -530,9 +530,6 @@ data to a peer.
        |                           |
        | Send STREAM /             |
        |      STREAM_DATA_BLOCKED  |
-       |                           |
-       | Peer Creates              |
-       |      Bidirectional Stream |
        v                           |
    +-------+                       |
    | Send  | Send RESET_STREAM     |


### PR DESCRIPTION
This isn't necessary, and removing it makes it smaller.

Closes #4611.