### PR TITLE
Recommend careful behavior around push streams

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -884,8 +884,9 @@ as-yet-unknown Push ID, both the associated client request and the pushed
 request header fields are unknown.  The client can buffer the stream data in
 expectation of the matching PUSH_PROMISE. The client can use stream flow control
 (see {{Section 4.1 of QUIC-TRANSPORT}}) to limit the amount of data a server may
-commit to the pushed stream.  Clients SHOULD discard data from push streams if
-no corresponding PUSH_PROMISE frame is processed in a reasonable amount of time.
+commit to the pushed stream.  Clients SHOULD abort reading and discard data
+already read from push streams if no corresponding PUSH_PROMISE frame is
+processed in a reasonable amount of time.
 
 Push stream data can also arrive after a client has canceled a push. In this
 case, the client can abort reading the stream with an error code of

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1134,8 +1134,8 @@ an error code of H3_STREAM_CREATION_ERROR or a reserved error code
 error of any kind.
 
 As certain stream types can affect connection state, a recipient SHOULD NOT
-discard data from incoming unidirectional streams prior to reading the type
-byte.
+discard data from incoming unidirectional streams prior to reading the stream
+type.
 
 Implementations MAY send stream types before knowing whether the peer supports
 them.  However, stream types that could modify the state or semantics of

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -884,7 +884,8 @@ as-yet-unknown Push ID, both the associated client request and the pushed
 request header fields are unknown.  The client can buffer the stream data in
 expectation of the matching PUSH_PROMISE. The client can use stream flow control
 (see {{Section 4.1 of QUIC-TRANSPORT}}) to limit the amount of data a server may
-commit to the pushed stream.
+commit to the pushed stream.  Clients SHOULD discard data from push streams if
+no corresponding PUSH_PROMISE frame is processed in a reasonable amount of time.
 
 Push stream data can also arrive after a client has canceled a push. In this
 case, the client can abort reading the stream with an error code of
@@ -1132,6 +1133,10 @@ an error code of H3_STREAM_CREATION_ERROR or a reserved error code
 ({{http-error-codes}}), but MUST NOT consider such streams to be a connection
 error of any kind.
 
+As certain stream types can affect connection state, a recipient SHOULD NOT
+discard data from incoming unidirectional streams prior to reading the type
+byte.
+
 Implementations MAY send stream types before knowing whether the peer supports
 them.  However, stream types that could modify the state or semantics of
 existing protocol components, including QPACK or other extensions, MUST NOT be
@@ -1192,6 +1197,10 @@ Push Stream Header {
 }
 ~~~~~~~~~~
 {: #fig-push-stream-header title="Push Stream Header"}
+
+A client SHOULD NOT abort reading on a push stream prior to reading the Push ID,
+as this could lead to disagreement between client and server on which Push IDs
+have already been consumed.
 
 Each Push ID MUST only be used once in a push stream header. If a client detects
 that a push stream header includes a Push ID that was used in another push


### PR DESCRIPTION
Note that all of these recommendations are SHOULD NOT -- an implementation under memory pressure might choose to discard data aggressively, even at the risk of degrading the connection state.  Closes #4930.