### PR TITLE
Merge singular and plural index entries

### DIFF
--- a/rfc9114.md
+++ b/rfc9114.md
@@ -1143,11 +1143,11 @@ using QUIC: data sent over a QUIC stream always maps to a particular HTTP
 transaction or to the entire HTTP/3 connection context.
 
 *[control stream]: #control-streams
+*[control streams]: #control-streams (((control stream)))
 *[push stream]: #push-streams
+*[push streams]: #push-streams (((push stream)))
 *[request stream]: #request-streams
-*[control streams]: #control-streams
-*[push streams]: #push-streams
-*[request streams]: #request-streams
+*[request streams]: #request-streams (((request streams)))
 
 ## Bidirectional Streams {#request-streams}
 
@@ -1785,7 +1785,9 @@ can have other effects regardless of the error code; for example, see
 {{request-response}}.
 
 *[stream error]: #errors
+*[stream errors]: #errors (((stream error)))
 *[connection error]: #errors
+*[connection errors]: #errors (((connection error)))
 
 ## HTTP/3 Error Codes {#http-error-codes}
 


### PR DESCRIPTION
@cabo was helpful enough to show me how to do this in https://github.com/cabo/kramdown-rfc/issues/166, so now singular and plural versions of the same term are a single index entry.