### PR TITLE
Hardcode references to other RFCs in C430

### DIFF
--- a/rfc9114.md
+++ b/rfc9114.md
@@ -21,29 +21,12 @@ author:
 
 normative:
 
-  QUIC-TRANSPORT:
-    title: "QUIC: A UDP-Based Multiplexed and Secure Transport"
-    date: {DATE}
-    seriesinfo:
-      RFC: 9000
-      DOI: 10.17487/RFC9000
-    author:
-      -
-        ins: J. Iyengar
-        name: Jana Iyengar
-        org: Fastly
-        role: editor
-      -
-        ins: M. Thomson
-        name: Martin Thomson
-        org: Mozilla
-        role: editor
-
   QPACK:
     title: "QPACK: Header Compression for HTTP over QUIC"
     date: {DATE}
     seriesinfo:
-      Internet-Draft: draft-ietf-quic-qpack-latest
+      RFC: 9204
+      DOI: 10.17487/RFC9204
     author:
       -
           ins: C. Krasic
@@ -59,10 +42,96 @@ normative:
           org: Facebook
           role: editor
 
+  HTTP:
+    title: "HTTP Semantics"
+    date: {DATE}
+    seriesinfo:
+      RFC: 9110
+      DOI: 10.17487/RFC9110
+    author:
+      -
+          ins: R. Fielding
+          name: Roy T. Fielding
+          org: Adobe
+          role: editor
+      -
+          ins: M. Nottingham
+          name: Mark Nottingham
+          org: Fastly
+          role: editor
+      -
+          ins: J. Reschke
+          name: Julian Reschke
+          org: greenbytes
+          role: editor
+
+  CACHING:
+    title: "HTTP Caching"
+    date: {DATE}
+    seriesinfo:
+      RFC: 9111
+      DOI: 10.17487/RFC9111
+    author:
+      -
+          ins: R. Fielding
+          name: Roy T. Fielding
+          org: Adobe
+          role: editor
+      -
+          ins: M. Nottingham
+          name: Mark Nottingham
+          org: Fastly
+          role: editor
+      -
+          ins: J. Reschke
+          name: Julian Reschke
+          org: greenbytes
+          role: editor
+
   URI: RFC3986
-  CACHING: I-D.ietf-httpbis-cache
 
 informative:
+
+  HTTP11:
+    title: "HTTP/1.1"
+    date: {DATE}
+    seriesinfo:
+      RFC: 9112
+      DOI: 10.17487/RFC9112
+    author:
+      -
+          ins: R. Fielding
+          name: Roy T. Fielding
+          org: Adobe
+          role: editor
+      -
+          ins: M. Nottingham
+          name: Mark Nottingham
+          org: Fastly
+          role: editor
+      -
+          ins: J. Reschke
+          name: Julian Reschke
+          org: greenbytes
+          role: editor
+
+  HTTP2:
+    title: "HTTP/2"
+    date: {DATE}
+    seriesinfo:
+      RFC: 9113
+      DOI: 10.17487/RFC9113
+    author:
+      -
+          ins: M. Thomson
+          name: Martin Thomson
+          org: Mozilla
+          role: editor
+      -
+          ins: C. Benfield
+          name: Cory Benfield
+          org: Apple Inc.
+          role: editor
 
   BREACH:
     title: "BREACH: Reviving the CRIME Attack"
@@ -90,25 +159,25 @@ subsumed by QUIC and describes how HTTP/2 extensions can be ported to HTTP/3.
 
 # Introduction
 
-HTTP semantics ({{!HTTP=I-D.ietf-httpbis-semantics}}) are used for a broad
-range of services on the Internet. These semantics have most commonly been used
-with HTTP/1.1 and HTTP/2.  HTTP/1.1 has been used over a variety of transport
-and session layers, while HTTP/2 has been used primarily with TLS over TCP.
-HTTP/3 supports the same semantics over a new transport protocol: QUIC.
+HTTP semantics ({{HTTP}}) are used for a broad range of services on the
+Internet. These semantics have most commonly been used with HTTP/1.1 and HTTP/2.
+HTTP/1.1 has been used over a variety of transport and session layers, while
+HTTP/2 has been used primarily with TLS over TCP. HTTP/3 supports the same
+semantics over a new transport protocol: QUIC.
 
 ## Prior Versions of HTTP
 
-HTTP/1.1 ({{?HTTP11=I-D.ietf-httpbis-messaging}}) uses whitespace-delimited text
-fields to convey HTTP messages.  While these exchanges are human readable, using
-whitespace for message formatting leads to parsing complexity and excessive
-tolerance of variant behavior.
+HTTP/1.1 ({{HTTP11}}) uses whitespace-delimited text fields to convey HTTP
+messages.  While these exchanges are human readable, using whitespace for
+message formatting leads to parsing complexity and excessive tolerance of
+variant behavior.
 
 Because HTTP/1.1 does not include a multiplexing layer, multiple TCP connections
 are often used to service requests in parallel. However, that has a negative
 impact on congestion control and network efficiency, since TCP does not share
 congestion control across multiple connections.
 
-HTTP/2 ({{?HTTP2=RFC7540}}) introduced a binary framing and multiplexing layer
+HTTP/2 ({{HTTP2}}) introduced a binary framing and multiplexing layer
 to improve latency without modifying the transport layer.  However, because the
 parallel nature of HTTP/2's multiplexing is not visible to TCP's loss recovery
 mechanisms, a lost or reordered packet causes all active transactions to
@@ -134,8 +203,8 @@ stream lifetime and flow-control issues to QUIC, a binary framing similar to the
 HTTP/2 framing is used on each stream. Some HTTP/2 features are subsumed by
 QUIC, while other features are implemented atop QUIC.
 
-QUIC is described in {{QUIC-TRANSPORT}}.  For a full description of HTTP/2, see
-{{?HTTP2}}.
+QUIC is described in {{!QUIC-TRANSPORT=RFC9000}}.  For a full description of
+HTTP/2, see {{HTTP2}}.
 
 # HTTP/3 Protocol Overview
 
@@ -159,7 +228,7 @@ consumes a single QUIC stream.  Streams are independent of each other, so one
 stream that is blocked or suffers packet loss does not prevent progress on other
 streams.
 
-Server push is an interaction mode introduced in HTTP/2 ({{?HTTP2}}) that
+Server push is an interaction mode introduced in HTTP/2 ({{HTTP2}}) that
 permits a server to push a request-response exchange to a client in anticipation
 of the client making the indicated request.  This trades off network usage
 against a potential latency gain.  Several HTTP/3 frames are used to manage
@@ -1461,7 +1530,7 @@ settings to have any meaning upon receipt.
 Because the setting has no defined meaning, the value of the setting can be any
 value the implementation selects.
 
-Setting identifiers that were defined in {{?HTTP2}} where there is no
+Setting identifiers that were defined in {{HTTP2}} where there is no
 corresponding HTTP/3 setting have also been reserved ({{iana-settings}}). These
 reserved settings MUST NOT be sent, and their receipt MUST be treated as a
 connection error of type H3_SETTINGS_ERROR.
@@ -2087,7 +2156,7 @@ using Standards Action or IESG Approval as defined in
 {{Sections 4.9 and 4.10 of RFC8126}}.
 
 While this registry is separate from the "HTTP/2 Frame Type" registry defined in
-{{?HTTP2}}, it is preferable that the assignments parallel each other where the
+{{HTTP2}}, it is preferable that the assignments parallel each other where the
 code spaces overlap.  If an entry is present in only one registry, every effort
 SHOULD be made to avoid assigning the corresponding value to an unrelated
 operation.  Expert reviewers MAY reject unrelated registrations that would
@@ -2136,7 +2205,7 @@ using Standards Action or IESG Approval as defined in
 {{Sections 4.9 and 4.10 of RFC8126}}.
 
 While this registry is separate from the "HTTP/2 Settings" registry defined in
-{{?HTTP2}}, it is preferable that the assignments parallel each other.  If an
+{{HTTP2}}, it is preferable that the assignments parallel each other.  If an
 entry is present in only one registry, every effort SHOULD be made to avoid
 assigning the corresponding value to an unrelated operation. Expert reviewers
 MAY reject unrelated registrations that would conflict with the same value in
@@ -2324,7 +2393,7 @@ removed. Because stream termination is handled by QUIC, an END_STREAM flag is
 not required.  This permits the removal of the Flags field from the generic
 frame layout.
 
-Frame payloads are largely drawn from {{?HTTP2}}. However, QUIC includes many
+Frame payloads are largely drawn from {{HTTP2}}. However, QUIC includes many
 features (e.g., flow control) that are also present in HTTP/2. In these cases,
 the HTTP mapping does not re-implement them. As a result, several HTTP/2 frame
 types are not required in HTTP/3. Where an HTTP/2-defined frame is no longer
@@ -2435,7 +2504,7 @@ CONTINUATION (0x09):
   HEADERS/PUSH_PROMISE frames than HTTP/2 are permitted.
 
 Frame types defined by extensions to HTTP/2 need to be separately registered for
-HTTP/3 if still applicable.  The IDs of frames defined in {{?HTTP2}} have been
+HTTP/3 if still applicable.  The IDs of frames defined in {{HTTP2}} have been
 reserved for simplicity.  Note that the frame type space in HTTP/3 is
 substantially larger (62 bits versus 8 bits), so many HTTP/3 frame types have no
 equivalent HTTP/2 code points.  See {{iana-frames}}.
@@ -2491,7 +2560,7 @@ their value to limit it to 30 bits for more efficient encoding or to make use
 of the 62-bit space if more than 30 bits are required.
 
 Settings need to be defined separately for HTTP/2 and HTTP/3. The IDs of
-settings defined in {{?HTTP2}} have been reserved for simplicity.  Note that
+settings defined in {{HTTP2}} have been reserved for simplicity.  Note that
 the settings identifier space in HTTP/3 is substantially larger (62 bits versus
 16 bits), so many HTTP/3 settings have no equivalent HTTP/2 code point. See
 {{iana-settings}}.

--- a/rfc9114.md
+++ b/rfc9114.md
@@ -23,7 +23,7 @@ normative:
 
   QPACK:
     title: "QPACK: Header Compression for HTTP over QUIC"
-    date: {DATE}
+    date: 1970-01-01
     seriesinfo:
       RFC: 9204
       DOI: 10.17487/RFC9204
@@ -44,7 +44,7 @@ normative:
 
   HTTP:
     title: "HTTP Semantics"
-    date: {DATE}
+    date: 1970-01-01
     seriesinfo:
       RFC: 9110
       DOI: 10.17487/RFC9110
@@ -67,7 +67,7 @@ normative:
 
   CACHING:
     title: "HTTP Caching"
-    date: {DATE}
+    date: 1970-01-01
     seriesinfo:
       RFC: 9111
       DOI: 10.17487/RFC9111
@@ -94,7 +94,7 @@ informative:
 
   HTTP11:
     title: "HTTP/1.1"
-    date: {DATE}
+    date: 1970-01-01
     seriesinfo:
       RFC: 9112
       DOI: 10.17487/RFC9112
@@ -117,7 +117,7 @@ informative:
 
   HTTP2:
     title: "HTTP/2"
-    date: {DATE}
+    date: 1970-01-01
     seriesinfo:
       RFC: 9113
       DOI: 10.17487/RFC9113


### PR DESCRIPTION
For now, these documents will need static information about the other RFCs.  Post-publication, this could be simplified away to their RFC numbers, which I've done for the RFC9000 reference.