### PR TITLE
Make the notation sections consistent

### DIFF
--- a/draft-ietf-quic-invariants.md
+++ b/draft-ietf-quic-invariants.md
@@ -133,7 +133,7 @@ x (A):
 
 x (A..B):
 : Indicates that x can be any length from A to B; A can be omitted to indicate
-  a minimum of zero bits and B can be omitted to indicate no set upper limit;
+  a minimum of zero bits, and B can be omitted to indicate no set upper limit;
   values in this format always end on a byte boundary
 
 x (L) = C:

--- a/draft-ietf-quic-invariants.md
+++ b/draft-ietf-quic-invariants.md
@@ -137,11 +137,12 @@ x (A..B):
   values in this format always end on a byte boundary
 
 x (L) = C:
-: Indicates that x, with a length described by L, has a fixed value of C
+: Indicates that x has a fixed value of C; the length of x is described by
+  L, which can use any of the length forms above
 
 x (L) ...:
-: Indicates that x is repeated zero or more times (and that each instance is
-  length L)
+: Indicates that x is repeated zero or more times and that each instance has a
+  length of L
 
 This document uses network byte order (that is, big endian) values.  Fields
 are placed starting from the high-order bits of each byte.

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -305,12 +305,12 @@ x (A):
 : Indicates that x is A bits long
 
 x (i):
-: Indicates that x holds an integer value using the variable-length encoding in
-{{integer-encoding}}
+: Indicates that x holds an integer value using the variable-length encoding
+  described in {{integer-encoding}}
 
 x (A..B):
 : Indicates that x can be any length from A to B; A can be omitted to indicate
-  a minimum of zero bits and B can be omitted to indicate no set upper limit;
+  a minimum of zero bits, and B can be omitted to indicate no set upper limit;
   values in this format always end on a byte boundary
 
 x (L) = C:

--- a/draft-ietf-quic-transport.md
+++ b/draft-ietf-quic-transport.md
@@ -314,19 +314,19 @@ x (A..B):
   values in this format always end on a byte boundary
 
 x (L) = C:
-: Indicates that x has a fixed value of C with the length described by
-  L, which can use any of the three length forms above
+: Indicates that x has a fixed value of C; the length of x is described by
+  L, which can use any of the length forms above
 
 x (L) = C..D:
 : Indicates that x has a value in the range from C to D, inclusive,
   with the length described by L, as above
 
 \[x (L)\]:
-: Indicates that x is optional (and has length of L)
+: Indicates that x is optional and has a length of L
 
 x (L) ...:
-: Indicates that zero or more instances of x are present (and that each
-  instance is length L)
+: Indicates that x is repeated zero or more times and that each instance has a
+  length of L
 
 This document uses network byte order (that is, big endian) values.  Fields
 are placed starting from the high-order bits of each byte.


### PR DESCRIPTION
These were not the same, even for the same items, so I fixed that.

Checked with:
```
diff -u <(sed -e '/x (A)/,/This document/p;d' draft-ietf-quic-invariants.md) \
        <(sed -e '/x (A)/,/This document/p;d' draft-ietf-quic-transport.md)
```

Which shows the three items that are only present in -transport (-invariants doesn't use these).