### PR TITLE
Pad hex literals to byte lengths

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1701,62 +1701,62 @@ can have other effects regardless of the error code; for example, see
 The following error codes are defined for use when abruptly terminating streams,
 aborting reading of streams, or immediately closing HTTP/3 connections.
 
-H3_NO_ERROR (0x100):
+H3_NO_ERROR (0x0100):
 : No error.  This is used when the connection or stream needs to be closed, but
   there is no error to signal.
 
-H3_GENERAL_PROTOCOL_ERROR (0x101):
+H3_GENERAL_PROTOCOL_ERROR (0x0101):
 : Peer violated protocol requirements in a way that does not match a more
   specific error code, or endpoint declines to use the more specific error code.
 
-H3_INTERNAL_ERROR (0x102):
+H3_INTERNAL_ERROR (0x0102):
 : An internal error has occurred in the HTTP stack.
 
-H3_STREAM_CREATION_ERROR (0x103):
+H3_STREAM_CREATION_ERROR (0x0103):
 : The endpoint detected that its peer created a stream that it will not accept.
 
-H3_CLOSED_CRITICAL_STREAM (0x104):
+H3_CLOSED_CRITICAL_STREAM (0x0104):
 : A stream required by the HTTP/3 connection was closed or reset.
 
-H3_FRAME_UNEXPECTED (0x105):
+H3_FRAME_UNEXPECTED (0x0105):
 : A frame was received that was not permitted in the current state or on the
   current stream.
 
-H3_FRAME_ERROR (0x106):
+H3_FRAME_ERROR (0x0106):
 : A frame that fails to satisfy layout requirements or with an invalid size
   was received.
 
-H3_EXCESSIVE_LOAD (0x107):
+H3_EXCESSIVE_LOAD (0x0107):
 : The endpoint detected that its peer is exhibiting a behavior that might be
   generating excessive load.
 
-H3_ID_ERROR (0x108):
+H3_ID_ERROR (0x0108):
 : A Stream ID or Push ID was used incorrectly, such as exceeding a limit,
   reducing a limit, or being reused.
 
-H3_SETTINGS_ERROR (0x109):
+H3_SETTINGS_ERROR (0x0109):
 : An endpoint detected an error in the payload of a SETTINGS frame.
 
-H3_MISSING_SETTINGS (0x10a):
+H3_MISSING_SETTINGS (0x010a):
 : No SETTINGS frame was received at the beginning of the control stream.
 
-H3_REQUEST_REJECTED (0x10b):
+H3_REQUEST_REJECTED (0x010b):
 : A server rejected a request without performing any application processing.
 
-H3_REQUEST_CANCELLED (0x10c):
+H3_REQUEST_CANCELLED (0x010c):
 : The request or its response (including pushed response) is cancelled.
 
-H3_REQUEST_INCOMPLETE (0x10d):
+H3_REQUEST_INCOMPLETE (0x010d):
 : The client's stream terminated without containing a fully-formed request.
 
-H3_MESSAGE_ERROR (0x10e):
+H3_MESSAGE_ERROR (0x010e):
 : An HTTP message was malformed and cannot be processed.
 
-H3_CONNECT_ERROR (0x10f):
+H3_CONNECT_ERROR (0x010f):
 : The TCP connection established in response to a CONNECT request was reset or
   abnormally closed.
 
-H3_VERSION_FALLBACK (0x110):
+H3_VERSION_FALLBACK (0x0110):
 : The requested operation cannot be served over HTTP/3.  The peer should
   retry over HTTP/1.1.
 
@@ -2199,23 +2199,23 @@ Required policy to avoid collisions with HTTP/2 error codes.
 | --------------------------------- | ---------- | ---------------------------------------- | ---------------------- |
 | Name                              | Value      | Description                              | Specification          |
 | --------------------------------- | ---------- | ---------------------------------------- | ---------------------- |
-| H3_NO_ERROR                       | 0x100      | No error                                 | {{http-error-codes}}   |
-| H3_GENERAL_PROTOCOL_ERROR         | 0x101      | General protocol error                   | {{http-error-codes}}   |
-| H3_INTERNAL_ERROR                 | 0x102      | Internal error                           | {{http-error-codes}}   |
-| H3_STREAM_CREATION_ERROR          | 0x103      | Stream creation error                    | {{http-error-codes}}   |
-| H3_CLOSED_CRITICAL_STREAM         | 0x104      | Critical stream was closed               | {{http-error-codes}}   |
-| H3_FRAME_UNEXPECTED               | 0x105      | Frame not permitted in the current state | {{http-error-codes}}   |
-| H3_FRAME_ERROR                    | 0x106      | Frame violated layout or size rules      | {{http-error-codes}}   |
-| H3_EXCESSIVE_LOAD                 | 0x107      | Peer generating excessive load           | {{http-error-codes}}   |
-| H3_ID_ERROR                       | 0x108      | An identifier was used incorrectly       | {{http-error-codes}}   |
-| H3_SETTINGS_ERROR                 | 0x109      | SETTINGS frame contained invalid values  | {{http-error-codes}}   |
-| H3_MISSING_SETTINGS               | 0x10a      | No SETTINGS frame received               | {{http-error-codes}}   |
-| H3_REQUEST_REJECTED               | 0x10b      | Request not processed                    | {{http-error-codes}}   |
-| H3_REQUEST_CANCELLED              | 0x10c      | Data no longer needed                    | {{http-error-codes}}   |
-| H3_REQUEST_INCOMPLETE             | 0x10d      | Stream terminated early                  | {{http-error-codes}}   |
-| H3_MESSAGE_ERROR                  | 0x10e      | Malformed message                        | {{http-error-codes}}   |
-| H3_CONNECT_ERROR                  | 0x10f      | TCP reset or error on CONNECT request    | {{http-error-codes}}   |
-| H3_VERSION_FALLBACK               | 0x110      | Retry over HTTP/1.1                      | {{http-error-codes}}   |
+| H3_NO_ERROR                       | 0x0100     | No error                                 | {{http-error-codes}}   |
+| H3_GENERAL_PROTOCOL_ERROR         | 0x0101     | General protocol error                   | {{http-error-codes}}   |
+| H3_INTERNAL_ERROR                 | 0x0102     | Internal error                           | {{http-error-codes}}   |
+| H3_STREAM_CREATION_ERROR          | 0x0103     | Stream creation error                    | {{http-error-codes}}   |
+| H3_CLOSED_CRITICAL_STREAM         | 0x0104     | Critical stream was closed               | {{http-error-codes}}   |
+| H3_FRAME_UNEXPECTED               | 0x0105     | Frame not permitted in the current state | {{http-error-codes}}   |
+| H3_FRAME_ERROR                    | 0x0106     | Frame violated layout or size rules      | {{http-error-codes}}   |
+| H3_EXCESSIVE_LOAD                 | 0x0107     | Peer generating excessive load           | {{http-error-codes}}   |
+| H3_ID_ERROR                       | 0x0108     | An identifier was used incorrectly       | {{http-error-codes}}   |
+| H3_SETTINGS_ERROR                 | 0x0109     | SETTINGS frame contained invalid values  | {{http-error-codes}}   |
+| H3_MISSING_SETTINGS               | 0x010a     | No SETTINGS frame received               | {{http-error-codes}}   |
+| H3_REQUEST_REJECTED               | 0x010b     | Request not processed                    | {{http-error-codes}}   |
+| H3_REQUEST_CANCELLED              | 0x010c     | Data no longer needed                    | {{http-error-codes}}   |
+| H3_REQUEST_INCOMPLETE             | 0x010d     | Stream terminated early                  | {{http-error-codes}}   |
+| H3_MESSAGE_ERROR                  | 0x010e     | Malformed message                        | {{http-error-codes}}   |
+| H3_CONNECT_ERROR                  | 0x010f     | TCP reset or error on CONNECT request    | {{http-error-codes}}   |
+| H3_VERSION_FALLBACK               | 0x0110     | Retry over HTTP/1.1                      | {{http-error-codes}}   |
 | --------------------------------- | ---------- | ---------------------------------------- | ---------------------- |
 {: #iana-error-table title="Initial HTTP/3 Error Codes"}
 

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -1177,15 +1177,15 @@ QPACK defines two settings for the HTTP/3 SETTINGS frame:
 The following error codes are defined for HTTP/3 to indicate failures of
 QPACK that prevent the stream or connection from continuing:
 
-QPACK_DECOMPRESSION_FAILED (0x200):
+QPACK_DECOMPRESSION_FAILED (0x0200):
 : The decoder failed to interpret an encoded field section and is not able to
   continue decoding that field section.
 
-QPACK_ENCODER_STREAM_ERROR (0x201):
+QPACK_ENCODER_STREAM_ERROR (0x0201):
 : The decoder failed to interpret an encoder instruction received on the
   encoder stream.
 
-QPACK_DECODER_STREAM_ERROR (0x202):
+QPACK_DECODER_STREAM_ERROR (0x0202):
 : The encoder failed to interpret a decoder instruction received on the
   decoder stream.
 
@@ -1457,13 +1457,13 @@ registered in the "HTTP/3 Stream Type" registry established in {{HTTP3}}.
 This document specifies three error codes. The entries in the following table
 are registered in the "HTTP/3 Error Code" registry established in {{HTTP3}}.
 
-| --------------------------------- | ----- | ---------------------------------------- | ---------------------- |
-| Name                              | Code  | Description                              | Specification          |
-| --------------------------------- | ----- | ---------------------------------------- | ---------------------- |
-| QPACK_DECOMPRESSION_FAILED        | 0x200 | Decoding of a field section failed       | {{error-handling}}     |
-| QPACK_ENCODER_STREAM_ERROR        | 0x201 | Error on the encoder stream              | {{error-handling}}     |
-| QPACK_DECODER_STREAM_ERROR        | 0x202 | Error on the decoder stream              | {{error-handling}}     |
-| --------------------------------- | ----- | ---------------------------------------- | ---------------------- |
+| --------------------------------- | ------ | ---------------------------------------- | ---------------------- |
+| Name                              | Code   | Description                              | Specification          |
+| --------------------------------- | ------ | ---------------------------------------- | ---------------------- |
+| QPACK_DECOMPRESSION_FAILED        | 0x0200 | Decoding of a field section failed       | {{error-handling}}     |
+| QPACK_ENCODER_STREAM_ERROR        | 0x0201 | Error on the encoder stream              | {{error-handling}}     |
+| QPACK_DECODER_STREAM_ERROR        | 0x0202 | Error on the decoder stream              | {{error-handling}}     |
+| --------------------------------- | ------ | ---------------------------------------- | ---------------------- |
 
 
 --- back

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -822,7 +822,7 @@ If TLS experiences an error, it generates an appropriate alert as defined in
 
 A TLS alert is converted into a QUIC connection error. The AlertDescription
 value is
-added to 0x100 to produce a QUIC error code from the range reserved for
+added to 0x0100 to produce a QUIC error code from the range reserved for
 CRYPTO_ERROR. The resulting value is sent in a QUIC CONNECTION_CLOSE frame of
 type 0x1c.
 
@@ -835,7 +835,7 @@ encountered, a QUIC endpoint MUST treat any alert from TLS as if it were at the
 
 QUIC permits the use of a generic code in place of a specific error code; see
 {{Section 11 of QUIC-TRANSPORT}}. For TLS alerts, this includes replacing any
-alert with a generic alert, such as handshake_failure (0x128 in QUIC).
+alert with a generic alert, such as handshake_failure (0x0128 in QUIC).
 Endpoints MAY use a generic error code to avoid possibly exposing confidential
 information.
 
@@ -1498,7 +1498,7 @@ from TLS where endpoints can update keys independently.
 This mechanism replaces the key update mechanism of TLS, which relies on
 KeyUpdate messages sent using 1-RTT encryption keys.  Endpoints MUST NOT send a
 TLS KeyUpdate message.  Endpoints MUST treat the receipt of a TLS KeyUpdate
-message as a connection error of type 0x10a, equivalent to a
+message as a connection error of type 0x010a, equivalent to a
 fatal TLS alert of unexpected_message; see {{tls-errors}}.
 
 {{ex-key-update}} shows a key update process, where the initial set of keys used
@@ -1815,17 +1815,17 @@ this purpose.
 
 When using ALPN, endpoints MUST immediately close a connection (see {{Section
 10.2 of QUIC-TRANSPORT}}) with a no_application_protocol TLS alert (QUIC error
-code 0x178; see {{tls-errors}}) if an application protocol is not negotiated.
+code 0x0178; see {{tls-errors}}) if an application protocol is not negotiated.
 While {{!ALPN}} only specifies that servers use this alert, QUIC clients MUST
-use error 0x178 to terminate a connection when ALPN negotiation fails.
+use error 0x0178 to terminate a connection when ALPN negotiation fails.
 
 An application protocol MAY restrict the QUIC versions that it can operate over.
 Servers MUST select an application protocol compatible with the QUIC version
 that the client has selected.  The server MUST treat the inability to select a
-compatible application protocol as a connection error of type 0x178
+compatible application protocol as a connection error of type 0x0178
 (no_application_protocol).  Similarly, a client MUST treat the selection of an
 incompatible application protocol by a server as a connection error of type
-0x178.
+0x0178.
 
 
 ## QUIC Transport Parameters Extension {#quic_parameters}
@@ -1849,8 +1849,8 @@ The quic_transport_parameters extension is carried in the ClientHello and the
 EncryptedExtensions messages during the handshake. Endpoints MUST send the
 quic_transport_parameters extension; endpoints that receive ClientHello or
 EncryptedExtensions messages without the quic_transport_parameters extension
-MUST close the connection with an error of type 0x16d (equivalent to a fatal TLS
-missing_extension alert, see {{tls-errors}}).
+MUST close the connection with an error of type 0x016d (equivalent to a fatal
+TLS missing_extension alert, see {{tls-errors}}).
 
 Transport parameters become available prior to the completion of the handshake.
 A server might use these values earlier than handshake completion. However, the

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -7688,7 +7688,7 @@ packets, or 0xe69e), 16 bits are required.
 
 In the same state, sending a packet with a number of 0xace8fe uses the 24-bit
 encoding, because at least 18 bits are required to represent twice the range
-(131,182 packets, or 0x2006e).
+(131,182 packets, or 0x02006e).
 
 
 ## Sample Packet Number Decoding Algorithm {#sample-packet-number-decoding}


### PR DESCRIPTION
One possible resolution to #4838; all literals are zero-padded to full bytes.