### PR TITLE
Fix typo in GOAWAY frame encoding

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1574,7 +1574,7 @@ maintenance.  GOAWAY by itself does not close a connection.
 GOAWAY Frame {
   Type (i) = 0x07,
   Length (i),
-  Stream ID/Push ID (..),
+  Stream ID/Push ID (i),
 }
 ~~~~~~~~~~
 {: #fig-goaway title="GOAWAY Frame"}


### PR DESCRIPTION
Noticed this minor editorial issue, I think this was a typo.