### PR TITLE
Negative base values are invalid

### DIFF
--- a/draft-ietf-quic-qpack.md
+++ b/draft-ietf-quic-qpack.md
@@ -1007,6 +1007,12 @@ recent entry in the table and did not insert any new entries, the Base will be
 greater than the Required Insert Count, so the delta will be positive and the
 sign bit is set to 0.
 
+The value of Base MUST NOT be negative. Though the protocol might operate
+correctly with a negative base using post-base indexing, it is unnecessary and
+inefficient. An endpoint MUST treat a field block with an S bit of 1 as invalid
+if the value of Required Insert Count is less than or equal to the value of
+Delta Base.
+
 An encoder that produces table updates before encoding a field section might set
 Base to the value of Required Insert Count.  In such case, both the sign bit and
 the Delta Base will be set to zero.


### PR DESCRIPTION
Happy to use MAY here, which would be fine in terms of achieving our goals.

Signed math is entirely valid here, but it introduces other problems; as there is no need to go negative (it's less efficient), this seems safest.

This is what people have implemented - at least in some cases - but we should confirm.  

Closes #4938.