### PR TITLE
Tweaks to more closely match RFC Editor XML

### DIFF
--- a/rfc9114.md
+++ b/rfc9114.md
@@ -509,7 +509,8 @@ continue sending the body of the request and close the stream normally.
 HTTP messages carry metadata as a series of key-value pairs called "HTTP
 fields"; see {{Sections 6.3 and 6.5 of HTTP}}. For a listing of registered HTTP
 fields, see the "Hypertext Transfer Protocol (HTTP) Field Name Registry"
-maintained at [](https://www.iana.org/assignments/http-fields/).
+maintained at [](https://www.iana.org/assignments/http-fields/){:
+brackets="angle"}.
 
 Field names are strings containing a subset of ASCII characters. Properties of
 HTTP field names and values are discussed in more detail in {{Section 5.1 of

--- a/rfc9114.md
+++ b/rfc9114.md
@@ -2599,31 +2599,33 @@ The IETF QUIC Working Group received an enormous amount of support from many
 people. Among others, the following people provided substantial contributions to
 this document:
 
-- Bence Béky
-- Daan De Meyer
-- Martin Duke
-- Roy Fielding
-- Alan Frindell
-- Alessandro Ghedini
-- Nick Harper
-- Ryan Hamilton
-- Christian Huitema
-- Subodh Iyengar
-- Robin Marx
-- Patrick McManus
-- Luca Niccolini
-- <t><t><contact asciiFullname="Kazuho Oku" fullname="奥 一穂"/></t></t>
-- Lucas Pardue
-- Roberto Peon
-- Julian Reschke
-- Eric Rescorla
-- Martin Seemann
-- Ben Schwartz
-- Ian Swett
-- Willy Taureau
-- Martin Thomson
-- Dmitri Tikhonov
-- Tatsuhiro Tsujikawa
+<ul spacing="compact">
+<li><t><contact fullname="Bence Béky"/></t></li>
+<li><t><contact fullname="Daan De Meyer"/></t></li>
+<li><t><contact fullname="Martin Duke"/></t></li>
+<li><t><contact fullname="Roy Fielding"/></t></li>
+<li><t><contact fullname="Alan Frindell"/></t></li>
+<li><t><contact fullname="Alessandro Ghedini"/></t></li>
+<li><t><contact fullname="Nick Harper"/></t></li>
+<li><t><contact fullname="Ryan Hamilton"/></t></li>
+<li><t><contact fullname="Christian Huitema"/></t></li>
+<li><t><contact fullname="Subodh Iyengar"/></t></li>
+<li><t><contact fullname="Robin Marx"/></t></li>
+<li><t><contact fullname="Patrick McManus"/></t></li>
+<li><t><contact fullname="Luca Niccolini"/></t></li>
+<li><t><contact asciiFullname="Kazuho Oku" fullname="奥 一穂"/></t></li>
+<li><t><contact fullname="Lucas Pardue"/></t></li>
+<li><t><contact fullname="Roberto Peon"/></t></li>
+<li><t><contact fullname="Julian Reschke"/></t></li>
+<li><t><contact fullname="Eric Rescorla"/></t></li>
+<li><t><contact fullname="Martin Seemann"/></t></li>
+<li><t><contact fullname="Ben Schwartz"/></t></li>
+<li><t><contact fullname="Ian Swett"/></t></li>
+<li><t><contact fullname="Willy Taureau"/></t></li>
+<li><t><contact fullname="Martin Thomson"/></t></li>
+<li><t><contact fullname="Dmitri Tikhonov"/></t></li>
+<li><t><contact fullname="Tatsuhiro Tsujikawa"/></t></li>
+</ul>
 
 A portion of Mike Bishop's contribution was supported by Microsoft during his
 employment there.

--- a/rfc9114.md
+++ b/rfc9114.md
@@ -1096,7 +1096,7 @@ The purpose is indicated by a stream type, which is sent as a variable-length
 integer at the start of the stream. The format and structure of data that
 follows this integer is determined by the stream type.
 
-~~~~~~~~~~ drawing
+~~~~~~~~~~ ascii-art
 Unidirectional Stream Header {
   Stream Type (i),
 }
@@ -1197,7 +1197,7 @@ Only servers can push; if a server receives a client-initiated push stream, this
 MUST be treated as a connection error of type H3_STREAM_CREATION_ERROR; see
 {{errors}}.
 
-~~~~~~~~~~ drawing
+~~~~~~~~~~ ascii-art
 Push Stream Header {
   Stream Type (i) = 0x01,
   Push ID (i),
@@ -1260,7 +1260,7 @@ Note that, unlike QUIC frames, HTTP/3 frames can span multiple packets.
 
 All frames have the following format:
 
-~~~~~~~~~~ drawing
+~~~~~~~~~~ ascii-art
 HTTP/3 Frame Format {
   Type (i),
   Length (i),
@@ -1304,7 +1304,7 @@ DATA frames MUST be associated with an HTTP request or response.  If a DATA
 frame is received on a control stream, the recipient MUST respond with a
 connection error of type H3_FRAME_UNEXPECTED; see {{errors}}.
 
-~~~~~~~~~~ drawing
+~~~~~~~~~~ ascii-art
 DATA Frame {
   Type (i) = 0x00,
   Length (i),
@@ -1318,7 +1318,7 @@ DATA Frame {
 The HEADERS frame (type=0x01) is used to carry an HTTP field section that is
 encoded using QPACK. See {{QPACK}} for more details.
 
-~~~~~~~~~~  drawing
+~~~~~~~~~~ ascii-art
 HEADERS Frame {
   Type (i) = 0x01,
   Length (i),
@@ -1365,7 +1365,7 @@ A CANCEL_PUSH frame is sent on the control stream.  Receiving a CANCEL_PUSH
 frame on a stream other than the control stream MUST be treated as a connection
 error of type H3_FRAME_UNEXPECTED.
 
-~~~~~~~~~~  drawing
+~~~~~~~~~~ ascii-art
 CANCEL_PUSH Frame {
   Type (i) = 0x03,
   Length (i),
@@ -1424,7 +1424,7 @@ The payload of a SETTINGS frame consists of zero or more parameters.  Each
 parameter consists of a setting identifier and a value, both encoded as QUIC
 variable-length integers.
 
-~~~~~~~~~~~~~~~  drawing
+~~~~~~~~~~~~~~~ ascii-art
 Setting {
   Identifier (i),
   Value (i),
@@ -1526,7 +1526,7 @@ error of type H3_SETTINGS_ERROR.
 The PUSH_PROMISE frame (type=0x05) is used to carry a promised request header
 section from server to client on a request stream, as in HTTP/2.
 
-~~~~~~~~~~  drawing
+~~~~~~~~~~ ascii-art
 PUSH_PROMISE Frame {
   Type (i) = 0x05,
   Length (i),
@@ -1586,7 +1586,7 @@ requests or pushes while still finishing processing of previously received
 requests and pushes.  This enables administrative actions, like server
 maintenance.  GOAWAY by itself does not close a connection.
 
-~~~~~~~~~~  drawing
+~~~~~~~~~~ ascii-art
 GOAWAY Frame {
   Type (i) = 0x07,
   Length (i),
@@ -1631,7 +1631,7 @@ wishes to manage the number of promised server pushes can increase the maximum
 Push ID by sending MAX_PUSH_ID frames as the server fulfills or cancels server
 pushes.
 
-~~~~~~~~~~  drawing
+~~~~~~~~~~ ascii-art
 MAX_PUSH_ID Frame {
   Type (i) = 0x0d,
   Length (i),

--- a/rfc9114.md
+++ b/rfc9114.md
@@ -1217,8 +1217,8 @@ H3_ID_ERROR; see {{errors}}.
 
 ### Reserved Stream Types {#stream-grease}
 
-Stream types of the format 0x1f * N + 0x21 for non-negative integer values of N
-are reserved to exercise the requirement that unknown types be ignored. These
+Stream types of the format `0x1f * N + 0x21` for non-negative integer values of
+N are reserved to exercise the requirement that unknown types be ignored. These
 streams have no semantics, and they can be sent when application-layer padding
 is desired. They MAY also be sent on connections where no data is currently
 being transferred. Endpoints MUST NOT consider these streams to have any meaning
@@ -1450,7 +1450,7 @@ The following settings are defined in HTTP/3:
   SETTINGS_MAX_FIELD_SECTION_SIZE (0x06):
   : The default value is unlimited.  See {{header-size-constraints}} for usage.
 
-Setting identifiers of the format 0x1f * N + 0x21 for non-negative integer
+Setting identifiers of the format `0x1f * N + 0x21` for non-negative integer
 values of N are reserved to exercise the requirement that unknown identifiers be
 ignored.  Such settings have no defined meaning. Endpoints SHOULD include at
 least one such setting in their SETTINGS frame. Endpoints MUST NOT consider such
@@ -1649,7 +1649,7 @@ a connection error of type H3_ID_ERROR.
 
 ### Reserved Frame Types {#frame-reserved}
 
-Frame types of the format 0x1f * N + 0x21 for non-negative integer values of N
+Frame types of the format `0x1f * N + 0x21` for non-negative integer values of N
 are reserved to exercise the requirement that unknown types be ignored
 ({{extensions}}).  These frames have no semantics, and they MAY be sent on any
 stream where frames are allowed to be sent. This enables their use for
@@ -1763,7 +1763,7 @@ H3_VERSION_FALLBACK (0x0110):
 : The requested operation cannot be served over HTTP/3.  The peer should
   retry over HTTP/1.1.
 
-Error codes of the format 0x1f * N + 0x21 for non-negative integer values of N
+Error codes of the format `0x1f * N + 0x21` for non-negative integer values of N
 are reserved to exercise the requirement that unknown error codes be treated as
 equivalent to H3_NO_ERROR ({{extensions}}). Implementations SHOULD select an
 error code from this space with some probability when they would have sent
@@ -2119,7 +2119,7 @@ The entries in {{iana-frame-table}} are registered by this document.
 | ------------ | ------- | -------------------------- |
 {: #iana-frame-table title="Initial HTTP/3 Frame Types"}
 
-Each code of the format 0x1f * N + 0x21 for non-negative integer values of N
+Each code of the format `0x1f * N + 0x21` for non-negative integer values of N
 (that is, 0x21, 0x40, ..., through 0x3ffffffffffffffe) MUST NOT be assigned by
 IANA and MUST NOT appear in the listing of assigned values.
 
@@ -2167,7 +2167,7 @@ The entries in {{iana-setting-table}} are registered by this document.
 For fomatting reasons, setting names can be abbreviated by removing the
 'SETTING_' prefix.
 
-Each code of the format 0x1f * N + 0x21 for non-negative integer values of N
+Each code of the format `0x1f * N + 0x21` for non-negative integer values of N
 (that is, 0x21, 0x40, ..., through 0x3ffffffffffffffe) MUST NOT be assigned by
 IANA and MUST NOT appear in the listing of assigned values.
 
@@ -2225,7 +2225,7 @@ Required policy to avoid collisions with HTTP/2 error codes.
 | --------------------------------- | ---------- | ---------------------------------------- | ---------------------- |
 {: #iana-error-table title="Initial HTTP/3 Error Codes"}
 
-Each code of the format 0x1f * N + 0x21 for non-negative integer values of N
+Each code of the format `0x1f * N + 0x21` for non-negative integer values of N
 (that is, 0x21, 0x40, ..., through 0x3ffffffffffffffe) MUST NOT be assigned by
 IANA and MUST NOT appear in the listing of assigned values.
 
@@ -2262,7 +2262,7 @@ The entries in the following table are registered by this document.
 | ---------------- | ------ | -------------------------- | ------ |
 {: #iana-stream-type-table title="Initial Stream Types"}
 
-Each code of the format 0x1f * N + 0x21 for non-negative integer values of N
+Each code of the format `0x1f * N + 0x21` for non-negative integer values of N
 (that is, 0x21, 0x40, ..., through 0x3ffffffffffffffe) MUST NOT be assigned by
 IANA and MUST NOT appear in the listing of assigned values.
 

--- a/rfc9114.md
+++ b/rfc9114.md
@@ -1102,7 +1102,7 @@ Unidirectional Stream Header {
   Stream Type (i),
 }
 ~~~~~~~~~~
-{: #fig-stream-header title="Unidirectional Stream Header"}
+{: title="Unidirectional Stream Header"}
 
 Two stream types are defined in this document: control streams
 ({{control-streams}}) and push streams ({{push-streams}}). {{QPACK}} defines
@@ -1204,7 +1204,7 @@ Push Stream Header {
   Push ID (i),
 }
 ~~~~~~~~~~
-{: #fig-push-stream-header title="Push Stream Header"}
+{: title="Push Stream Header"}
 
 A client SHOULD NOT abort reading on a push stream prior to reading the Push ID,
 as this could lead to disagreement between client and server on which Push IDs
@@ -1268,7 +1268,7 @@ HTTP/3 Frame Format {
   Frame Payload (..),
 }
 ~~~~~~~~~~
-{: #fig-frame title="HTTP/3 Frame Format"}
+{: title="HTTP/3 Frame Format"}
 
 A frame includes the following fields:
 
@@ -1312,7 +1312,7 @@ DATA Frame {
   Data (..),
 }
 ~~~~~~~~~~
-{: #fig-data title="DATA Frame"}
+{: title="DATA Frame"}
 
 ### HEADERS {#frame-headers}
 
@@ -1326,7 +1326,7 @@ HEADERS Frame {
   Encoded Field Section (..),
 }
 ~~~~~~~~~~
-{: #fig-headers title="HEADERS Frame"}
+{: title="HEADERS Frame"}
 
 HEADERS frames can only be sent on request or push streams.  If a HEADERS frame
 is received on a control stream, the recipient MUST respond with a connection
@@ -1373,7 +1373,7 @@ CANCEL_PUSH Frame {
   Push ID (i),
 }
 ~~~~~~~~~~
-{: #fig-cancel-push title="CANCEL_PUSH Frame"}
+{: title="CANCEL_PUSH Frame"}
 
 The CANCEL_PUSH frame carries a Push ID encoded as a variable-length integer.
 The Push ID identifies the server push that is being cancelled; see
@@ -1437,7 +1437,7 @@ SETTINGS Frame {
   Setting (..) ...,
 }
 ~~~~~~~~~~~~~~~
-{: #fig-ext-settings title="SETTINGS Frame"}
+{: title="SETTINGS Frame"}
 
 An implementation MUST ignore any parameter with an identifier it does
 not understand.
@@ -1535,7 +1535,7 @@ PUSH_PROMISE Frame {
   Encoded Field Section (..),
 }
 ~~~~~~~~~~
-{: #fig-push-promise title="PUSH_PROMISE Frame"}
+{: title="PUSH_PROMISE Frame"}
 
 The payload consists of:
 
@@ -1594,7 +1594,7 @@ GOAWAY Frame {
   Stream ID/Push ID (i),
 }
 ~~~~~~~~~~
-{: #fig-goaway title="GOAWAY Frame"}
+{: title="GOAWAY Frame"}
 
 The GOAWAY frame is always sent on the control stream.  In the server-to-client
 direction, it carries a QUIC Stream ID for a client-initiated bidirectional
@@ -1639,7 +1639,7 @@ MAX_PUSH_ID Frame {
   Push ID (i),
 }
 ~~~~~~~~~~
-{: #fig-max-push title="MAX_PUSH_ID Frame"}
+{: title="MAX_PUSH_ID Frame"}
 
 The MAX_PUSH_ID frame carries a single variable-length integer that identifies
 the maximum value for a Push ID that the server can use; see {{server-push}}.  A
@@ -2252,7 +2252,7 @@ Sender:
 Specifications for permanent registrations MUST include a description of the
 stream type, including the layout and semantics of the stream contents.
 
-The entries in the following table are registered by this document.
+The entries in {{iana-stream-type-table}} are registered by this document.
 
 | ---------------- | ------ | -------------------------- | ------ |
 | Stream Type      | Value  | Specification              | Sender |

--- a/rfc9114.md
+++ b/rfc9114.md
@@ -203,10 +203,7 @@ Additional resources are provided in the final sections:
 
 ## Conventions and Terminology
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
-"SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this
-document are to be interpreted as described in BCP 14 {{!RFC2119}} {{!RFC8174}}
-when, and only when, they appear in all capitals, as shown here.
+{::boilerplate bcp14-tagged}
 
 This document uses the variable-length integer encoding from
 {{QUIC-TRANSPORT}}.

--- a/rfc9114.md
+++ b/rfc9114.md
@@ -1218,11 +1218,11 @@ H3_ID_ERROR; see {{errors}}.
 ### Reserved Stream Types {#stream-grease}
 
 Stream types of the format `0x1f * N + 0x21` for non-negative integer values of
-N are reserved to exercise the requirement that unknown types be ignored. These
-streams have no semantics, and they can be sent when application-layer padding
-is desired. They MAY also be sent on connections where no data is currently
-being transferred. Endpoints MUST NOT consider these streams to have any meaning
-upon receipt.
+`N` are reserved to exercise the requirement that unknown types be ignored.
+These streams have no semantics, and they can be sent when application-layer
+padding is desired. They MAY also be sent on connections where no data is
+currently being transferred. Endpoints MUST NOT consider these streams to have
+any meaning upon receipt.
 
 The payload and length of the stream are selected in any manner the sending
 implementation chooses.  When sending a reserved stream type, the implementation
@@ -1451,8 +1451,8 @@ The following settings are defined in HTTP/3:
   : The default value is unlimited.  See {{header-size-constraints}} for usage.
 
 Setting identifiers of the format `0x1f * N + 0x21` for non-negative integer
-values of N are reserved to exercise the requirement that unknown identifiers be
-ignored.  Such settings have no defined meaning. Endpoints SHOULD include at
+values of `N` are reserved to exercise the requirement that unknown identifiers
+be ignored.  Such settings have no defined meaning. Endpoints SHOULD include at
 least one such setting in their SETTINGS frame. Endpoints MUST NOT consider such
 settings to have any meaning upon receipt.
 
@@ -1649,8 +1649,8 @@ a connection error of type H3_ID_ERROR.
 
 ### Reserved Frame Types {#frame-reserved}
 
-Frame types of the format `0x1f * N + 0x21` for non-negative integer values of N
-are reserved to exercise the requirement that unknown types be ignored
+Frame types of the format `0x1f * N + 0x21` for non-negative integer values of
+`N` are reserved to exercise the requirement that unknown types be ignored
 ({{extensions}}).  These frames have no semantics, and they MAY be sent on any
 stream where frames are allowed to be sent. This enables their use for
 application-layer padding.  Endpoints MUST NOT consider these frames to have any
@@ -1763,9 +1763,9 @@ H3_VERSION_FALLBACK (0x0110):
 : The requested operation cannot be served over HTTP/3.  The peer should
   retry over HTTP/1.1.
 
-Error codes of the format `0x1f * N + 0x21` for non-negative integer values of N
-are reserved to exercise the requirement that unknown error codes be treated as
-equivalent to H3_NO_ERROR ({{extensions}}). Implementations SHOULD select an
+Error codes of the format `0x1f * N + 0x21` for non-negative integer values of
+`N` are reserved to exercise the requirement that unknown error codes be treated
+as equivalent to H3_NO_ERROR ({{extensions}}). Implementations SHOULD select an
 error code from this space with some probability when they would have sent
 H3_NO_ERROR.
 
@@ -2119,7 +2119,7 @@ The entries in {{iana-frame-table}} are registered by this document.
 | ------------ | ------- | -------------------------- |
 {: #iana-frame-table title="Initial HTTP/3 Frame Types"}
 
-Each code of the format `0x1f * N + 0x21` for non-negative integer values of N
+Each code of the format `0x1f * N + 0x21` for non-negative integer values of `N`
 (that is, 0x21, 0x40, ..., through 0x3ffffffffffffffe) MUST NOT be assigned by
 IANA and MUST NOT appear in the listing of assigned values.
 
@@ -2167,7 +2167,7 @@ The entries in {{iana-setting-table}} are registered by this document.
 For fomatting reasons, setting names can be abbreviated by removing the
 'SETTING_' prefix.
 
-Each code of the format `0x1f * N + 0x21` for non-negative integer values of N
+Each code of the format `0x1f * N + 0x21` for non-negative integer values of `N`
 (that is, 0x21, 0x40, ..., through 0x3ffffffffffffffe) MUST NOT be assigned by
 IANA and MUST NOT appear in the listing of assigned values.
 
@@ -2225,7 +2225,7 @@ Required policy to avoid collisions with HTTP/2 error codes.
 | --------------------------------- | ---------- | ---------------------------------------- | ---------------------- |
 {: #iana-error-table title="Initial HTTP/3 Error Codes"}
 
-Each code of the format `0x1f * N + 0x21` for non-negative integer values of N
+Each code of the format `0x1f * N + 0x21` for non-negative integer values of `N`
 (that is, 0x21, 0x40, ..., through 0x3ffffffffffffffe) MUST NOT be assigned by
 IANA and MUST NOT appear in the listing of assigned values.
 
@@ -2262,7 +2262,7 @@ The entries in {{iana-stream-type-table}} are registered by this document.
 | ---------------- | ------ | -------------------------- | ------ |
 {: #iana-stream-type-table title="Initial Stream Types"}
 
-Each code of the format `0x1f * N + 0x21` for non-negative integer values of N
+Each code of the format `0x1f * N + 0x21` for non-negative integer values of `N`
 (that is, 0x21, 0x40, ..., through 0x3ffffffffffffffe) MUST NOT be assigned by
 IANA and MUST NOT appear in the listing of assigned values.
 


### PR DESCRIPTION
Of note:
- Replace the BCP14 boilerplate with the bcp14-tagged invocation, which causes all the BCP14 terms to get the appropriate `<bcp14>` tags added by kramdown-rfc2629
- Change all instance of `drawing` to `ascii-art`
- Add angle brackets to the one bare URL in the document
- The removal of backticks was apparently a tooling issue, not a deliberate change -- their XML still places `<tt>` around these segments, which the backticks map to, but their text output does not include `"` which my text output does when the backticks are present.  I've restored them, to have the XML correct, and they can finagle the text output as desired.
- Remove any unused figure/table anchors, except one place where I added a reference instead to match the parallel sections.
- Use the same format for the Acknowledgements list as RFC9000 (albeit a bit different from what the RFC Editor changed it to).