### PR TITLE
PATH_RESPONSE can't occur in 0-RTT

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -3525,7 +3525,7 @@ the table.
 | 0x18        | NEW_CONNECTION_ID    | {{frame-new-connection-id}}    | __01 | P    |
 | 0x19        | RETIRE_CONNECTION_ID | {{frame-retire-connection-id}} | __01 |      |
 | 0x1a        | PATH_CHALLENGE       | {{frame-path-challenge}}       | __01 | P    |
-| 0x1b        | PATH_RESPONSE        | {{frame-path-response}}        | __01 | P    |
+| 0x1b        | PATH_RESPONSE        | {{frame-path-response}}        | ___1 | P    |
 | 0x1c - 0x1d | CONNECTION_CLOSE     | {{frame-connection-close}}     | ih01 | N    |
 | 0x1e        | HANDSHAKE_DONE       | {{frame-handshake-done}}       | ___1 |      |
 {: #frame-types title="Frame Types"}


### PR DESCRIPTION
You only send a PATH_RESPONSE when a PATH_CHALLENGE is received.  PATH_CHALLENGE can't have been sent in Initial or Handshake, so the client's first opportunity to process a PATH_CHALLENGE is when it begins consuming 1-RTT packets from the server.  At the point 1-RTT packets are being read, the client is no longer allowed to send 0-RTT packets, because:

> A client MUST NOT send 0-RTT packets once it starts processing 1-RTT packets from the server. This means that 0-RTT packets cannot contain any response to frames from 1-RTT packets.

Therefore, PATH_RESPONSE is part of the class of frames which are simply not possible in 0-RTT.

Fixes #4625.