### PR TITLE
Taken from, not defined in

### DIFF
--- a/draft-ietf-quic-invariants.md
+++ b/draft-ietf-quic-invariants.md
@@ -118,9 +118,8 @@ This document uses terms and notational conventions from {{QUIC-TRANSPORT}}.
 
 # Notational Conventions
 
-Packet diagrams in this document use a format taken from {{QUIC-TRANSPORT}} to
-illustrate the order and size of fields.  That format is defined in this
-section.
+The format of packets is described using the notation defined in this section.
+This notation is the same as that used in {{QUIC-TRANSPORT}}.
 
 Complex fields are named and then followed by a list of fields surrounded by a
 pair of matching braces. Each field in this list is separated by commas.

--- a/draft-ietf-quic-invariants.md
+++ b/draft-ietf-quic-invariants.md
@@ -118,8 +118,9 @@ This document uses terms and notational conventions from {{QUIC-TRANSPORT}}.
 
 # Notational Conventions
 
-Packet diagrams in this document use a format defined in {{QUIC-TRANSPORT}} to
-illustrate the order and size of fields.
+Packet diagrams in this document use a format taken from {{QUIC-TRANSPORT}} to
+illustrate the order and size of fields.  That format is defined in this
+section.
 
 Complex fields are named and then followed by a list of fields surrounded by a
 pair of matching braces. Each field in this list is separated by commas.


### PR DESCRIPTION
Fixes #4550 
Fixes #4551 

This makes it clearer that the notation is copied from v1, not defined there and normatively referenced.  (Note, figures aren't normative anyway.)