### PR TITLE
Capitalization and Consistency

### DIFF
--- a/rfc9204.md
+++ b/rfc9204.md
@@ -149,7 +149,7 @@ Absolute Index:
 
 Base:
 
-: A reference point for relative and post-base indices.  Representations that
+: A reference point for relative and post-Base indices.  Representations that
   reference dynamic table entries are relative to a Base.
 
 Insert Count:
@@ -992,7 +992,7 @@ greater than the Required Insert Count, so the encoded difference will be
 positive and the sign bit is set to 0.
 
 The value of Base MUST NOT be negative. Though the protocol might operate
-correctly with a negative base using post-base indexing, it is unnecessary and
+correctly with a negative Base using post-Base indexing, it is unnecessary and
 inefficient. An endpoint MUST treat a field block with a sign bit of 1 as
 invalid if the value of Required Insert Count is less than or equal to the value
 of Delta Base.
@@ -1006,9 +1006,9 @@ any value for the Base; setting Delta Base to zero is one of the most efficient
 encodings.
 
 For example, with a Required Insert Count of 9, a decoder receives a sign bit
-of 1 and a Delta Base of 2.  This sets the Base to 6 and enables post-base
+of 1 and a Delta Base of 2.  This sets the Base to 6 and enables post-Base
 indexing for three entries.  In this example, a relative index of 1 refers to
-the fifth entry that was added to the table; a post-base index of 1 refers to
+the fifth entry that was added to the table; a post-Base index of 1 refers to
 the eighth entry.
 
 
@@ -1036,7 +1036,7 @@ dynamic table.
 
 ### Indexed Field Line with Post-Base Index
 
-An indexed field line with post-base index representation identifies an entry
+An indexed field line with post-Base index representation identifies an entry
 in the dynamic table with an absolute index greater than or equal to the value
 of the Base.
 
@@ -1049,7 +1049,7 @@ of the Base.
 {: title="Indexed Field Line with Post-Base Index"}
 
 This representation starts with the '0001' 4-bit pattern.  This is followed
-by the post-base index ({{post-base}}) of the matching field line, represented
+by the post-Base index ({{post-base}}) of the matching field line, represented
 as an integer with a 4-bit prefix; see {{prefixed-integers}}.
 
 
@@ -1094,7 +1094,7 @@ encoded as an 8-bit prefix string literal; see {{string-literals}}.
 
 ### Literal Field Line with Post-Base Name Reference
 
-A literal field line with post-base name reference representation encodes a
+A literal field line with post-Base name reference representation encodes a
 field line where the field name matches the field name of a dynamic table entry
 with an absolute index greater than or equal to the value of the Base.
 
@@ -1112,7 +1112,7 @@ with an absolute index greater than or equal to the value of the Base.
 
 This representation starts with the '0000' 4-bit pattern.  The fifth bit is
 the 'N' bit as described in {{literal-name-reference}}.  This is followed by a
-post-base index of the dynamic table entry ({{post-base}}) encoded as an
+post-Base index of the dynamic table entry ({{post-base}}) encoded as an
 integer with a 3-bit prefix; see {{prefixed-integers}}.
 
 Only the field name is taken from the dynamic table entry; the field value is
@@ -1781,13 +1781,13 @@ encodeInsert(buffer, staticNameIndex, dynamicNameIndex, fieldLine)
 # Encode a static index reference
 encodeStaticIndexReference(buffer, staticIndex)
 
-# Encode a dynamic index reference relative to base
+# Encode a dynamic index reference relative to Base
 encodeDynamicIndexReference(buffer, dynamicIndex, base)
 
 # Encode a literal with an optional static name index
 encodeLiteral(buffer, staticNameIndex, fieldLine)
 
-# Encode a literal with a dynamic name index relative to base
+# Encode a literal with a dynamic name index relative to Base
 encodeDynamicLiteral(buffer, dynamicNameIndex, base, fieldLine)
 
 # Encoding Algorithm
@@ -1815,7 +1815,7 @@ for line in fieldLines:
   if dynamicIndex is None:
     # Could not index it, literal
     if dynamicNameIndex is not None:
-      # Encode literal with dynamic name, possibly above base
+      # Encode literal with dynamic name, possibly above Base
       encodeDynamicLiteral(streamBuffer, dynamicNameIndex,
                            base, line)
       requiredInsertCount = max(requiredInsertCount,
@@ -1827,7 +1827,7 @@ for line in fieldLines:
     # Dynamic index reference
     assert(dynamicIndex is not None)
     requiredInsertCount = max(requiredInsertCount, dynamicIndex)
-    # Encode dynamicIndex, possibly above base
+    # Encode dynamicIndex, possibly above Base
     encodeDynamicIndexReference(streamBuffer, dynamicIndex, base)
 
 # encode the prefix

--- a/rfc9204.md
+++ b/rfc9204.md
@@ -1762,9 +1762,9 @@ Stream: Encoder
                               Size=215
 ~~~
 
-# Sample One Pass Encoding Algorithm
+# Sample Single-Pass Encoding Algorithm
 
-Pseudocode for single pass encoding, excluding handling of duplicates,
+Pseudocode for single-pass encoding, excluding handling of duplicates,
 non-blocking mode, available encoder stream flow control and reference tracking.
 
 ~~~ pseudocode

--- a/rfc9204.md
+++ b/rfc9204.md
@@ -879,7 +879,7 @@ protocol.
 
 Each encoded field section is prefixed with two integers.  The Required Insert
 Count is encoded as an integer with an 8-bit prefix using the encoding described
-in {{ric}}.  The Base is encoded as a sign bit ('S') and a Delta Base value
+in {{ric}}.  The Base is encoded as a Sign bit ('S') and a Delta Base value
 with a 7-bit prefix; see {{base}}.
 
 ~~~~~~~~~~  ascii-art
@@ -967,16 +967,16 @@ The Base is used to resolve references in the dynamic table as described in
 {{relative-indexing}}.
 
 To save space, the Base is encoded relative to the Required Insert Count using a
-one-bit sign ('S') and the Delta Base value.  A sign bit of 0 indicates that the
-Base is greater than or equal to the value of the Required Insert Count; the
-decoder adds the value of Delta Base to the Required Insert Count to determine
-the value of the Base.  A sign bit of 1 indicates that the Base is less than the
-Required Insert Count; the decoder subtracts the value of Delta Base from the
-Required Insert Count and also subtracts one to determine the value of the Base.
-That is:
+one-bit Sign ('S' in {{fig-base-index}}) and the Delta Base value.  A Sign bit
+of 0 indicates that the Base is greater than or equal to the value of the
+Required Insert Count; the decoder adds the value of Delta Base to the Required
+Insert Count to determine the value of the Base.  A Sign bit of 1 indicates that
+the Base is less than the Required Insert Count; the decoder subtracts the value
+of Delta Base from the Required Insert Count and also subtracts one to determine
+the value of the Base. That is:
 
 ~~~ pseudocode
-   if S == 0:
+   if Sign == 0:
       Base = ReqInsertCount + DeltaBase
    else:
       Base = ReqInsertCount - DeltaBase - 1
@@ -985,27 +985,27 @@ That is:
 A single-pass encoder determines the Base before encoding a field section.  If
 the encoder inserted entries in the dynamic table while encoding the field
 section and is referencing them, Required Insert Count will be greater than the
-Base, so the encoded difference is negative and the sign bit is set to 1.  If
+Base, so the encoded difference is negative and the Sign bit is set to 1.  If
 the field section was not encoded using representations that reference the most
 recent entry in the table and did not insert any new entries, the Base will be
 greater than the Required Insert Count, so the encoded difference will be
-positive and the sign bit is set to 0.
+positive and the Sign bit is set to 0.
 
 The value of Base MUST NOT be negative. Though the protocol might operate
 correctly with a negative Base using post-Base indexing, it is unnecessary and
-inefficient. An endpoint MUST treat a field block with a sign bit of 1 as
+inefficient. An endpoint MUST treat a field block with a Sign bit of 1 as
 invalid if the value of Required Insert Count is less than or equal to the value
 of Delta Base.
 
 An encoder that produces table updates before encoding a field section might set
-Base to the value of Required Insert Count.  In such a case, both the sign bit
+Base to the value of Required Insert Count.  In such a case, both the Sign bit
 and the Delta Base will be set to zero.
 
 A field section that was encoded without references to the dynamic table can use
 any value for the Base; setting Delta Base to zero is one of the most efficient
 encodings.
 
-For example, with a Required Insert Count of 9, a decoder receives a sign bit
+For example, with a Required Insert Count of 9, a decoder receives a Sign bit
 of 1 and a Delta Base of 2.  This sets the Base to 6 and enables post-Base
 indexing for three entries.  In this example, a relative index of 1 refers to
 the fifth entry that was added to the table; a post-Base index of 1 refers to

--- a/rfc9204.md
+++ b/rfc9204.md
@@ -647,9 +647,9 @@ encoding.
 This document expands the definition of string literals by permitting them to
 begin other than on a byte boundary.  An "N-bit prefix string literal" begins
 mid-byte, with the first (8-N) bits allocated to a previous field. The string
-uses one bit for the Huffman flag, followed by the string length encoded as a
-(N-1)-bit prefix integer.  The prefix size, N, can have a value between 2 and 8,
-inclusive. The remainder of the string literal is unmodified.
+uses one bit for the Huffman flag, followed by the length of the encoded string
+as a (N-1)-bit prefix integer.  The prefix size, N, can have a value between 2
+and 8, inclusive. The remainder of the string literal is unmodified.
 
 A string literal without a prefix length noted is an 8-bit prefix string literal
 and follows the definitions in {{RFC7541}} without modification.

--- a/rfc9204.md
+++ b/rfc9204.md
@@ -987,8 +987,8 @@ section and is referencing them, Required Insert Count will be greater than the
 Base, so the encoded difference is negative and the sign bit is set to 1.  If
 the field section was not encoded using representations that reference the most
 recent entry in the table and did not insert any new entries, the Base will be
-greater than the Required Insert Count, so the delta will be positive and the
-sign bit is set to 0.
+greater than the Required Insert Count, so the encoded difference will be
+positive and the sign bit is set to 0.
 
 The value of Base MUST NOT be negative. Though the protocol might operate
 correctly with a negative base using post-base indexing, it is unnecessary and

--- a/rfc9204.md
+++ b/rfc9204.md
@@ -992,9 +992,9 @@ positive and the sign bit is set to 0.
 
 The value of Base MUST NOT be negative. Though the protocol might operate
 correctly with a negative base using post-base indexing, it is unnecessary and
-inefficient. An endpoint MUST treat a field block with an S bit of 1 as invalid
-if the value of Required Insert Count is less than or equal to the value of
-Delta Base.
+inefficient. An endpoint MUST treat a field block with a sign bit of 1 as
+invalid if the value of Required Insert Count is less than or equal to the value
+of Delta Base.
 
 An encoder that produces table updates before encoding a field section might set
 Base to the value of Required Insert Count.  In such a case, both the sign bit
@@ -1004,11 +1004,11 @@ A field section that was encoded without references to the dynamic table can use
 any value for the Base; setting Delta Base to zero is one of the most efficient
 encodings.
 
-For example, with a Required Insert Count of 9, a decoder receives an S bit of 1
-and a Delta Base of 2.  This sets the Base to 6 and enables post-base indexing
-for three entries.  In this example, a relative index of 1 refers to the fifth
-entry that was added to the table; a post-base index of 1 refers to the eighth
-entry.
+For example, with a Required Insert Count of 9, a decoder receives a sign bit
+of 1 and a Delta Base of 2.  This sets the Base to 6 and enables post-base
+indexing for three entries.  In this example, a relative index of 1 refers to
+the fifth entry that was added to the table; a post-base index of 1 refers to
+the eighth entry.
 
 
 ### Indexed Field Line

--- a/rfc9204.md
+++ b/rfc9204.md
@@ -638,15 +638,16 @@ throughout. This string format includes optional Huffman encoding.
 
 HPACK defines string literals to begin on a byte boundary.  They begin with a
 single bit flag, denoted as 'H' in this document (indicating whether the string
-is Huffman encoded), followed by the Length encoded as a 7-bit prefix integer,
-and finally Length bytes of data. When Huffman encoding is enabled, the Huffman
-table from {{Section B of RFC7541}} is used without modification and Length
-indicates the size of the string after encoding.
+is Huffman encoded), followed by the string length encoded as a 7-bit prefix
+integer, and finally the indicated number of bytes of data. When Huffman
+encoding is enabled, the Huffman table from {{Section B of RFC7541}} is used
+without modification and the indicated length is the size of the string after
+encoding.
 
 This document expands the definition of string literals by permitting them to
 begin other than on a byte boundary.  An "N-bit prefix string literal" begins
 mid-byte, with the first (8-N) bits allocated to a previous field. The string
-uses one bit for the Huffman flag, followed by the Length encoded as a
+uses one bit for the Huffman flag, followed by the string length encoded as a
 (N-1)-bit prefix integer.  The prefix size, N, can have a value between 2 and 8,
 inclusive. The remainder of the string literal is unmodified.
 


### PR DESCRIPTION
Fixes #4976.  While there are legitimate arguments for both capitalizing and not capitalizing Base, this is a smaller change and easier to be sure we got them all.  That gets my vote at this point in the process.

Each capitalization decision discussed in the issue is in a separate commit, in case we need to lift out and revisit one.