### PR TITLE
Which HTTP/2 settings must be rejected?

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1439,10 +1439,10 @@ settings to have any meaning upon receipt.
 Because the setting has no defined meaning, the value of the setting can be any
 value the implementation selects.
 
-Setting identifiers which were used in HTTP/2 where there is no corresponding
-HTTP/3 setting have also been reserved ({{iana-settings}}). These settings MUST
-NOT be sent, and their receipt MUST be treated as a connection error of type
-H3_SETTINGS_ERROR.
+Setting identifiers which were defined in {{?HTTP2}} where there is no
+corresponding HTTP/3 setting have also been reserved ({{iana-settings}}). These
+reserved settings MUST NOT be sent, and their receipt MUST be treated as a
+connection error of type H3_SETTINGS_ERROR.
 
 Additional settings can be defined by extensions to HTTP/3; see {{extensions}}
 for more details.


### PR DESCRIPTION
Specifically those defined in RFC 7540.