### PR TITLE
Update discussion of Version Negotiation

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1436,11 +1436,7 @@ packet that lists the QUIC version selected by the client.
 How to perform version negotiation is left as future work defined by future
 standards-track specifications.  In particular, that future work will
 ensure robustness against version downgrade attacks; see
-{{version-downgrade}}.  New versions of QUIC (including
-non-standards-track versions) might be specified prior to the
-availability of a version negotiation mechanism.  Until a version
-negotiation mechanism is available, new versions of QUIC MUST respond to
-Version Negotiation packets as specified above.
+{{version-downgrade}}.
 
 
 ### Version Negotiation Between Draft Versions

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1408,8 +1408,6 @@ This system allows a server to process packets with unsupported versions without
 retaining state.  Though either the Initial packet or the Version Negotiation
 packet that is sent in response could be lost, the client will send new packets
 until it successfully receives a response or it abandons the connection attempt.
-As a result, the client discards all state for the connection and does not send
-any more packets on the connection.
 
 A server MAY limit the number of Version Negotiation packets it sends.  For
 instance, a server that is able to recognize packets as 0-RTT might choose not

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1417,11 +1417,12 @@ expectation that it will eventually receive an Initial packet.
 
 ## Handling Version Negotiation Packets {#handle-vn}
 
-Version Negotiation packets are designed to allow future versions of QUIC to
-negotiate the version in use between endpoints.  Future versions of QUIC might
-change how implementations that support multiple versions of QUIC react to
-Version Negotiation packets when attempting to establish a connection using this
-version.
+Version Negotiation packets are designed to allow for functionality to be
+defined in the future that allows QUIC to negotiate the version of QUIC to use
+between endpoints.  Future standards-track specifications might change how
+implementations that support multiple versions of QUIC react to Version
+Negotiation packets received in response to an attempt to establish a
+connection using this version.
 
 A client that supports only this version of QUIC MUST abandon the current
 connection attempt if it receives a Version Negotiation packet, with the
@@ -1431,8 +1432,13 @@ earlier Version Negotiation packet. A client MUST discard a Version Negotiation
 packet that lists the QUIC version selected by the client.
 
 How to perform version negotiation is left as future work defined by future
-versions of QUIC.  In particular, that future work will ensure robustness
-against version downgrade attacks; see {{version-downgrade}}.
+standards-track specifications.  In particular, that future work will
+ensure robustness against version downgrade attacks; see
+{{version-downgrade}}.  New versions of QUIC (including
+non-standards-track versions) might be specified prior to the
+availability of a version negotiation mechanism.  Until a version
+negotiation mechanism is available, new versions of QUIC MUST respond to
+Version Negotiation packets as specified above.
 
 
 ### Version Negotiation Between Draft Versions

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1421,7 +1421,7 @@ expectation that it will eventually receive an Initial packet.
 
 Version Negotiation packets are designed to allow for functionality to be
 defined in the future that allows QUIC to negotiate the version of QUIC to use
-between endpoints.  Future standards-track specifications might change how
+for a connection.  Future standards-track specifications might change how
 implementations that support multiple versions of QUIC react to Version
 Negotiation packets received in response to an attempt to establish a
 connection using this version.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1408,6 +1408,8 @@ This system allows a server to process packets with unsupported versions without
 retaining state.  Though either the Initial packet or the Version Negotiation
 packet that is sent in response could be lost, the client will send new packets
 until it successfully receives a response or it abandons the connection attempt.
+As a result, the client discards all state for the connection and does not send
+any more packets on the connection.
 
 A server MAY limit the number of Version Negotiation packets it sends.  For
 instance, a server that is able to recognize packets as 0-RTT might choose not


### PR DESCRIPTION
Remove a sentence (apparently) about handling version negotiation packets from the section that's supposed to be about sending them.

Clarify that the handling of version negotiation packets is meant to be specified only by standards-track documents (since it is in some sense a cross-version invariant rather than version-specific behavior).  In particular, those documents will not necessarily be specifications for a future version of QUIC.

New versions of QUIC specified prior to the existence of a version negotiation mechanism are to respond to Version Negotiation packets in the same manner as v1.