### PR TITLE
Rearrange and rename to align with updated HTTP/2 spec

### DIFF
--- a/rfc9114.md
+++ b/rfc9114.md
@@ -581,7 +581,7 @@ types of common attacks against HTTP; they are deliberately strict because being
 permissive can expose implementations to these vulnerabilities.
 
 
-### HTTP Fields {#header-formatting}
+## HTTP Fields {#header-formatting}
 
 HTTP messages carry metadata as a series of key-value pairs called "HTTP
 fields"; see {{Sections 6.3 and 6.5 of HTTP}}. For a listing of registered HTTP

--- a/rfc9114.md
+++ b/rfc9114.md
@@ -418,9 +418,9 @@ origin can indicate that it is not authoritative for a request by sending a 421
 of HTTP}}.
 
 
-# HTTP Request Lifecycle
+# Expressing HTTP Semantics in HTTP/3 {#http-request-lifecycle}
 
-## HTTP Message Exchanges {#request-response}
+## HTTP Message Framing {#request-response}
 
 A client sends an HTTP request on a request stream, which is a client-initiated
 bidirectional QUIC stream; see {{request-streams}}.  A client MUST send only a
@@ -440,7 +440,8 @@ response following a final HTTP response MUST be treated as malformed
 
 An HTTP message (request or response) consists of:
 
-1. the header section, sent as a single HEADERS frame (see {{frame-headers}}),
+1. the header section, including message control data, sent as a single HEADERS
+   frame (see {{frame-headers}}),
 
 2. optionally, the content, if present, sent as a series of DATA frames
    (see {{frame-data}}), and
@@ -505,166 +506,6 @@ having their request terminated abruptly, though clients can always discard
 responses at their discretion for other reasons.  If the server sends a partial
 or complete response but does not abort reading the request, clients SHOULD
 continue sending the body of the request and close the stream normally.
-
-
-### Field Formatting and Compression {#header-formatting}
-
-HTTP messages carry metadata as a series of key-value pairs called "HTTP
-fields"; see {{Sections 6.3 and 6.5 of HTTP}}. For a listing of registered HTTP
-fields, see the "Hypertext Transfer Protocol (HTTP) Field Name Registry"
-maintained at [](https://www.iana.org/assignments/http-fields/).
-
-Field names are strings containing a subset of ASCII characters. Properties of
-HTTP field names and values are discussed in more detail in {{Section 5.1 of
-HTTP}}. As in HTTP/2, characters in field names MUST be converted to
-lowercase prior to their encoding. A request or response containing uppercase
-characters in field names MUST be treated as malformed ({{malformed}}).
-
-Like HTTP/2, HTTP/3 does not use the Connection header field to indicate
-connection-specific fields; in this protocol, connection-specific metadata is
-conveyed by other means.  An endpoint MUST NOT generate an HTTP/3 field section
-containing connection-specific fields; any message containing
-connection-specific fields MUST be treated as malformed ({{malformed}}).
-
-The only exception to this is the TE header field, which MAY be present in an
-HTTP/3 request header; when it is, it MUST NOT contain any value other than
-"trailers".
-
-An intermediary transforming an HTTP/1.x message to HTTP/3 MUST remove
-connection-specific header fields as discussed in {{Section 7.6.1 of
-HTTP}}, or their messages will be treated by other HTTP/3 endpoints as
-malformed ({{malformed}}).
-
-#### Pseudo-Header Fields
-
-Like HTTP/2, HTTP/3 employs a series of pseudo-header fields, where the field
-name begins with the ':' character (ASCII 0x3a).  These pseudo-header fields
-convey the target URI, the method of the request, and the status code for the
-response.
-
-Pseudo-header fields are not HTTP fields.  Endpoints MUST NOT generate
-pseudo-header fields other than those defined in this document; however, an
-extension could negotiate a modification of this restriction; see
-{{extensions}}.
-
-Pseudo-header fields are only valid in the context in which they are defined.
-Pseudo-header fields defined for requests MUST NOT appear in responses;
-pseudo-header fields defined for responses MUST NOT appear in requests.
-Pseudo-header fields MUST NOT appear in trailer sections. Endpoints MUST treat a
-request or response that contains undefined or invalid pseudo-header fields as
-malformed ({{malformed}}).
-
-All pseudo-header fields MUST appear in the header section before regular header
-fields.  Any request or response that contains a pseudo-header field that
-appears in a header section after a regular header field MUST be treated as
-malformed ({{malformed}}).
-
-The following pseudo-header fields are defined for requests:
-
-  ":method":
-
-  : Contains the HTTP method ({{Section 9 of HTTP}})
-
-  ":scheme":
-
-  : Contains the scheme portion of the target URI ({{Section 3.1 of URI}}).
-
-  : ":scheme" is not restricted to URIs with scheme "http" and "https".
-    A proxy or
-    gateway can translate requests for non-HTTP schemes, enabling the use of
-    HTTP to interact with non-HTTP services.
-
-  : See {{other-schemes}} for guidance on using a scheme other than "https".
-
-  ":authority":
-
-  : Contains the authority portion of the target URI ({{Section 3.2 of URI}}).
-    The authority MUST NOT include the deprecated "userinfo"
-    subcomponent for URIs of scheme "http" or "https".
-
-  : To ensure that the HTTP/1.1 request line can be reproduced accurately, this
-    pseudo-header field MUST be omitted when translating from an HTTP/1.1
-    request that has a request target in origin or asterisk form; see {{Section
-    7.1 of HTTP}}.  Clients that generate HTTP/3 requests directly
-    SHOULD use the ":authority" pseudo-header field instead of the Host field.
-    An intermediary that converts an HTTP/3 request to HTTP/1.1 MUST create a
-    Host field if one is not present in a request by copying the value of the
-    ":authority" pseudo-header field.
-
-  ":path":
-
-  : Contains the path and query parts of the target URI (the "path-absolute"
-    production and optionally a '?' character followed by the "query"
-    production; see {{Sections 3.3 and 3.4 of URI}}.  A request in
-    asterisk form includes the value '*' for the ":path" pseudo-header field.
-
-  : This pseudo-header field MUST NOT be empty for "http" or "https" URIs;
-    "http" or "https" URIs that do not contain a path component MUST include a
-    value of '/'.  The exception to this rule is an OPTIONS request for an
-    "http" or "https" URI that does not include a path component; these MUST
-    include a ":path" pseudo-header field with a value of '*'; see
-    {{Section 7.1 of HTTP}}.
-
-All HTTP/3 requests MUST include exactly one value for the ":method", ":scheme",
-and ":path" pseudo-header fields, unless the request is a CONNECT request; see
-{{connect}}.
-
-If the ":scheme" pseudo-header field identifies a scheme that has a mandatory
-authority component (including "http" and "https"), the request MUST contain
-either an ":authority" pseudo-header field or a "Host" header field.  If these
-fields are present, they MUST NOT be empty.  If both fields are present, they
-MUST contain the same value.  If the scheme does not have a mandatory authority
-component and none is provided in the request target, the request MUST NOT
-contain the ":authority" pseudo-header or "Host" header fields.
-
-An HTTP request that omits mandatory pseudo-header fields or contains invalid
-values for those pseudo-header fields is malformed ({{malformed}}).
-
-HTTP/3 does not define a way to carry the version identifier that is included in
-the HTTP/1.1 request line.
-
-For responses, a single ":status" pseudo-header field is defined that carries
-the HTTP status code; see {{Section 15 of HTTP}}.  This pseudo-header
-field MUST be included in all responses; otherwise, the response is malformed
-(see {{malformed}}).
-
-HTTP/3 does not define a way to carry the version or reason phrase that is
-included in an HTTP/1.1 status line.
-
-#### Field Compression
-
-{{QPACK}} describes a variation of HPACK that gives an encoder some control over
-how much head-of-line blocking can be caused by compression.  This allows an
-encoder to balance compression efficiency with latency.  HTTP/3 uses QPACK to
-compress header and trailer sections, including the pseudo-header fields present
-in the header section.
-
-To allow for better compression efficiency, the "Cookie" field ({{!RFC6265}})
-MAY be split into separate field lines, each with one or more cookie-pairs,
-before compression. If a decompressed field section contains multiple cookie
-field lines, these MUST be concatenated into a single byte string using the
-two-byte delimiter of 0x3b, 0x20 (the ASCII string "; ") before being passed
-into a context other than HTTP/2 or HTTP/3, such as an HTTP/1.1 connection, or a
-generic HTTP server application.
-
-#### Header Size Constraints
-
-An HTTP/3 implementation MAY impose a limit on the maximum size of the message
-header it will accept on an individual HTTP message.  A server that receives a
-larger header section than it is willing to handle can send an HTTP 431 (Request
-Header Fields Too Large) status code ({{?RFC6585}}).  A client can discard
-responses that it cannot process.  The size of a field list is calculated based
-on the uncompressed size of fields, including the length of the name and value
-in bytes plus an overhead of 32 bytes for each field.
-
-If an implementation wishes to advise its peer of this limit, it can be conveyed
-as a number of bytes in the SETTINGS_MAX_FIELD_SECTION_SIZE parameter. An
-implementation that has received this parameter SHOULD NOT send an HTTP message
-header that exceeds the indicated size, as the peer will likely refuse to
-process it.  However, an HTTP message can traverse one or more intermediaries
-before reaching the origin server; see {{Section 3.7 of HTTP}}.  Because
-this limit is applied separately by each implementation that processes the
-message, messages below this limit are not guaranteed to be accepted.
 
 ### Request Cancellation and Rejection {#request-cancellation}
 
@@ -738,6 +579,171 @@ prior to closing or resetting the stream.  Clients MUST NOT accept a malformed
 response.  Note that these requirements are intended to protect against several
 types of common attacks against HTTP; they are deliberately strict because being
 permissive can expose implementations to these vulnerabilities.
+
+
+### HTTP Fields {#header-formatting}
+
+HTTP messages carry metadata as a series of key-value pairs called "HTTP
+fields"; see {{Sections 6.3 and 6.5 of HTTP}}. For a listing of registered HTTP
+fields, see the "Hypertext Transfer Protocol (HTTP) Field Name Registry"
+maintained at [](https://www.iana.org/assignments/http-fields/).
+
+Field names are strings containing a subset of ASCII characters. Properties of
+HTTP field names and values are discussed in more detail in {{Section 5.1 of
+HTTP}}. As in HTTP/2, characters in field names MUST be converted to
+lowercase prior to their encoding. A request or response containing uppercase
+characters in field names MUST be treated as malformed ({{malformed}}).
+
+Like HTTP/2, HTTP/3 does not use the Connection header field to indicate
+connection-specific fields; in this protocol, connection-specific metadata is
+conveyed by other means.  An endpoint MUST NOT generate an HTTP/3 field section
+containing connection-specific fields; any message containing
+connection-specific fields MUST be treated as malformed ({{malformed}}).
+
+The only exception to this is the TE header field, which MAY be present in an
+HTTP/3 request header; when it is, it MUST NOT contain any value other than
+"trailers".
+
+An intermediary transforming an HTTP/1.x message to HTTP/3 MUST remove
+connection-specific header fields as discussed in {{Section 7.6.1 of
+HTTP}}, or their messages will be treated by other HTTP/3 endpoints as
+malformed ({{malformed}}).
+
+#### Field Compression
+
+{{QPACK}} describes a variation of HPACK that gives an encoder some control over
+how much head-of-line blocking can be caused by compression.  This allows an
+encoder to balance compression efficiency with latency.  HTTP/3 uses QPACK to
+compress header and trailer sections, including the control data present in the
+header section.
+
+To allow for better compression efficiency, the "Cookie" field ({{!RFC6265}})
+MAY be split into separate field lines, each with one or more cookie-pairs,
+before compression. If a decompressed field section contains multiple cookie
+field lines, these MUST be concatenated into a single byte string using the
+two-byte delimiter of 0x3b, 0x20 (the ASCII string "; ") before being passed
+into a context other than HTTP/2 or HTTP/3, such as an HTTP/1.1 connection, or a
+generic HTTP server application.
+
+#### Header Size Constraints
+
+An HTTP/3 implementation MAY impose a limit on the maximum size of the message
+header it will accept on an individual HTTP message.  A server that receives a
+larger header section than it is willing to handle can send an HTTP 431 (Request
+Header Fields Too Large) status code ({{?RFC6585}}).  A client can discard
+responses that it cannot process.  The size of a field list is calculated based
+on the uncompressed size of fields, including the length of the name and value
+in bytes plus an overhead of 32 bytes for each field.
+
+If an implementation wishes to advise its peer of this limit, it can be conveyed
+as a number of bytes in the SETTINGS_MAX_FIELD_SECTION_SIZE parameter. An
+implementation that has received this parameter SHOULD NOT send an HTTP message
+header that exceeds the indicated size, as the peer will likely refuse to
+process it.  However, an HTTP message can traverse one or more intermediaries
+before reaching the origin server; see {{Section 3.7 of HTTP}}.  Because
+this limit is applied separately by each implementation that processes the
+message, messages below this limit are not guaranteed to be accepted.
+
+## HTTP Control Data
+
+Like HTTP/2, HTTP/3 employs a series of pseudo-header fields, where the field
+name begins with the ':' character (ASCII 0x3a).  These pseudo-header fields
+convey message control data (see {{Section 6.2 of HTTP}}).
+
+Pseudo-header fields are not HTTP fields.  Endpoints MUST NOT generate
+pseudo-header fields other than those defined in this document; however, an
+extension could negotiate a modification of this restriction; see
+{{extensions}}.
+
+Pseudo-header fields are only valid in the context in which they are defined.
+Pseudo-header fields defined for requests MUST NOT appear in responses;
+pseudo-header fields defined for responses MUST NOT appear in requests.
+Pseudo-header fields MUST NOT appear in trailer sections. Endpoints MUST treat a
+request or response that contains undefined or invalid pseudo-header fields as
+malformed ({{malformed}}).
+
+All pseudo-header fields MUST appear in the header section before regular header
+fields.  Any request or response that contains a pseudo-header field that
+appears in a header section after a regular header field MUST be treated as
+malformed ({{malformed}}).
+
+### Request Pseudo-Header Fields
+
+The following pseudo-header fields are defined for requests:
+
+  ":method":
+
+  : Contains the HTTP method ({{Section 9 of HTTP}})
+
+  ":scheme":
+
+  : Contains the scheme portion of the target URI ({{Section 3.1 of URI}}).
+
+  : ":scheme" is not restricted to URIs with scheme "http" and "https".
+    A proxy or
+    gateway can translate requests for non-HTTP schemes, enabling the use of
+    HTTP to interact with non-HTTP services.
+
+  : See {{other-schemes}} for guidance on using a scheme other than "https".
+
+  ":authority":
+
+  : Contains the authority portion of the target URI ({{Section 3.2 of URI}}).
+    The authority MUST NOT include the deprecated "userinfo"
+    subcomponent for URIs of scheme "http" or "https".
+
+  : To ensure that the HTTP/1.1 request line can be reproduced accurately, this
+    pseudo-header field MUST be omitted when translating from an HTTP/1.1
+    request that has a request target in origin or asterisk form; see {{Section
+    7.1 of HTTP}}.  Clients that generate HTTP/3 requests directly
+    SHOULD use the ":authority" pseudo-header field instead of the Host field.
+    An intermediary that converts an HTTP/3 request to HTTP/1.1 MUST create a
+    Host field if one is not present in a request by copying the value of the
+    ":authority" pseudo-header field.
+
+  ":path":
+
+  : Contains the path and query parts of the target URI (the "path-absolute"
+    production and optionally a '?' character followed by the "query"
+    production; see {{Sections 3.3 and 3.4 of URI}}.  A request in
+    asterisk form includes the value '*' for the ":path" pseudo-header field.
+
+  : This pseudo-header field MUST NOT be empty for "http" or "https" URIs;
+    "http" or "https" URIs that do not contain a path component MUST include a
+    value of '/'.  The exception to this rule is an OPTIONS request for an
+    "http" or "https" URI that does not include a path component; these MUST
+    include a ":path" pseudo-header field with a value of '*'; see
+    {{Section 7.1 of HTTP}}.
+
+All HTTP/3 requests MUST include exactly one value for the ":method", ":scheme",
+and ":path" pseudo-header fields, unless the request is a CONNECT request; see
+{{connect}}.
+
+If the ":scheme" pseudo-header field identifies a scheme that has a mandatory
+authority component (including "http" and "https"), the request MUST contain
+either an ":authority" pseudo-header field or a "Host" header field.  If these
+fields are present, they MUST NOT be empty.  If both fields are present, they
+MUST contain the same value.  If the scheme does not have a mandatory authority
+component and none is provided in the request target, the request MUST NOT
+contain the ":authority" pseudo-header or "Host" header fields.
+
+An HTTP request that omits mandatory pseudo-header fields or contains invalid
+values for those pseudo-header fields is malformed ({{malformed}}).
+
+HTTP/3 does not define a way to carry the version identifier that is included in
+the HTTP/1.1 request line.  HTTP/3 requests implicitly have a protocol version
+of "3.0".
+
+### Response Pseudo-Header Fields
+
+For responses, a single ":status" pseudo-header field is defined that carries
+the HTTP status code; see {{Section 15 of HTTP}}.  This pseudo-header
+field MUST be included in all responses; otherwise, the response is malformed
+(see {{malformed}}).
+
+HTTP/3 does not define a way to carry the version or reason phrase that is
+included in an HTTP/1.1 status line. HTTP/3 responses implicitly have a protocol
+version of "3.0".
 
 
 ## The CONNECT Method {#connect}
@@ -836,12 +842,12 @@ treat receipt of a push stream as a connection error of type H3_ID_ERROR
 references a Push ID that is greater than the maximum Push ID.
 
 The Push ID is used in one or more PUSH_PROMISE frames ({{frame-push-promise}})
-that carry the header section of the request message.  These frames are sent on
-the request stream that generated the push.  This allows the server push to be
-associated with a client request.  When the same Push ID is promised on multiple
-request streams, the decompressed request field sections MUST contain the same
-fields in the same order, and both the name and the value in each field MUST be
-identical.
+that carry the control data and header fields of the request message.  These
+frames are sent on the request stream that generated the push.  This allows the
+server push to be associated with a client request.  When the same Push ID is
+promised on multiple request streams, the decompressed request field sections
+MUST contain the same fields in the same order, and both the name and the value
+in each field MUST be identical.
 
 The Push ID is then included with the push stream that ultimately fulfills
 those promises; see {{push-streams}}.  The push stream identifies the Push ID of

--- a/rfc9114.md
+++ b/rfc9114.md
@@ -676,7 +676,7 @@ connection-specific header fields as discussed in {{Section 7.6.1 of
 HTTP}}, or their messages will be treated by other HTTP/3 endpoints as
 malformed ({{malformed}}).
 
-#### Field Compression
+### Field Compression
 
 {{QPACK}} describes a variation of HPACK that gives an encoder some control over
 how much head-of-line blocking can be caused by compression.  This allows an
@@ -692,7 +692,7 @@ two-byte delimiter of 0x3b, 0x20 (the ASCII string "; ") before being passed
 into a context other than HTTP/2 or HTTP/3, such as an HTTP/1.1 connection, or a
 generic HTTP server application.
 
-#### Header Size Constraints
+### Header Size Constraints
 
 An HTTP/3 implementation MAY impose a limit on the maximum size of the message
 header it will accept on an individual HTTP message.  A server that receives a

--- a/rfc9114.md
+++ b/rfc9114.md
@@ -648,10 +648,10 @@ message, messages below this limit are not guaranteed to be accepted.
 
 Like HTTP/2, HTTP/3 employs a series of pseudo-header fields, where the field
 name begins with the ':' character (ASCII 0x3a).  These pseudo-header fields
-convey message control data (see {{Section 6.2 of HTTP}}).
+convey message control data; see {{Section 6.2 of HTTP}}.
 
 Pseudo-header fields are not HTTP fields.  Endpoints MUST NOT generate
-pseudo-header fields other than those defined in this document; however, an
+pseudo-header fields other than those defined in this document. However, an
 extension could negotiate a modification of this restriction; see
 {{extensions}}.
 


### PR DESCRIPTION
The diff looks larger than it is; I moved some sections around to more closely resemble the TOC of the HTTP/2 spec, and changed a section title that seemed a bit odd a year later.  The relocated sections haven't changed.

Old TOC:
4.  HTTP Request Lifecycle
4.1.  HTTP Message Exchanges
4.1.1.  Field Formatting and Compression
4.1.2.  Request Cancellation and Rejection
4.1.3.  Malformed Requests and Responses
4.2.  The CONNECT Method
4.3.  HTTP Upgrade
4.4.  Server Push

New TOC:
4.  Expressing HTTP Semantics in HTTP/3
4.1.  HTTP Message Framing
4.1.1.  Request Cancellation and Rejection
4.1.2.  Malformed Requests and Responses
4.2.  HTTP Fields
4.3.  HTTP Control Data
4.3.1.  Request Pseudo-Header Fields
4.3.2.  Response Pseudo-Header Fields
4.4.  The CONNECT Method
4.5.  HTTP Upgrade
4.6.  Server Push

Comparison H2 TOC:
8.  Expressing HTTP Semantics in HTTP/2
8.1.  HTTP Message Framing
8.1.1.  Malformed Messages
8.2.  HTTP Fields
8.2.1.  Field Validity
8.2.2.  Connection-Specific Header Fields
8.2.3.  Compressing the Cookie Header Field
8.3.  HTTP Control Data
8.3.1.  Request Pseudo-Header Fields
8.3.2.  Response Pseudo-Header Fields
8.4.  Server Push
8.4.1.  Push Requests
8.4.2.  Push Responses
8.5.  The CONNECT Method
8.6.  The Upgrade Header Field

...and then some further sections as well.

Fixes #4953.