### PR TITLE
Manually insert BCP 14 boilerplate

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -217,7 +217,10 @@ Additional resources are provided in the final sections:
 
 ## Conventions and Terminology
 
-{::boilerplate bcp14}
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this
+document are to be interpreted as described in BCP 14 {{!RFC2119}} {{!RFC8174}}
+when, and only when, they appear in all capitals, as shown here.
 
 This document uses the variable-length integer encoding from
 {{QUIC-TRANSPORT}}.

--- a/draft-ietf-quic-invariants.md
+++ b/draft-ietf-quic-invariants.md
@@ -108,7 +108,10 @@ every version of QUIC.
 
 # Conventions and Definitions
 
-{::boilerplate bcp14}
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this
+document are to be interpreted as described in BCP 14 {{!RFC2119}} {{!RFC8174}}
+when, and only when, they appear in all capitals, as shown here.
 
 This document defines requirements on future QUIC versions, even where normative
 language is not used.

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -124,7 +124,10 @@ with substantially less head-of-line blocking under the same loss conditions.
 
 ## Conventions and Definitions
 
-{::boilerplate bcp14}
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this
+document are to be interpreted as described in BCP 14 {{!RFC2119}} {{!RFC8174}}
+when, and only when, they appear in all capitals, as shown here.
 
 Definitions of terms that are used in this document:
 

--- a/draft-ietf-quic-recovery.md
+++ b/draft-ietf-quic-recovery.md
@@ -109,7 +109,10 @@ control mechanisms for QUIC.
 
 # Conventions and Definitions
 
-{::boilerplate bcp14}
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this
+document are to be interpreted as described in BCP 14 {{!RFC2119}} {{!RFC8174}}
+when, and only when, they appear in all capitals, as shown here.
 
 Definitions of terms that are used in this document:
 

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -136,7 +136,10 @@ This document describes how TLS acts as a security component of QUIC.
 
 # Notational Conventions
 
-{::boilerplate bcp14}
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this
+document are to be interpreted as described in BCP 14 {{!RFC2119}} {{!RFC8174}}
+when, and only when, they appear in all capitals, as shown here.
 
 This document uses the terminology established in {{QUIC-TRANSPORT}}.
 

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -221,7 +221,10 @@ set of version-independent properties of QUIC can cite {{QUIC-INVARIANTS}}.
 
 ## Terms and Definitions
 
-{::boilerplate bcp14}
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this
+document are to be interpreted as described in BCP 14 {{!RFC2119}} {{!RFC8174}}
+when, and only when, they appear in all capitals, as shown here.
 
 Commonly used terms in the document are described below.
 


### PR DESCRIPTION
kramdown-rfc2629 inserts a non-breaking space when expanding
`{::boilerplate bcp14}`, which xml2rfc subsequently mangles to produce
invalid XML.  Rather than deal with that, insert the boilerplate with
regular spaces instead.

Note that this is necessary to make #4871 work properly, as that tool drops the non-breaking whitespace character between "BCP" and "14".