### PR TITLE
Recovery RFCEditor #6

### DIFF
--- a/rfc9002.md
+++ b/rfc9002.md
@@ -600,7 +600,7 @@ When ack-eliciting packets in multiple packet number spaces are in flight, the
 timer MUST be set to the earlier value of the Initial and Handshake packet
 number spaces.
 
-An endpoint MUST NOT set its PTO timer for the application data packet number
+An endpoint MUST NOT set its PTO timer for the Application Data packet number
 space until the handshake is confirmed. Doing so prevents the endpoint from
 retransmitting information in packets when either the peer does not yet have the
 keys to process them or the endpoint does not yet have the keys to process their


### PR DESCRIPTION
For this document, I believe the best option is to use "Application Data" when referring to the packet number space, and "application data" when referring to generic application data, such as when discussing being app-limited due to lack of application data.


6) [rfced] Throughout the text, the following term appears to be used 
inconsistently. Please review these occurrences and let us know if/how they
may be made consistent. 

application data / Application Data 

Note that RFC-to-be 9000 <draft-ietf-quic-transport> uses the lowercase 
form consistently.

We raised a similar question for RFC-to-be 9001; the authors decided on the following:

> The outcome is that figures will use title case for consistency (as appropriate) 
> and text will use the  lowercase form.  There is one reference to TLS 
> Application Data, where I have kept the title case to match the usage in RFC 8446.

(see https://www.rfc-editor.org/pipermail/c430/2021-April/000016.html)