### PR TITLE
RFC Editor Copyedits

### DIFF
--- a/rfc9114.md
+++ b/rfc9114.md
@@ -178,26 +178,26 @@ state of the table without modifying it.
 The following sections provide a detailed overview of the lifecycle of an HTTP/3
 connection:
 
-- "Connection Setup and Management" ({{connection-setup}}) covers how an HTTP/3
+- "{{<<connection-setup}}" ({{connection-setup}}) covers how an HTTP/3
   endpoint is discovered and an HTTP/3 connection is established.
-- "HTTP Request Lifecycle" ({{http-request-lifecycle}}) describes how HTTP
+- "{{<<http-request-lifecycle}}" ({{http-request-lifecycle}}) describes how HTTP
   semantics are expressed using frames.
-- "Connection Closure" ({{connection-closure}}) describes how HTTP/3 connections
-  are terminated, either gracefully or abruptly.
+- "{{<<connection-closure}}" ({{connection-closure}}) describes how HTTP/3
+  connections are terminated, either gracefully or abruptly.
 
 The details of the wire protocol and interactions with the transport are
 described in subsequent sections:
 
-- "Stream Mapping and Usage" ({{stream-mapping}}) describes the way QUIC streams
+- "{{<<stream-mapping}}" ({{stream-mapping}}) describes the way QUIC streams
   are used.
-- "HTTP Framing Layer" ({{http-framing-layer}}) describes the frames used on
-  most streams.
-- "Error Handling" ({{errors}}) describes how error conditions are handled and
+- "{{<<http-framing-layer}}" ({{http-framing-layer}}) describes the frames used
+  on most streams.
+- "{{<<errors}}" ({{errors}}) describes how error conditions are handled and
   expressed, either on a particular stream or for the connection as a whole.
 
 Additional resources are provided in the final sections:
 
-- "Extensions to HTTP/3" ({{extensions}}) describes how new capabilities can be
+- "{{<<extensions}}" ({{extensions}}) describes how new capabilities can be
   added in future documents.
 - A more detailed comparison between HTTP/2 and HTTP/3 can be found in
   {{h2-considerations}}.


### PR DESCRIPTION
This PR contains (most?) of the changes to the HTTP/3 spec the RFC editor made directly.  There are a few I've chosen not to incorporate here.  I will note them on the PR when they affect a particular line; general ones are:

- ~~Combined references to sections; I don't see a way to do that in Markdown, but #4955 tracks this.~~
- The `<sup>` tag produces parentheses in the .txt version for me, but apparently not for the RFC Editor.  However, the XML still contains the correct output, so I'm not currently planning to make changes.