### PR TITLE
Reword "to the encoder"

### DIFF
--- a/rfc9204.md
+++ b/rfc9204.md
@@ -204,8 +204,8 @@ QPACK preserves the ordering of field lines within each field section.  An
 encoder MUST emit field representations in the order they appear in the input
 field section.
 
-QPACK is designed to contain the more complex state tracking to the encoder,
-while the decoder is relatively simple.
+QPACK is designed to place the burden of optional state tracking on the encoder,
+resulting in relatively simple decoders.
 
 ### Limits on Dynamic Table Insertions {#blocked-insertion}
 


### PR DESCRIPTION
Inspired by @LPardue's suggestion; fixes #4968.