### PR TITLE
References in transport

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -205,8 +205,8 @@ Additional resources are provided in the final sections:
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this
-document are to be interpreted as described in BCP 14 {{!RFC2119}} {{!RFC8174}}
-when, and only when, they appear in all capitals, as shown here.
+document are to be interpreted as described in BCP 14 {{!BCP14}} when, and only
+when, they appear in all capitals, as shown here.
 
 This document uses the variable-length integer encoding from
 {{QUIC-TRANSPORT}}.

--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -118,8 +118,8 @@ with substantially less head-of-line blocking under the same loss conditions.
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this
-document are to be interpreted as described in BCP 14 {{!RFC2119}} {{!RFC8174}}
-when, and only when, they appear in all capitals, as shown here.
+document are to be interpreted as described in BCP 14 {{!BCP14}} when, and only
+when, they appear in all capitals, as shown here.
 
 Definitions of terms that are used in this document:
 

--- a/rfc8999.md
+++ b/rfc8999.md
@@ -103,8 +103,8 @@ every version of QUIC.
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this
-document are to be interpreted as described in BCP 14 {{!RFC2119}} {{!RFC8174}}
-when, and only when, they appear in all capitals, as shown here.
+document are to be interpreted as described in BCP 14 {{!BCP14}} when, and only
+when, they appear in all capitals, as shown here.
 
 This document defines requirements on future QUIC versions, even where normative
 language is not used.

--- a/rfc9000.md
+++ b/rfc9000.md
@@ -82,11 +82,11 @@ normative:
 informative:
 
   EARLY-DESIGN:
-    title: "QUIC: Multiplexed Transport Over UDP"
+    title: "QUIC: Multiplexed Stream Transport Over UDP"
     author:
       - ins: J. Roskind
     date: 2013-12-02
-    target: "https://goo.gl/dMVtFi"
+    target: "https://docs.google.com/document/d/1RNHkx_VvKWyWg6Lr8SZ-saqsQx7rFV-ev2jRFUoVD34/edit?usp=sharing"
 
   SLOWLORIS:
     title: "Welcome to Slowloris - the low bandwidth, yet greedy and poisonous HTTP client!"

--- a/rfc9000.md
+++ b/rfc9000.md
@@ -4276,7 +4276,7 @@ size.
 Both DPLPMTUD and PMTUD send datagrams that are larger than the current maximum
 datagram size, referred to as PMTU probes.  All QUIC packets that are not sent
 in a PMTU probe SHOULD be sized to fit within the maximum datagram size to avoid
-the datagram being fragmented or dropped ({{?RFC8085}}).
+the datagram being fragmented or dropped ({{?BCP145}}).
 
 If a QUIC endpoint determines that the PMTU between any pair of local and
 remote IP addresses cannot support the smallest allowed maximum datagram size
@@ -4313,12 +4313,12 @@ without exceeding the minimum MTU for the IP version. The size of the quoted
 packet can actually be smaller, or the information unintelligible, as described
 in {{Section 1.1 of DPLPMTUD}}.
 
-QUIC endpoints using PMTUD SHOULD validate ICMP messages to protect from
-packet injection as specified in {{!RFC8201}} and {{Section 5.2 of RFC8085}}.
-This validation SHOULD use the quoted packet supplied in the payload of an ICMP
+QUIC endpoints using PMTUD SHOULD validate ICMP messages to protect from packet
+injection as specified in {{!RFC8201}} and {{Section 5.2 of BCP145}}.  This
+validation SHOULD use the quoted packet supplied in the payload of an ICMP
 message to associate the message with a corresponding transport connection (see
 {{Section 4.6.1 of DPLPMTUD}}).  ICMP message validation MUST include matching
-IP addresses and UDP ports ({{!RFC8085}}) and, when possible, connection IDs to
+IP addresses and UDP ports ({{!BCP145}}) and, when possible, connection IDs to
 an active QUIC session.  The endpoint SHOULD ignore all ICMP messages that fail
 validation.
 

--- a/rfc9000.md
+++ b/rfc9000.md
@@ -96,6 +96,39 @@ informative:
     target:
      "https://web.archive.org/web/20150315054838/http://ha.ckers.org/slowloris/"
 
+  GATEWAY:
+    title: "An experimental study of home gateway characteristics"
+    author:
+      -
+        initials: S.
+        surname: Hätönen
+        fullname: Seppo Hätönen
+      -
+        initials: A.
+        surname: Nyrhinen
+        fullname: Aki Nyrhinen
+      -
+        initials: L.
+        surname: Eggert
+        fullname: Lars Eggert
+      -
+        initials: S.
+        surname: Strowes
+        fullname: Stephen Strowes
+      -
+        initials: P.
+        surname: Sarolahti
+        fullname: Pasi Sarolahti
+      -
+        initials: M.
+        surname: Kojo
+        fullname: Markku Kojo
+    date: 2010-11
+    refcontent:
+      - "Proceedings of the 10th ACM SIGCOMM conference on Internet measurement - IMC '10"
+    seriesinfo:
+      DOI: 10.1145/1879141.1879174
+
   RFC3449:
 
 
@@ -213,8 +246,8 @@ set of version-independent properties of QUIC can cite {{QUIC-INVARIANTS}}.
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this
-document are to be interpreted as described in BCP 14 {{!RFC2119}} {{!RFC8174}}
-when, and only when, they appear in all capitals, as shown here.
+document are to be interpreted as described in BCP 14 {{!BCP14}} when, and only
+when, they appear in all capitals, as shown here.
 
 Commonly used terms in the document are described below.
 
@@ -2832,7 +2865,7 @@ see {{termination}}.  However, state in middleboxes might time out earlier than
 that.  Though REQ-5 in {{?RFC4787}} recommends a 2 minute timeout interval,
 experience shows that sending packets every 30 seconds is necessary to prevent
 the majority of middleboxes from losing state for UDP flows
-{{?GATEWAY=DOI.10.1145/1879141.1879174}}.
+{{GATEWAY}}.
 
 
 ## Immediate Close {#immediate-close}
@@ -7071,7 +7104,7 @@ datagrams.
 This document does not offer specific countermeasures that can be implemented
 by endpoints aside from the generic measures described in {{forgery-generic}}.
 However, countermeasures for address spoofing at the network level, in
-particular ingress filtering {{?BCP38=RFC2827}}, are especially effective
+particular ingress filtering {{?BCP38}}, are especially effective
 against attacks that use spoofing and originate from an external network.
 
 

--- a/rfc9000.md
+++ b/rfc9000.md
@@ -89,9 +89,11 @@ informative:
     target: "https://goo.gl/dMVtFi"
 
   SLOWLORIS:
-    title: "Welcome to Slowloris..."
+    title: "Welcome to Slowloris - the low bandwidth, yet greedy and poisonous HTTP client!"
     author:
-      - ins: R. RSnake Hansen
+      -
+        initials: R.
+        surname: "\"RSnake\" Hansen"
     date: 2009-06
     target:
      "https://web.archive.org/web/20150315054838/http://ha.ckers.org/slowloris/"
@@ -4314,7 +4316,7 @@ packet can actually be smaller, or the information unintelligible, as described
 in {{Section 1.1 of DPLPMTUD}}.
 
 QUIC endpoints using PMTUD SHOULD validate ICMP messages to protect from packet
-injection as specified in {{!RFC8201}} and {{Section 5.2 of BCP145}}.  This
+injection as specified in {{!RFC8201}} and {{Section 5.2 of RFC8085}}.  This
 validation SHOULD use the quoted packet supplied in the payload of an ICMP
 message to associate the message with a corresponding transport connection (see
 {{Section 4.6.1 of DPLPMTUD}}).  ICMP message validation MUST include matching

--- a/rfc9001.md
+++ b/rfc9001.md
@@ -133,8 +133,8 @@ This document describes how TLS acts as a security component of QUIC.
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this
-document are to be interpreted as described in BCP 14 {{!RFC2119}} {{!RFC8174}}
-when, and only when, they appear in all capitals, as shown here.
+document are to be interpreted as described in BCP 14 {{!BCP14}} when, and only
+when, they appear in all capitals, as shown here.
 
 This document uses the terminology established in {{QUIC-TRANSPORT}}.
 

--- a/rfc9002.md
+++ b/rfc9002.md
@@ -106,8 +106,8 @@ control mechanisms for QUIC.
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this
-document are to be interpreted as described in BCP 14 {{!RFC2119}} {{!RFC8174}}
-when, and only when, they appear in all capitals, as shown here.
+document are to be interpreted as described in BCP 14 {{!BCP14}} when, and only
+when, they appear in all capitals, as shown here.
 
 Definitions of terms that are used in this document:
 


### PR DESCRIPTION
This includes all the updates to references in transport.

This includes new code again.  See https://github.com/cabo/kramdown-rfc2629/pull/120

It would be possible to cite BCP38 as an RFC and avoid this, but I think that the BCP reference is correct.  Not as sure about the BCP145 reference, as we need to point to the RFC directly to get the section reference, but I think that is OK on balance.

