### PR TITLE
Application-Layer, not Application Layer

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -312,7 +312,7 @@ host identifier to an IP address, establishing a QUIC connection to that address
 on the indicated port (including validation of the server certificate as
 described above), and sending an HTTP/3 request message targeting the URI
 to the server over that secured connection.  Unless some other mechanism is used
-to select HTTP/3, the token "h3" is used in the Application Layer Protocol
+to select HTTP/3, the token "h3" is used in the Application-Layer Protocol
 Negotiation (ALPN; see {{!RFC7301}}) extension during the TLS handshake.
 
 Connectivity problems (e.g., blocking UDP) can result in QUIC connection
@@ -2045,7 +2045,7 @@ registries that manage the assignment of codepoints in HTTP/3.
 ## Registration of HTTP/3 Identification String {#iana-alpn}
 
 This document creates a new registration for the identification of
-HTTP/3 in the "Application Layer Protocol Negotiation (ALPN)
+HTTP/3 in the "Application-Layer Protocol Negotiation (ALPN)
 Protocol IDs" registry established in {{?RFC7301}}.
 
 The "h3" string identifies HTTP/3:

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -617,7 +617,7 @@ negotiated.
 The first Initial packet from a client contains the start or all of its first
 cryptographic handshake message, which for TLS is the ClientHello.  Servers
 might need to parse the entire ClientHello (e.g., to access extensions such as
-Server Name Identification (SNI) or Application Layer Protocol Negotiation
+Server Name Identification (SNI) or Application-Layer Protocol Negotiation
 (ALPN)) in order to decide whether to accept the new incoming QUIC connection.
 If the ClientHello spans multiple Initial packets, such servers would need to
 buffer the first received fragments, which could consume excessive resources if

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -1792,7 +1792,7 @@ parameters as a connection error of type TRANSPORT_PARAMETER_ERROR.
 Endpoints use transport parameters to authenticate the negotiation of
 connection IDs during the handshake; see {{cid-auth}}.
 
-Application Layer Protocol Negotiation (ALPN; see {{?ALPN=RFC7301}}) allows
+Application-Layer Protocol Negotiation (ALPN; see {{?ALPN=RFC7301}}) allows
 clients to offer multiple application protocols during connection
 establishment. The transport parameters that a client includes during the
 handshake apply to all application protocols that the client offers. Application


### PR DESCRIPTION
Fixes #4837, as well as other instances of the term.  RFC 7301 does indeed hyphenate (and that's correct, since "application-layer" is being used as a single unit to describe "protocol").