### PR TITLE
Two small tweaks to connection IDs

### DIFF
--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1131,10 +1131,9 @@ is 1.
 
 Additional connection IDs are communicated to the peer using NEW_CONNECTION_ID
 frames ({{frame-new-connection-id}}).  The sequence number on each newly issued
-connection ID MUST increase by 1.  The connection ID randomly selected by the
-client in the Initial packet and any connection ID provided by a Retry packet
-are not assigned sequence numbers unless a server opts to retain them as its
-initial connection ID.
+connection ID MUST increase by 1.  The connection ID that a client selects for
+the first Destination Connection ID field it sends and any connection ID
+provided by a Retry packet are not assigned sequence numbers.
 
 When an endpoint issues a connection ID, it MUST accept packets that carry this
 connection ID for the duration of the connection or until its peer invalidates


### PR DESCRIPTION
The value the client puts in the Destination Connection ID field is not
random, but unpredictable.  But we could be clearer and just say what
this refers to.

The second error here was that the server can't use the value it puts in
Retry.  Rather than talk about retaining the values, I'm striking that
clause.

Closes #4677.