### PR TITLE
A smidge less HTTP/2 discussion

### DIFF
--- a/rfc9114.md
+++ b/rfc9114.md
@@ -1612,7 +1612,7 @@ error of type H3_SETTINGS_ERROR.
 ### PUSH_PROMISE {#frame-push-promise}
 
 The PUSH_PROMISE frame (type=0x05) is used to carry a promised request header
-section from server to client on a request stream, as in HTTP/2.
+section from server to client on a request stream.
 
 ~~~~~~~~~~ ascii-art
 PUSH_PROMISE Frame {
@@ -2401,10 +2401,10 @@ differences from HTTP/2, and describes how to map HTTP/2 extensions into HTTP/3.
 HTTP/3 begins from the premise that similarity to HTTP/2 is preferable, but not
 a hard requirement.  HTTP/3 departs from HTTP/2 where QUIC differs from TCP,
 either to take advantage of QUIC features (like streams) or to accommodate
-important shortcomings (such as a lack of total ordering). These differences
-make HTTP/3 similar to HTTP/2 in key aspects, such as the relationship of
-requests and responses to streams. However, the details of the HTTP/3 design are
-substantially different from HTTP/2.
+important shortcomings (such as a lack of total ordering). While HTTP/3 is
+similar to HTTP/2 in key aspects, such as the relationship of requests and
+responses to streams, the details of the HTTP/3 design are substantially
+different from HTTP/2.
 
 Some important departures are noted in this section.
 


### PR DESCRIPTION
Removed one HTTP/2 reference which seems extraneous, and corrected the polarity of another.  This fixes #4946 by doing almost nothing; speak now if you think more is warranted.