### PR TITLE
RPC text changes for -tls

### DIFF
--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1051,7 +1051,7 @@ from the Destination Connection ID field from the client's first Initial
 packet.
 
 This secret is determined by using HKDF-Extract (see {{Section 2.2 of HKDF}})
-with a salt of 0x38762cf7f55934b34d179ae6a4c80cadccbb7f0a and the input keying
+with a salt of 0x38762cf7f55934b34d179ae6a4c80cadccbb7f0a and an input keying
 material (IKM) of the Destination Connection ID field. This produces an
 intermediate pseudorandom key (PRK) that is used to derive two separate secrets
 for sending and receiving.

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1202,11 +1202,11 @@ The header protection algorithm uses both the header protection key and a sample
 of the ciphertext from the packet Payload field.
 
 The same number of bytes are always sampled, but an allowance needs to be made
-for the endpoint removing protection, which will not know the length of the
-Packet Number field.  The sample of ciphertext is taken starting from an offset
-of 4 bytes after the start of the Packet Number field.  That is, in sampling
-packet ciphertext for header protection, the Packet Number field is assumed to
-be 4 bytes long (its maximum possible encoded length).
+for the removal of protection by a receiving endpoint, which will not know the
+length of the Packet Number field.  The sample of ciphertext is taken starting
+from an offset of 4 bytes after the start of the Packet Number field.  That is,
+in sampling packet ciphertext for header protection, the Packet Number field is
+assumed to be 4 bytes long (its maximum possible encoded length).
 
 An endpoint MUST discard packets that are not long enough to contain a complete
 sample.

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -167,7 +167,7 @@ Layer     |                      Records                      |
 ~~~~
 {: #tls-layers title="TLS Layers"}
 
-Each content-layer message (e.g., Handshake, Alerts, and Application Data) is
+Each content-layer message (e.g., handshake, alerts, and application data) is
 carried as a series of typed TLS records by the record layer.  Records are
 individually cryptographically protected and then transmitted over a reliable
 transport (typically TCP), which provides sequencing and guaranteed delivery.
@@ -193,13 +193,13 @@ shared secrets that cannot be controlled by either participating peer.
 
 TLS provides two basic handshake modes of interest to QUIC:
 
- * A full 1-RTT handshake, in which the client is able to send Application Data
+ * A full 1-RTT handshake, in which the client is able to send application data
    after one round trip and the server immediately responds after receiving the
    first handshake message from the client.
 
  * A 0-RTT handshake, in which the client uses information it has previously
-   learned about the server to send Application Data immediately.  This
-   Application Data can be replayed by an attacker, so 0-RTT is not suitable for
+   learned about the server to send application data immediately.  This
+   application data can be replayed by an attacker, so 0-RTT is not suitable for
    carrying instructions that might initiate any action that could cause
    unwanted effects if replayed.
 
@@ -232,17 +232,17 @@ QUIC has its own key update mechanism; see {{key-update}}.
 
 Data is protected using a number of encryption levels:
 
-- Initial Keys
-- Early Data (0-RTT) Keys
-- Handshake Keys
-- Application Data (1-RTT) Keys
+- Initial keys
+- Early data (0-RTT) keys
+- Handshake keys
+- Application data (1-RTT) keys
 
-Application Data can only appear in the early data and Application Data
+Application data can only appear in the early data and application data
 levels. Handshake and alert messages may appear in any level.
 
 The 0-RTT handshake can be used if the client and server have previously
 communicated.  In the 1-RTT handshake, the client is unable to send protected
-Application Data until it has received all of the handshake messages sent by the
+application data until it has received all of the handshake messages sent by the
 server.
 
 

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -118,6 +118,29 @@ informative:
     seriesinfo:
       DOI: 10.1007/3-540-36492-7_7
 
+  NAN:
+    title: "Nonces Are Noticed: AEAD Revisited"
+    author:
+      -
+        initials: M.
+        surname: Bellare
+        name: Mihir Bellare
+      -
+        initials: R.
+        surname: Ng
+        name: Ruth Ng
+      -
+        initials: B.
+        surname: Tackmann
+        name: Björn Tackmann
+    date: 2019
+    refcontent:
+      - "Advances in Cryptology - CRYPTO 2019"
+      - "Lecture Notes in Computer Science, vol 11692"
+      - "pp. 235-265"
+    seriesinfo:
+      DOI: 10.1007/978-3-030-26948-7_9
+
 
 --- abstract
 
@@ -1988,7 +2011,7 @@ limit the level of amplification.
 
 ## Header Protection Analysis {#header-protect-analysis}
 
-{{?NAN=DOI.10.1007/978-3-030-26948-7_9}} analyzes authenticated encryption
+{{NAN}} analyzes authenticated encryption
 algorithms that provide nonce privacy, referred to as "Hide Nonce" (HN)
 transforms. The general header protection construction in this document is
 one of those algorithms (HN1). Header protection is applied after the packet

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -102,6 +102,22 @@ informative:
     date: 2020-05-16
     target: "https://eprint.iacr.org/2020/718"
 
+  CCM-ANALYSIS:
+    title: "On the Security of CTR + CBC-MAC"
+    author:
+      -
+        initials: J.
+        surname: Jonsson
+        name: Jakob Jonsson
+    date: 2003
+    refcontent:
+      - "Selected Areas in Cryptography"
+      - "SAC 2002"
+      - "Lecture Notes in Computer Science, vol 2595"
+      - "pp. 76-93"
+    seriesinfo:
+      DOI: 10.1007/3-540-36492-7_7
+
 
 --- abstract
 
@@ -2510,11 +2526,11 @@ for AEAD_AES_128_CCM. However, any AEAD that is used with QUIC requires limits
 on use that ensure that both confidentiality and integrity are preserved. This
 section documents that analysis.
 
-{{?CCM-ANALYSIS=DOI.10.1007/3-540-36492-7_7}} is used as the basis of this
+{{CCM-ANALYSIS}} is used as the basis of this
 analysis. The results of that analysis are used to derive usage limits that are
 based on those chosen in {{?TLS13}}.
 
-For confidentiality, Theorem 2 in {{?CCM-ANALYSIS}} establishes that an attacker
+For confidentiality, Theorem 2 in {{CCM-ANALYSIS}} establishes that an attacker
 gains a distinguishing advantage over an ideal pseudorandom permutation (PRP) of
 no more than the following:
 
@@ -2522,7 +2538,7 @@ no more than the following:
 (2l * q)^2 / 2^n
 ~~~
 
-The integrity limit in Theorem 1 in {{?CCM-ANALYSIS}} provides an attacker a
+The integrity limit in Theorem 1 in {{CCM-ANALYSIS}} provides an attacker a
 strictly higher advantage for the same number of messages. As the targets for
 the confidentiality advantage and the integrity advantage are the same, only
 Theorem 1 needs to be considered.

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1613,11 +1613,11 @@ key update, but has not updated keys in response.
 
 Endpoints responding to an apparent key update MUST NOT generate a timing
 side-channel signal that might indicate that the Key Phase bit was invalid (see
-{{hp-side-channel}}).  Endpoints can use dummy packet protection keys in
-place of discarded keys when key updates are not yet permitted.  Using dummy
-keys will generate no variation in the timing signal produced by attempting to
-remove packet protection, and results in all packets with an invalid Key Phase
-bit being rejected.
+{{hp-side-channel}}).  Endpoints can use randomized packet protection keys in
+place of discarded keys when key updates are not yet permitted.  Using
+randomized keys will generate no variation in the timing signal produced by
+attempting to remove packet protection, and results in all packets with an
+invalid Key Phase bit being rejected.
 
 The process of creating new packet protection keys for receiving packets could
 reveal that a key update has occurred. An endpoint MAY generate new keys as

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -129,7 +129,7 @@ TLS 1.3 provides critical latency improvements for connection establishment over
 previous versions.  Absent packet loss, most new connections can be established
 and secured within a single round trip; on subsequent connections between the
 same client and server, the client can often send application data immediately,
-that is, using a zero round trip setup.
+that is, using a zero round-trip setup.
 
 This document describes how TLS acts as a security component of QUIC.
 
@@ -167,8 +167,8 @@ Layer     |                      Records                      |
 ~~~~
 {: #tls-layers title="TLS Layers"}
 
-Each Content layer message (e.g., Handshake, Alerts, and Application Data) is
-carried as a series of typed TLS records by the Record layer.  Records are
+Each content-layer message (e.g., Handshake, Alerts, and Application Data) is
+carried as a series of typed TLS records by the record layer.  Records are
 individually cryptographically protected and then transmitted over a reliable
 transport (typically TCP), which provides sequencing and guaranteed delivery.
 
@@ -178,17 +178,17 @@ exchange completes successfully, both client and server will agree on a secret.
 TLS supports both pre-shared key (PSK) and Diffie-Hellman over either finite
 fields or elliptic curves ((EC)DHE) key exchanges.  PSK is the basis for Early
 Data (0-RTT); the latter provides forward secrecy (FS) when the (EC)DHE
-keys are destroyed.  The two modes can also be combined, to provide forward
+keys are destroyed.  The two modes can also be combined to provide forward
 secrecy while using the PSK for authentication.
 
 After completing the TLS handshake, the client will have learned and
-authenticated an identity for the server and the server is optionally able to
+authenticated an identity for the server, and the server is optionally able to
 learn and authenticate an identity for the client.  TLS supports X.509
 {{?RFC5280}} certificate-based authentication for both server and client.
 When PSK key exchange is used (as in resumption), knowledge of the PSK
 serves to authenticate the peer.
 
-The TLS key exchange is resistant to tampering by attackers and it produces
+The TLS key exchange is resistant to tampering by attackers, and it produces
 shared secrets that cannot be controlled by either participating peer.
 
 TLS provides two basic handshake modes of interest to QUIC:
@@ -199,7 +199,7 @@ TLS provides two basic handshake modes of interest to QUIC:
 
  * A 0-RTT handshake, in which the client uses information it has previously
    learned about the server to send Application Data immediately.  This
-   Application Data can be replayed by an attacker so 0-RTT is not suitable for
+   Application Data can be replayed by an attacker, so 0-RTT is not suitable for
    carrying instructions that might initiate any action that could cause
    unwanted effects if replayed.
 
@@ -237,12 +237,12 @@ Data is protected using a number of encryption levels:
 - Handshake Keys
 - Application Data (1-RTT) Keys
 
-Application Data may appear only in the Early Data and Application Data
-levels. Handshake and Alert messages may appear in any level.
+Application Data can only appear in the early data and Application Data
+levels. Handshake and alert messages may appear in any level.
 
 The 0-RTT handshake can be used if the client and server have previously
 communicated.  In the 1-RTT handshake, the client is unable to send protected
-Application Data until it has received all of the Handshake messages sent by the
+Application Data until it has received all of the handshake messages sent by the
 server.
 
 
@@ -251,7 +251,7 @@ server.
 QUIC {{QUIC-TRANSPORT}} assumes responsibility for the confidentiality and
 integrity protection of packets.  For this it uses keys derived from a TLS
 handshake {{!TLS13}}, but instead of carrying TLS records over QUIC (as with
-TCP), TLS Handshake and Alert messages are carried directly over the QUIC
+TCP), TLS handshake and alert messages are carried directly over the QUIC
 transport, which takes over the responsibilities of the TLS record layer, as
 shown in {{quic-layers}}.
 
@@ -296,7 +296,7 @@ protection being called out specially.
 ~~~
 +------------+                               +------------+
 |            |<---- Handshake Messages ----->|            |
-|            |<- Validate 0-RTT parameters ->|            |
+|            |<- Validate 0-RTT Parameters ->|            |
 |            |<--------- 0-RTT Keys ---------|            |
 |    QUIC    |<------- Handshake Keys -------|    TLS     |
 |            |<--------- 1-RTT Keys ---------|            |
@@ -314,7 +314,7 @@ protection being called out specially.
 {: #schematic title="QUIC and TLS Interactions"}
 
 Unlike TLS over TCP, QUIC applications that want to send data do not send it
-through TLS "application_data" records. Rather, they send it as QUIC STREAM
+using TLS application data records. Rather, they send it as QUIC STREAM
 frames or other frame types, which are then carried in QUIC packets.
 
 # Carrying TLS Messages {#carrying-tls}

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -377,15 +377,20 @@ indicate which keys were used to protect a given packet, as shown in
 {{packet-types-keys}}. When packets of different types need to be sent,
 endpoints SHOULD use coalesced packets to send them in the same UDP datagram.
 
-| Packet Type         | Encryption Keys | PN Space         |
-| :------------------ | :-------------- | :--------------- |
-| Initial             | Initial secrets | Initial          |
-| 0-RTT Protected     | 0-RTT           | Application data |
-| Handshake           | Handshake       | Handshake        |
-| Retry               | Retry           | N/A              |
-| Version Negotiation | N/A             | N/A              |
-| Short Header        | 1-RTT           | Application data |
-{: #packet-types-keys title="Encryption Keys by Packet Type"}
+<table anchor="packet-types-keys" align="center">
+<name>Encryption Keys by Packet Type</name>
+<thead>
+<tr><th>Packet Type</th><th>Encryption Keys</th><th>PN Space</th></tr>
+</thead>
+<tbody>
+<tr><th>Initial</th><td>Initial secrets</td><td>Initial</td></tr>
+<tr><th>0-RTT Protected</th><td>0-RTT</td><td>Application data</td></tr>
+<tr><th>Handshake</th><td>Handshake</td><td>Handshake</td></tr>
+<tr><th>Retry</th><td>Retry</td><td>N/A</td></tr>
+<tr><th>Version Negotiation</th><td>N/A</td><td>N/A</td></tr>
+<tr><th>Short Header</th><td>1-RTT</td><td>Application data</td></tr>
+</tbody>
+</table>
 
 {{Section 17 of QUIC-TRANSPORT}} shows how packets at the various encryption
 levels fit into the handshake process.

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1128,7 +1128,7 @@ mask that might result from a shorter packet number encoding are unused.
 header protection only differs in the order in which the packet number length
 (pn_length) is determined (here "^" is used to represent exclusive OR).
 
-~~~
+~~~pseudocode
 mask = header_protection(hp_key, sample)
 
 pn_length = (packet[0] & 0x03) + 1
@@ -1225,7 +1225,7 @@ encoding.
 
 The sampled ciphertext can be determined by the following pseudocode:
 
-~~~
+~~~pseudocode
 # pn_offset is the start of the Packet Number field.
 sample_offset = pn_offset + 4
 
@@ -1234,13 +1234,13 @@ sample = packet[sample_offset..sample_offset+sample_length]
 
 Where the packet number offset of a short header packet can be calculated as:
 
-~~~
+~~~pseudocode
 pn_offset = 1 + len(connection_id)
 ~~~
 
 And the packet number offset of a long header packet can be calculated as:
 
-~~~
+~~~pseudocode
 pn_offset = 7 + len(destination_connection_id) +
                 len(source_connection_id) +
                 len(payload_length)
@@ -1268,7 +1268,7 @@ This algorithm samples 16 bytes from the packet ciphertext. This value is used
 as the input to AES-ECB.  In pseudocode, the header protection function is
 defined as:
 
-~~~
+~~~pseudocode
 header_protection(hp_key, sample):
   mask = AES-ECB(hp_key, sample)
 ~~~
@@ -1292,7 +1292,7 @@ integers.
 The encryption mask is produced by invoking ChaCha20 to protect 5 zero bytes. In
 pseudocode, the header protection function is defined as:
 
-~~~
+~~~pseudocode
 header_protection(hp_key, sample):
   counter = sample[0..3]
   nonce = sample[4..15]
@@ -1541,7 +1541,7 @@ corresponding key and IV are created from that secret as defined in
 
 For example, to update write keys with TLS 1.3, HKDF-Expand-Label is used as:
 
-~~~
+~~~pseudocode
 secret_<n+1> = HKDF-Expand-Label(secret_<n>, "quic ku",
                                  "", Hash.length)
 ~~~
@@ -1836,7 +1836,7 @@ QUIC might define a different method for negotiating transport configuration.
 Including transport parameters in the TLS handshake provides integrity
 protection for these values.
 
-~~~
+~~~tls-presentation
    enum {
       quic_transport_parameters(0x39), (65535)
    } ExtensionType;
@@ -1983,7 +1983,7 @@ one of those algorithms (HN1). Header protection is applied after the packet
 protection AEAD, sampling a set of bytes (`sample`) from the AEAD output and
 encrypting the header field using a pseudorandom function (PRF) as follows:
 
-~~~
+~~~pseudocode
 protected_field = field XOR PRF(hp_key, sample)
 ~~~
 

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -141,6 +141,28 @@ informative:
     seriesinfo:
       DOI: 10.1007/978-3-030-26948-7_9
 
+  GCM-MU:
+    title: "The Multi-user Security of GCM, Revisited: Tight Bounds for Nonce Randomization"
+    author:
+      -
+        initials: V.
+        surname: Hoang
+        name: Viet Tung Hoang
+      -
+        initials: S.
+        surname: Tessaro
+        name: Stefano Tessaro
+      -
+        initials: A.
+        surname: Thiruvengadam
+        name: Aishwarya Thiruvengadam
+    date: 2018
+    refcontent:
+      - "CCS '18: Proceedings of the 2018 ACM SIGSAC Conference on Computer and Communications Security"
+      - "pp. 1429-1440"
+    seriesinfo:
+      DOI: 10.1145/3243734.3243816
+
 
 --- abstract
 
@@ -1780,7 +1802,7 @@ possible packets (2<sup>62</sup>) and so can be disregarded. For
 AEAD_AES_128_CCM, the confidentiality limit is 2<sup>21.5</sup> encrypted
 packets; see {{ccm-bounds}}. Applying a limit reduces the probability that an
 attacker can distinguish the AEAD in use from a random permutation; see
-{{AEBounds}}, {{ROBUST}}, and {{?GCM-MU=DOI.10.1145/3243734.3243816}}.
+{{AEBounds}}, {{ROBUST}}, and {{GCM-MU}}.
 
 In addition to counting packets sent, endpoints MUST count the number of
 received packets that fail authentication during the lifetime of a connection.
@@ -1794,7 +1816,7 @@ invalid packets; see {{gcm-bounds}}. For AEAD_CHACHA20_POLY1305, the integrity
 limit is 2<sup>36</sup> invalid packets; see {{AEBounds}}. For AEAD_AES_128_CCM,
 the integrity limit is 2<sup>21.5</sup> invalid packets; see
 {{ccm-bounds}}. Applying this limit reduces the probability that an attacker can
-successfully forge a packet; see {{AEBounds}}, {{ROBUST}}, and {{?GCM-MU}}.
+successfully forge a packet; see {{AEBounds}}, {{ROBUST}}, and {{GCM-MU}}.
 
 Endpoints that limit the size of packets MAY use higher confidentiality and
 integrity limits; see {{aead-analysis}} for details.
@@ -2471,7 +2493,7 @@ operations per packet.
 
 ## Analysis of AEAD_AES_128_GCM and AEAD_AES_256_GCM Usage Limits {#gcm-bounds}
 
-{{?GCM-MU}} specifies concrete bounds for AEAD_AES_128_GCM and AEAD_AES_256_GCM
+{{GCM-MU}} specifies concrete bounds for AEAD_AES_128_GCM and AEAD_AES_256_GCM
 as used in TLS 1.3 and QUIC. This section documents this analysis using several
 simplifying assumptions:
 
@@ -2482,14 +2504,14 @@ simplifying assumptions:
 - The amount of offline work done by an attacker does not dominate other factors
   in the analysis.
 
-The bounds in {{?GCM-MU}} are tighter and more complete than those used in
+The bounds in {{GCM-MU}} are tighter and more complete than those used in
 {{AEBounds}}, which allows for larger limits than those described in
 {{?TLS13}}.
 
 
 ### Confidentiality Limit
 
-For confidentiality, Theorem (4.3) in {{?GCM-MU}} establishes that, for a single
+For confidentiality, Theorem (4.3) in {{GCM-MU}} establishes that, for a single
 user that does not repeat nonces, the dominant term in determining the
 distinguishing advantage between a real and random AEAD algorithm gained by an
 attacker is:
@@ -2513,7 +2535,7 @@ limit for endpoints that allow for the packet size to be as large as
 
 ### Integrity Limit
 
-For integrity, Theorem (4.3) in {{?GCM-MU}} establishes that an attacker gains
+For integrity, Theorem (4.3) in {{GCM-MU}} establishes that an attacker gains
 an advantage in successfully forging a packet of no more than the following:
 
 ~~~

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -1613,9 +1613,9 @@ Endpoints responding to an apparent key update MUST NOT generate a timing
 side-channel signal that might indicate that the Key Phase bit was invalid (see
 {{hp-side-channel}}).  Endpoints can use randomized packet protection keys in
 place of discarded keys when key updates are not yet permitted.  Using
-randomized keys will generate no variation in the timing signal produced by
-attempting to remove packet protection, and results in all packets with an
-invalid Key Phase bit being rejected.
+randomized keys ensures that attempting to remove packet protection does not
+result in timing variations, and results in packets with an invalid Key Phase
+bit being rejected.
 
 The process of creating new packet protection keys for receiving packets could
 reveal that a key update has occurred. An endpoint MAY generate new keys as

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -727,7 +727,7 @@ verification that the identity of the server is included in a certificate and
 that the certificate is issued by a trusted entity (see for example
 {{?RFC2818}}).
 
-<aside markdown="block"><t markdown="block">
+<aside markdown="block">
 Note: Where servers provide certificates for authentication, the size of the
   certificate chain can consume a large number of bytes.  Controlling the size
   of certificate chains is critical to performance in QUIC as servers are
@@ -736,7 +736,7 @@ Note: Where servers provide certificates for authentication, the size of the
   certificate chain can be managed by limiting the number of names or
   extensions; using keys with small public key representations, like ECDSA; or
   by using certificate compression {{?COMPRESS=RFC8879}}.
-</t></aside>
+</aside>
 
 A server MAY request that the client authenticate during the handshake. A server
 MAY refuse a connection if the client is unable to authenticate when requested.
@@ -1096,14 +1096,14 @@ server sends a Retry packet to use the connection ID value selected by the
 server.  The secrets do not change when a client changes the Destination
 Connection ID it uses in response to an Initial packet from the server.
 
-<aside markdown="block"><t markdown="block">
+<aside markdown="block">
 Note: The Destination Connection ID field could be any length up to 20 bytes,
   including zero length if the server sends a Retry packet with a zero-length
   Source Connection ID field. After a Retry, the Initial keys provide the client
   no assurance that the server received its packet, so the client has to rely on
   the exchange that included the Retry packet to validate the server address;
   see {{Section 8.1 of QUIC-TRANSPORT}}.
-</t></aside>
+</aside>
 
 {{test-vectors}} contains sample Initial packets.
 
@@ -1424,13 +1424,13 @@ decrypt 0-RTT packets it receives and instead MUST discard them.
 Once a client has installed 1-RTT keys, it MUST NOT send any more 0-RTT
 packets.
 
-<aside markdown="block"><t markdown="block">
+<aside markdown="block">
 Note: 0-RTT data can be acknowledged by the server as it receives it, but any
   packets containing acknowledgments of 0-RTT data cannot have packet protection
   removed by the client until the TLS handshake is complete.  The 1-RTT keys
   necessary to remove packet protection cannot be derived until the client
   receives all server handshake messages.
-</t></aside>
+</aside>
 
 
 ## Receiving Out-of-Order Protected Packets {#pre-hs-protected}
@@ -1463,11 +1463,11 @@ acknowledgments for 1-RTT packets until the TLS handshake is complete.  Received
 packets protected with 1-RTT keys MAY be stored and later decrypted and used
 once the handshake is complete.
 
-<aside markdown="block"><t markdown="block">
+<aside markdown="block">
 Note: TLS implementations might provide all 1-RTT secrets prior to handshake
   completion.  Even where QUIC implementations have 1-RTT read keys, those keys
   are not to be used prior to completing the handshake.
-</t></aside>
+</aside>
 
 The requirement for the server to wait for the client Finished message creates
 a dependency on that message being delivered.  A client can avoid the
@@ -1622,10 +1622,10 @@ implemented by tracking the lowest packet number sent with each key phase and
 the highest acknowledged packet number in the 1-RTT space: once the latter is
 higher than or equal to the former, another key update can be initiated.
 
-<aside markdown="block"><t markdown="block">
+<aside markdown="block">
 Note: Keys of packets other than the 1-RTT packets are never updated; their keys
   are derived solely from the TLS handshake state.
-</t></aside>
+</aside>
 
 The endpoint that initiates a key update also updates the keys that it uses for
 receiving packets.  These keys will be needed to process packets the peer sends

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -2192,7 +2192,7 @@ c300000001088394c8f03e5157080000449e00000002
 
 Protecting the payload produces output that is sampled for header protection.
 Because the header uses a 4-byte packet number encoding, the first 16 bytes of
-the protected payload is sampled and then applied to the header:
+the protected payload is sampled and then applied to the header as follows:
 
 ~~~
 sample = d1b1c98dd7689fb8ec11d242b123dc9b

--- a/draft-ietf-quic-tls.md
+++ b/draft-ietf-quic-tls.md
@@ -677,7 +677,7 @@ verification that the identity of the server is included in a certificate and
 that the certificate is issued by a trusted entity (see for example
 {{?RFC2818}}).
 
-<aside><t>
+<aside markdown="block"><t markdown="block">
 Note: Where servers provide certificates for authentication, the size of the
   certificate chain can consume a large number of bytes.  Controlling the size
   of certificate chains is critical to performance in QUIC as servers are
@@ -1046,7 +1046,7 @@ server sends a Retry packet to use the connection ID value selected by the
 server.  The secrets do not change when a client changes the Destination
 Connection ID it uses in response to an Initial packet from the server.
 
-<aside><t>
+<aside markdown="block"><t markdown="block">
 Note: The Destination Connection ID field could be any length up to 20 bytes,
   including zero length if the server sends a Retry packet with a zero-length
   Source Connection ID field. After a Retry, the Initial keys provide the client
@@ -1374,7 +1374,7 @@ decrypt 0-RTT packets it receives and instead MUST discard them.
 Once a client has installed 1-RTT keys, it MUST NOT send any more 0-RTT
 packets.
 
-<aside><t>
+<aside markdown="block"><t markdown="block">
 Note: 0-RTT data can be acknowledged by the server as it receives it, but any
   packets containing acknowledgments of 0-RTT data cannot have packet protection
   removed by the client until the TLS handshake is complete.  The 1-RTT keys
@@ -1413,7 +1413,7 @@ acknowledgments for 1-RTT packets until the TLS handshake is complete.  Received
 packets protected with 1-RTT keys MAY be stored and later decrypted and used
 once the handshake is complete.
 
-<aside><t>
+<aside markdown="block"><t markdown="block">
 Note: TLS implementations might provide all 1-RTT secrets prior to handshake
   completion.  Even where QUIC implementations have 1-RTT read keys, those keys
   are not to be used prior to completing the handshake.
@@ -1572,7 +1572,7 @@ implemented by tracking the lowest packet number sent with each key phase and
 the highest acknowledged packet number in the 1-RTT space: once the latter is
 higher than or equal to the former, another key update can be initiated.
 
-<aside><t>
+<aside markdown="block"><t markdown="block">
 Note: Keys of packets other than the 1-RTT packets are never updated; their keys
   are derived solely from the TLS handshake state.
 </t></aside>


### PR DESCRIPTION
This isn't 100% faithful.  I've made some extremely minor edits along with this (s/may/can in one place).

Most of this is just transcribing the addition or removal of punctuation (commas and hyphens for the most part).  The RPC caught one bad section reference.

This doesn't fix references, but it should suffice for now; we need to do a pass on references separately.