### PR TITLE
HTTP cross references

### DIFF
--- a/rfc9114.md
+++ b/rfc9114.md
@@ -1324,6 +1324,14 @@ HTTP/2 and HTTP/3 frames is provided in {{h2-frames}}.
 | Reserved     | Yes            | Yes            | Yes         | {{frame-reserved}}     |
 {: #stream-frame-mapping title="HTTP/3 Frames and Stream Type Overview"}
 
+*[DATA]: #frame-data
+*[HEADERS]: #frame-headers
+*[CANCEL_PUSH]: #frame-cancel-push
+*[SETTINGS]: #frame-settings
+*[PUSH_PROMISE]: #frame-push-promise
+*[GOAWAY]: #frame-goaway
+*[MAX_PUSH_ID]: #frame-max-push-id
+
 The SETTINGS frame can only occur as the first frame of a Control stream; this
 is indicated in {{stream-frame-mapping}} with a (1).  Specific guidance
 is provided in the relevant section.
@@ -1522,6 +1530,9 @@ The following settings are defined in HTTP/3:
 
   SETTINGS_MAX_FIELD_SECTION_SIZE (0x06):
   : The default value is unlimited.  See {{header-size-constraints}} for usage.
+    {: anchor="SETTINGS_MAX_FIELD_SECTION_SIZE"}
+
+*[SETTINGS_MAX_FIELD_SECTION_SIZE]: #
 
 Setting identifiers of the format `0x1f * N + 0x21` for non-negative integer
 values of `N` are reserved to exercise the requirement that unknown identifiers
@@ -1780,61 +1791,96 @@ aborting reading of streams, or immediately closing HTTP/3 connections.
 H3_NO_ERROR (0x0100):
 : No error.  This is used when the connection or stream needs to be closed, but
   there is no error to signal.
+  {: anchor="H3_NO_ERROR"}
 
 H3_GENERAL_PROTOCOL_ERROR (0x0101):
 : Peer violated protocol requirements in a way that does not match a more
   specific error code or endpoint declines to use the more specific error code.
+  {: anchor="H3_GENERAL_PROTOCOL_ERROR"}
 
 H3_INTERNAL_ERROR (0x0102):
 : An internal error has occurred in the HTTP stack.
+  {: anchor="H3_INTERNAL_ERROR"}
 
 H3_STREAM_CREATION_ERROR (0x0103):
 : The endpoint detected that its peer created a stream that it will not accept.
+  {: anchor="H3_STREAM_CREATION_ERROR"}
 
 H3_CLOSED_CRITICAL_STREAM (0x0104):
 : A stream required by the HTTP/3 connection was closed or reset.
+  {: anchor="H3_CLOSED_CRITICAL_STREAM"}
 
 H3_FRAME_UNEXPECTED (0x0105):
 : A frame was received that was not permitted in the current state or on the
   current stream.
+  {: anchor="H3_FRAME_UNEXPECTED"}
 
 H3_FRAME_ERROR (0x0106):
 : A frame that fails to satisfy layout requirements or with an invalid size
   was received.
+  {: anchor="H3_FRAME_ERROR"}
 
 H3_EXCESSIVE_LOAD (0x0107):
 : The endpoint detected that its peer is exhibiting a behavior that might be
   generating excessive load.
+  {: anchor="H3_EXCESSIVE_LOAD"}
 
 H3_ID_ERROR (0x0108):
 : A stream ID or push ID was used incorrectly, such as exceeding a limit,
   reducing a limit, or being reused.
+  {: anchor="H3_ID_ERROR"}
 
 H3_SETTINGS_ERROR (0x0109):
 : An endpoint detected an error in the payload of a SETTINGS frame.
+  {: anchor="H3_SETTINGS_ERROR"}
 
 H3_MISSING_SETTINGS (0x010a):
 : No SETTINGS frame was received at the beginning of the control stream.
+  {: anchor="H3_MISSING_SETTINGS"}
 
 H3_REQUEST_REJECTED (0x010b):
 : A server rejected a request without performing any application processing.
+  {: anchor="H3_REQUEST_REJECTED"}
 
 H3_REQUEST_CANCELLED (0x010c):
 : The request or its response (including pushed response) is cancelled.
+  {: anchor="H3_REQUEST_CANCELLED"}
 
 H3_REQUEST_INCOMPLETE (0x010d):
 : The client's stream terminated without containing a fully formed request.
+  {: anchor="H3_REQUEST_INCOMPLETE"}
 
 H3_MESSAGE_ERROR (0x010e):
 : An HTTP message was malformed and cannot be processed.
+  {: anchor="H3_MESSAGE_ERROR"}
 
 H3_CONNECT_ERROR (0x010f):
 : The TCP connection established in response to a CONNECT request was reset or
   abnormally closed.
+  {: anchor="H3_CONNECT_ERROR"}
 
 H3_VERSION_FALLBACK (0x0110):
 : The requested operation cannot be served over HTTP/3.  The peer should
   retry over HTTP/1.1.
+  {: anchor="H3_VERSION_FALLBACK"}
+
+*[H3_NO_ERROR]: #
+*[H3_GENERAL_PROTOCOL_ERROR]: #
+*[H3_INTERNAL_ERROR]: #
+*[H3_STREAM_CREATION_ERROR]: #
+*[H3_CLOSED_CRITICAL_STREAM]: #
+*[H3_FRAME_UNEXPECTED]: #
+*[H3_FRAME_ERROR]: #
+*[H3_EXCESSIVE_LOAD]: #
+*[H3_ID_ERROR]: #
+*[H3_SETTINGS_ERROR]: #
+*[H3_MISSING_SETTINGS]: #
+*[H3_REQUEST_REJECTED]: #
+*[H3_REQUEST_CANCELLED]: #
+*[H3_REQUEST_INCOMPLETE]: #
+*[H3_MESSAGE_ERROR]: #
+*[H3_CONNECT_ERROR]: #
+*[H3_VERSION_FALLBACK]: #
 
 Error codes of the format `0x1f * N + 0x21` for non-negative integer values of
 `N` are reserved to exercise the requirement that unknown error codes be treated

--- a/rfc9114.md
+++ b/rfc9114.md
@@ -342,6 +342,7 @@ HTTP}}.
 Packet diagrams in this document use the format defined in
 {{Section 1.3 of QUIC-TRANSPORT}} to illustrate the order and size of fields.
 
+*[malformed]: #
 
 # Connection Setup and Management {#connection-setup}
 
@@ -501,8 +502,7 @@ by a single final HTTP response, in the same manner as a standard response.
 Push is described in more detail in {{server-push}}.
 
 On a given stream, receipt of multiple requests or receipt of an additional HTTP
-response following a final HTTP response MUST be treated as malformed
-({{malformed}}).
+response following a final HTTP response MUST be treated as malformed.
 
 An HTTP message (request or response) consists of:
 
@@ -659,13 +659,13 @@ Field names are strings containing a subset of ASCII characters. Properties of
 HTTP field names and values are discussed in more detail in {{Section 5.1 of
 HTTP}}. As in HTTP/2, characters in field names MUST be converted to
 lowercase prior to their encoding. A request or response containing uppercase
-characters in field names MUST be treated as malformed ({{malformed}}).
+characters in field names MUST be treated as malformed.
 
 Like HTTP/2, HTTP/3 does not use the Connection header field to indicate
 connection-specific fields; in this protocol, connection-specific metadata is
 conveyed by other means.  An endpoint MUST NOT generate an HTTP/3 field section
 containing connection-specific fields; any message containing
-connection-specific fields MUST be treated as malformed ({{malformed}}).
+connection-specific fields MUST be treated as malformed.
 
 The only exception to this is the TE header field, which MAY be present in an
 HTTP/3 request header; when it is, it MUST NOT contain any value other than
@@ -674,7 +674,7 @@ HTTP/3 request header; when it is, it MUST NOT contain any value other than
 An intermediary transforming an HTTP/1.x message to HTTP/3 MUST remove
 connection-specific header fields as discussed in {{Section 7.6.1 of
 HTTP}}, or their messages will be treated by other HTTP/3 endpoints as
-malformed ({{malformed}}).
+malformed.
 
 ### Field Compression
 
@@ -727,12 +727,12 @@ Pseudo-header fields defined for requests MUST NOT appear in responses;
 pseudo-header fields defined for responses MUST NOT appear in requests.
 Pseudo-header fields MUST NOT appear in trailer sections. Endpoints MUST treat a
 request or response that contains undefined or invalid pseudo-header fields as
-malformed ({{malformed}}).
+malformed.
 
 All pseudo-header fields MUST appear in the header section before regular header
 fields.  Any request or response that contains a pseudo-header field that
 appears in a header section after a regular header field MUST be treated as
-malformed ({{malformed}}).
+malformed.
 
 ### Request Pseudo-Header Fields
 
@@ -793,7 +793,7 @@ component and none is provided in the request target, the request MUST NOT
 contain the ":authority" pseudo-header or "Host" header fields.
 
 An HTTP request that omits mandatory pseudo-header fields or contains invalid
-values for those pseudo-header fields is malformed ({{malformed}}).
+values for those pseudo-header fields is malformed.
 
 HTTP/3 does not define a way to carry the version identifier that is included in
 the HTTP/1.1 request line.  HTTP/3 requests implicitly have a protocol version
@@ -1955,17 +1955,17 @@ authenticated transports.
 ## Intermediary-Encapsulation Attacks
 
 The HTTP/3 field encoding allows the expression of names that are not valid
-field names in the syntax used by HTTP ({{Section 5.1 of HTTP}}). Requests
-or responses containing invalid field names MUST be treated as malformed
-({{malformed}}).  Therefore, an intermediary cannot translate an HTTP/3 request
-or response containing an invalid field name into an HTTP/1.1 message.
+field names in the syntax used by HTTP ({{Section 5.1 of HTTP}}). Requests or
+responses containing invalid field names MUST be treated as malformed.
+Therefore, an intermediary cannot translate an HTTP/3 request or response
+containing an invalid field name into an HTTP/1.1 message.
 
 Similarly, HTTP/3 can transport field values that are not valid. While most
 values that can be encoded will not alter field parsing, carriage return (ASCII
 0x0d), line feed (ASCII 0x0a), and the null character (ASCII 0x00) might be
 exploited by an attacker if they are translated verbatim. Any request or
 response that contains a character not permitted in a field value MUST be
-treated as malformed ({{malformed}}).  Valid characters are defined by the
+treated as malformed.  Valid characters are defined by the
 "field-content" ABNF rule in {{Section 5.5 of HTTP}}.
 
 ## Cacheability of Pushed Responses

--- a/rfc9114.md
+++ b/rfc9114.md
@@ -833,7 +833,7 @@ A CONNECT request MUST be constructed as follows:
 
 The request stream remains open at the end of the request to carry the data to
 be transferred.  A CONNECT request that does not conform to these restrictions
-is malformed; see {{malformed}}.
+is malformed.
 
 A proxy that supports CONNECT establishes a TCP connection ({{!RFC0793}}) to the
 server identified in the ":authority" pseudo-header field.  Once this connection
@@ -897,7 +897,7 @@ used to refer to the push in various contexts throughout the lifetime of the
 HTTP/3 connection.
 
 The push ID space begins at zero and ends at a maximum value set by the
-MAX_PUSH_ID frame; see {{frame-max-push-id}}.  In particular, a server is not
+MAX_PUSH_ID frame.  In particular, a server is not
 able to push until after the client sends a MAX_PUSH_ID frame.  A client sends
 MAX_PUSH_ID frames to control the number of pushes that a server can promise.  A
 server SHOULD use push IDs sequentially, beginning from zero.  A client MUST
@@ -977,6 +977,8 @@ time the pushed response is received.
 
 Pushed responses that are not cacheable MUST NOT be stored by any HTTP cache.
 They MAY be made available to the application separately.
+
+*[push ID]: #server-push
 
 # Connection Closure
 

--- a/rfc9114.md
+++ b/rfc9114.md
@@ -435,7 +435,7 @@ MAY be offered in the same handshake.
 
 While connection-level options pertaining to the core QUIC protocol are set in
 the initial crypto handshake, settings specific to HTTP/3 are conveyed in the
-SETTINGS frame ({{frame-settings}}). After the QUIC connection is established, a
+SETTINGS frame. After the QUIC connection is established, a
 SETTINGS frame MUST be sent by each endpoint as the initial frame of their
 respective HTTP control stream.
 
@@ -507,10 +507,9 @@ response following a final HTTP response MUST be treated as malformed.
 An HTTP message (request or response) consists of:
 
 1. the header section, including message control data, sent as a single HEADERS
-   frame (see {{frame-headers}}),
+   frame,
 
-2. optionally, the content, if present, sent as a series of DATA frames
-   (see {{frame-data}}), and
+2. optionally, the content, if present, sent as a series of DATA frames, and
 
 3. optionally, the trailer section, if present, sent as a single HEADERS frame.
 
@@ -523,7 +522,7 @@ any HEADERS frame, or a HEADERS or DATA frame after the trailing HEADERS frame,
 is considered invalid.  Other frame types, especially unknown frame types,
 might be permitted subject to their own rules; see {{extensions}}.
 
-A server MAY send one or more PUSH_PROMISE frames ({{frame-push-promise}})
+A server MAY send one or more PUSH_PROMISE frames
 before, after, or interleaved with the frames of a response message. These
 PUSH_PROMISE frames are not part of the response; see {{server-push}} for more
 details.  PUSH_PROMISE frames are not permitted on push streams; a pushed
@@ -905,7 +904,7 @@ treat receipt of a push stream as a connection error of type H3_ID_ERROR
 when no MAX_PUSH_ID frame has been sent or when the stream
 references a push ID that is greater than the maximum push ID.
 
-The push ID is used in one or more PUSH_PROMISE frames ({{frame-push-promise}})
+The push ID is used in one or more PUSH_PROMISE frames
 that carry the control data and header fields of the request message.  These
 frames are sent on the request stream that generated the push.  This allows the
 server push to be associated with a client request.  When the same push ID is
@@ -1009,14 +1008,13 @@ NOT actively keep connections open.
 
 Even when a connection is not idle, either endpoint can decide to stop using the
 connection and initiate a graceful connection close.  Endpoints initiate the
-graceful shutdown of an HTTP/3 connection by sending a GOAWAY frame
-({{frame-goaway}}). The GOAWAY frame contains an identifier that indicates to
-the receiver the range of requests or pushes that were or might be processed in
-this connection.  The server sends a client-initiated bidirectional stream ID;
-the client sends a push ID ({{server-push}}).  Requests or pushes with the
-indicated identifier or greater are rejected ({{request-cancellation}}) by the
-sender of the GOAWAY. This identifier MAY be zero if no requests or pushes were
-processed.
+graceful shutdown of an HTTP/3 connection by sending a GOAWAY frame. The GOAWAY
+frame contains an identifier that indicates to the receiver the range of
+requests or pushes that were or might be processed in this connection.  The
+server sends a client-initiated bidirectional stream ID; the client sends a push
+ID ({{server-push}}).  Requests or pushes with the indicated identifier or
+greater are rejected ({{request-cancellation}}) by the sender of the GOAWAY.
+This identifier MAY be zero if no requests or pushes were processed.
 
 The information in the GOAWAY frame enables a client and server to agree on
 which requests or pushes were accepted prior to the shutdown of the HTTP/3
@@ -1627,8 +1625,7 @@ The payload consists of:
 
 Push ID:
 : A variable-length integer that identifies the server push operation.  A push
-  ID is used in push stream headers ({{server-push}}) and CANCEL_PUSH frames
-  ({{frame-cancel-push}}).
+  ID is used in push stream headers ({{server-push}}) and CANCEL_PUSH frames.
 
 Encoded Field Section:
 : QPACK-encoded request header fields for the promised response.  See {{QPACK}}

--- a/rfc9114.md
+++ b/rfc9114.md
@@ -1145,6 +1145,9 @@ transaction or to the entire HTTP/3 connection context.
 *[control stream]: #control-streams
 *[push stream]: #push-streams
 *[request stream]: #request-streams
+*[control streams]: #control-streams
+*[push streams]: #push-streams
+*[request streams]: #request-streams
 
 ## Bidirectional Streams {#request-streams}
 
@@ -1409,9 +1412,9 @@ HEADERS Frame {
 ~~~~~~~~~~
 {: title="HEADERS Frame"}
 
-HEADERS frames can only be sent on request or push streams.  If a HEADERS frame
-is received on a control stream, the recipient MUST respond with a connection
-error of type H3_FRAME_UNEXPECTED.
+HEADERS frames can only be sent on request streams or push streams.  If a
+HEADERS frame is received on a control stream, the recipient MUST respond with a
+connection error of type H3_FRAME_UNEXPECTED.
 
 ### CANCEL_PUSH {#frame-cancel-push}
 

--- a/rfc9114.md
+++ b/rfc9114.md
@@ -437,7 +437,7 @@ While connection-level options pertaining to the core QUIC protocol are set in
 the initial crypto handshake, settings specific to HTTP/3 are conveyed in the
 SETTINGS frame ({{frame-settings}}). After the QUIC connection is established, a
 SETTINGS frame MUST be sent by each endpoint as the initial frame of their
-respective HTTP control stream; see {{control-streams}}.
+respective HTTP control stream.
 
 ## Connection Reuse
 
@@ -914,7 +914,7 @@ MUST contain the same fields in the same order, and both the name and the value
 in each field MUST be identical.
 
 The push ID is then included with the push stream that ultimately fulfills
-those promises; see {{push-streams}}.  The push stream identifies the push ID of
+those promises.  The push stream identifies the push ID of
 the promise that it fulfills, then contains a response to the promised request
 as described in {{request-response}}.
 
@@ -1141,6 +1141,10 @@ When HTTP fields and data are sent over QUIC, the QUIC layer handles most of
 the stream management.  HTTP does not need to do any separate multiplexing when
 using QUIC: data sent over a QUIC stream always maps to a particular HTTP
 transaction or to the entire HTTP/3 connection context.
+
+*[control stream]: #control-streams
+*[push stream]: #push-streams
+*[request stream]: #request-streams
 
 ## Bidirectional Streams {#request-streams}
 

--- a/rfc9114.md
+++ b/rfc9114.md
@@ -518,7 +518,7 @@ Header and trailer sections are described in {{Sections 6.3 and 6.5 of
 HTTP}}; the content is described in {{Section 6.4 of HTTP}}.
 
 Receipt of an invalid sequence of frames MUST be treated as a connection error
-of type H3_FRAME_UNEXPECTED; see {{errors}}.  In particular, a DATA frame before
+of type H3_FRAME_UNEXPECTED.  In particular, a DATA frame before
 any HEADERS frame, or a HEADERS or DATA frame after the trailing HEADERS frame,
 is considered invalid.  Other frame types, especially unknown frame types,
 might be permitted subject to their own rules; see {{extensions}}.
@@ -528,7 +528,7 @@ before, after, or interleaved with the frames of a response message. These
 PUSH_PROMISE frames are not part of the response; see {{server-push}} for more
 details.  PUSH_PROMISE frames are not permitted on push streams; a pushed
 response that includes PUSH_PROMISE frames MUST be treated as a connection error
-of type H3_FRAME_UNEXPECTED; see {{errors}}.
+of type H3_FRAME_UNEXPECTED.
 
 Frames of unknown types ({{extensions}}), including reserved frames
 ({{frame-reserved}}) MAY be sent on a request or push stream before, after, or
@@ -559,7 +559,7 @@ Because some messages are large or unbounded, endpoints SHOULD begin processing
 partial HTTP messages once enough of the message has been received to make
 progress.  If a client-initiated stream terminates without enough of the HTTP
 message to provide a complete response, the server SHOULD abort its response
-stream with the error code H3_REQUEST_INCOMPLETE; see {{errors}}.
+stream with the error code H3_REQUEST_INCOMPLETE.
 
 A server can send a complete response prior to the client sending an entire
 request if the response does not depend on any portion of the request that has
@@ -638,7 +638,7 @@ Content-Length field even though no content is included in DATA frames.
 Intermediaries that process HTTP requests or responses (i.e., any intermediary
 not acting as a tunnel) MUST NOT forward a malformed request or response.
 Malformed requests or responses that are detected MUST be treated as a stream
-error ({{errors}}) of type H3_MESSAGE_ERROR.
+error of type H3_MESSAGE_ERROR.
 
 For malformed requests, a server MAY send an HTTP response indicating the error
 prior to closing or resetting the stream.  Clients MUST NOT accept a malformed
@@ -850,7 +850,7 @@ frames.
 Once the CONNECT method has completed, only DATA frames are permitted to be sent
 on the stream.  Extension frames MAY be used if specifically permitted by the
 definition of the extension.  Receipt of any other known frame type MUST be
-treated as a connection error of type H3_FRAME_UNEXPECTED; see {{errors}}.
+treated as a connection error of type H3_FRAME_UNEXPECTED.
 
 The TCP connection can be closed by either peer. When the client ends the
 request stream (that is, the receive stream at the proxy enters the "Data Recvd"
@@ -863,8 +863,7 @@ data from the target of the CONNECT.
 
 A TCP connection error is signaled by abruptly terminating the stream. A proxy
 treats any error in the TCP connection, which includes receiving a TCP segment
-with the RST bit set, as a stream error of type H3_CONNECT_ERROR; see
-{{errors}}.
+with the RST bit set, as a stream error of type H3_CONNECT_ERROR.
 
 Correspondingly, if a proxy detects an error with the stream or the QUIC
 connection, it MUST close the TCP connection.  If the proxy detects that the
@@ -903,7 +902,7 @@ able to push until after the client sends a MAX_PUSH_ID frame.  A client sends
 MAX_PUSH_ID frames to control the number of pushes that a server can promise.  A
 server SHOULD use push IDs sequentially, beginning from zero.  A client MUST
 treat receipt of a push stream as a connection error of type H3_ID_ERROR
-({{errors}}) when no MAX_PUSH_ID frame has been sent or when the stream
+when no MAX_PUSH_ID frame has been sent or when the stream
 references a push ID that is greater than the maximum push ID.
 
 The push ID is used in one or more PUSH_PROMISE frames ({{frame-push-promise}})
@@ -1063,8 +1062,7 @@ An endpoint MAY send multiple GOAWAY frames indicating different identifiers,
 but the identifier in each frame MUST NOT be greater than the identifier in any
 previous frame, since clients might already have retried unprocessed requests on
 another HTTP connection.  Receiving a GOAWAY containing a larger identifier than
-previously received MUST be treated as a connection error of type H3_ID_ERROR;
-see {{errors}}.
+previously received MUST be treated as a connection error of type H3_ID_ERROR.
 
 An endpoint that is attempting to gracefully shut down a connection can send a
 GOAWAY frame with a value set to the maximum possible value (2<sup>62</sup>-4
@@ -1160,7 +1158,7 @@ permitted at a time.
 HTTP/3 does not use server-initiated bidirectional streams, though an extension
 could define a use for these streams.  Clients MUST treat receipt of a
 server-initiated bidirectional stream as a connection error of type
-H3_STREAM_CREATION_ERROR ({{errors}}) unless such an extension has been
+H3_STREAM_CREATION_ERROR unless such an extension has been
 negotiated.
 
 ## Unidirectional Streams
@@ -1268,8 +1266,7 @@ responses followed by a single final HTTP response, as defined in
 {{server-push}}.
 
 Only servers can push; if a server receives a client-initiated push stream, this
-MUST be treated as a connection error of type H3_STREAM_CREATION_ERROR; see
-{{errors}}.
+MUST be treated as a connection error of type H3_STREAM_CREATION_ERROR.
 
 ~~~~~~~~~~ ascii-art
 Push Stream Header {
@@ -1286,7 +1283,7 @@ which push IDs have already been consumed.
 Each push ID MUST only be used once in a push stream header. If a client detects
 that a push stream header includes a push ID that was used in another push
 stream header, the client MUST treat this as a connection error of type
-H3_ID_ERROR; see {{errors}}.
+H3_ID_ERROR.
 
 ### Reserved Stream Types {#stream-grease}
 
@@ -1367,13 +1364,12 @@ Each frame's payload MUST contain exactly the fields identified in its
 description.  A frame payload that contains additional bytes after the
 identified fields or a frame payload that terminates before the end of the
 identified fields MUST be treated as a connection error of type
-H3_FRAME_ERROR; see {{errors}}.  In particular, redundant length encodings MUST
+H3_FRAME_ERROR.  In particular, redundant length encodings MUST
 be verified to be self-consistent; see {{frame-parsing}}.
 
 When a stream terminates cleanly, if the last frame on the stream was truncated,
-this MUST be treated as a connection error of type H3_FRAME_ERROR; see
-{{errors}}. Streams that terminate abruptly may be reset at any point in a
-frame.
+this MUST be treated as a connection error of type H3_FRAME_ERROR. Streams that
+terminate abruptly may be reset at any point in a frame.
 
 ## Frame Definitions {#frames}
 
@@ -1384,7 +1380,7 @@ associated with HTTP request or response content.
 
 DATA frames MUST be associated with an HTTP request or response.  If a DATA
 frame is received on a control stream, the recipient MUST respond with a
-connection error of type H3_FRAME_UNEXPECTED; see {{errors}}.
+connection error of type H3_FRAME_UNEXPECTED.
 
 ~~~~~~~~~~ ascii-art
 DATA Frame {
@@ -1411,7 +1407,7 @@ HEADERS Frame {
 
 HEADERS frames can only be sent on request or push streams.  If a HEADERS frame
 is received on a control stream, the recipient MUST respond with a connection
-error of type H3_FRAME_UNEXPECTED; see {{errors}}.
+error of type H3_FRAME_UNEXPECTED.
 
 ### CANCEL_PUSH {#frame-cancel-push}
 
@@ -1655,11 +1651,10 @@ uses a push ID that they have already consumed and discarded are forced to
 ignore the promise.
 
 If a PUSH_PROMISE frame is received on the control stream, the client MUST
-respond with a connection error of type H3_FRAME_UNEXPECTED; see {{errors}}.
+respond with a connection error of type H3_FRAME_UNEXPECTED.
 
 A client MUST NOT send a PUSH_PROMISE frame.  A server MUST treat the receipt of
-a PUSH_PROMISE frame as a connection error of type H3_FRAME_UNEXPECTED; see
-{{errors}}.
+a PUSH_PROMISE frame as a connection error of type H3_FRAME_UNEXPECTED.
 
 See {{server-push}} for a description of the overall server push mechanism.
 
@@ -1691,7 +1686,7 @@ a variable-length integer.
 
 The GOAWAY frame applies to the entire connection, not a specific stream.  A
 client MUST treat a GOAWAY frame on a stream other than the control stream as a
-connection error of type H3_FRAME_UNEXPECTED; see {{errors}}.
+connection error of type H3_FRAME_UNEXPECTED.
 
 See {{connection-shutdown}} for more information on the use of the GOAWAY frame.
 
@@ -1782,6 +1777,9 @@ use of an error code in an unexpected context or receipt of an unknown error
 code MUST be treated as equivalent to H3_NO_ERROR.  However, closing a stream
 can have other effects regardless of the error code; for example, see
 {{request-response}}.
+
+*[stream error]: #errors
+*[connection error]: #errors
 
 ## HTTP/3 Error Codes {#http-error-codes}
 
@@ -2018,7 +2016,7 @@ they are used unnecessarily or to excess.
 An endpoint that does not monitor such behavior exposes itself to a risk of
 denial-of-service attack.  Implementations SHOULD track the use of these
 features and set limits on their use.  An endpoint MAY treat activity that is
-suspicious as a connection error of type H3_EXCESSIVE_LOAD ({{errors}}), but
+suspicious as a connection error of type H3_EXCESSIVE_LOAD, but
 false positives will result in disrupting valid connections and requests.
 
 ### Limits on Field Section Size


### PR DESCRIPTION
This replaces the frequent references to definition sections noted in #4949 with index entries which are hyperlinked in the HTML output.  As people review, I'd like particular attention on anywhere we think the cross-reference is so critical it needs to be explicit so it appears in the text output as well.

I've attempted to keep any cross-references that pointed to a section which is *not* the one the hyperlink would take you to (e.g. Connection Closure is not the definition of the GOAWAY frame).

You can see the hyperlinked output [here](https://quicwg.org/base-drafts/http/xrefs/rfc9114.html).

Fixes #4949.