### PR TITLE
Recovery RFCEditor #3: Why reset min_rtt

### DIFF
--- a/rfc9002.md
+++ b/rfc9002.md
@@ -345,11 +345,11 @@ path's actual RTT increases however, the min_rtt will not adapt to it, allowing
 future RTT samples that are smaller than the new RTT to be included in
 smoothed_rtt.
 
-Endpoints SHOULD set the min_rtt to the newest RTT sample after persistent
-congestion is established. This is to allow a connection to reset its estimate
-of min_rtt and smoothed_rtt ({{smoothed-rtt}}) after a disruptive network event,
-and because it is possible that an increase in path delay resulted in persistent
-congestion being incorrectly declared.
+Endpoints SHOULD set the min_rtt to the newest RTT sample after persistent
+congestion is established because it is possible that an increase in path delay
+resulted in persistent congestion being incorrectly declared. This also allows
+a connection to reset its estimate of min_rtt and smoothed_rtt after a
+disruptive network event (Section 5.3).
 
 Endpoints MAY re-establish the min_rtt at other times in the connection, such as
 when traffic volume is low and an acknowledgment is received with a low


### PR DESCRIPTION
3) <!-- [rfced] Does the following improve the readability of the paragraph?  

Current:
   Endpoints SHOULD set the min_rtt to the newest RTT sample after 
   persistent congestion is established. This is to allow a connection 
   to reset its estimate of min_rtt and smoothed_rtt after a 
   disruptive network event (Section 5.3), and because it is possible 
   that an increase in path delay resulted in persistent congestion 
   being incorrectly declared.

Perhaps:
   Endpoints SHOULD set the min_rtt to the newest RTT sample after 
   persistent congestion is established because it is possible that 
   an increase in path delay resulted in persistent congestion being 
   incorrectly declared. This also allows a connection to reset its 
   estimate of min_rtt and smoothed_rtt after a disruptive network 
   event (Section 5.3). 
-->