### PR TITLE
Easy RFC Editor Questions

### DIFF
--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -606,7 +606,7 @@ The following pseudo-header fields are defined for requests:
     {{Section 7.1 of SEMANTICS}}.
 
 All HTTP/3 requests MUST include exactly one value for the ":method", ":scheme",
-and ":path" pseudo-header fields, unless it is a CONNECT request; see
+and ":path" pseudo-header fields, unless the request is a CONNECT request; see
 {{connect}}.
 
 If the ":scheme" pseudo-header field identifies a scheme that has a mandatory

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1056,9 +1056,9 @@ byte stream to the application. Although QUIC permits out-of-order delivery
 within a stream, HTTP/3 does not make use of this feature.
 
 QUIC streams can be either unidirectional, carrying data only from initiator to
-receiver, or bidirectional.  Streams can be initiated by either the client or
-the server.  For more detail on QUIC streams, see
-{{Section 2 of QUIC-TRANSPORT}}.
+receiver, or bidirectional, carrying data in both directions.  Streams can be
+initiated by either the client or the server.  For more detail on QUIC streams,
+see {{Section 2 of QUIC-TRANSPORT}}.
 
 When HTTP fields and data are sent over QUIC, the QUIC layer handles most of
 the stream management.  HTTP does not need to do any separate multiplexing when

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1,6 +1,5 @@
 ---
-title: Hypertext Transfer Protocol Version 3 (HTTP/3)
-abbrev: HTTP/3
+title: HTTP/3
 docname: draft-ietf-quic-http-latest
 date: {DATE}
 category: std

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -1111,12 +1111,14 @@ window of these streams will increase the chance that the remote peer reaches
 the limit early and becomes blocked. In particular, implementations should
 consider that remote peers may wish to exercise reserved stream behavior
 ({{stream-grease}}) with some of the unidirectional streams they are permitted
-to use. To avoid blocking, the transport parameters sent by both clients and
-servers MUST allow the peer to create at least one unidirectional stream for the
-HTTP control stream plus the number of unidirectional streams required by
-mandatory extensions (three being the minimum number required for the base
-HTTP/3 protocol and QPACK), and SHOULD provide at least 1,024 bytes of flow
-control credit to each stream.
+to use.
+
+Each endpoint needs to create at least one unidirectional stream for the HTTP
+control stream. QPACK requires two additional unidirectional streams, and other
+extensions might require further streams. Therefore, the transport parameters
+sent by both clients and servers MUST allow the peer to create at least three
+unidirectional streams. These transport parameters SHOULD also provide at least
+1,024 bytes of flow control credit to each unidirectional stream.
 
 Note that an endpoint is not required to grant additional credits to create more
 unidirectional streams if its peer consumes all the initial credits before

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -2149,6 +2149,9 @@ The entries in {{iana-setting-table}} are registered by this document.
 | ----------------------- | ------- | ----------------------- | --------- |
 {: #iana-setting-table title="Initial HTTP/3 Settings"}
 
+For fomatting reasons, setting names can be abbreviated by removing the
+'SETTING_' prefix.
+
 Each code of the format `0x1f * N + 0x21` for non-negative integer values of N
 (that is, 0x21, 0x40, ..., through 0x3ffffffffffffffe) MUST NOT be assigned by
 IANA and MUST NOT appear in the listing of assigned values.

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -2576,7 +2576,8 @@ for what might be a temporary or intermittent error.
 # Acknowledgments
 {:numbered="false"}
 
-The original authors of this specification were Robbie Shade and Mike Warres.
+Robbie Shade and Mike Warres were the authors of draft-shade-quic-http2-mapping,
+which was the basis for this document.
 
 The IETF QUIC Working Group received an enormous amount of support from many
 people. Among others, the following people provided substantial contributions to

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -675,10 +675,10 @@ possible, it is RECOMMENDED that servers send an HTTP response with an
 appropriate status code rather than canceling a request it has already begun
 processing.
 
-Implementations SHOULD cancel requests by abruptly terminating any
-directions of a stream that are still open.  This means resetting the
-sending parts of streams and aborting reading on receiving parts of streams;
-see {{Section 2.4 of QUIC-TRANSPORT}}.
+Implementations SHOULD cancel requests by abruptly terminating any directions of
+a stream that are still open.  To do so, an implementation resets the sending
+parts of streams and aborts reading on the receiving parts of streams; see
+{{Section 2.4 of QUIC-TRANSPORT}}.
 
 When the server cancels a request without performing any application processing,
 the request is considered "rejected."  The server SHOULD abort its response

--- a/draft-ietf-quic-http.md
+++ b/draft-ietf-quic-http.md
@@ -2576,7 +2576,7 @@ for what might be a temporary or intermittent error.
 {:numbered="false"}
 
 Robbie Shade and Mike Warres were the authors of draft-shade-quic-http2-mapping,
-which was the basis for this document.
+a precursor of this document.
 
 The IETF QUIC Working Group received an enormous amount of support from many
 people. Among others, the following people provided substantial contributions to


### PR DESCRIPTION
This PR covers questions asked during Auth48 which aren't pure copyediting, but seem to have a straightforward single-location fix.  Individual commits, so it's easy to pull one out if someone disagrees.