### PR TITLE
Conform to HTTP Style Guide

### DIFF
--- a/rfc9114.md
+++ b/rfc9114.md
@@ -745,27 +745,26 @@ The following pseudo-header fields are defined for requests:
 
   : Contains the scheme portion of the target URI ({{Section 3.1 of URI}}).
 
-  : ":scheme" is not restricted to URIs with scheme "http" and "https".
-    A proxy or
-    gateway can translate requests for non-HTTP schemes, enabling the use of
-    HTTP to interact with non-HTTP services.
+  : The :scheme pseudo-header is not restricted to URIs with scheme "http" and
+    "https". A proxy or gateway can translate requests for non-HTTP schemes,
+    enabling the use of HTTP to interact with non-HTTP services.
 
   : See {{other-schemes}} for guidance on using a scheme other than "https".
 
   ":authority":
 
   : Contains the authority portion of the target URI ({{Section 3.2 of URI}}).
-    The authority MUST NOT include the deprecated "userinfo"
+    The authority MUST NOT include the deprecated userinfo
     subcomponent for URIs of scheme "http" or "https".
 
   : To ensure that the HTTP/1.1 request line can be reproduced accurately, this
     pseudo-header field MUST be omitted when translating from an HTTP/1.1
     request that has a request target in origin or asterisk form; see {{Section
     7.1 of HTTP}}.  Clients that generate HTTP/3 requests directly SHOULD use
-    the ":authority" pseudo-header field instead of the Host header field. An
+    the :authority pseudo-header field instead of the Host header field. An
     intermediary that converts an HTTP/3 request to HTTP/1.1 MUST create a Host
     field if one is not present in a request by copying the value of the
-    ":authority" pseudo-header field.
+    :authority pseudo-header field.
 
   ":path":
 
@@ -776,20 +775,20 @@ The following pseudo-header fields are defined for requests:
   : This pseudo-header field MUST NOT be empty for "http" or "https" URIs;
     "http" or "https" URIs that do not contain a path component MUST include a
     value of `/` (ASCII 0x2f).  An OPTIONS request that does not include a path
-    component includes the value `*` (ASCII 0x2a) for the ":path" pseudo-header
+    component includes the value `*` (ASCII 0x2a) for the :path pseudo-header
     field; see {{Section 7.1 of HTTP}}.
 
-All HTTP/3 requests MUST include exactly one value for the ":method", ":scheme",
-and ":path" pseudo-header fields, unless the request is a CONNECT request; see
+All HTTP/3 requests MUST include exactly one value for the :method, :scheme,
+and :path pseudo-header fields, unless the request is a CONNECT request; see
 {{connect}}.
 
-If the ":scheme" pseudo-header field identifies a scheme that has a mandatory
+If the :scheme pseudo-header field identifies a scheme that has a mandatory
 authority component (including "http" and "https"), the request MUST contain
-either an ":authority" pseudo-header field or a Host header field.  If these
+either an :authority pseudo-header field or a Host header field.  If these
 fields are present, they MUST NOT be empty.  If both fields are present, they
 MUST contain the same value.  If the scheme does not have a mandatory authority
 component and none is provided in the request target, the request MUST NOT
-contain the ":authority" pseudo-header or Host header fields.
+contain the :authority pseudo-header or Host header fields.
 
 An HTTP request that omits mandatory pseudo-header fields or contains invalid
 values for those pseudo-header fields is malformed.
@@ -824,9 +823,9 @@ a tunnel over a single stream.
 
 A CONNECT request MUST be constructed as follows:
 
-- The ":method" pseudo-header field is set to "CONNECT"
-- The ":scheme" and ":path" pseudo-header fields are omitted
-- The ":authority" pseudo-header field contains the host and port to connect to
+- The :method pseudo-header field is set to "CONNECT"
+- The :scheme and :path pseudo-header fields are omitted
+- The :authority pseudo-header field contains the host and port to connect to
   (equivalent to the authority-form of the request-target of CONNECT requests;
   see {{Section 7.1 of HTTP}}).
 
@@ -835,7 +834,7 @@ be transferred.  A CONNECT request that does not conform to these restrictions
 is malformed.
 
 A proxy that supports CONNECT establishes a TCP connection ({{!RFC0793}}) to the
-server identified in the ":authority" pseudo-header field.  Once this connection
+server identified in the :authority pseudo-header field.  Once this connection
 is successfully established, the proxy sends a HEADERS frame containing a 2xx
 series status code to the client, as defined in {{Section 15.3 of HTTP}}.
 
@@ -929,7 +928,7 @@ following properties:
 - safe; see {{Section 9.2.1 of HTTP}}
 - does not include request content or a trailer section
 
-The server MUST include a value in the ":authority" pseudo-header field for
+The server MUST include a value in the :authority pseudo-header field for
 which the server is authoritative.  If the client has not yet validated the
 connection for the origin indicated by the pushed request, it MUST perform the
 same verification process it would do before sending a request for that origin

--- a/rfc9114.md
+++ b/rfc9114.md
@@ -632,11 +632,11 @@ frames but is invalid due to:
 - the inclusion of invalid characters in field names or values.
 
 A request or response that is defined as having content when it contains a
-Content-Length header field ({{Section 6.4.1 of RFC9110}}),
-is malformed if the value of a Content-Length header field does not equal the
-sum of the DATA frame lengths received. A response that is defined as never
-having content, even when a Content-Length is present, can have a non-zero
-Content-Length field even though no content is included in DATA frames.
+Content-Length header field ({{Section 6.4.1 of RFC9110}}) is malformed if the
+value of the Content-Length header field does not equal the sum of the DATA
+frame lengths received. A response that is defined as never having content, even
+when a Content-Length is present, can have a non-zero Content-Length field even
+though no content is included in DATA frames.
 
 Intermediaries that process HTTP requests or responses (i.e., any intermediary
 not acting as a tunnel) MUST NOT forward a malformed request or response.

--- a/rfc9114.md
+++ b/rfc9114.md
@@ -21,7 +21,8 @@ author:
 
 normative:
 
-  QPACK:
+  RFC9204:
+    display: QPACK
     title: "QPACK: Header Compression for HTTP over QUIC"
     date: 1970-01-01
     seriesinfo:
@@ -42,7 +43,8 @@ normative:
           org: Facebook
           role: editor
 
-  HTTP:
+  RFC9110:
+    display: HTTP
     title: "HTTP Semantics"
     date: 1970-01-01
     seriesinfo:
@@ -65,7 +67,8 @@ normative:
           org: greenbytes
           role: editor
 
-  CACHING:
+  RFC9111:
+    display: HTTP-CACHING
     title: "HTTP Caching"
     date: 1970-01-01
     seriesinfo:
@@ -92,7 +95,8 @@ normative:
 
 informative:
 
-  HTTP11:
+  RFC9112:
+    display: HTTP/1.1
     title: "HTTP/1.1"
     date: 1970-01-01
     seriesinfo:
@@ -115,7 +119,8 @@ informative:
           org: greenbytes
           role: editor
 
-  HTTP2:
+  RFC9113:
+    display: HTTP/2
     title: "HTTP/2"
     date: 1970-01-01
     seriesinfo:
@@ -159,7 +164,7 @@ subsumed by QUIC and describes how HTTP/2 extensions can be ported to HTTP/3.
 
 # Introduction
 
-HTTP semantics ({{HTTP}}) are used for a broad range of services on the
+HTTP semantics ({{RFC9110}}) are used for a broad range of services on the
 Internet. These semantics have most commonly been used with HTTP/1.1 and HTTP/2.
 HTTP/1.1 has been used over a variety of transport and session layers, while
 HTTP/2 has been used primarily with TLS over TCP. HTTP/3 supports the same
@@ -167,7 +172,7 @@ semantics over a new transport protocol: QUIC.
 
 ## Prior Versions of HTTP
 
-HTTP/1.1 ({{HTTP11}}) uses whitespace-delimited text fields to convey HTTP
+HTTP/1.1 ({{RFC9112}}) uses whitespace-delimited text fields to convey HTTP
 messages.  While these exchanges are human readable, using whitespace for
 message formatting leads to parsing complexity and excessive tolerance of
 variant behavior.
@@ -177,7 +182,7 @@ are often used to service requests in parallel. However, that has a negative
 impact on congestion control and network efficiency, since TCP does not share
 congestion control across multiple connections.
 
-HTTP/2 ({{HTTP2}}) introduced a binary framing and multiplexing layer
+HTTP/2 ({{RFC9113}}) introduced a binary framing and multiplexing layer
 to improve latency without modifying the transport layer.  However, because the
 parallel nature of HTTP/2's multiplexing is not visible to TCP's loss recovery
 mechanisms, a lost or reordered packet causes all active transactions to
@@ -190,7 +195,7 @@ The QUIC transport protocol incorporates stream multiplexing and per-stream flow
 control, similar to that provided by the HTTP/2 framing layer. By providing
 reliability at the stream level and congestion control across the entire
 connection, QUIC has the capability to improve the performance of HTTP compared
-to a TCP mapping.  QUIC also incorporates TLS 1.3 ({{?TLS13=RFC8446}}) at the
+to a TCP mapping.  QUIC also incorporates TLS 1.3 ({{?TLS=RFC8446}}) at the
 transport layer, offering comparable confidentiality and integrity to running
 TLS over TCP, with the improved connection setup latency of TCP Fast Open
 ({{?TFO=RFC7413}}).
@@ -204,7 +209,7 @@ HTTP/2 framing is used on each stream. Some HTTP/2 features are subsumed by
 QUIC, while other features are implemented atop QUIC.
 
 QUIC is described in {{!QUIC-TRANSPORT=RFC9000}}.  For a full description of
-HTTP/2, see {{HTTP2}}.
+HTTP/2, see {{RFC9113}}.
 
 # HTTP/3 Protocol Overview
 
@@ -228,7 +233,7 @@ consumes a single QUIC stream.  Streams are independent of each other, so one
 stream that is blocked or suffers packet loss does not prevent progress on other
 streams.
 
-Server push is an interaction mode introduced in HTTP/2 ({{HTTP2}}) that
+Server push is an interaction mode introduced in HTTP/2 ({{RFC9113}}) that
 permits a server to push a request-response exchange to a client in anticipation
 of the client making the indicated request.  This trades off network usage
 against a potential latency gain.  Several HTTP/3 frames are used to manage
@@ -237,7 +242,7 @@ server push, such as PUSH_PROMISE, MAX_PUSH_ID, and CANCEL_PUSH.
 As in HTTP/2, request and response fields are compressed for transmission.
 Because HPACK ({{?HPACK=RFC7541}}) relies on in-order transmission of
 compressed field sections (a guarantee not provided by QUIC), HTTP/3 replaces
-HPACK with QPACK ({{QPACK}}). QPACK uses separate unidirectional streams to
+HPACK with QPACK ({{RFC9204}}). QPACK uses separate unidirectional streams to
 modify and track field table state, while encoded field sections refer to the
 state of the table without modifying it.
 
@@ -333,11 +338,11 @@ stream:
 stream error:
 : An application-level error on the individual stream.
 
-The term "content" is defined in {{Section 6.4 of HTTP}}.
+The term "content" is defined in {{Section 6.4 of RFC9110}}.
 
 Finally, the terms "resource", "message", "user agent", "origin server",
 "gateway", "intermediary", "proxy", and "tunnel" are defined in {{Section 3 of
-HTTP}}.
+RFC9110}}.
 
 Packet diagrams in this document use the format defined in
 {{Section 1.3 of QUIC-TRANSPORT}} to illustrate the order and size of fields.
@@ -352,14 +357,13 @@ HTTP relies on the notion of an authoritative response: a response that has been
 determined to be the most appropriate response for that request given the state
 of the target resource at the time of response message origination by (or at the
 direction of) the origin server identified within the target URI.  Locating an
-authoritative server for an HTTP URI is discussed in
-{{Section 4.3 of HTTP}}.
+authoritative server for an HTTP URI is discussed in {{Section 4.3 of RFC9110}}.
 
 The "https" scheme associates authority with possession of a certificate that
 the client considers to be trustworthy for the host identified by the authority
 component of the URI.  Upon receiving a server certificate in the TLS handshake,
 the client MUST verify that the certificate is an acceptable match for the URI's
-origin server using the process described in {{Section 4.3.4 of HTTP}}. If
+origin server using the process described in {{Section 4.3.4 of RFC9110}}. If
 the certificate cannot be verified with respect to the URI's origin server, the
 client MUST NOT consider the server authoritative for that origin.
 
@@ -451,7 +455,7 @@ Once a connection to a server endpoint exists, this connection MAY be reused for
 requests with multiple different URI authority components.  To use an existing
 connection for a new origin, clients MUST validate the certificate presented by
 the server for the new origin server using the process described in {{Section
-4.3.4 of HTTP}}.  This implies that clients will need to retain the
+4.3.4 of RFC9110}}.  This implies that clients will need to retain the
 server certificate and any additional information needed to verify that
 certificate; clients that do not do so will be unable to reuse the connection
 for additional origins.
@@ -482,7 +486,7 @@ processed and gracefully complete or terminate any necessary remaining tasks.
 A server that does not wish clients to reuse HTTP/3 connections for a particular
 origin can indicate that it is not authoritative for a request by sending a 421
 (Misdirected Request) status code in response to the request; see {{Section 7.4
-of HTTP}}.
+of RFC9110}}.
 
 
 # Expressing HTTP Semantics in HTTP/3 {#http-request-lifecycle}
@@ -493,7 +497,7 @@ A client sends an HTTP request on a request stream, which is a client-initiated
 bidirectional QUIC stream; see {{request-streams}}.  A client MUST send only a
 single request on a given stream.  A server sends zero or more interim HTTP
 responses on the same stream as the request, followed by a single final HTTP
-response, as detailed below. See {{Section 15 of HTTP}} for a description
+response, as detailed below. See {{Section 15 of RFC9110}} for a description
 of interim and final HTTP responses.
 
 Pushed responses are sent on a server-initiated unidirectional QUIC stream; see
@@ -514,7 +518,7 @@ An HTTP message (request or response) consists of:
 3. optionally, the trailer section, if present, sent as a single HEADERS frame.
 
 Header and trailer sections are described in {{Sections 6.3 and 6.5 of
-HTTP}}; the content is described in {{Section 6.4 of HTTP}}.
+RFC9110}}; the content is described in {{Section 6.4 of RFC9110}}.
 
 Receipt of an invalid sequence of frames MUST be treated as a connection error
 of type H3_FRAME_UNEXPECTED.  In particular, a DATA frame before
@@ -538,11 +542,11 @@ table. While these updates are not directly part of the message exchange, they
 must be received and processed before the message can be consumed.  See
 {{header-formatting}} for more details.
 
-Transfer codings (see {{Section 7 of HTTP11}}) are not defined for HTTP/3;
+Transfer codings (see {{Section 7 of RFC9112}}) are not defined for HTTP/3;
 the Transfer-Encoding header field MUST NOT be used.
 
 A response MAY consist of multiple messages when and only when one or more
-interim responses (1xx; see {{Section 15.2 of HTTP}}) precede a final
+interim responses (1xx; see {{Section 15.2 of RFC9110}}) precede a final
 response to the same request.  Interim responses do not contain content
 or trailer sections.
 
@@ -612,7 +616,7 @@ idempotent actions such as GET, PUT, or DELETE can be safely retried; a client
 SHOULD NOT automatically retry a request with a non-idempotent method unless it
 has some means to know that the request semantics are idempotent
 independent of the method or some means to detect that the original request was
-never applied.  See {{Section 9.2.2 of HTTP}} for more details.
+never applied.  See {{Section 9.2.2 of RFC9110}} for more details.
 
 ### Malformed Requests and Responses {#malformed}
 
@@ -628,7 +632,7 @@ frames but is invalid due to:
 - the inclusion of invalid characters in field names or values.
 
 A request or response that is defined as having content when it contains a
-Content-Length header field ({{Section 6.4.1 of HTTP}}),
+Content-Length header field ({{Section 6.4.1 of RFC9110}}),
 is malformed if the value of a Content-Length header field does not equal the
 sum of the DATA frame lengths received. A response that is defined as never
 having content, even when a Content-Length is present, can have a non-zero
@@ -649,14 +653,14 @@ permissive can expose implementations to these vulnerabilities.
 ## HTTP Fields {#header-formatting}
 
 HTTP messages carry metadata as a series of key-value pairs called "HTTP
-fields"; see {{Sections 6.3 and 6.5 of HTTP}}. For a listing of registered HTTP
-fields, see the "Hypertext Transfer Protocol (HTTP) Field Name Registry"
+fields"; see {{Sections 6.3 and 6.5 of RFC9110}}. For a listing of registered
+HTTP fields, see the "Hypertext Transfer Protocol (HTTP) Field Name Registry"
 maintained at [](https://www.iana.org/assignments/http-fields/){:
 brackets="angle"}.
 
 Field names are strings containing a subset of ASCII characters. Properties of
 HTTP field names and values are discussed in more detail in {{Section 5.1 of
-HTTP}}. As in HTTP/2, characters in field names MUST be converted to
+RFC9110}}. As in HTTP/2, characters in field names MUST be converted to
 lowercase prior to their encoding. A request or response containing uppercase
 characters in field names MUST be treated as malformed.
 
@@ -672,20 +676,20 @@ HTTP/3 request header; when it is, it MUST NOT contain any value other than
 
 An intermediary transforming an HTTP/1.x message to HTTP/3 MUST remove
 connection-specific header fields as discussed in {{Section 7.6.1 of
-HTTP}}, or their messages will be treated by other HTTP/3 endpoints as
+RFC9110}}, or their messages will be treated by other HTTP/3 endpoints as
 malformed.
 
 ### Field Compression
 
-{{QPACK}} describes a variation of HPACK that gives an encoder some control over
-how much head-of-line blocking can be caused by compression.  This allows an
-encoder to balance compression efficiency with latency.  HTTP/3 uses QPACK to
+{{RFC9204}} describes a variation of HPACK that gives an encoder some control
+over how much head-of-line blocking can be caused by compression.  This allows
+an encoder to balance compression efficiency with latency.  HTTP/3 uses QPACK to
 compress header and trailer sections, including the control data present in the
 header section.
 
 To allow for better compression efficiency, the Cookie header field
-({{!RFC6265}}) MAY be split into separate field lines, each with one or more
-cookie-pairs, before compression. If a decompressed field section contains
+({{!COOKIES=RFC6265}}) MAY be split into separate field lines, each with one or
+more cookie-pairs, before compression. If a decompressed field section contains
 multiple cookie field lines, these MUST be concatenated into a single byte
 string using the two-byte delimiter of `; ` (ASCII 0x3b, 0x20) before being
 passed into a context other than HTTP/2 or HTTP/3, such as an HTTP/1.1
@@ -706,7 +710,7 @@ as a number of bytes in the SETTINGS_MAX_FIELD_SECTION_SIZE parameter. An
 implementation that has received this parameter SHOULD NOT send an HTTP message
 header that exceeds the indicated size, as the peer will likely refuse to
 process it.  However, an HTTP message can traverse one or more intermediaries
-before reaching the origin server; see {{Section 3.7 of HTTP}}.  Because
+before reaching the origin server; see {{Section 3.7 of RFC9110}}.  Because
 this limit is applied separately by each implementation that processes the
 message, messages below this limit are not guaranteed to be accepted.
 
@@ -714,7 +718,7 @@ message, messages below this limit are not guaranteed to be accepted.
 
 Like HTTP/2, HTTP/3 employs a series of pseudo-header fields, where the field
 name begins with the `:` character (ASCII 0x3a).  These pseudo-header fields
-convey message control data; see {{Section 6.2 of HTTP}}.
+convey message control data; see {{Section 6.2 of RFC9110}}.
 
 Pseudo-header fields are not HTTP fields.  Endpoints MUST NOT generate
 pseudo-header fields other than those defined in this document. However, an
@@ -739,7 +743,7 @@ The following pseudo-header fields are defined for requests:
 
   ":method":
 
-  : Contains the HTTP method ({{Section 9 of HTTP}})
+  : Contains the HTTP method ({{Section 9 of RFC9110}})
 
   ":scheme":
 
@@ -760,7 +764,7 @@ The following pseudo-header fields are defined for requests:
   : To ensure that the HTTP/1.1 request line can be reproduced accurately, this
     pseudo-header field MUST be omitted when translating from an HTTP/1.1
     request that has a request target in origin or asterisk form; see {{Section
-    7.1 of HTTP}}.  Clients that generate HTTP/3 requests directly SHOULD use
+    7.1 of RFC9110}}.  Clients that generate HTTP/3 requests directly SHOULD use
     the :authority pseudo-header field instead of the Host header field. An
     intermediary that converts an HTTP/3 request to HTTP/1.1 MUST create a Host
     field if one is not present in a request by copying the value of the
@@ -776,7 +780,7 @@ The following pseudo-header fields are defined for requests:
     "http" or "https" URIs that do not contain a path component MUST include a
     value of `/` (ASCII 0x2f).  An OPTIONS request that does not include a path
     component includes the value `*` (ASCII 0x2a) for the :path pseudo-header
-    field; see {{Section 7.1 of HTTP}}.
+    field; see {{Section 7.1 of RFC9110}}.
 
 All HTTP/3 requests MUST include exactly one value for the :method, :scheme,
 and :path pseudo-header fields, unless the request is a CONNECT request; see
@@ -800,7 +804,7 @@ of "3.0".
 ### Response Pseudo-Header Fields
 
 For responses, a single ":status" pseudo-header field is defined that carries
-the HTTP status code; see {{Section 15 of HTTP}}.  This pseudo-header
+the HTTP status code; see {{Section 15 of RFC9110}}.  This pseudo-header
 field MUST be included in all responses; otherwise, the response is malformed
 (see {{malformed}}).
 
@@ -813,7 +817,7 @@ version of "3.0".
 
 The CONNECT method requests that the recipient establish a tunnel to the
 destination origin server identified by the request-target; see {{Section 9.3.6
-of HTTP}}. It is primarily used with HTTP proxies to establish a TLS
+of RFC9110}}. It is primarily used with HTTP proxies to establish a TLS
 session with an origin server for the purposes of interacting with "https"
 resources.
 
@@ -827,7 +831,7 @@ A CONNECT request MUST be constructed as follows:
 - The :scheme and :path pseudo-header fields are omitted
 - The :authority pseudo-header field contains the host and port to connect to
   (equivalent to the authority-form of the request-target of CONNECT requests;
-  see {{Section 7.1 of HTTP}}).
+  see {{Section 7.1 of RFC9110}}).
 
 The request stream remains open at the end of the request to carry the data to
 be transferred.  A CONNECT request that does not conform to these restrictions
@@ -836,7 +840,7 @@ is malformed.
 A proxy that supports CONNECT establishes a TCP connection ({{!RFC0793}}) to the
 server identified in the :authority pseudo-header field.  Once this connection
 is successfully established, the proxy sends a HEADERS frame containing a 2xx
-series status code to the client, as defined in {{Section 15.3 of HTTP}}.
+series status code to the client, as defined in {{Section 15.3 of RFC9110}}.
 
 All DATA frames on the stream correspond to data sent or received on the TCP
 connection. The payload of any DATA frame sent by the client is transmitted by
@@ -874,13 +878,13 @@ segment with the RST bit set.
 
 Since CONNECT creates a tunnel to an arbitrary server, proxies that support
 CONNECT SHOULD restrict its use to a set of known ports or a list of safe
-request targets; see {{Section 9.3.6 of HTTP}} for more details.
+request targets; see {{Section 9.3.6 of RFC9110}} for more details.
 
 ## HTTP Upgrade
 
 HTTP/3 does not support the HTTP Upgrade mechanism ({{Section 7.8 of
-HTTP}}) or the 101 (Switching Protocols) informational status code
-({{Section 15.2.2 of HTTP}}).
+RFC9110}}) or the 101 (Switching Protocols) informational status code
+({{Section 15.2.2 of RFC9110}}).
 
 ## Server Push
 
@@ -888,7 +892,7 @@ Server push is an interaction mode that permits a server to push a
 request-response exchange to a client in anticipation of the client making the
 indicated request.  This trades off network usage against a potential latency
 gain.  HTTP/3 server push is similar to what is described in
-{{Section 8.2 of HTTP2}}, but it uses different mechanisms.
+{{Section 8.2 of RFC9113}}, but it uses different mechanisms.
 
 Each server push is assigned a unique push ID by the server.  The push ID is
 used to refer to the push in various contexts throughout the lifetime of the
@@ -924,8 +928,8 @@ be fulfilling a previous promise.
 Not all requests can be pushed.  A server MAY push requests that have the
 following properties:
 
-- cacheable; see {{Section 9.2.3 of HTTP}}
-- safe; see {{Section 9.2.1 of HTTP}}
+- cacheable; see {{Section 9.2.3 of RFC9110}}
+- safe; see {{Section 9.2.1 of RFC9110}}
 - does not include request content or a trailer section
 
 The server MUST include a value in the :authority pseudo-header field for
@@ -967,10 +971,10 @@ case, the client can abort reading the stream with an error code of
 H3_REQUEST_CANCELLED. This asks the server not to transfer additional data and
 indicates that it will be discarded upon receipt.
 
-Pushed responses that are cacheable (see {{Section 3 of CACHING}}) can be
+Pushed responses that are cacheable (see {{Section 3 of RFC9111}}) can be
 stored by the client, if it implements an HTTP cache. Pushed responses are
 considered successfully validated on the origin server (e.g., if the "no-cache"
-cache response directive is present; see {{Section 5.2.2.3 of CACHING}}) at the
+cache response directive is present; see {{Section 5.2.2.3 of RFC9111}}) at the
 time the pushed response is received.
 
 Pushed responses that are not cacheable MUST NOT be stored by any HTTP cache.
@@ -1182,7 +1186,7 @@ Unidirectional Stream Header {
 {: title="Unidirectional Stream Header"}
 
 Two stream types are defined in this document: control streams
-({{control-streams}}) and push streams ({{push-streams}}). {{QPACK}} defines
+({{control-streams}}) and push streams ({{push-streams}}). {{RFC9204}} defines
 two additional stream types. Other stream types can be defined by extensions to
 HTTP/3; see {{extensions}} for more details. Some stream types are reserved
 ({{stream-grease}}).
@@ -1400,7 +1404,7 @@ DATA Frame {
 ### HEADERS {#frame-headers}
 
 The HEADERS frame (type=0x01) is used to carry an HTTP field section that is
-encoded using QPACK. See {{QPACK}} for more details.
+encoded using QPACK. See {{RFC9204}} for more details.
 
 ~~~~~~~~~~ ascii-art
 HEADERS Frame {
@@ -1545,7 +1549,7 @@ settings to have any meaning upon receipt.
 Because the setting has no defined meaning, the value of the setting can be any
 value the implementation selects.
 
-Setting identifiers that were defined in {{HTTP2}} where there is no
+Setting identifiers that were defined in {{RFC9113}} where there is no
 corresponding HTTP/3 setting have also been reserved ({{iana-settings}}). These
 reserved settings MUST NOT be sent, and their receipt MUST be treated as a
 connection error of type H3_SETTINGS_ERROR.
@@ -1630,8 +1634,8 @@ Push ID:
   ID is used in push stream headers ({{server-push}}) and CANCEL_PUSH frames.
 
 Encoded Field Section:
-: QPACK-encoded request header fields for the promised response.  See {{QPACK}}
-  for more details.
+: QPACK-encoded request header fields for the promised response.  See
+  {{RFC9204}} for more details.
 
 A server MUST NOT use a push ID that is larger than the client has provided in a
 MAX_PUSH_ID frame ({{frame-max-push-id}}). A client MUST treat receipt of a
@@ -1936,13 +1940,13 @@ the extension is disabled if the setting is omitted.
 # Security Considerations
 
 The security considerations of HTTP/3 should be comparable to those of HTTP/2
-with TLS.  However, many of the considerations from {{Section 10 of HTTP2}}
+with TLS.  However, many of the considerations from {{Section 10 of RFC9113}}
 apply to {{QUIC-TRANSPORT}} and are discussed in that document.
 
 ## Server Authority
 
 HTTP/3 relies on the HTTP definition of authority. The security considerations
-of establishing authority are discussed in {{Section 17.1 of HTTP}}.
+of establishing authority are discussed in {{Section 17.1 of RFC9110}}.
 
 ## Cross-Protocol Attacks
 
@@ -1958,7 +1962,7 @@ authenticated transports.
 ## Intermediary-Encapsulation Attacks
 
 The HTTP/3 field encoding allows the expression of names that are not valid
-field names in the syntax used by HTTP ({{Section 5.1 of HTTP}}). Requests or
+field names in the syntax used by HTTP ({{Section 5.1 of RFC9110}}). Requests or
 responses containing invalid field names MUST be treated as malformed.
 Therefore, an intermediary cannot translate an HTTP/3 request or response
 containing an invalid field name into an HTTP/1.1 message.
@@ -1969,7 +1973,7 @@ values that can be encoded will not alter field parsing, carriage return (ASCII
 exploited by an attacker if they are translated verbatim. Any request or
 response that contains a character not permitted in a field value MUST be
 treated as malformed.  Valid characters are defined by the
-"field-content" ABNF rule in {{Section 5.5 of HTTP}}.
+"field-content" ABNF rule in {{Section 5.5 of RFC9110}}.
 
 ## Cacheability of Pushed Responses
 
@@ -2012,7 +2016,7 @@ legitimate, such as optional-to-understand extensions and padding to increase
 resistance to traffic analysis.
 
 Compression of field sections also offers some opportunities to waste processing
-resources; see {{Section 7 of QPACK}} for more details on potential abuses.
+resources; see {{Section 7 of RFC9204}} for more details on potential abuses.
 
 All these features -- i.e., server push, unknown protocol elements, field
 compression -- have legitimate uses.  These features become a burden only when
@@ -2066,7 +2070,7 @@ terminates.
 Compression can allow an attacker to recover secret data when it is compressed
 in the same context as data under attacker control. HTTP/3 enables compression
 of fields ({{header-formatting}}); the following concerns also apply to the use
-of HTTP compressed content-codings; see {{Section 8.4.1 of HTTP}}.
+of HTTP compressed content-codings; see {{Section 8.4.1 of RFC9110}}.
 
 There are demonstrable attacks on compression that exploit the characteristics
 of the web (e.g., {{BREACH}}).  The attacker induces multiple requests
@@ -2080,7 +2084,7 @@ compression contexts are used for each source of data.  Compression MUST NOT be
 used if the source of data cannot be reliably determined.
 
 Further considerations regarding the compression of field sections are
-described in {{QPACK}}.
+described in {{RFC9204}}.
 
 ## Padding and Traffic Analysis
 
@@ -2207,7 +2211,7 @@ using Standards Action or IESG Approval as defined in
 {{Sections 4.9 and 4.10 of RFC8126}}.
 
 While this registry is separate from the "HTTP/2 Frame Type" registry defined in
-{{HTTP2}}, it is preferable that the assignments parallel each other where the
+{{RFC9113}}, it is preferable that the assignments parallel each other where the
 code spaces overlap.  If an entry is present in only one registry, every effort
 SHOULD be made to avoid assigning the corresponding value to an unrelated
 operation.  Expert reviewers MAY reject unrelated registrations that would
@@ -2256,7 +2260,7 @@ using Standards Action or IESG Approval as defined in
 {{Sections 4.9 and 4.10 of RFC8126}}.
 
 While this registry is separate from the "HTTP/2 Settings" registry defined in
-{{HTTP2}}, it is preferable that the assignments parallel each other.  If an
+{{RFC9113}}, it is preferable that the assignments parallel each other.  If an
 entry is present in only one registry, every effort SHOULD be made to avoid
 assigning the corresponding value to an unrelated operation. Expert reviewers
 MAY reject unrelated registrations that would conflict with the same value in
@@ -2444,7 +2448,7 @@ removed. Because stream termination is handled by QUIC, an END_STREAM flag is
 not required.  This permits the removal of the Flags field from the generic
 frame layout.
 
-Frame payloads are largely drawn from {{HTTP2}}. However, QUIC includes many
+Frame payloads are largely drawn from {{RFC9113}}. However, QUIC includes many
 features (e.g., flow control) that are also present in HTTP/2. In these cases,
 the HTTP mapping does not re-implement them. As a result, several HTTP/2 frame
 types are not required in HTTP/3. Where an HTTP/2-defined frame is no longer
@@ -2483,7 +2487,7 @@ make all modifications to the dynamic table, ensuring a total order of updates.
 All frames that contain encoded fields merely reference the table state at a
 given time without modifying it.
 
-{{QPACK}} provides additional details.
+{{RFC9204}} provides additional details.
 
 ### Flow-Control Differences
 
@@ -2555,7 +2559,7 @@ CONTINUATION (0x09):
   HEADERS/PUSH_PROMISE frames than HTTP/2 are permitted.
 
 Frame types defined by extensions to HTTP/2 need to be separately registered for
-HTTP/3 if still applicable.  The IDs of frames defined in {{HTTP2}} have been
+HTTP/3 if still applicable.  The IDs of frames defined in {{RFC9113}} have been
 reserved for simplicity.  Note that the frame type space in HTTP/3 is
 substantially larger (62 bits versus 8 bits), so many HTTP/3 frame types have no
 equivalent HTTP/2 code points.  See {{iana-frames}}.
@@ -2575,7 +2579,7 @@ settings are reserved, and their receipt is an error.  See
 Below is a listing of how each HTTP/2 SETTINGS parameter is mapped:
 
 SETTINGS_HEADER_TABLE_SIZE (0x01):
-: See {{QPACK}}.
+: See {{RFC9204}}.
 
 SETTINGS_ENABLE_PUSH (0x02):
 : This is removed in favor of the MAX_PUSH_ID frame, which provides a more
@@ -2611,7 +2615,7 @@ their value to limit it to 30 bits for more efficient encoding or to make use
 of the 62-bit space if more than 30 bits are required.
 
 Settings need to be defined separately for HTTP/2 and HTTP/3. The IDs of
-settings defined in {{HTTP2}} have been reserved for simplicity.  Note that
+settings defined in {{RFC9113}} have been reserved for simplicity.  Note that
 the settings identifier space in HTTP/3 is substantially larger (62 bits versus
 16 bits), so many HTTP/3 settings have no equivalent HTTP/2 code point. See
 {{iana-settings}}.
@@ -2627,7 +2631,7 @@ QUIC has the same concepts of "stream" and "connection" errors that HTTP/2
 provides. However, the differences between HTTP/2 and HTTP/3 mean that error
 codes are not directly portable between versions.
 
-The HTTP/2 error codes defined in {{Section 7 of HTTP2}} logically map to
+The HTTP/2 error codes defined in {{Section 7 of RFC9113}} logically map to
 the HTTP/3 error codes as follows:
 
 NO_ERROR (0x00):
@@ -2663,7 +2667,7 @@ CANCEL (0x08):
 : H3_REQUEST_CANCELLED in {{http-error-codes}}.
 
 COMPRESSION_ERROR (0x09):
-: Multiple error codes are defined in {{QPACK}}.
+: Multiple error codes are defined in {{RFC9204}}.
 
 CONNECT_ERROR (0x0a):
 : H3_CONNECT_ERROR in {{http-error-codes}}.

--- a/rfc9114.md
+++ b/rfc9114.md
@@ -635,8 +635,8 @@ A request or response that is defined as having content when it contains a
 Content-Length header field ({{Section 6.4.1 of RFC9110}}) is malformed if the
 value of the Content-Length header field does not equal the sum of the DATA
 frame lengths received. A response that is defined as never having content, even
-when a Content-Length is present, can have a non-zero Content-Length field even
-though no content is included in DATA frames.
+when a Content-Length is present, can have a non-zero Content-Length header
+field even though no content is included in DATA frames.
 
 Intermediaries that process HTTP requests or responses (i.e., any intermediary
 not acting as a tunnel) MUST NOT forward a malformed request or response.

--- a/rfc9114.md
+++ b/rfc9114.md
@@ -683,13 +683,13 @@ encoder to balance compression efficiency with latency.  HTTP/3 uses QPACK to
 compress header and trailer sections, including the control data present in the
 header section.
 
-To allow for better compression efficiency, the "Cookie" field ({{!RFC6265}})
-MAY be split into separate field lines, each with one or more cookie-pairs,
-before compression. If a decompressed field section contains multiple cookie
-field lines, these MUST be concatenated into a single byte string using the
-two-byte delimiter of `; ` (ASCII 0x3b, 0x20) before being passed into a context
-other than HTTP/2 or HTTP/3, such as an HTTP/1.1 connection, or a generic HTTP
-server application.
+To allow for better compression efficiency, the Cookie header field
+({{!RFC6265}}) MAY be split into separate field lines, each with one or more
+cookie-pairs, before compression. If a decompressed field section contains
+multiple cookie field lines, these MUST be concatenated into a single byte
+string using the two-byte delimiter of `; ` (ASCII 0x3b, 0x20) before being
+passed into a context other than HTTP/2 or HTTP/3, such as an HTTP/1.1
+connection, or a generic HTTP server application.
 
 ### Header Size Constraints
 
@@ -761,10 +761,10 @@ The following pseudo-header fields are defined for requests:
   : To ensure that the HTTP/1.1 request line can be reproduced accurately, this
     pseudo-header field MUST be omitted when translating from an HTTP/1.1
     request that has a request target in origin or asterisk form; see {{Section
-    7.1 of HTTP}}.  Clients that generate HTTP/3 requests directly
-    SHOULD use the ":authority" pseudo-header field instead of the Host field.
-    An intermediary that converts an HTTP/3 request to HTTP/1.1 MUST create a
-    Host field if one is not present in a request by copying the value of the
+    7.1 of HTTP}}.  Clients that generate HTTP/3 requests directly SHOULD use
+    the ":authority" pseudo-header field instead of the Host header field. An
+    intermediary that converts an HTTP/3 request to HTTP/1.1 MUST create a Host
+    field if one is not present in a request by copying the value of the
     ":authority" pseudo-header field.
 
   ":path":
@@ -785,11 +785,11 @@ and ":path" pseudo-header fields, unless the request is a CONNECT request; see
 
 If the ":scheme" pseudo-header field identifies a scheme that has a mandatory
 authority component (including "http" and "https"), the request MUST contain
-either an ":authority" pseudo-header field or a "Host" header field.  If these
+either an ":authority" pseudo-header field or a Host header field.  If these
 fields are present, they MUST NOT be empty.  If both fields are present, they
 MUST contain the same value.  If the scheme does not have a mandatory authority
 component and none is provided in the request target, the request MUST NOT
-contain the ":authority" pseudo-header or "Host" header fields.
+contain the ":authority" pseudo-header or Host header fields.
 
 An HTTP request that omits mandatory pseudo-header fields or contains invalid
 values for those pseudo-header fields is malformed.

--- a/rfc9114.md
+++ b/rfc9114.md
@@ -570,7 +570,7 @@ the request stream.  Clients MUST NOT discard complete responses as a result of
 having their request terminated abruptly, though clients can always discard
 responses at their discretion for other reasons.  If the server sends a partial
 or complete response but does not abort reading the request, clients SHOULD
-continue sending the body of the request and close the stream normally.
+continue sending the content of the request and close the stream normally.
 
 ### Request Cancellation and Rejection {#request-cancellation}
 
@@ -927,7 +927,7 @@ following properties:
 
 - cacheable; see {{Section 9.2.3 of HTTP}}
 - safe; see {{Section 9.2.1 of HTTP}}
-- does not include a request body or trailer section
+- does not include request content or a trailer section
 
 The server MUST include a value in the ":authority" pseudo-header field for
 which the server is authoritative.  If the client has not yet validated the
@@ -938,7 +938,7 @@ the client MUST NOT consider the server authoritative for that origin.
 
 Clients SHOULD send a CANCEL_PUSH frame upon receipt of a PUSH_PROMISE frame
 carrying a request that is not cacheable, is not known to be safe, that
-indicates the presence of a request body, or for which it does not consider the
+indicates the presence of request content, or for which it does not consider the
 server authoritative.  Any corresponding responses MUST NOT be used or cached.
 
 Each pushed response is associated with one or more client requests.  The push

--- a/rfc9114.md
+++ b/rfc9114.md
@@ -2689,8 +2689,8 @@ errors to the downstream, but error codes largely reflect connection-local
 problems that generally do not make sense to propagate.
 
 An intermediary that encounters an error from an upstream origin can indicate
-this by sending an HTTP status code such as 502, which is suitable for a broad
-class of errors.
+this by sending an HTTP status code such as 502 (Bad Gateway), which is suitable
+for a broad class of errors.
 
 There are some rare cases where it is beneficial to propagate the error by
 mapping it to the closest matching error type to the receiver. For example, an


### PR DESCRIPTION
Fixes #4951 and some other things besides.  This presupposes a resolution of https://github.com/httpwg/admin/issues/41 to be "treat them the same as regular fields," which is ugly but logically consistent.  Easy enough to adjust if that isn't the eventual decision, of course.