### PR TITLE
Reference the concept, not the header

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -472,7 +472,7 @@ table. While these updates are not directly part of the message exchange, they
 must be received and processed before the message can be consumed.  See
 {{header-formatting}} for more details.
 
-Transfer codings (see {{Section 6.1 of HTTP11}}) are not defined for HTTP/3;
+Transfer codings (see {{Section 7 of HTTP11}}) are not defined for HTTP/3;
 the Transfer-Encoding header field MUST NOT be used.
 
 A response MAY consist of multiple messages when and only when one or more


### PR DESCRIPTION
Noticed in https://github.com/httpwg/http2-spec/issues/938 that we're pointing to different sections:

- 6.1 is the Transfer-Encoding header
- 7.1 is `chunked` specifically
- 7 is transfer codings in general

Since this passage is referring to the concept in general not being present in HTTP/3, Section 7 is the correct reference.