### PR TITLE
QPACK Auth48 edits

### DIFF
--- a/rfc9114.md
+++ b/rfc9114.md
@@ -1143,9 +1143,9 @@ using QUIC: data sent over a QUIC stream always maps to a particular HTTP
 transaction or to the entire HTTP/3 connection context.
 
 *[control stream]: #control-streams
+*[control streams]: control streams
 *[push stream]: #push-streams
 *[request stream]: #request-streams
-*[control streams]: #control-streams
 *[push streams]: #push-streams
 *[request streams]: #request-streams
 

--- a/rfc9204.md
+++ b/rfc9204.md
@@ -248,7 +248,7 @@ absolute index lower than the draining index, the number of unacknowledged
 references to those entries will eventually become zero, allowing them to be
 evicted.
 
-~~~~~~~~~~  drawing
+~~~~~~~~~~  ascii-art
              <-- Newer Entries          Older Entries -->
                (Larger Indicies)      (Smaller Indicies)
    +--------+---------------------------------+----------+
@@ -550,7 +550,7 @@ refers to the most recently inserted value in the dynamic table.  Note that this
 means the entry referenced by a given relative index will change while
 interpreting instructions on the encoder stream.
 
-~~~~~ drawing
+~~~~~ ascii-art
       +-----+---------------+-------+
       | n-1 |      ...      |   d   |  Absolute Index
       + - - +---------------+ - - - +
@@ -573,7 +573,7 @@ sections and dynamic table updates are processed out of order.
 In a field line representation, a relative index of 0 refers to the entry with
 absolute index equal to Base - 1.
 
-~~~~~ drawing
+~~~~~ ascii-art
                Base
                 |
                 V
@@ -601,7 +601,7 @@ Post-Base indices allow an encoder to process a field section in a single pass
 and include references to entries added while processing this (or other) field
 sections.
 
-~~~~~ drawing
+~~~~~ ascii-art
                Base
                 |
                 V
@@ -700,7 +700,7 @@ an instruction that starts with the '001' 3-bit pattern.  This is followed
 by the new dynamic table capacity represented as an integer with a 5-bit prefix;
 see {{prefixed-integers}}.
 
-~~~~~~~~~~ drawing
+~~~~~~~~~~ ascii-art
   0   1   2   3   4   5   6   7
 +---+---+---+---+---+---+---+---+
 | 0 | 0 | 1 |   Capacity (5+)   |
@@ -733,7 +733,7 @@ table.
 The field name reference is followed by the field value represented as a string
 literal; see {{string-literals}}.
 
-~~~~~~~~~~ drawing
+~~~~~~~~~~ ascii-art
      0   1   2   3   4   5   6   7
    +---+---+---+---+---+---+---+---+
    | 1 | T |    Name Index (6+)    |
@@ -756,7 +756,7 @@ This is followed by the name represented as a 6-bit prefix string literal and
 the value represented as an 8-bit prefix string literal; see
 {{string-literals}}.
 
-~~~~~~~~~~ drawing
+~~~~~~~~~~ ascii-art
      0   1   2   3   4   5   6   7
    +---+---+---+---+---+---+---+---+
    | 0 | 1 | H | Name Length (5+)  |
@@ -778,7 +778,7 @@ instruction that starts with the '000' 3-bit pattern.  This is followed by
 the relative index of the existing entry represented as an integer with a 5-bit
 prefix; see {{prefixed-integers}}.
 
-~~~~~~~~~~ drawing
+~~~~~~~~~~ ascii-art
      0   1   2   3   4   5   6   7
    +---+---+---+---+---+---+---+---+
    | 0 | 0 | 0 |    Index (5+)     |
@@ -805,10 +805,10 @@ instruction starts with the '1' 1-bit pattern, followed by the field
 section's associated stream ID encoded as a 7-bit prefix integer; see
 {{prefixed-integers}}.
 
-This instruction is used as described in Sections {{<<known-received-count}} and
-{{<<state-synchronization}}.
+This instruction is used as described in Sections {{<known-received-count}} and
+{{<state-synchronization}}.
 
-~~~~~~~~~~ drawing
+~~~~~~~~~~ ascii-art
   0   1   2   3   4   5   6   7
 +---+---+---+---+---+---+---+---+
 | 1 |      Stream ID (7+)       |
@@ -834,7 +834,7 @@ pattern, followed by the stream ID of the affected stream encoded as a
 
 This instruction is used as described in {{state-synchronization}}.
 
-~~~~~~~~~~ drawing
+~~~~~~~~~~ ascii-art
   0   1   2   3   4   5   6   7
 +---+---+---+---+---+---+---+---+
 | 0 | 1 |     Stream ID (6+)    |
@@ -851,7 +851,7 @@ the Increment parameter.  The decoder should send an Increment value that
 increases the Known Received Count to the total number of dynamic table
 insertions and duplications processed so far.
 
-~~~~~~~~~~ drawing
+~~~~~~~~~~ ascii-art
   0   1   2   3   4   5   6   7
 +---+---+---+---+---+---+---+---+
 | 0 | 0 |     Increment (6+)    |
@@ -881,7 +881,7 @@ Count is encoded as an integer with an 8-bit prefix using the encoding described
 in {{ric}}.  The Base is encoded as a sign bit ('S') and a Delta Base value
 with a 7-bit prefix; see {{base}}.
 
-~~~~~~~~~~  drawing
+~~~~~~~~~~  ascii-art
   0   1   2   3   4   5   6   7
 +---+---+---+---+---+---+---+---+
 |   Required Insert Count (8+)  |
@@ -902,7 +902,7 @@ Count to determine when it is safe to process the rest of the field section.
 
 The encoder transforms the Required Insert Count as follows before encoding:
 
-~~~
+~~~ pseudocode
    if ReqInsertCount == 0:
       EncInsertCount = 0
    else:
@@ -913,7 +913,7 @@ Here `MaxEntries` is the maximum number of entries that the dynamic table can
 have.  The smallest entry has empty name and value strings and has the size of
 32.  Hence, `MaxEntries` is calculated as:
 
-~~~
+~~~ pseudocode
    MaxEntries = floor( MaxTableCapacity / 32 )
 ~~~
 
@@ -930,7 +930,7 @@ connection error of type QPACK_DECOMPRESSION_FAILED.
 `TotalNumberOfInserts` is the total number of inserts into the decoder's dynamic
 table.
 
-~~~
+~~~ pseudocode
    FullRange = 2 * MaxEntries
    if EncodedInsertCount == 0:
       ReqInsertCount = 0
@@ -974,7 +974,7 @@ Required Insert Count; the decoder subtracts the value of Delta Base from the
 Required Insert Count and also subtracts one to determine the value of the Base.
 That is:
 
-~~~
+~~~ pseudocode
    if S == 0:
       Base = ReqInsertCount + DeltaBase
    else:
@@ -1011,7 +1011,7 @@ An indexed field line representation identifies an entry in the static table
 or an entry in the dynamic table with an absolute index less than the value of
 the Base.
 
-~~~~~~~~~~ drawing
+~~~~~~~~~~ ascii-art
   0   1   2   3   4   5   6   7
 +---+---+---+---+---+---+---+---+
 | 1 | T |      Index (6+)       |
@@ -1033,7 +1033,7 @@ An indexed field line with post-base index representation identifies an entry
 in the dynamic table with an absolute index greater than or equal to the value
 of the Base.
 
-~~~~~~~~~~ drawing
+~~~~~~~~~~ ascii-art
   0   1   2   3   4   5   6   7
 +---+---+---+---+---+---+---+---+
 | 0 | 0 | 0 | 1 |  Index (4+)   |
@@ -1049,11 +1049,11 @@ as an integer with a 4-bit prefix; see {{prefixed-integers}}.
 ### Literal Field Line with Name Reference {#literal-name-reference}
 
 A literal field line with name reference representation encodes a field line
-where the field name matches the field name of an entry in the static table, or
+where the field name matches the field name of an entry in the static table or
 the field name of an entry in the dynamic table with an absolute index less than
 the value of the Base.
 
-~~~~~~~~~~ drawing
+~~~~~~~~~~ ascii-art
      0   1   2   3   4   5   6   7
    +---+---+---+---+---+---+---+---+
    | 0 | 1 | N | T |Name Index (4+)|
@@ -1091,7 +1091,7 @@ A literal field line with post-base name reference representation encodes a
 field line where the field name matches the field name of a dynamic table entry
 with an absolute index greater than or equal to the value of the Base.
 
-~~~~~~~~~~ drawing
+~~~~~~~~~~ ascii-art
      0   1   2   3   4   5   6   7
    +---+---+---+---+---+---+---+---+
    | 0 | 0 | 0 | 0 | N |NameIdx(3+)|
@@ -1101,7 +1101,7 @@ with an absolute index greater than or equal to the value of the Base.
    |  Value String (Length bytes)  |
    +-------------------------------+
 ~~~~~~~~~~
-{: title="Literal Field Line With Post-Base Name Reference"}
+{: title="Literal Field Line with Post-Base Name Reference"}
 
 This representation starts with the '0000' 4-bit pattern.  The fifth bit is
 the 'N' bit as described in {{literal-name-reference}}.  This is followed by a
@@ -1117,7 +1117,7 @@ encoded as an 8-bit prefix string literal; see {{string-literals}}.
 The literal field line with literal name representation encodes a
 field name and a field value as string literals.
 
-~~~~~~~~~~ drawing
+~~~~~~~~~~ ascii-art
      0   1   2   3   4   5   6   7
    +---+---+---+---+---+---+---+---+
    | 0 | 0 | 1 | N | H |NameLen(3+)|
@@ -1570,7 +1570,7 @@ Any line breaks that appear within field names or values are due to formatting.
 # Encoding and Decoding Examples
 
 The following examples represent a series of exchanges between an encoder and a
-decoder.  The exchanges are designed to exercise most QPACK instructions, and
+decoder.  The exchanges are designed to exercise most QPACK instructions and
 highlight potentially common patterns and their impact on dynamic table state.
 The encoder sends three encoded field sections containing one field line each,
 as well as two speculative inserts that are not referenced.
@@ -1761,7 +1761,7 @@ Stream: Encoder
 Pseudocode for single pass encoding, excluding handling of duplicates,
 non-blocking mode, available encoder stream flow control and reference tracking.
 
-~~~
+~~~ pseudocode
 # Helper functions:
 # ====
 # Encode an integer with the specified prefix and length

--- a/rfc9204.md
+++ b/rfc9204.md
@@ -640,7 +640,7 @@ HPACK defines string literals to begin on a byte boundary.  They begin with a
 single bit flag, denoted as 'H' in this document (indicating whether the string
 is Huffman-coded), followed by the Length encoded as a 7-bit prefix integer, and
 finally Length bytes of data. When Huffman encoding is enabled, the Huffman
-table from {{Section B of RFC7541}} is used without modification, and Length
+table from {{Section B of RFC7541}} is used without modification and Length
 indicates the size of the string after encoding.
 
 This document expands the definition of string literals by permitting them to
@@ -1212,8 +1212,8 @@ attack into a linear-time attack.
 QPACK mitigates, but does not completely prevent, attacks modeled on CRIME
 ({{CRIME}}) by forcing a guess to match an entire field line rather than
 individual characters. An attacker can only learn whether a guess is correct or
-not, so it is reduced to a brute-force guess for the field values associated
-with a given field name.
+not, so the attacker is reduced to a brute-force guess for the field values
+associated with a given field name.
 
 Therefore, the viability of recovering specific field values depends on the
 entropy of values. As a result, values with high entropy are unlikely to be
@@ -1378,7 +1378,7 @@ immediately sent due to flow control is not affected by this limit.
 Implementations should limit the size of unsent data, especially on the decoder
 stream where flexibility to choose what to send is limited.  Possible responses
 to an excess of unsent data might include limiting the ability of the peer to
-open new streams, reading only from the encoder stream or closing the
+open new streams, reading only from the encoder stream, or closing the
 connection.
 
 

--- a/rfc9204.md
+++ b/rfc9204.md
@@ -1,6 +1,7 @@
 ---
 title: "QPACK: Header Compression for HTTP/3"
 abbrev: QPACK
+number: 9204
 docname: draft-ietf-quic-qpack-latest
 date: {DATE}
 category: std
@@ -44,24 +45,6 @@ normative:
           org: Akamai Technologies
           role: editor
 
-  QUIC-TRANSPORT:
-    title: "QUIC: A UDP-Based Multiplexed and Secure Transport"
-    date: {DATE}
-    seriesinfo:
-      RFC: 9000
-      DOI: 10.17487/RFC9000
-    author:
-      -
-        ins: J. Iyengar
-        name: Jana Iyengar
-        org: Fastly
-        role: editor
-      -
-        ins: M. Thomson
-        name: Martin Thomson
-        org: Mozilla
-        role: editor
-
   SEMANTICS: I-D.ietf-httpbis-semantics
   RFC2360:
 
@@ -92,17 +75,17 @@ informative:
 
 --- abstract
 
-This specification defines QPACK, a compression format for efficiently
-representing HTTP fields, to be used in HTTP/3. This is a variation of HPACK
-compression that seeks to reduce head-of-line blocking.
+This specification defines QPACK: a compression format for efficiently
+representing HTTP fields that is to be used in HTTP/3. This is a variation of
+HPACK compression that seeks to reduce head-of-line blocking.
 
 
 --- middle
 
 # Introduction
 
-The QUIC transport protocol ({{QUIC-TRANSPORT}}) is designed to support HTTP
-semantics, and its design subsumes many of the features of HTTP/2
+The QUIC transport protocol ({{!QUIC-TRANSPORT=RFC9000}}) is designed to support
+HTTP semantics, and its design subsumes many of the features of HTTP/2
 ({{?RFC7540}}). HTTP/2 uses HPACK ({{!RFC7541}}) for compression of the header
 and trailer sections.  If HPACK were used for HTTP/3 ({{HTTP3}}), it would
 induce head-of-line blocking for field sections due to built-in assumptions of a
@@ -121,7 +104,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 document are to be interpreted as described in BCP 14 {{!RFC2119}} {{!RFC8174}}
 when, and only when, they appear in all capitals, as shown here.
 
-Definitions of terms that are used in this document:
+The following terms are used in this document:
 
 HTTP fields:
 
@@ -174,22 +157,22 @@ Insert Count:
 
 : The total number of entries inserted in the dynamic table.
 
-QPACK is a name, not an acronym.
+Note that QPACK is a name, not an abbreviation.
 
 ## Notational Conventions
 
-Diagrams use the format described in {{Section 3.1 of RFC2360}}, with the
-following additional conventions:
+Diagrams in this document use the format described in {{Section 3.1 of
+RFC2360}}, with the following additional conventions:
 
 x (A)
-: Indicates that x is A bits long
+: Indicates that x is A bits long.
 
 x (A+)
 : Indicates that x uses the prefixed integer encoding defined in
   {{prefixed-integers}}, beginning with an A-bit prefix.
 
 x ...
-: Indicates that x is variable-length and extends to the end of the region.
+: Indicates that x is variable length and extends to the end of the region.
 
 # Compression Process Overview
 
@@ -251,7 +234,7 @@ the decoder; see {{header-acknowledgment}}.
 To ensure that the encoder is not prevented from adding new entries, the encoder
 can avoid referencing entries that are close to eviction.  Rather than
 reference such an entry, the encoder can emit a Duplicate instruction
-({{duplicate}}), and reference the duplicate instead.
+({{duplicate}}) and reference the duplicate instead.
 
 Determining which entries are too close to eviction to reference is an encoder
 preference.  One heuristic is to target a fixed amount of available space in the
@@ -294,7 +277,7 @@ referenced dynamic table entries. For a field section encoded with no references
 to the dynamic table, the Required Insert Count is zero.
 
 When the decoder receives an encoded field section with a Required Insert Count
-greater than its own Insert Count, the stream cannot be processed immediately,
+greater than its own Insert Count, the stream cannot be processed immediately
 and is considered "blocked"; see {{blocked-decoding}}.
 
 The decoder specifies an upper bound on the number of streams that can be
@@ -310,29 +293,29 @@ becoming blocked.
 An encoder can decide whether to risk having a stream become blocked. If
 permitted by the value of SETTINGS_QPACK_BLOCKED_STREAMS, compression efficiency
 can often be improved by referencing dynamic table entries that are still in
-transit, but if there is loss or reordering the stream can become blocked at the
-decoder.  An encoder can avoid the risk of blocking by only referencing dynamic
-table entries that have been acknowledged, but this could mean using literals.
-Since literals make the encoded field section larger, this can result in the
-encoder becoming blocked on congestion or flow control limits.
+transit, but if there is loss or reordering, the stream can become blocked at
+the decoder.  An encoder can avoid the risk of blocking by only referencing
+dynamic table entries that have been acknowledged, but this could mean using
+literals. Since literals make the encoded field section larger, this can result
+in the encoder becoming blocked on congestion or flow-control limits.
 
-### Avoiding Flow Control Deadlocks
+### Avoiding Flow-Control Deadlocks
 
 Writing instructions on streams that are limited by flow control can produce
 deadlocks.
 
-A decoder might stop issuing flow control credit on the stream that carries an
+A decoder might stop issuing flow-control credit on the stream that carries an
 encoded field section until the necessary updates are received on the encoder
-stream. If the granting of flow control credit on the encoder stream (or the
+stream. If the granting of flow-control credit on the encoder stream (or the
 connection as a whole) depends on the consumption and release of data on the
 stream carrying the encoded field section, a deadlock might result.
 
 More generally, a stream containing a large instruction can become deadlocked if
-the decoder withholds flow control credit until the instruction is completely
+the decoder withholds flow-control credit until the instruction is completely
 received.
 
 To avoid these deadlocks, an encoder SHOULD NOT write an instruction unless
-sufficient stream and connection flow control credit is available for the entire
+sufficient stream and connection flow-control credit is available for the entire
 instruction.
 
 ### Known Received Count
@@ -346,8 +329,8 @@ order to be able to send Insert Count Increment instructions.
 A Section Acknowledgment instruction ({{header-acknowledgment}}) implies that
 the decoder has received all dynamic table state necessary to decode the field
 section.  If the Required Insert Count of the acknowledged field section is
-greater than the current Known Received Count, Known Received Count is updated
-to that Required Insert Count value.
+greater than the current Known Received Count, the Known Received Count is
+updated to that Required Insert Count value.
 
 An Insert Count Increment instruction ({{insert-count-increment}}) increases the
 Known Received Count by its Increment parameter.  See {{new-table-entries}} for
@@ -374,7 +357,7 @@ decoder's Insert Count, the field section can be processed immediately.
 Otherwise, the stream on which the field section was received becomes blocked.
 
 While blocked, encoded field section data SHOULD remain in the blocked stream's
-flow control window. This data is unusable until the stream becomes unblocked,
+flow-control window. This data is unusable until the stream becomes unblocked,
 and releasing the flow control prematurely makes the decoder vulnerable to
 memory exhaustion attacks. A stream becomes unblocked when the Insert Count
 becomes greater than or equal to the Required Insert Count for all encoded
@@ -418,7 +401,7 @@ any updates to the dynamic table have been received.
 
 The Section Acknowledgment and Stream Cancellation instructions permit the
 encoder to remove references to entries in the dynamic table.  When an entry
-with absolute index lower than the Known Received Count has zero references,
+with an absolute index lower than the Known Received Count has zero references,
 then it is considered evictable; see {{blocked-insertion}}.
 
 #### New Table Entries
@@ -429,7 +412,7 @@ when to emit Insert Count Increment instructions; see
 dynamic table entry will provide the timeliest feedback to the encoder, but
 could be redundant with other decoder feedback. By delaying an Insert Count
 Increment instruction, the decoder might be able to coalesce multiple Insert
-Count Increment instructions, or replace them entirely with Section
+Count Increment instructions or replace them entirely with Section
 Acknowledgments; see {{header-acknowledgment}}. However, delaying too long
 may lead to compression inefficiencies if the encoder waits for an entry to be
 acknowledged before using it.
@@ -466,7 +449,7 @@ Note that the QPACK static table is indexed from 0, whereas the HPACK static
 table is indexed from 1.
 
 When the decoder encounters an invalid static table index in a field line
-representation it MUST treat this as a connection error of type
+representation, it MUST treat this as a connection error of type
 QPACK_DECOMPRESSION_FAILED.  If this index is received on the encoder stream,
 this MUST be treated as a connection error of type QPACK_ENCODER_STREAM_ERROR.
 
@@ -532,7 +515,7 @@ it can choose to use a lower dynamic table capacity; see
 {{set-dynamic-capacity}}.
 
 For clients using 0-RTT data in HTTP/3, the server's maximum table capacity is
-the remembered value of the setting, or zero if the value was not previously
+the remembered value of the setting or zero if the value was not previously
 sent.  When the client's 0-RTT value of the SETTING is zero, the server MAY set
 it to a non-zero value in its SETTINGS frame. If the remembered value is
 non-zero, the server MUST send the same non-zero value in its SETTINGS frame. If
@@ -545,8 +528,8 @@ rejected, the maximum table capacity is 0 until the encoder processes a SETTINGS
 frame with a non-zero value of SETTINGS_QPACK_MAX_TABLE_CAPACITY.
 
 When the maximum table capacity is zero, the encoder MUST NOT insert entries
-into the dynamic table, and MUST NOT send any encoder instructions on the
-encoder stream.
+into the dynamic table and MUST NOT send any encoder instructions on the encoder
+stream.
 
 
 ### Absolute Indexing {#indexing}
@@ -611,7 +594,7 @@ In this example, Base = n - 2
 
 Post-Base indices are used in field line representations for entries with
 absolute indices greater than or equal to Base, starting at 0 for the entry with
-absolute index equal to Base, and increasing in the same direction as the
+absolute index equal to Base and increasing in the same direction as the
 absolute index.
 
 Post-Base indices allow an encoder to process a field section in a single pass
@@ -657,14 +640,14 @@ HPACK defines string literals to begin on a byte boundary.  They begin with a
 single bit flag, denoted as 'H' in this document (indicating whether the string
 is Huffman-coded), followed by the Length encoded as a 7-bit prefix integer, and
 finally Length bytes of data. When Huffman encoding is enabled, the Huffman
-table from {{Section B of RFC7541}} is used without modification and Length
+table from {{Section B of RFC7541}} is used without modification, and Length
 indicates the size of the string after encoding.
 
 This document expands the definition of string literals by permitting them to
 begin other than on a byte boundary.  An "N-bit prefix string literal" begins
 mid-byte, with the first (8-N) bits allocated to a previous field. The string
-uses one bit for the Huffman flag, followed by the Length encoded as an
-(N-1)-bit prefix integer.  The prefix size, N, can have a value between 2 and 8
+uses one bit for the Huffman flag, followed by the Length encoded as a
+(N-1)-bit prefix integer.  The prefix size, N, can have a value between 2 and 8,
 inclusive. The remainder of the string literal is unmodified.
 
 A string literal without a prefix length noted is an 8-bit prefix string literal
@@ -683,15 +666,15 @@ QPACK defines two unidirectional stream types:
    to encoder.
 
 HTTP/3 endpoints contain a QPACK encoder and decoder. Each endpoint MUST
-initiate at most one encoder stream and at most one decoder stream. Receipt of a
-second instance of either stream type MUST be treated as a connection error of
-type H3_STREAM_CREATION_ERROR.
+initiate, at most, one encoder stream and, at most, one decoder stream. Receipt
+of a second instance of either stream type MUST be treated as a connection error
+of type H3_STREAM_CREATION_ERROR.
 
 These streams MUST NOT be closed. Closure of either unidirectional stream type
 MUST be treated as a connection error of type H3_CLOSED_CRITICAL_STREAM.
 
 An endpoint MAY avoid creating an encoder stream if it will not be used (for
-example if its encoder does not wish to use the dynamic table, or if the maximum
+example, if its encoder does not wish to use the dynamic table or if the maximum
 size of the dynamic table permitted by the peer is zero).
 
 An endpoint MAY avoid creating a decoder stream if its decoder sets the maximum
@@ -736,7 +719,7 @@ Reducing the dynamic table capacity can cause entries to be evicted; see
 evictable; see {{blocked-insertion}}.  Changing the capacity of the dynamic
 table is not acknowledged as this instruction does not insert an entry.
 
-### Insert With Name Reference
+### Insert with Name Reference
 
 An encoder adds an entry to the dynamic table where the field name matches the
 field name of an entry stored in the static or the dynamic table using an
@@ -763,13 +746,13 @@ literal; see {{string-literals}}.
 {: title="Insert Field Line -- Indexed Name"}
 
 
-### Insert With Literal Name
+### Insert with Literal Name
 
 An encoder adds an entry to the dynamic table where both the field name and the
 field value are represented as string literals using an instruction that starts
 with the '01' 2-bit pattern.
 
-This is followed by the name represented as a 6-bit prefix string literal, and
+This is followed by the name represented as a 6-bit prefix string literal and
 the value represented as an 8-bit prefix string literal; see
 {{string-literals}}.
 
@@ -803,7 +786,7 @@ prefix; see {{prefixed-integers}}.
 ~~~~~~~~~~
 {:#fig-index-with-duplication title="Duplicate"}
 
-The existing entry is re-inserted into the dynamic table without resending
+The existing entry is reinserted into the dynamic table without resending
 either the name or the value. This is useful to avoid adding a reference to an
 older entry, which might block inserting new entries.
 
@@ -822,8 +805,8 @@ instruction starts with the '1' 1-bit pattern, followed by the field
 section's associated stream ID encoded as a 7-bit prefix integer; see
 {{prefixed-integers}}.
 
-This instruction is used as described in {{known-received-count}} and
-in {{state-synchronization}}.
+This instruction is used as described in Sections {{<<known-received-count}} and
+{{<<state-synchronization}}.
 
 ~~~~~~~~~~ drawing
   0   1   2   3   4   5   6   7
@@ -877,7 +860,7 @@ insertions and duplications processed so far.
 {:#fig-size-sync title="Insert Count Increment"}
 
 An encoder that receives an Increment field equal to zero, or one that increases
-the Known Received Count beyond what the encoder has sent MUST treat this as a
+the Known Received Count beyond what the encoder has sent, MUST treat this as a
 connection error of type QPACK_DECODER_STREAM_ERROR.
 
 
@@ -886,7 +869,7 @@ connection error of type QPACK_DECODER_STREAM_ERROR.
 An encoded field section consists of a prefix and a possibly empty sequence of
 representations defined in this section.  Each representation corresponds to a
 single field line.  These representations reference the static table or the
-dynamic table in a particular state, but do not modify that state.
+dynamic table in a particular state, but they do not modify that state.
 
 Encoded field sections are carried in frames on streams defined by the enclosing
 protocol.
@@ -928,7 +911,7 @@ The encoder transforms the Required Insert Count as follows before encoding:
 
 Here `MaxEntries` is the maximum number of entries that the dynamic table can
 have.  The smallest entry has empty name and value strings and has the size of
-32.  Hence `MaxEntries` is calculated as
+32.  Hence, `MaxEntries` is calculated as:
 
 ~~~
    MaxEntries = floor( MaxTableCapacity / 32 )
@@ -944,7 +927,7 @@ the following.  If the decoder encounters a value of EncodedInsertCount that
 could not have been produced by a conformant encoder, it MUST treat this as a
 connection error of type QPACK_DECOMPRESSION_FAILED.
 
-TotalNumberOfInserts is the total number of inserts into the decoder's dynamic
+`TotalNumberOfInserts` is the total number of inserts into the decoder's dynamic
 table.
 
 ~~~
@@ -1008,8 +991,8 @@ greater than the Required Insert Count, so the delta will be positive and the
 sign bit is set to 0.
 
 An encoder that produces table updates before encoding a field section might set
-Base to the value of Required Insert Count.  In such case, both the sign bit and
-the Delta Base will be set to zero.
+Base to the value of Required Insert Count.  In such a case, both the sign bit
+and the Delta Base will be set to zero.
 
 A field section that was encoded without references to the dynamic table can use
 any value for the Base; setting Delta Base to zero is one of the most efficient
@@ -1017,14 +1000,14 @@ encodings.
 
 For example, with a Required Insert Count of 9, a decoder receives an S bit of 1
 and a Delta Base of 2.  This sets the Base to 6 and enables post-base indexing
-for three entries.  In this example, a relative index of 1 refers to the 5th
-entry that was added to the table; a post-base index of 1 refers to the 8th
+for three entries.  In this example, a relative index of 1 refers to the fifth
+entry that was added to the table; a post-base index of 1 refers to the eighth
 entry.
 
 
 ### Indexed Field Line
 
-An indexed field line representation identifies an entry in the static table,
+An indexed field line representation identifies an entry in the static table
 or an entry in the dynamic table with an absolute index less than the value of
 the Base.
 
@@ -1036,7 +1019,7 @@ the Base.
 ~~~~~~~~~~
 {: title="Indexed Field Line"}
 
-This representation starts with the '1' 1-bit pattern, followed by the 'T' bit
+This representation starts with the '1' 1-bit pattern, followed by the 'T' bit,
 indicating whether the reference is into the static or dynamic table.  The 6-bit
 prefix integer ({{prefixed-integers}}) that follows is used to locate the
 table entry for the field line.  When T=1, the number represents the static
@@ -1044,7 +1027,7 @@ table index; when T=0, the number is the relative index of the entry in the
 dynamic table.
 
 
-### Indexed Field Line With Post-Base Index
+### Indexed Field Line with Post-Base Index
 
 An indexed field line with post-base index representation identifies an entry
 in the dynamic table with an absolute index greater than or equal to the value
@@ -1063,7 +1046,7 @@ by the post-base index ({{post-base}}) of the matching field line, represented
 as an integer with a 4-bit prefix; see {{prefixed-integers}}.
 
 
-### Literal Field Line With Name Reference {#literal-name-reference}
+### Literal Field Line with Name Reference {#literal-name-reference}
 
 A literal field line with name reference representation encodes a field line
 where the field name matches the field name of an entry in the static table, or
@@ -1080,7 +1063,7 @@ the value of the Base.
    |  Value String (Length bytes)  |
    +-------------------------------+
 ~~~~~~~~~~
-{: title="Literal Field Line With Name Reference"}
+{: title="Literal Field Line with Name Reference"}
 
 This representation starts with the '01' 2-bit pattern.  The following bit,
 'N', indicates whether an intermediary is permitted to add this field line to
@@ -1102,7 +1085,7 @@ Only the field name is taken from the dynamic table entry; the field value is
 encoded as an 8-bit prefix string literal; see {{string-literals}}.
 
 
-### Literal Field Line With Post-Base Name Reference
+### Literal Field Line with Post-Base Name Reference
 
 A literal field line with post-base name reference representation encodes a
 field line where the field name matches the field name of a dynamic table entry
@@ -1129,7 +1112,7 @@ Only the field name is taken from the dynamic table entry; the field value is
 encoded as an 8-bit prefix string literal; see {{string-literals}}.
 
 
-### Literal Field Line With Literal Name
+### Literal Field Line with Literal Name
 
 The literal field line with literal name representation encodes a
 field name and a field value as string literals.
@@ -1146,7 +1129,7 @@ field name and a field value as string literals.
    |  Value String (Length bytes)  |
    +-------------------------------+
 ~~~~~~~~~~
-{: title="Literal Field Line With Literal Name"}
+{: title="Literal Field Line with Literal Name"}
 
 This representation starts with the '001' 3-bit pattern.  The fourth bit is
 the 'N' bit as described in {{literal-name-reference}}.  The name follows,
@@ -1206,10 +1189,10 @@ do both, they can adaptively modify requests in order to confirm guesses about
 the dynamic table state. If a guess is compressed into a shorter length, the
 attacker can observe the encoded length and infer that the guess was correct.
 
-This is possible even over the Transport Layer Security Protocol (TLS, see
-{{?TLS=RFC8446}}) and the QUIC Transport Protocol (see {{QUIC-TRANSPORT}}),
-because while TLS and QUIC provide confidentiality protection for content, they
-only provide a limited amount of protection for the length of that content.
+This is possible even over the Transport Layer Security Protocol
+({{?TLS=RFC8446}}) and the QUIC Transport Protocol ({{QUIC-TRANSPORT}}), because
+while TLS and QUIC provide confidentiality protection for content, they only
+provide a limited amount of protection for the length of that content.
 
 Note:
 
@@ -1226,13 +1209,13 @@ attack into a linear-time attack.
 
 ### Applicability to QPACK and HTTP
 
-QPACK mitigates but does not completely prevent attacks modeled on CRIME
-({{CRIME}}) by forcing a guess to match an entire field line, rather than
+QPACK mitigates, but does not completely prevent, attacks modeled on CRIME
+({{CRIME}}) by forcing a guess to match an entire field line rather than
 individual characters. An attacker can only learn whether a guess is correct or
-not, so is reduced to a brute force guess for the field values associated with a
-given field name.
+not, so it is reduced to a brute-force guess for the field values associated
+with a given field name.
 
-The viability of recovering specific field values therefore depends on the
+Therefore, the viability of recovering specific field values depends on the
 entropy of values. As a result, values with high entropy are unlikely to be
 recovered successfully. However, values with low entropy remain vulnerable.
 
@@ -1298,7 +1281,7 @@ Note:
   be ineffectual if the attacker has a reliable way of causing values to be
   reinstalled. For example, a request to load an image in a web browser
   typically includes the Cookie header field (a potentially highly valued target
-  for this sort of attack), and web sites can easily force an image to be
+  for this sort of attack), and websites can easily force an image to be
   loaded, thereby refreshing the entry in the dynamic table.
 
 ### Never-Indexed Literals
@@ -1339,7 +1322,7 @@ representation will evolve over time as new attacks are discovered.
 
 There is no currently known attack against a static Huffman encoding. A study
 has shown that using a static Huffman encoding table created an information
-leakage, however this same study concluded that an attacker could not take
+leakage; however, this same study concluded that an attacker could not take
 advantage of this information leakage to recover any meaningful amount of
 information (see {{PETAL}}).
 
@@ -1371,7 +1354,7 @@ allows and signaling this to the decoder (see {{set-dynamic-capacity}}).
 A decoder can limit the amount of state memory used for blocked streams by
 setting an appropriate value for the maximum number of blocked streams.  In
 HTTP/3, this is realized by setting an appropriate value for the
-SETTINGS_QPACK_BLOCKED_STREAMS parameter.  Streams which risk becoming blocked
+SETTINGS_QPACK_BLOCKED_STREAMS parameter.  Streams that risk becoming blocked
 consume no additional state memory on the encoder.
 
 An encoder allocates memory to track all dynamic table references in
@@ -1395,7 +1378,7 @@ immediately sent due to flow control is not affected by this limit.
 Implementations should limit the size of unsent data, especially on the decoder
 stream where flexibility to choose what to send is limited.  Possible responses
 to an excess of unsent data might include limiting the ability of the peer to
-open new streams, reading only from the encoder stream, or closing the
+open new streams, reading only from the encoder stream or closing the
 connection.
 
 
@@ -1413,7 +1396,7 @@ largest individual field the HTTP implementation can be configured to accept.
 
 If an implementation encounters a value larger than it is able to decode, this
 MUST be treated as a stream error of type QPACK_DECOMPRESSION_FAILED if on a
-request stream, or a connection error of the appropriate type if on the encoder
+request stream or a connection error of the appropriate type if on the encoder
 or decoder stream.
 
 
@@ -1430,31 +1413,33 @@ This document specifies two settings. The entries in the following table are
 registered in the "HTTP/3 Settings" registry established in {{HTTP3}}.
 
 |------------------------------|--------|---------------------------| ------- |
-| Setting Name                 | Code   | Specification             | Default |
+| Setting Name                 |  Code  | Specification             | Default |
 | ---------------------------- | :----: | ------------------------- | ------- |
-| QPACK_MAX_TABLE_CAPACITY     | 0x01    | {{configuration}}         | 0       |
-| QPACK_BLOCKED_STREAMS        | 0x07    | {{configuration}}         | 0       |
+| QPACK_MAX_TABLE_CAPACITY     |  0x01  | {{configuration}}         | 0       |
+| QPACK_BLOCKED_STREAMS        |  0x07  | {{configuration}}         | 0       |
 | ---------------------------- | ------ | ------------------------- | ------- |
+{: title="Additions to the HTTP/3 Settings Registry"}
 
-For fomatting reasons, the setting names here are abbreviated by removing the
-'SETTING_' prefix.
+For formatting reasons, the setting names here are abbreviated by removing the
+'SETTINGS_' prefix.
 
 ## Stream Type Registration
 
 This document specifies two stream types. The entries in the following table are
-registered in the "HTTP/3 Stream Type" registry established in {{HTTP3}}.
+registered in the "HTTP/3 Stream Types" registry established in {{HTTP3}}.
 
 | ---------------------------- | ------ | ------------------------- | ------ |
-| Stream Type                  | Code   | Specification             | Sender |
+| Stream Type                  |  Code  | Specification             | Sender |
 | ---------------------------- | :----: | ------------------------- | ------ |
-| QPACK Encoder Stream         | 0x02   | {{enc-dec-stream-def}}    | Both   |
-| QPACK Decoder Stream         | 0x03   | {{enc-dec-stream-def}}    | Both   |
+| QPACK Encoder Stream         |  0x02  | {{enc-dec-stream-def}}    | Both   |
+| QPACK Decoder Stream         |  0x03  | {{enc-dec-stream-def}}    | Both   |
 | ---------------------------- | ------ | ------------------------- | ------ |
+{: title="Additions to the HTTP/3 Stream Types Registry"}
 
 ## Error Code Registration
 
 This document specifies three error codes. The entries in the following table
-are registered in the "HTTP/3 Error Code" registry established in {{HTTP3}}.
+are registered in the "HTTP/3 Error Codes" registry established in {{HTTP3}}.
 
 | --------------------------------- | ------ | ---------------------------------------- | ---------------------- |
 | Name                              | Code   | Description                              | Specification          |
@@ -1463,7 +1448,7 @@ are registered in the "HTTP/3 Error Code" registry established in {{HTTP3}}.
 | QPACK_ENCODER_STREAM_ERROR        | 0x0201 | Error on the encoder stream              | {{error-handling}}     |
 | QPACK_DECODER_STREAM_ERROR        | 0x0202 | Error on the decoder stream              | {{error-handling}}     |
 | --------------------------------- | ------ | ---------------------------------------- | ---------------------- |
-
+{: title="Additions to the HTTP/3 Error Codes Registry"}
 
 --- back
 
@@ -1577,6 +1562,7 @@ the smallest number of bytes.
 | 96    | x-forwarded-for                  |                                                             |
 | 97    | x-frame-options                  | deny                                                        |
 | 98    | x-frame-options                  | sameorigin                                                  |
+{: title="Static Table"}
 
 Any line breaks that appear within field names or values are due to formatting.
 
@@ -1595,7 +1581,7 @@ the current number of outstanding encoded field sections with references to that
 entry (Ref), along with the name and value.  Entries above the 'acknowledged'
 line have been acknowledged by the decoder.
 
-## Literal Field Line With Name Reference
+## Literal Field Line with Name Reference
 
 The encoder sends an encoded field section containing a literal representation
 of a field with a static name reference.
@@ -1772,13 +1758,13 @@ Stream: Encoder
 
 # Sample One Pass Encoding Algorithm
 
-Pseudo-code for single pass encoding, excluding handling of duplicates,
+Pseudocode for single pass encoding, excluding handling of duplicates,
 non-blocking mode, available encoder stream flow control and reference tracking.
 
 ~~~
 # Helper functions:
 # ====
-# Encode an interger with the specified prefix and length
+# Encode an integer with the specified prefix and length
 encodeInteger(buffer, prefix, value, prefixLength)
 
 # Encode a dynamic table insert instruction with optional static
@@ -1865,8 +1851,9 @@ The IETF QUIC Working Group received an enormous amount of support from many
 people.
 
 The compression design team did substantial work exploring the problem space and
-influencing the initial draft.  The contributions of design team members Roberto
-Peon, Martin Thomson, and Dmitri Tikhonov are gratefully acknowledged.
+influencing the initial draft version of this document.  The contributions of
+design team members Roberto Peon, Martin Thomson, and Dmitri Tikhonov are
+gratefully acknowledged.
 
 The following people also provided substantial contributions to this document:
 
@@ -1880,10 +1867,10 @@ The following people also provided substantial contributions to this document:
 - Biren Roy
 - Ian Swett
 
-This draft draws heavily on the text of {{!RFC7541}}.  The indirect input of
+This document draws heavily on the text of {{!RFC7541}}.  The indirect input of
 those authors is also gratefully acknowledged.
 
-Buck's contribution was supported by Google during his employment there.
+Buck Krasic's contribution was supported by Google during his employment there.
 
-A portion of Mike's contribution was supported by Microsoft during his
+A portion of Mike Bishop's contribution was supported by Microsoft during his
 employment there.

--- a/rfc9204.md
+++ b/rfc9204.md
@@ -1852,20 +1852,23 @@ people.
 
 The compression design team did substantial work exploring the problem space and
 influencing the initial draft version of this document.  The contributions of
-design team members Roberto Peon, Martin Thomson, and Dmitri Tikhonov are
+design team members <contact fullname="Roberto Peon"/>, <contact
+fullname="Martin Thomson"/>, and <contact fullname="Dmitri Tikhonov"/> are
 gratefully acknowledged.
 
 The following people also provided substantial contributions to this document:
 
-- Bence Béky
-- Alessandro Ghedini
-- Ryan Hamilton
-- Robin Marx
-- Patrick McManus
-- <t><t><contact asciiFullname="Kazuho Oku" fullname="奥 一穂"/></t></t>
-- Lucas Pardue
-- Biren Roy
-- Ian Swett
+<ul spacing="compact">
+<li><t><contact fullname="Bence Béky"/></t></li>
+<li><t><contact fullname="Alessandro Ghedini"/></t></li>
+<li><t><contact fullname="Ryan Hamilton"/></t></li>
+<li><t><contact fullname="Robin Marx"/></t></li>
+<li><t><contact fullname="Patrick McManus"/></t></li>
+<li><t><contact asciiFullname="Kazuho Oku" fullname="奥 一穂"/></t></li>
+<li><t><contact fullname="Lucas Pardue"/></t></li>
+<li><t><contact fullname="Biren Roy"/></t></li>
+<li><t><contact fullname="Ian Swett"/></t></li>
+</ul>
 
 This document draws heavily on the text of {{!RFC7541}}.  The indirect input of
 those authors is also gratefully acknowledged.


### PR DESCRIPTION
This PR contains, as best I can, the content and XML changes made by the RFC Editor during Auth48, including those I disagree with.  I'll note and propose reversions where appropriate.

Things not addressed:

- In Section 1.2, the RFC Editor added `indent=9` to the `<dl>` tag; I'm not sure how to do that from Markdown
- The change in #4980 was pulled out into a separate issue.