### PR TITLE
A minimum-length varint encoding is not mandatory

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -4418,10 +4418,12 @@ encoding properties.
 
 Examples and a sample decoding algorithm are shown in {{sample-varint}}.
 
+Values do not need to be encoded on the minimum number of bytes necessary, with
+the sole exception of the Frame Type field; see {{frames}}.
+
 Versions ({{versions}}), packet numbers sent in the header
 ({{packet-encoding}}), and the length of connection IDs in long header packets
 ({{long-header}}) are described using integers, but do not use this encoding.
-
 
 
 # Packet Formats {#packet-formats}


### PR DESCRIPTION
With one exception.

Closes #4678.