### PR TITLE
editorial: an byte → a byte

### DIFF
--- a/draft-ietf-quic-invariants.md
+++ b/draft-ietf-quic-invariants.md
@@ -134,7 +134,7 @@ x (A):
 x (A..B):
 : Indicates that x can be any length from A to B; A can be omitted to indicate
   a minimum of zero bits and B can be omitted to indicate no set upper limit;
-  values in this format always end on an byte boundary
+  values in this format always end on a byte boundary
 
 x (L) = C:
 : Indicates that x, with a length described by L, has a fixed value of C

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -307,7 +307,7 @@ x (i):
 x (A..B):
 : Indicates that x can be any length from A to B; A can be omitted to indicate
   a minimum of zero bits and B can be omitted to indicate no set upper limit;
-  values in this format always end on an byte boundary
+  values in this format always end on a byte boundary
 
 x (L) = C:
 : Indicates that x has a fixed value of C with the length described by


### PR DESCRIPTION
Draft 34 changed notation from "octet" to "byte" in a few places, but forgot to change the article in two places.