### PR TITLE
Martin Duke's QPACK comments

### DIFF
--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -471,9 +471,10 @@ this MUST be treated as a connection error of type QPACK_ENCODER_STREAM_ERROR.
 ## Dynamic Table {#header-table-dynamic}
 
 The dynamic table consists of a list of field lines maintained in first-in,
-first-out order. Each HTTP/3 endpoint holds a dynamic table that is initially
+first-out order.  Each QPACK decoder holds a dynamic table that is initially
 empty.  Entries are added by encoder instructions received on the encoder
-stream; see {{encoder-instructions}}.
+stream; see {{encoder-instructions}}.  The encoder tracks the contents of the
+dynamic table maintained by the decoder.
 
 The dynamic table can contain duplicate entries (i.e., entries with the same
 name and same value).  Therefore, duplicate entries MUST NOT be treated as an
@@ -486,8 +487,8 @@ Dynamic table entries can have empty values.
 The size of the dynamic table is the sum of the size of its entries.
 
 The size of an entry is the sum of its name's length in bytes, its value's
-length in bytes, and 32.  The size of an entry is calculated using the length of
-its name and value without Huffman encoding applied.
+length in bytes, and 32 bytes.  The size of an entry is calculated using the
+length of its name and value without Huffman encoding applied.
 
 ### Dynamic Table Capacity and Eviction {#eviction}
 

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -487,8 +487,8 @@ Dynamic table entries can have empty values.
 The size of the dynamic table is the sum of the size of its entries.
 
 The size of an entry is the sum of its name's length in bytes, its value's
-length in bytes, and 32 bytes.  The size of an entry is calculated using the
-length of its name and value without Huffman encoding applied.
+length in bytes, and 32 additional bytes.  The size of an entry is calculated
+using the length of its name and value without Huffman encoding applied.
 
 ### Dynamic Table Capacity and Eviction {#eviction}
 

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -471,10 +471,10 @@ this MUST be treated as a connection error of type QPACK_ENCODER_STREAM_ERROR.
 ## Dynamic Table {#header-table-dynamic}
 
 The dynamic table consists of a list of field lines maintained in first-in,
-first-out order.  Each QPACK decoder holds a dynamic table that is initially
-empty.  Entries are added by encoder instructions received on the encoder
-stream; see {{encoder-instructions}}.  The encoder tracks the contents of the
-dynamic table maintained by the decoder.
+first-out order.  A QPACK encoder and decoder share a dynamic table that is
+initially empty.  The encoder adds entries to the dynamic table and sends them
+to the decoder via instructions on the encoder stream; see
+{{encoder-instructions}}.
 
 The dynamic table can contain duplicate entries (i.e., entries with the same
 name and same value).  Therefore, duplicate entries MUST NOT be treated as an


### PR DESCRIPTION
Fixes #4748.
Fixes #4749.

I opted to reframe the language from HTTP/3 endpoint to decoder, since encoder and decoder instances are what this spec primarily talks about.  We already say that HTTP/3 endpoints contain both an encoder and a decoder.

I also added a comment that encoders track the contents of the table at the decoder. I specifically did not say that they keep a full copy of the table, however; they might not.
