### PR TITLE
Use ACK-eliciting packets in flight to identify anti-deadlock probes

### DIFF
--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1480,7 +1480,7 @@ GetLossTimeAndSpace():
 GetPtoTimeAndSpace():
   duration = (smoothed_rtt + max(4 * rttvar, kGranularity))
       * (2 ^ pto_count)
-  // Arm PTO when there are no ACK-eliciting packets in flight.
+  // Anti-deadlock PTO starts from the current time
   if (no ack-eliciting packets in flight):
     assert(!PeerCompletedAddressValidation())
     if (has handshake keys):

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1480,8 +1480,8 @@ GetLossTimeAndSpace():
 GetPtoTimeAndSpace():
   duration = (smoothed_rtt + max(4 * rttvar, kGranularity))
       * (2 ^ pto_count)
-  // Arm PTO from now when there are no inflight packets.
-  if (no in-flight packets):
+  // Arm PTO from now when there are no ACK-eliciting packets.
+  if (no ack-eliciting packets in flight):
     assert(!PeerCompletedAddressValidation())
     if (has handshake keys):
       return (now() + duration), Handshake
@@ -1557,7 +1557,7 @@ OnLossDetectionTimeout():
     SetLossDetectionTimer()
     return
 
-  if (bytes_in_flight > 0):
+  if (any ack-eliciting packets in flight):
     // PTO. Send new data if available, else retransmit old data.
     // If neither is available, send a single PING frame.
     _, pn_space = GetPtoTimeAndSpace()

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1480,8 +1480,7 @@ GetLossTimeAndSpace():
 GetPtoTimeAndSpace():
   duration = (smoothed_rtt + max(4 * rttvar, kGranularity))
       * (2 ^ pto_count)
-  // Arm PTO from now when there are no ACK-eliciting packets in
-  // flight.
+  // Arm PTO when there are no ACK-eliciting packets in flight.
   if (no ack-eliciting packets in flight):
     assert(!PeerCompletedAddressValidation())
     if (has handshake keys):

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1557,12 +1557,7 @@ OnLossDetectionTimeout():
     SetLossDetectionTimer()
     return
 
-  if (any ack-eliciting packets in flight):
-    // PTO. Send new data if available, else retransmit old data.
-    // If neither is available, send a single PING frame.
-    _, pn_space = GetPtoTimeAndSpace()
-    SendOneOrTwoAckElicitingPackets(pn_space)
-  else:
+  if (no ack-eliciting packets in flight):
     assert(!PeerCompletedAddressValidation())
     // Client sends an anti-deadlock packet: Initial is padded
     // to earn more anti-amplification credit,
@@ -1571,6 +1566,11 @@ OnLossDetectionTimeout():
       SendOneAckElicitingHandshakePacket()
     else:
       SendOneAckElicitingPaddedInitialPacket()
+  else:
+    // PTO. Send new data if available, else retransmit old data.
+    // If neither is available, send a single PING frame.
+    _, pn_space = GetPtoTimeAndSpace()
+    SendOneOrTwoAckElicitingPackets(pn_space)
 
   pto_count++
   SetLossDetectionTimer()

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1480,7 +1480,8 @@ GetLossTimeAndSpace():
 GetPtoTimeAndSpace():
   duration = (smoothed_rtt + max(4 * rttvar, kGranularity))
       * (2 ^ pto_count)
-  // Arm PTO from now when there are no ACK-eliciting packets.
+  // Arm PTO from now when there are no ACK-eliciting packets in
+  // flight.
   if (no ack-eliciting packets in flight):
     assert(!PeerCompletedAddressValidation())
     if (has handshake keys):

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -1491,7 +1491,7 @@ GetPtoTimeAndSpace():
   pto_timeout = infinite
   pto_space = Initial
   for space in [ Initial, Handshake, ApplicationData ]:
-    if (no in-flight packets in space):
+    if (no ack-eliciting packets in flight in space):
         continue;
     if (space == ApplicationData):
       // Skip Application Data until handshake confirmed.


### PR DESCRIPTION
If a client's first Handshake ACK is padded (e.g. due to being
coalesced with an Initial packet) and the server's first flight is
incomplete due to anti-amplification limits, an anti-deadlock probe
may be necessary even though bytes_in_flight is nonzero.

Fixes #4846 .