### PR TITLE
Add cross references

### DIFF
--- a/rfc9000.md
+++ b/rfc9000.md
@@ -3579,6 +3579,27 @@ the table.
 | 0x1e       | HANDSHAKE_DONE       | {{frame-handshake-done}}       | ___1 |      |
 {: #frame-types title="Frame Types"}
 
+*[PADDING]: #frame-padding
+*[PING]: #frame-ping
+*[ACK]: #frame-ack
+*[RESET_STREAM]: #frame-reset-stream
+*[STOP_SENDING]: #frame-stop-sending
+*[CRYPTO]: #frame-crypto
+*[NEW_TOKEN]: #frame-new-token
+*[STREAM]: #frame-stream
+*[MAX_DATA]: #frame-max-data
+*[MAX_STREAM_DATA]: #frame-max-stream-data
+*[MAX_STREAMS]: #frame-max-streams
+*[DATA_BLOCKED]: #frame-data-blocked
+*[STREAM_DATA_BLOCKED]: #frame-stream-data-blocked
+*[STREAMS_BLOCKED]: #frame-streams-blocked
+*[NEW_CONNECTION_ID]: #frame-new-connection-id
+*[RETIRE_CONNECTION_ID]: #frame-retire-connection-id
+*[PATH_CHALLENGE]: #frame-path-challenge
+*[PATH_RESPONSE]: #frame-path-response
+*[CONNECTION_CLOSE]: #frame-connection-close
+*[HANDSHAKE_DONE]: #frame-handshake-done
+
 The format and semantics of each frame type are explained in more detail in
 {{frame-formats}}.  The remainder of this section provides a summary of
 important and general information.

--- a/rfc9000.md
+++ b/rfc9000.md
@@ -5293,12 +5293,14 @@ original_destination_connection_id (0x00):
 : This parameter is the value of the Destination Connection ID field from the
   first Initial packet sent by the client; see {{cid-auth}}.  This transport
   parameter is only sent by a server.
+{: anchor="original_destination_connection_id"}
 
 max_idle_timeout (0x01):
 
 : The maximum idle timeout is a value in milliseconds that is encoded as an
   integer; see ({{idle-timeout}}).  Idle timeout is disabled when both endpoints
   omit this transport parameter or specify a value of 0.
+  {: anchor="max_idle_timeout"}
 
 stateless_reset_token (0x02):
 
@@ -5308,6 +5310,7 @@ stateless_reset_token (0x02):
   A server that does not send this transport parameter cannot use stateless
   reset ({{stateless-reset}}) for the connection ID negotiated during the
   handshake.
+  {: anchor="stateless_reset_token"}
 
 max_udp_payload_size (0x03):
 
@@ -5315,6 +5318,7 @@ max_udp_payload_size (0x03):
   size of UDP payloads that the endpoint is willing to receive.  UDP datagrams
   with payloads larger than this limit are not likely to be processed by the
   receiver.
+  {: anchor="max_udp_payload_size"}
 
 : The default for this parameter is the maximum permitted UDP payload of 65527.
   Values below 1200 are invalid.
@@ -5330,6 +5334,7 @@ initial_max_data (0x04):
   initial value for the maximum amount of data that can be sent on the
   connection.  This is equivalent to sending a MAX_DATA ({{frame-max-data}}) for
   the connection immediately after completing the handshake.
+  {: anchor="initial_max_data"}
 
 initial_max_stream_data_bidi_local (0x05):
 
@@ -5340,6 +5345,7 @@ initial_max_stream_data_bidi_local (0x05):
   identifier with the least significant two bits set to 0x00; in server
   transport parameters, this applies to streams with the least significant two
   bits set to 0x01.
+  {: anchor="initial_max_stream_data_bidi_local"}
 
 initial_max_stream_data_bidi_remote (0x06):
 
@@ -5350,6 +5356,7 @@ initial_max_stream_data_bidi_remote (0x06):
   identifier with the least significant two bits set to 0x01; in server
   transport parameters, this applies to streams with the least significant two
   bits set to 0x00.
+  {: anchor="initial_max_stream_data_bidi_remote"}
 
 initial_max_stream_data_uni (0x07):
 
@@ -5360,6 +5367,7 @@ initial_max_stream_data_uni (0x07):
   identifier with the least significant two bits set to 0x03; in server
   transport parameters, this applies to streams with the least significant two
   bits set to 0x02.
+  {: anchor="initial_max_stream_data_uni"}
 
 initial_max_streams_bidi (0x08):
 
@@ -5370,6 +5378,7 @@ initial_max_streams_bidi (0x08):
   open bidirectional streams until a MAX_STREAMS frame is sent.  Setting this
   parameter is equivalent to sending a MAX_STREAMS ({{frame-max-streams}}) of
   the corresponding type with the same value.
+  {: anchor="initial_max_streams_bidi"}
 
 initial_max_streams_uni (0x09):
 
@@ -5380,6 +5389,7 @@ initial_max_streams_uni (0x09):
   open unidirectional streams until a MAX_STREAMS frame is sent.  Setting this
   parameter is equivalent to sending a MAX_STREAMS ({{frame-max-streams}}) of
   the corresponding type with the same value.
+  {: anchor="initial_max_streams_uni"}
 
 ack_delay_exponent (0x0a):
 
@@ -5387,6 +5397,7 @@ ack_delay_exponent (0x0a):
   used to decode the ACK Delay field in the ACK frame ({{frame-ack}}). If this
   value is absent, a default value of 3 is assumed (indicating a multiplier of
   8). Values above 20 are invalid.
+  {: anchor="ack_delay_exponent"}
 
 max_ack_delay (0x0b):
 
@@ -5397,6 +5408,7 @@ max_ack_delay (0x0b):
   commonly fire up to 1ms late, then it should send a max_ack_delay of 6ms.  If
   this value is absent, a default of 25 milliseconds is assumed. Values of
   2<sup>14</sup> or greater are invalid.
+  {: anchor="max_ack_delay"}
 
 disable_active_migration (0x0c):
 
@@ -5407,6 +5419,7 @@ disable_active_migration (0x0c):
   the peer used during the handshake.  This transport parameter does not
   prohibit connection migration after a client has acted on a preferred_address
   transport parameter.  This parameter is a zero-length value.
+  {: anchor="disable_active_migration"}
 
 preferred_address (0x0d):
 
@@ -5416,6 +5429,7 @@ preferred_address (0x0d):
   a preferred address of one address family by sending an all-zero address and
   port (0.0.0.0:0 or \[::]:0) for the other family. IP addresses are encoded in
   network byte order.
+  {: anchor="preferred_address"}
 
 : The preferred_address transport parameter contains an address and port for
   both IPv4 and IPv6.  The four-byte IPv4 Address field is followed by the
@@ -5460,7 +5474,9 @@ active_connection_id_limit (0x0e):
   connection ID received during the handshake, that received in the
   preferred_address transport parameter, and those received in NEW_CONNECTION_ID
   frames.
-  The value of the active_connection_id_limit parameter MUST be at least 2.
+  {: anchor="active_connection_id_limit"}
+
+: The value of the active_connection_id_limit parameter MUST be at least 2.
   An endpoint that receives a value less than 2 MUST close the connection
   with an error of type TRANSPORT_PARAMETER_ERROR.
   If this transport parameter is absent, a default of 2 is assumed.  If an
@@ -5472,12 +5488,32 @@ initial_source_connection_id (0x0f):
 
 : This is the value that the endpoint included in the Source Connection ID field
   of the first Initial packet it sends for the connection; see {{cid-auth}}.
+  {: anchor="initial_source_connection_id"}
 
 retry_source_connection_id (0x10):
 
 : This is the value that the server included in the Source Connection ID field
   of a Retry packet; see {{cid-auth}}.  This transport parameter is only sent by
   a server.
+  {: anchor="retry_source_connection_id"}
+
+*[original_destination_connection_id]: #
+*[max_idle_timeout]: #
+*[stateless_reset_token]: #
+*[max_udp_payload_size]: #
+*[initial_max_data]: #
+*[initial_max_stream_data_bidi_local]: #
+*[initial_max_stream_data_bidi_remote]: #
+*[initial_max_stream_data_uni]: #
+*[initial_max_streams_bidi]: #
+*[initial_max_streams_uni]: #
+*[ack_delay_exponent]: #
+*[max_ack_delay]: #
+*[disable_active_migration]: #
+*[preferred_address]: #
+*[active_connection_id_limit]: #
+*[initial_source_connection_id]: #
+*[retry_source_connection_id]: #
 
 If present, transport parameters that set initial per-stream flow control limits
 (initial_max_stream_data_bidi_local, initial_max_stream_data_bidi_remote, and
@@ -6481,30 +6517,36 @@ NO_ERROR (0x00):
 
 : An endpoint uses this with CONNECTION_CLOSE to signal that the connection is
   being closed abruptly in the absence of any error.
+  {: anchor="NO_ERROR"}
 
 INTERNAL_ERROR (0x01):
 
 : The endpoint encountered an internal error and cannot continue with the
   connection.
+  {: anchor="INTERNAL_ERROR"}
 
 CONNECTION_REFUSED (0x02):
 
 : The server refused to accept a new connection.
+  {: anchor="CONNECTION_REFUSED"}
 
 FLOW_CONTROL_ERROR (0x03):
 
 : An endpoint received more data than it permitted in its advertised data
   limits; see {{flow-control}}.
+  {: anchor="FLOW_CONTROL_ERROR"}
 
 STREAM_LIMIT_ERROR (0x04):
 
 : An endpoint received a frame for a stream identifier that exceeded its
   advertised stream limit for the corresponding stream type.
+  {: anchor="STREAM_LIMIT_ERROR"}
 
 STREAM_STATE_ERROR (0x05):
 
 : An endpoint received a frame for a stream that was not in a state that
   permitted that frame; see {{stream-states}}.
+  {: anchor="STREAM_STATE_ERROR"}
 
 FINAL_SIZE_ERROR (0x06):
 
@@ -6514,55 +6556,66 @@ FINAL_SIZE_ERROR (0x06):
   stream data that was already received, or (3) an endpoint received a STREAM
   frame or a RESET_STREAM frame containing a different final size to the one
   already established.
+  {: anchor="FINAL_SIZE_ERROR"}
 
 FRAME_ENCODING_ERROR (0x07):
 
 : An endpoint received a frame that was badly formatted -- for instance, a frame
   of an unknown type or an ACK frame that has more acknowledgment ranges than
   the remainder of the packet could carry.
+  {: anchor="FRAME_ENCODING_ERROR"}
 
 TRANSPORT_PARAMETER_ERROR (0x08):
 
 : An endpoint received transport parameters that were badly formatted, included
   an invalid value, omitted a mandatory transport parameter, included a
   forbidden transport parameter, or were otherwise in error.
+  {: anchor="TRANSPORT_PARAMETER_ERROR"}
 
 CONNECTION_ID_LIMIT_ERROR (0x09):
 
 : The number of connection IDs provided by the peer exceeds the advertised
   active_connection_id_limit.
+  {: anchor="CONNECTION_ID_LIMIT_ERROR"}
 
 PROTOCOL_VIOLATION (0x0a):
 
 : An endpoint detected an error with protocol compliance that was not covered by
   more specific error codes.
+  {: anchor="PROTOCOL_VIOLATION"}
 
 INVALID_TOKEN (0x0b):
 : A server received a client Initial that contained an invalid Token field.
+  {: anchor="INVALID_TOKEN"}
 
 APPLICATION_ERROR (0x0c):
 
 : The application or application protocol caused the connection to be closed.
+  {: anchor="APPLICATION_ERROR"}
 
 CRYPTO_BUFFER_EXCEEDED (0x0d):
 
 : An endpoint has received more data in CRYPTO frames than it can buffer.
+  {: anchor="CRYPTO_BUFFER_EXCEEDED"}
 
 KEY_UPDATE_ERROR (0x0e):
 
 : An endpoint detected errors in performing key updates; see
   {{Section 6 of QUIC-TLS}}.
+  {: anchor="KEY_UPDATE_ERROR"}
 
 AEAD_LIMIT_REACHED (0x0f):
 
 : An endpoint has reached the confidentiality or integrity limit for the AEAD
   algorithm used by the given connection.
+  {: anchor="AEAD_LIMIT_REACHED"}
 
 NO_VIABLE_PATH (0x10):
 
 : An endpoint has determined that the network path is incapable of supporting
   QUIC.  An endpoint is unlikely to receive a CONNECTION_CLOSE frame carrying
   this code except when the path does not support a large enough MTU.
+  {: anchor="NO_VIABLE_PATH"}
 
 CRYPTO_ERROR (0x0100-0x01ff):
 
@@ -6570,6 +6623,26 @@ CRYPTO_ERROR (0x0100-0x01ff):
   carrying error codes specific to the cryptographic handshake that is used.
   Codes for errors occurring when TLS is used for the cryptographic handshake
   are described in {{Section 4.8 of QUIC-TLS}}.
+  {: anchor="CRYPTO_ERROR"}
+
+*[NO_ERROR]: #
+*[INTERNAL_ERROR]: #
+*[CONNECTION_REFUSED]: #
+*[FLOW_CONTROL_ERROR]: #
+*[STREAM_LIMIT_ERROR]: #
+*[STREAM_STATE_ERROR]: #
+*[FINAL_SIZE_ERROR]: #
+*[FRAME_ENCODING_ERROR]: #
+*[TRANSPORT_PARAMETER_ERROR]: #
+*[CONNECTION_ID_LIMIT_ERROR]: #
+*[PROTOCOL_VIOLATION]: #
+*[INVALID_TOKEN]: #
+*[APPLICATION_ERROR]: #
+*[CRYPTO_BUFFER_EXCEEDED]: #
+*[KEY_UPDATE_ERROR]: #
+*[AEAD_LIMIT_REACHED]: #
+*[NO_VIABLE_PATH]: #
+*[CRYPTO_ERROR]: #
 
 See {{iana-error-codes}} for details on registering new error codes.
 


### PR DESCRIPTION
This adds cross references for all uses of the names of frames,
transport parameters, and error codes.  It should make the document more
usable as a result.

A side-effect of this is that there is now an index.

